### PR TITLE
Extract shared CSS architecture from prototype files

### DIFF
--- a/docs/plans/issue-41-css-extraction.md
+++ b/docs/plans/issue-41-css-extraction.md
@@ -1,0 +1,755 @@
+# Issue #41: Extract Common Design Tokens and CSS from Prototypes - Implementation Plan
+
+**Version:** 1.0
+**Created:** 2025-12-07
+**Status:** Planning
+**Target Framework:** HTML/CSS Prototypes + Future .NET Blazor
+
+---
+
+## 1. Requirement Summary
+
+Extract duplicated CSS and Tailwind configuration from 27 HTML prototype files into a shared stylesheet architecture. Currently, each prototype contains:
+
+1. **Tailwind config block** (~65 lines) with identical design tokens
+2. **Common CSS styles** in `<style>` tags (scrollbar, focus states, `.sr-only`, etc.)
+3. **Component-specific styles** that vary by file type
+
+The goal is to create a centralized CSS architecture that:
+- Eliminates code duplication across all prototype files
+- Provides a single source of truth for design tokens
+- Creates a maintainable structure that mirrors production Blazor CSS
+- Maintains browser live preview compatibility (no build step required)
+
+---
+
+## 2. Current State Analysis
+
+### 2.1 Prototype Inventory (27 files)
+
+| Category | Count | Files |
+|----------|-------|-------|
+| Root prototypes | 2 | `dashboard.html`, `component-showcase.html` |
+| Feedback components | 9 | `feedback-alerts.html`, `feedback-confirmation.html`, `feedback-drawers.html`, `feedback-empty-states.html`, `feedback-loading.html`, `feedback-modals.html`, `feedback-skeletons.html`, `feedback-toasts.html`, `feedback-tooltips.html` |
+| Form components | 12 | `forms/index.html`, `forms/components/01-text-input.html` through `forms/components/10-file-upload.html` |
+| Data display | 5 | `components/data-display/cards.html`, `components/data-display/lists.html`, `components/data-display/primitives.html`, `components/data-display/showcase.html`, `components/data-display/tables.html` |
+
+### 2.2 Duplicated Content Patterns
+
+#### Tailwind Config Block (identical across most files)
+Lines 13-76 in most files contain the same `tailwind.config` JavaScript object with:
+- Background colors (`bg.primary`, `bg.secondary`, `bg.tertiary`, `bg.hover`)
+- Text colors (`text.primary`, `text.secondary`, `text.tertiary`, `text.inverse`)
+- Accent colors (`accent.orange`, `accent.blue` with variants)
+- Semantic colors (`success`, `warning`, `error`, `info` with bg/border variants)
+- Border colors
+- Font families (`sans`, `mono`)
+
+#### Common CSS Styles (duplicated with slight variations)
+```css
+/* Scrollbar styles - found in all files */
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: #1d2022; }
+::-webkit-scrollbar-thumb { background: #3f4447; border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { background: #4a4f52; }
+
+/* Focus styles - found in all files */
+*:focus-visible { outline: 2px solid #098ecf; outline-offset: 2px; }
+
+/* Screen reader utility - found in form components */
+.sr-only { position: absolute; width: 1px; height: 1px; ... }
+
+/* Animations - found in multiple files */
+@keyframes shimmer { ... }
+@keyframes pulse { ... }
+@keyframes slideIn { ... }
+```
+
+### 2.3 Inconsistencies Found
+
+| File | Issue |
+|------|-------|
+| `feedback-alerts.html` | Uses different color scheme (`dark-900`, `dark-800`) not matching design system |
+| Various files | Some use hex colors directly, others use rgba() |
+| Form components | Most extensive component styles, well-organized |
+| Dashboard | Contains sidebar/dropdown specific animations |
+
+---
+
+## 3. Architectural Considerations
+
+### 3.1 Constraints
+
+1. **No Build Step**: Prototypes must work with browser live preview (Tailwind CDN)
+2. **Relative Path Complexity**: Files exist at multiple nesting levels:
+   - `docs/prototypes/*.html` (2 levels from css/)
+   - `docs/prototypes/forms/*.html` (3 levels)
+   - `docs/prototypes/forms/components/*.html` (4 levels)
+   - `docs/prototypes/components/data-display/*.html` (4 levels)
+3. **Tailwind CDN Config**: The `tailwind.config` must remain inline in each file (CDN limitation)
+4. **Browser Caching**: Changes to shared CSS should propagate to all prototypes
+
+### 3.2 Tailwind CDN Constraint
+
+The Tailwind Play CDN (`cdn.tailwindcss.com`) requires configuration to be inline:
+```html
+<script>
+  tailwind.config = { /* must be inline */ }
+</script>
+```
+
+**Decision**: Create a shared JavaScript file for Tailwind config that can be loaded before the CDN script processes the page. This requires a specific script loading order.
+
+### 3.3 CSS Custom Properties Strategy
+
+CSS custom properties (variables) will be used to:
+- Define all design tokens in one place
+- Allow Tailwind utility classes to reference these tokens
+- Enable easy theme modifications
+- Support future dark/light mode if needed
+
+---
+
+## 4. Target File Structure
+
+```
+docs/prototypes/
++-- css/
+|   +-- tokens.css              # CSS custom properties (design tokens)
+|   +-- tailwind.config.js      # Shared Tailwind configuration (loaded via script)
+|   +-- base.css                # Reset, scrollbar, focus states, box-sizing
+|   +-- utilities.css           # Utility classes (sr-only, animations)
+|   +-- components/
+|   |   +-- buttons.css         # Button component styles
+|   |   +-- forms.css           # Form input, select, checkbox, toggle styles
+|   |   +-- cards.css           # Card container styles
+|   |   +-- tables.css          # Table and data display styles
+|   |   +-- alerts.css          # Alert and notification styles
+|   |   +-- navigation.css      # Navbar, sidebar, breadcrumb styles
+|   |   +-- modals.css          # Modal and drawer styles
+|   |   +-- loading.css         # Spinner, skeleton, progress styles
+|   +-- main.css                # Single import file (imports all above)
+|   +-- README.md               # CSS architecture documentation
++-- [existing prototype files]
+```
+
+### 4.1 File Responsibilities
+
+| File | Purpose | Approximate Size |
+|------|---------|------------------|
+| `tokens.css` | CSS custom properties for colors, spacing, typography, shadows, radii | ~120 lines |
+| `tailwind.config.js` | Shared Tailwind theme extending design tokens | ~80 lines |
+| `base.css` | Browser reset, scrollbar, focus ring, box-sizing | ~50 lines |
+| `utilities.css` | `.sr-only`, animation keyframes, common utility classes | ~80 lines |
+| `components/buttons.css` | `.btn`, `.btn-primary`, `.btn-secondary`, etc. | ~100 lines |
+| `components/forms.css` | `.form-input`, `.form-select`, `.form-checkbox`, etc. | ~200 lines |
+| `components/cards.css` | `.card`, `.card-header`, `.stat-card`, etc. | ~80 lines |
+| `components/tables.css` | `.table`, `.table-header`, `.table-row`, etc. | ~100 lines |
+| `components/alerts.css` | `.alert`, `.alert-info`, `.alert-success`, etc. | ~80 lines |
+| `components/navigation.css` | `.navbar`, `.sidebar`, `.breadcrumb`, etc. | ~120 lines |
+| `components/modals.css` | `.modal`, `.drawer`, `.modal-overlay`, etc. | ~80 lines |
+| `components/loading.css` | `.skeleton`, `.spinner`, `.progress`, etc. | ~60 lines |
+| `main.css` | Import statements only | ~20 lines |
+
+---
+
+## 5. Subagent Task Plan
+
+### 5.1 design-specialist
+
+**Deliverables:**
+1. Review and validate CSS custom property naming conventions
+2. Confirm all design tokens from `docs/design-system.md` are represented in `tokens.css`
+3. Identify any missing tokens needed for existing prototypes
+4. Provide accessibility validation for focus states and color contrast
+5. Document any design system updates needed based on findings
+
+**Acceptance Criteria:**
+- [ ] All colors from design-system.md mapped to CSS custom properties
+- [ ] All spacing values from design-system.md mapped
+- [ ] All typography values from design-system.md mapped
+- [ ] All shadow/elevation values from design-system.md mapped
+- [ ] All border-radius values from design-system.md mapped
+- [ ] Focus ring styling meets WCAG 2.1 AA requirements
+
+### 5.2 html-prototyper
+
+**Deliverables:**
+
+**Phase 1: Create CSS Architecture**
+1. Create `docs/prototypes/css/tokens.css` with all design tokens as CSS custom properties
+2. Create `docs/prototypes/css/tailwind.config.js` referencing CSS custom properties
+3. Create `docs/prototypes/css/base.css` with reset and focus styles
+4. Create `docs/prototypes/css/utilities.css` with utility classes and animations
+
+**Phase 2: Extract Component Styles**
+1. Create `docs/prototypes/css/components/buttons.css`
+2. Create `docs/prototypes/css/components/forms.css`
+3. Create `docs/prototypes/css/components/cards.css`
+4. Create `docs/prototypes/css/components/tables.css`
+5. Create `docs/prototypes/css/components/alerts.css`
+6. Create `docs/prototypes/css/components/navigation.css`
+7. Create `docs/prototypes/css/components/modals.css`
+8. Create `docs/prototypes/css/components/loading.css`
+9. Create `docs/prototypes/css/main.css` that imports all component files
+
+**Phase 3: Refactor Prototype Files**
+1. Update all 27 prototype HTML files to use shared CSS imports
+2. Remove duplicated inline styles
+3. Update Tailwind config to load from shared file
+4. Verify each prototype renders correctly
+
+**Acceptance Criteria:**
+- [ ] All CSS files created in `docs/prototypes/css/` structure
+- [ ] `tokens.css` contains all design system tokens
+- [ ] `tailwind.config.js` properly extends Tailwind with design tokens
+- [ ] `base.css` contains scrollbar, focus, and reset styles
+- [ ] `utilities.css` contains `.sr-only` and animation keyframes
+- [ ] Each component CSS file contains relevant extracted styles
+- [ ] `main.css` imports all files in correct order
+- [ ] All 27 prototypes updated to use shared CSS
+- [ ] All prototypes render identically to before refactoring
+- [ ] No inline `<style>` blocks for common styles remain
+
+### 5.3 dotnet-specialist
+
+**Deliverables:**
+1. Review CSS architecture for alignment with future Blazor structure
+2. Ensure CSS file organization maps to planned Blazor component structure
+3. Identify any CSS that should be component-scoped vs global
+4. Validate CSS custom property naming for C# constant generation
+
+**Acceptance Criteria:**
+- [ ] CSS structure aligns with `src/DiscordBot.Bot/wwwroot/css/` target structure
+- [ ] Component CSS files map to Blazor component directories
+- [ ] Naming conventions support future CSS isolation files
+
+### 5.4 docs-writer
+
+**Deliverables:**
+1. Create `docs/prototypes/css/README.md` documenting the CSS architecture
+2. Update `docs/design-system.md` with CSS file references
+3. Document how to add new components/styles
+4. Document the Tailwind CDN configuration approach
+
+**Acceptance Criteria:**
+- [ ] README explains file structure and purpose
+- [ ] README includes usage examples for adding new prototypes
+- [ ] README documents Tailwind config loading mechanism
+- [ ] design-system.md updated with CSS architecture section
+
+---
+
+## 6. Implementation Phases
+
+### Phase 1: Foundation (Day 1-2)
+
+| Task | Owner | Dependencies | Deliverables |
+|------|-------|--------------|--------------|
+| Create directory structure | html-prototyper | None | `css/` folder with subdirectories |
+| Create tokens.css | html-prototyper | design-specialist review | CSS custom properties file |
+| Create tailwind.config.js | html-prototyper | tokens.css | Shared Tailwind config |
+| Create base.css | html-prototyper | tokens.css | Reset and focus styles |
+| Create utilities.css | html-prototyper | tokens.css | Utility classes |
+| Design system review | design-specialist | tokens.css draft | Validation report |
+
+### Phase 2: Component Extraction (Day 2-3)
+
+| Task | Owner | Dependencies | Deliverables |
+|------|-------|--------------|--------------|
+| Extract button styles | html-prototyper | Phase 1 | buttons.css |
+| Extract form styles | html-prototyper | Phase 1 | forms.css |
+| Extract card styles | html-prototyper | Phase 1 | cards.css |
+| Extract table styles | html-prototyper | Phase 1 | tables.css |
+| Extract alert styles | html-prototyper | Phase 1 | alerts.css |
+| Extract navigation styles | html-prototyper | Phase 1 | navigation.css |
+| Extract modal styles | html-prototyper | Phase 1 | modals.css |
+| Extract loading styles | html-prototyper | Phase 1 | loading.css |
+| Create main.css | html-prototyper | All component CSS | Import manifest |
+
+### Phase 3: Prototype Refactoring (Day 3-4)
+
+| Task | Owner | Dependencies | Deliverables |
+|------|-------|--------------|--------------|
+| Update root prototypes (2) | html-prototyper | Phase 2 | Refactored HTML files |
+| Update feedback prototypes (9) | html-prototyper | Phase 2 | Refactored HTML files |
+| Update form prototypes (12) | html-prototyper | Phase 2 | Refactored HTML files |
+| Update data-display prototypes (5) | html-prototyper | Phase 2 | Refactored HTML files |
+| Visual regression testing | html-prototyper | All updates | Test report |
+
+### Phase 4: Documentation & Review (Day 4-5)
+
+| Task | Owner | Dependencies | Deliverables |
+|------|-------|--------------|--------------|
+| Create CSS README | docs-writer | Phase 2, 3 | README.md |
+| Update design-system.md | docs-writer | Phase 2 | Updated documentation |
+| Blazor alignment review | dotnet-specialist | Phase 2 | Alignment report |
+| Accessibility audit | design-specialist | Phase 3 | Audit report |
+| Final review | All | All phases | Sign-off |
+
+---
+
+## 7. Detailed File Specifications
+
+### 7.1 tokens.css
+
+```css
+/* ===========================================
+   DESIGN TOKENS
+   Source of truth for all design system values
+   =========================================== */
+
+:root {
+  /* ----------------------------------------
+     Background Colors
+     ---------------------------------------- */
+  --color-bg-primary: #1d2022;
+  --color-bg-secondary: #262a2d;
+  --color-bg-tertiary: #2f3336;
+  --color-bg-hover: #363a3e;
+
+  /* ----------------------------------------
+     Text Colors
+     ---------------------------------------- */
+  --color-text-primary: #d7d3d0;
+  --color-text-secondary: #a8a5a3;
+  --color-text-tertiary: #7a7876;
+  --color-text-inverse: #1d2022;
+
+  /* ----------------------------------------
+     Accent Colors - Orange (Primary)
+     ---------------------------------------- */
+  --color-accent-orange: #cb4e1b;
+  --color-accent-orange-hover: #e5591f;
+  --color-accent-orange-active: #b04517;
+  --color-accent-orange-muted: rgba(203, 78, 27, 0.2);
+
+  /* ----------------------------------------
+     Accent Colors - Blue (Secondary)
+     ---------------------------------------- */
+  --color-accent-blue: #098ecf;
+  --color-accent-blue-hover: #0ba3ea;
+  --color-accent-blue-active: #0879b3;
+  --color-accent-blue-muted: rgba(9, 142, 207, 0.2);
+
+  /* ----------------------------------------
+     Semantic Colors
+     ---------------------------------------- */
+  --color-success: #10b981;
+  --color-success-bg: rgba(16, 185, 129, 0.1);
+  --color-success-border: rgba(16, 185, 129, 0.3);
+
+  --color-warning: #f59e0b;
+  --color-warning-bg: rgba(245, 158, 11, 0.1);
+  --color-warning-border: rgba(245, 158, 11, 0.3);
+
+  --color-error: #ef4444;
+  --color-error-bg: rgba(239, 68, 68, 0.1);
+  --color-error-border: rgba(239, 68, 68, 0.3);
+
+  --color-info: #06b6d4;
+  --color-info-bg: rgba(6, 182, 212, 0.1);
+  --color-info-border: rgba(6, 182, 212, 0.3);
+
+  /* ----------------------------------------
+     Border Colors
+     ---------------------------------------- */
+  --color-border-primary: #3f4447;
+  --color-border-secondary: #2f3336;
+  --color-border-focus: #098ecf;
+
+  /* ----------------------------------------
+     Spacing Scale
+     ---------------------------------------- */
+  --space-0: 0;
+  --space-1: 0.25rem;    /* 4px */
+  --space-2: 0.5rem;     /* 8px */
+  --space-3: 0.75rem;    /* 12px */
+  --space-4: 1rem;       /* 16px */
+  --space-5: 1.25rem;    /* 20px */
+  --space-6: 1.5rem;     /* 24px */
+  --space-8: 2rem;       /* 32px */
+  --space-10: 2.5rem;    /* 40px */
+  --space-12: 3rem;      /* 48px */
+  --space-16: 4rem;      /* 64px */
+
+  /* ----------------------------------------
+     Typography
+     ---------------------------------------- */
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+               "Helvetica Neue", Arial, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo,
+               Monaco, Consolas, monospace;
+
+  /* Font Sizes */
+  --text-xs: 0.75rem;    /* 12px */
+  --text-sm: 0.875rem;   /* 14px */
+  --text-base: 1rem;     /* 16px */
+  --text-lg: 1.125rem;   /* 18px */
+  --text-xl: 1.25rem;    /* 20px */
+  --text-2xl: 1.5rem;    /* 24px */
+  --text-3xl: 1.875rem;  /* 30px */
+  --text-4xl: 2.25rem;   /* 36px */
+
+  /* ----------------------------------------
+     Border Radius
+     ---------------------------------------- */
+  --radius-sm: 0.25rem;  /* 4px */
+  --radius-md: 0.375rem; /* 6px */
+  --radius-lg: 0.5rem;   /* 8px */
+  --radius-xl: 0.75rem;  /* 12px */
+  --radius-full: 9999px;
+
+  /* ----------------------------------------
+     Shadows
+     ---------------------------------------- */
+  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
+  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.3),
+               0 2px 4px -1px rgba(0, 0, 0, 0.2);
+  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.3),
+               0 4px 6px -2px rgba(0, 0, 0, 0.2);
+  --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.3),
+               0 10px 10px -5px rgba(0, 0, 0, 0.2);
+
+  /* ----------------------------------------
+     Transitions
+     ---------------------------------------- */
+  --transition-fast: 0.15s ease-in-out;
+  --transition-normal: 0.2s ease-in-out;
+  --transition-slow: 0.3s ease-in-out;
+
+  /* ----------------------------------------
+     Z-Index Scale
+     ---------------------------------------- */
+  --z-dropdown: 10;
+  --z-sticky: 20;
+  --z-fixed: 30;
+  --z-modal-backdrop: 40;
+  --z-modal: 50;
+  --z-popover: 60;
+  --z-tooltip: 70;
+}
+```
+
+### 7.2 tailwind.config.js
+
+```javascript
+// Shared Tailwind CSS configuration for prototypes
+// Load this file BEFORE the Tailwind CDN script
+
+window.tailwindConfig = {
+  theme: {
+    extend: {
+      colors: {
+        bg: {
+          primary: 'var(--color-bg-primary)',
+          secondary: 'var(--color-bg-secondary)',
+          tertiary: 'var(--color-bg-tertiary)',
+          hover: 'var(--color-bg-hover)',
+        },
+        text: {
+          primary: 'var(--color-text-primary)',
+          secondary: 'var(--color-text-secondary)',
+          tertiary: 'var(--color-text-tertiary)',
+          inverse: 'var(--color-text-inverse)',
+        },
+        accent: {
+          orange: {
+            DEFAULT: 'var(--color-accent-orange)',
+            hover: 'var(--color-accent-orange-hover)',
+            active: 'var(--color-accent-orange-active)',
+            muted: 'var(--color-accent-orange-muted)',
+          },
+          blue: {
+            DEFAULT: 'var(--color-accent-blue)',
+            hover: 'var(--color-accent-blue-hover)',
+            active: 'var(--color-accent-blue-active)',
+            muted: 'var(--color-accent-blue-muted)',
+          },
+        },
+        success: {
+          DEFAULT: 'var(--color-success)',
+          bg: 'var(--color-success-bg)',
+          border: 'var(--color-success-border)',
+        },
+        warning: {
+          DEFAULT: 'var(--color-warning)',
+          bg: 'var(--color-warning-bg)',
+          border: 'var(--color-warning-border)',
+        },
+        error: {
+          DEFAULT: 'var(--color-error)',
+          bg: 'var(--color-error-bg)',
+          border: 'var(--color-error-border)',
+        },
+        info: {
+          DEFAULT: 'var(--color-info)',
+          bg: 'var(--color-info-bg)',
+          border: 'var(--color-info-border)',
+        },
+        border: {
+          primary: 'var(--color-border-primary)',
+          secondary: 'var(--color-border-secondary)',
+          focus: 'var(--color-border-focus)',
+        },
+      },
+      fontFamily: {
+        sans: ['var(--font-sans)'],
+        mono: ['var(--font-mono)'],
+      },
+      borderRadius: {
+        sm: 'var(--radius-sm)',
+        DEFAULT: 'var(--radius-md)',
+        md: 'var(--radius-md)',
+        lg: 'var(--radius-lg)',
+        xl: 'var(--radius-xl)',
+        full: 'var(--radius-full)',
+      },
+      boxShadow: {
+        sm: 'var(--shadow-sm)',
+        DEFAULT: 'var(--shadow-md)',
+        md: 'var(--shadow-md)',
+        lg: 'var(--shadow-lg)',
+        xl: 'var(--shadow-xl)',
+      },
+      transitionDuration: {
+        fast: '150ms',
+        normal: '200ms',
+        slow: '300ms',
+      },
+    },
+  },
+};
+
+// Auto-apply config when Tailwind loads
+if (typeof tailwind !== 'undefined') {
+  tailwind.config = window.tailwindConfig;
+}
+```
+
+### 7.3 Updated HTML Template Structure
+
+After refactoring, prototype files will follow this pattern:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>[Page Title] - Discord Bot Admin</title>
+
+  <!-- Design Tokens (CSS Custom Properties) -->
+  <link rel="stylesheet" href="../css/tokens.css">
+
+  <!-- Base Styles (Reset, Scrollbar, Focus) -->
+  <link rel="stylesheet" href="../css/base.css">
+
+  <!-- Component Styles -->
+  <link rel="stylesheet" href="../css/main.css">
+
+  <!-- Tailwind CSS CDN -->
+  <script src="../css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
+</head>
+<body class="bg-bg-primary text-text-primary font-sans antialiased">
+  <!-- Page content -->
+</body>
+</html>
+```
+
+**Path Adjustment Examples:**
+- `docs/prototypes/*.html` -> `href="css/tokens.css"`
+- `docs/prototypes/forms/*.html` -> `href="../css/tokens.css"`
+- `docs/prototypes/forms/components/*.html` -> `href="../../css/tokens.css"`
+- `docs/prototypes/components/data-display/*.html` -> `href="../../css/tokens.css"`
+
+---
+
+## 8. Testing Strategy
+
+### 8.1 Visual Regression Testing
+
+| Test | Method | Pass Criteria |
+|------|--------|---------------|
+| Dashboard layout | Screenshot comparison | Pixel-perfect match |
+| Form components | Manual inspection | All states functional |
+| Feedback components | Interactive testing | Animations work correctly |
+| Data display tables | Responsive testing | Breakpoints match original |
+| Color consistency | Computed style check | All colors resolve correctly |
+
+### 8.2 Browser Compatibility
+
+| Browser | Version | Priority |
+|---------|---------|----------|
+| Chrome | Latest | Primary |
+| Firefox | Latest | Primary |
+| Safari | Latest | Secondary |
+| Edge | Latest | Secondary |
+
+### 8.3 Path Resolution Testing
+
+Each nesting level must be verified:
+- [ ] Root prototypes load CSS correctly
+- [ ] forms/index.html loads CSS correctly
+- [ ] forms/components/*.html files load CSS correctly
+- [ ] components/data-display/*.html files load CSS correctly
+
+---
+
+## 9. Acceptance Criteria
+
+### 9.1 CSS Architecture
+
+- [ ] All files created in `docs/prototypes/css/` directory
+- [ ] `tokens.css` contains all design tokens from design-system.md
+- [ ] CSS custom properties follow `--color-*`, `--space-*`, `--text-*` naming
+- [ ] `tailwind.config.js` properly references CSS custom properties
+- [ ] `base.css` contains scrollbar, focus, and reset styles
+- [ ] `utilities.css` contains `.sr-only` and all animation keyframes
+- [ ] Component CSS files contain extracted component-specific styles
+- [ ] `main.css` imports all files in correct cascade order
+- [ ] No duplicate style definitions across CSS files
+
+### 9.2 Prototype Refactoring
+
+- [ ] All 27 prototype files updated with shared CSS imports
+- [ ] No inline `<style>` blocks for common/shared styles
+- [ ] Tailwind config loaded from shared JavaScript file
+- [ ] Relative paths correct for each nesting level
+- [ ] All prototypes render identically after refactoring
+
+### 9.3 Documentation
+
+- [ ] `docs/prototypes/css/README.md` created
+- [ ] Architecture overview documented
+- [ ] Usage instructions for new prototypes
+- [ ] `docs/design-system.md` updated with CSS file references
+
+### 9.4 Quality
+
+- [ ] All browsers render consistently
+- [ ] No CSS parse errors in browser console
+- [ ] Focus states visible and accessible
+- [ ] Scrollbar styling applied correctly
+
+---
+
+## 10. Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Tailwind CDN caching issues | Medium | Low | Add version query param to script URL |
+| CSS specificity conflicts | Medium | Medium | Use consistent selector patterns, document cascade |
+| Relative path errors | High | High | Create path mapping table, test all files |
+| Missing component styles | Medium | Medium | Comprehensive style audit before extraction |
+| Browser CSS variable support | Low | High | All modern browsers support; document minimum versions |
+| Tailwind config not loading | Medium | High | Test script load order, add fallback |
+
+---
+
+## 11. Timeline Summary
+
+| Phase | Duration | Deliverables |
+|-------|----------|--------------|
+| Phase 1: Foundation | 2 days | tokens.css, tailwind.config.js, base.css, utilities.css |
+| Phase 2: Component Extraction | 1.5 days | All component CSS files, main.css |
+| Phase 3: Prototype Refactoring | 1.5 days | All 27 HTML files updated |
+| Phase 4: Documentation & Review | 1 day | README, design-system.md updates, testing |
+| **Total** | **6 days** | Complete CSS architecture + refactored prototypes |
+
+---
+
+## 12. Future Considerations
+
+### 12.1 Blazor Production CSS
+
+This CSS architecture is designed to migrate to production:
+
+```
+src/DiscordBot.Bot/wwwroot/css/
++-- tokens.css              # Same file, production path
++-- base.css                # Same file
++-- utilities.css           # Same file
++-- components/             # Component styles (or use CSS isolation)
++-- main.css                # Production import manifest
+```
+
+### 12.2 CSS Isolation Mapping
+
+| Prototype CSS | Blazor CSS Isolation |
+|---------------|---------------------|
+| `buttons.css` | `Button.razor.css` |
+| `forms.css` | `Input.razor.css`, `Select.razor.css`, etc. |
+| `cards.css` | `Card.razor.css` |
+| `tables.css` | `DataTable.razor.css` |
+| Global styles | `App.razor` or site.css |
+
+### 12.3 Potential Enhancements
+
+1. **CSS Custom Property Fallbacks**: Add fallback values for older browsers
+2. **Dark/Light Mode**: Add alternate token sets for theme switching
+3. **Print Styles**: Add print media queries if needed
+4. **Prefers-reduced-motion**: Add motion preferences support
+
+---
+
+## Appendix A: Complete File List to Create
+
+```
+docs/prototypes/css/
++-- tokens.css
++-- tailwind.config.js
++-- base.css
++-- utilities.css
++-- main.css
++-- README.md
++-- components/
+    +-- buttons.css
+    +-- forms.css
+    +-- cards.css
+    +-- tables.css
+    +-- alerts.css
+    +-- navigation.css
+    +-- modals.css
+    +-- loading.css
+```
+
+## Appendix B: Files to Refactor
+
+```
+docs/prototypes/dashboard.html
+docs/prototypes/component-showcase.html
+docs/prototypes/feedback-alerts.html
+docs/prototypes/feedback-confirmation.html
+docs/prototypes/feedback-drawers.html
+docs/prototypes/feedback-empty-states.html
+docs/prototypes/feedback-loading.html
+docs/prototypes/feedback-modals.html
+docs/prototypes/feedback-skeletons.html
+docs/prototypes/feedback-toasts.html
+docs/prototypes/feedback-tooltips.html
+docs/prototypes/forms/index.html
+docs/prototypes/forms/components/01-text-input.html
+docs/prototypes/forms/components/02-validation-states.html
+docs/prototypes/forms/components/03-select-dropdown.html
+docs/prototypes/forms/components/04-checkbox.html
+docs/prototypes/forms/components/05-radio-button.html
+docs/prototypes/forms/components/06-toggle-switch.html
+docs/prototypes/forms/components/07-form-group.html
+docs/prototypes/forms/components/08-date-time.html
+docs/prototypes/forms/components/09-number-input.html
+docs/prototypes/forms/components/10-file-upload.html
+docs/prototypes/components/data-display/cards.html
+docs/prototypes/components/data-display/lists.html
+docs/prototypes/components/data-display/primitives.html
+docs/prototypes/components/data-display/showcase.html
+docs/prototypes/components/data-display/tables.html
+```
+
+---
+
+*Document Version: 1.0*
+*Created: 2025-12-07*
+*Author: Systems Architect*

--- a/docs/prototypes/component-showcase.html
+++ b/docs/prototypes/component-showcase.html
@@ -5,99 +5,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Component Library Showcase - Discord Bot Admin</title>
 
-  <!-- Tailwind CSS CDN -->
-  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Shared Styles -->
+  <link rel="stylesheet" href="css/main.css">
 
-  <!-- Tailwind Config with Design System -->
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            bg: {
-              primary: '#1d2022',
-              secondary: '#262a2d',
-              tertiary: '#2f3336',
-              hover: '#363a3e',
-            },
-            text: {
-              primary: '#d7d3d0',
-              secondary: '#a8a5a3',
-              tertiary: '#7a7876',
-              inverse: '#1d2022',
-            },
-            accent: {
-              orange: {
-                DEFAULT: '#cb4e1b',
-                hover: '#e5591f',
-                active: '#b04517',
-                muted: 'rgba(203, 78, 27, 0.2)',
-              },
-              blue: {
-                DEFAULT: '#098ecf',
-                hover: '#0ba3ea',
-                active: '#0879b3',
-                muted: 'rgba(9, 142, 207, 0.2)',
-              },
-            },
-            success: {
-              DEFAULT: '#10b981',
-              bg: 'rgba(16, 185, 129, 0.1)',
-              border: 'rgba(16, 185, 129, 0.3)',
-            },
-            warning: {
-              DEFAULT: '#f59e0b',
-              bg: 'rgba(245, 158, 11, 0.1)',
-              border: 'rgba(245, 158, 11, 0.3)',
-            },
-            error: {
-              DEFAULT: '#ef4444',
-              bg: 'rgba(239, 68, 68, 0.1)',
-              border: 'rgba(239, 68, 68, 0.3)',
-            },
-            info: {
-              DEFAULT: '#06b6d4',
-              bg: 'rgba(6, 182, 212, 0.1)',
-              border: 'rgba(6, 182, 212, 0.3)',
-            },
-            border: {
-              primary: '#3f4447',
-              secondary: '#2f3336',
-              focus: '#098ecf',
-            },
-          },
-          fontFamily: {
-            sans: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', 'sans-serif'],
-            mono: ['ui-monospace', 'SFMono-Regular', '"SF Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
-          },
-        },
-      },
-    }
-  </script>
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
 
   <style>
-    /* Custom scrollbar for dark theme */
-    ::-webkit-scrollbar {
-      width: 8px;
-      height: 8px;
-    }
-    ::-webkit-scrollbar-track {
-      background: #1d2022;
-    }
-    ::-webkit-scrollbar-thumb {
-      background: #3f4447;
-      border-radius: 4px;
-    }
-    ::-webkit-scrollbar-thumb:hover {
-      background: #4a4f52;
-    }
-
-    /* Focus states */
-    *:focus-visible {
-      outline: 2px solid #098ecf;
-      outline-offset: 2px;
-    }
-
+    /* Page-specific styles */
     /* Card hover effect */
     .component-card {
       transition: all 0.2s ease-in-out;

--- a/docs/prototypes/components/data-display/cards.html
+++ b/docs/prototypes/components/data-display/cards.html
@@ -5,98 +5,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Card Components - Discord Bot Admin UI</title>
 
-  <!-- Tailwind CSS CDN -->
-  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Shared Styles -->
+  <link rel="stylesheet" href="../../css/main.css">
 
-  <!-- Tailwind Config with Design System -->
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            bg: {
-              primary: '#1d2022',
-              secondary: '#262a2d',
-              tertiary: '#2f3336',
-              hover: '#363a3e',
-            },
-            text: {
-              primary: '#d7d3d0',
-              secondary: '#a8a5a3',
-              tertiary: '#7a7876',
-              inverse: '#1d2022',
-            },
-            accent: {
-              orange: {
-                DEFAULT: '#cb4e1b',
-                hover: '#e5591f',
-                active: '#b04517',
-                muted: 'rgba(203, 78, 27, 0.2)',
-              },
-              blue: {
-                DEFAULT: '#098ecf',
-                hover: '#0ba3ea',
-                active: '#0879b3',
-                muted: 'rgba(9, 142, 207, 0.2)',
-              },
-            },
-            success: {
-              DEFAULT: '#10b981',
-              bg: 'rgba(16, 185, 129, 0.1)',
-              border: 'rgba(16, 185, 129, 0.3)',
-            },
-            warning: {
-              DEFAULT: '#f59e0b',
-              bg: 'rgba(245, 158, 11, 0.1)',
-              border: 'rgba(245, 158, 11, 0.3)',
-            },
-            error: {
-              DEFAULT: '#ef4444',
-              bg: 'rgba(239, 68, 68, 0.1)',
-              border: 'rgba(239, 68, 68, 0.3)',
-            },
-            info: {
-              DEFAULT: '#06b6d4',
-              bg: 'rgba(6, 182, 212, 0.1)',
-              border: 'rgba(6, 182, 212, 0.3)',
-            },
-            border: {
-              primary: '#3f4447',
-              secondary: '#2f3336',
-              focus: '#098ecf',
-            },
-          },
-          fontFamily: {
-            sans: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', 'sans-serif'],
-            mono: ['ui-monospace', 'SFMono-Regular', '"SF Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
-          },
-        },
-      },
-    }
-  </script>
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="../../css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
 
   <style>
-    /* Custom scrollbar for dark theme */
-    ::-webkit-scrollbar {
-      width: 8px;
-      height: 8px;
-    }
-    ::-webkit-scrollbar-track {
-      background: #1d2022;
-    }
-    ::-webkit-scrollbar-thumb {
-      background: #3f4447;
-      border-radius: 4px;
-    }
-    ::-webkit-scrollbar-thumb:hover {
-      background: #4a4f52;
-    }
-
-    /* Focus states */
-    *:focus-visible {
-      outline: 2px solid #098ecf;
-      outline-offset: 2px;
-    }
+    /* Page-specific styles */
 
     /* Interactive card transition */
     .card-interactive {

--- a/docs/prototypes/components/data-display/lists.html
+++ b/docs/prototypes/components/data-display/lists.html
@@ -5,98 +5,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Lists & Pagination - Component Library</title>
 
-  <!-- Tailwind CSS CDN -->
-  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Shared Styles -->
+  <link rel="stylesheet" href="../../css/main.css">
 
-  <!-- Tailwind Config with Design System -->
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            bg: {
-              primary: '#1d2022',
-              secondary: '#262a2d',
-              tertiary: '#2f3336',
-              hover: '#363a3e',
-            },
-            text: {
-              primary: '#d7d3d0',
-              secondary: '#a8a5a3',
-              tertiary: '#7a7876',
-              inverse: '#1d2022',
-            },
-            accent: {
-              orange: {
-                DEFAULT: '#cb4e1b',
-                hover: '#e5591f',
-                active: '#b04517',
-                muted: 'rgba(203, 78, 27, 0.2)',
-              },
-              blue: {
-                DEFAULT: '#098ecf',
-                hover: '#0ba3ea',
-                active: '#0879b3',
-                muted: 'rgba(9, 142, 207, 0.2)',
-              },
-            },
-            success: {
-              DEFAULT: '#10b981',
-              bg: 'rgba(16, 185, 129, 0.1)',
-              border: 'rgba(16, 185, 129, 0.3)',
-            },
-            warning: {
-              DEFAULT: '#f59e0b',
-              bg: 'rgba(245, 158, 11, 0.1)',
-              border: 'rgba(245, 158, 11, 0.3)',
-            },
-            error: {
-              DEFAULT: '#ef4444',
-              bg: 'rgba(239, 68, 68, 0.1)',
-              border: 'rgba(239, 68, 68, 0.3)',
-            },
-            info: {
-              DEFAULT: '#06b6d4',
-              bg: 'rgba(6, 182, 212, 0.1)',
-              border: 'rgba(6, 182, 212, 0.3)',
-            },
-            border: {
-              primary: '#3f4447',
-              secondary: '#2f3336',
-              focus: '#098ecf',
-            },
-          },
-          fontFamily: {
-            sans: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', 'sans-serif'],
-            mono: ['ui-monospace', 'SFMono-Regular', '"SF Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
-          },
-        },
-      },
-    }
-  </script>
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="../../css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
 
   <style>
-    /* Custom scrollbar for dark theme */
-    ::-webkit-scrollbar {
-      width: 8px;
-      height: 8px;
-    }
-    ::-webkit-scrollbar-track {
-      background: #1d2022;
-    }
-    ::-webkit-scrollbar-thumb {
-      background: #3f4447;
-      border-radius: 4px;
-    }
-    ::-webkit-scrollbar-thumb:hover {
-      background: #4a4f52;
-    }
-
-    /* Focus states */
-    *:focus-visible {
-      outline: 2px solid #098ecf;
-      outline-offset: 2px;
-    }
+    /* Page-specific styles */
 
     /* Collapsible list animation */
     .collapsible-content {

--- a/docs/prototypes/components/data-display/primitives.html
+++ b/docs/prototypes/components/data-display/primitives.html
@@ -5,145 +5,19 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Data Display Primitives - Component Library</title>
 
-  <!-- Tailwind CSS CDN -->
-  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Shared CSS -->
+  <link rel="stylesheet" href="../../css/main.css">
 
-  <!-- Tailwind Config with Design System -->
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            bg: {
-              primary: '#1d2022',
-              secondary: '#262a2d',
-              tertiary: '#2f3336',
-              hover: '#363a3e',
-            },
-            text: {
-              primary: '#d7d3d0',
-              secondary: '#a8a5a3',
-              tertiary: '#7a7876',
-              inverse: '#1d2022',
-            },
-            accent: {
-              orange: {
-                DEFAULT: '#cb4e1b',
-                hover: '#e5591f',
-                active: '#b04517',
-                muted: 'rgba(203, 78, 27, 0.2)',
-              },
-              blue: {
-                DEFAULT: '#098ecf',
-                hover: '#0ba3ea',
-                active: '#0879b3',
-                muted: 'rgba(9, 142, 207, 0.2)',
-              },
-            },
-            success: {
-              DEFAULT: '#10b981',
-              bg: 'rgba(16, 185, 129, 0.1)',
-              border: 'rgba(16, 185, 129, 0.3)',
-            },
-            warning: {
-              DEFAULT: '#f59e0b',
-              bg: 'rgba(245, 158, 11, 0.1)',
-              border: 'rgba(245, 158, 11, 0.3)',
-            },
-            error: {
-              DEFAULT: '#ef4444',
-              bg: 'rgba(239, 68, 68, 0.1)',
-              border: 'rgba(239, 68, 68, 0.3)',
-            },
-            info: {
-              DEFAULT: '#06b6d4',
-              bg: 'rgba(6, 182, 212, 0.1)',
-              border: 'rgba(6, 182, 212, 0.3)',
-            },
-            border: {
-              primary: '#3f4447',
-              secondary: '#2f3336',
-              focus: '#098ecf',
-            },
-          },
-          fontFamily: {
-            sans: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', 'sans-serif'],
-            mono: ['ui-monospace', 'SFMono-Regular', '"SF Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
-          },
-        },
-      },
-    }
-  </script>
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="../../css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
 
   <style>
-    /* Custom scrollbar for dark theme */
-    ::-webkit-scrollbar {
-      width: 8px;
-      height: 8px;
-    }
-    ::-webkit-scrollbar-track {
-      background: #1d2022;
-    }
-    ::-webkit-scrollbar-thumb {
-      background: #3f4447;
-      border-radius: 4px;
-    }
-    ::-webkit-scrollbar-thumb:hover {
-      background: #4a4f52;
-    }
-
-    /* Focus states */
-    *:focus-visible {
-      outline: 2px solid #098ecf;
-      outline-offset: 2px;
-    }
-
-    /* Status indicator pulse animation */
-    @keyframes pulse {
-      0%, 100% { opacity: 1; }
-      50% { opacity: 0.5; }
-    }
-    .status-pulse {
-      animation: pulse 2s infinite;
-    }
-
-    /* Spinner animation */
-    @keyframes spin {
-      from { transform: rotate(0deg); }
-      to { transform: rotate(360deg); }
-    }
-    .animate-spin {
-      animation: spin 1s linear infinite;
-    }
-
-    /* Skeleton shimmer animation */
-    @keyframes shimmer {
-      0% {
-        background-position: -200% 0;
-      }
-      100% {
-        background-position: 200% 0;
-      }
-    }
-    .skeleton {
-      background: linear-gradient(
-        90deg,
-        #262a2d 0%,
-        #363a3e 50%,
-        #262a2d 100%
-      );
-      background-size: 200% 100%;
-      animation: shimmer 1.5s ease-in-out infinite;
-    }
-
     /* Progress bar indeterminate animation */
     @keyframes indeterminate {
-      0% {
-        transform: translateX(-100%);
-      }
-      100% {
-        transform: translateX(300%);
-      }
+      0% { transform: translateX(-100%); }
+      100% { transform: translateX(300%); }
     }
     .progress-indeterminate {
       animation: indeterminate 1.5s ease-in-out infinite;
@@ -151,12 +25,8 @@
 
     /* Striped progress bar animation */
     @keyframes stripe {
-      0% {
-        background-position: 0 0;
-      }
-      100% {
-        background-position: 40px 0;
-      }
+      0% { background-position: 0 0; }
+      100% { background-position: 40px 0; }
     }
     .progress-striped {
       background-image: linear-gradient(

--- a/docs/prototypes/components/data-display/showcase.html
+++ b/docs/prototypes/components/data-display/showcase.html
@@ -5,98 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Data Display Showcase - Admin Dashboard</title>
 
-  <!-- Tailwind CSS CDN -->
+  <!-- Shared CSS -->
+  <link rel="stylesheet" href="../../css/main.css">
+
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="../../css/tailwind.config.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
-
-  <!-- Tailwind Config with Design System -->
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            bg: {
-              primary: '#1d2022',
-              secondary: '#262a2d',
-              tertiary: '#2f3336',
-              hover: '#363a3e',
-            },
-            text: {
-              primary: '#d7d3d0',
-              secondary: '#a8a5a3',
-              tertiary: '#7a7876',
-              inverse: '#1d2022',
-            },
-            accent: {
-              orange: {
-                DEFAULT: '#cb4e1b',
-                hover: '#e5591f',
-                active: '#b04517',
-                muted: 'rgba(203, 78, 27, 0.2)',
-              },
-              blue: {
-                DEFAULT: '#098ecf',
-                hover: '#0ba3ea',
-                active: '#0879b3',
-                muted: 'rgba(9, 142, 207, 0.2)',
-              },
-            },
-            success: {
-              DEFAULT: '#10b981',
-              bg: 'rgba(16, 185, 129, 0.1)',
-              border: 'rgba(16, 185, 129, 0.3)',
-            },
-            warning: {
-              DEFAULT: '#f59e0b',
-              bg: 'rgba(245, 158, 11, 0.1)',
-              border: 'rgba(245, 158, 11, 0.3)',
-            },
-            error: {
-              DEFAULT: '#ef4444',
-              bg: 'rgba(239, 68, 68, 0.1)',
-              border: 'rgba(239, 68, 68, 0.3)',
-            },
-            info: {
-              DEFAULT: '#06b6d4',
-              bg: 'rgba(6, 182, 212, 0.1)',
-              border: 'rgba(6, 182, 212, 0.3)',
-            },
-            border: {
-              primary: '#3f4447',
-              secondary: '#2f3336',
-              focus: '#098ecf',
-            },
-          },
-          fontFamily: {
-            sans: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', 'sans-serif'],
-            mono: ['ui-monospace', 'SFMono-Regular', '"SF Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
-          },
-        },
-      },
-    }
-  </script>
-
-  <style>
-    ::-webkit-scrollbar { width: 8px; height: 8px; }
-    ::-webkit-scrollbar-track { background: #1d2022; }
-    ::-webkit-scrollbar-thumb { background: #3f4447; border-radius: 4px; }
-    ::-webkit-scrollbar-thumb:hover { background: #4a4f52; }
-    *:focus-visible { outline: 2px solid #098ecf; outline-offset: 2px; }
-
-    @keyframes shimmer {
-      0% { background-position: -200% 0; }
-      100% { background-position: 200% 0; }
-    }
-    .skeleton {
-      background: linear-gradient(90deg, #262a2d 0%, #363a3e 50%, #262a2d 100%);
-      background-size: 200% 100%;
-      animation: shimmer 1.5s ease-in-out infinite;
-    }
-    @keyframes pulse {
-      0%, 100% { opacity: 1; }
-      50% { opacity: 0.5; }
-    }
-    .status-pulse { animation: pulse 2s infinite; }
-  </style>
+  <script>tailwind.config = window.tailwindConfig;</script>
 </head>
 <body class="bg-bg-primary text-text-primary font-sans antialiased min-h-screen">
 

--- a/docs/prototypes/components/data-display/tables.html
+++ b/docs/prototypes/components/data-display/tables.html
@@ -5,87 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Data Tables - Component Library</title>
 
-  <!-- Tailwind CSS CDN -->
+  <!-- Shared CSS -->
+  <link rel="stylesheet" href="../../css/main.css">
+
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="../../css/tailwind.config.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
-
-  <!-- Tailwind Config with Design System -->
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            bg: {
-              primary: '#1d2022',
-              secondary: '#262a2d',
-              tertiary: '#2f3336',
-              hover: '#363a3e',
-            },
-            text: {
-              primary: '#d7d3d0',
-              secondary: '#a8a5a3',
-              tertiary: '#7a7876',
-              inverse: '#1d2022',
-            },
-            accent: {
-              orange: {
-                DEFAULT: '#cb4e1b',
-                hover: '#e5591f',
-                active: '#b04517',
-                muted: 'rgba(203, 78, 27, 0.2)',
-              },
-              blue: {
-                DEFAULT: '#098ecf',
-                hover: '#0ba3ea',
-                active: '#0879b3',
-                muted: 'rgba(9, 142, 207, 0.2)',
-              },
-            },
-            success: {
-              DEFAULT: '#10b981',
-              bg: 'rgba(16, 185, 129, 0.1)',
-              border: 'rgba(16, 185, 129, 0.3)',
-            },
-            warning: {
-              DEFAULT: '#f59e0b',
-              bg: 'rgba(245, 158, 11, 0.1)',
-              border: 'rgba(245, 158, 11, 0.3)',
-            },
-            error: {
-              DEFAULT: '#ef4444',
-              bg: 'rgba(239, 68, 68, 0.1)',
-              border: 'rgba(239, 68, 68, 0.3)',
-            },
-            border: {
-              primary: '#3f4447',
-              secondary: '#2f3336',
-              focus: '#098ecf',
-            },
-          },
-          fontFamily: {
-            sans: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', 'sans-serif'],
-            mono: ['ui-monospace', 'SFMono-Regular', '"SF Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
-          },
-        },
-      },
-    }
-  </script>
-
-  <style>
-    ::-webkit-scrollbar { width: 8px; height: 8px; }
-    ::-webkit-scrollbar-track { background: #1d2022; }
-    ::-webkit-scrollbar-thumb { background: #3f4447; border-radius: 4px; }
-    ::-webkit-scrollbar-thumb:hover { background: #4a4f52; }
-    *:focus-visible { outline: 2px solid #098ecf; outline-offset: 2px; }
-    @keyframes shimmer {
-      0% { background-position: -200% 0; }
-      100% { background-position: 200% 0; }
-    }
-    .skeleton {
-      background: linear-gradient(90deg, #262a2d 0%, #363a3e 50%, #262a2d 100%);
-      background-size: 200% 100%;
-      animation: shimmer 1.5s ease-in-out infinite;
-    }
-  </style>
+  <script>tailwind.config = window.tailwindConfig;</script>
 </head>
 <body class="bg-bg-primary text-text-primary font-sans antialiased min-h-screen p-8">
 

--- a/docs/prototypes/css/base.css
+++ b/docs/prototypes/css/base.css
@@ -1,0 +1,55 @@
+/**
+ * Base Styles
+ * Discord Bot Admin UI
+ *
+ * Contains reset styles, scrollbar customization, and focus states.
+ */
+
+/* ==========================================
+   BOX SIZING RESET
+   ========================================== */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+/* ==========================================
+   CUSTOM SCROLLBAR FOR DARK THEME
+   ========================================== */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--color-bg-primary, #1d2022);
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--color-border-primary, #3f4447);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #4a4f52;
+}
+
+/* Firefox scrollbar */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-border-primary, #3f4447) var(--color-bg-primary, #1d2022);
+}
+
+/* ==========================================
+   FOCUS VISIBLE STATES
+   ========================================== */
+*:focus-visible {
+  outline: 2px solid var(--color-border-focus, #098ecf);
+  outline-offset: 2px;
+}
+
+/* Remove default focus outline for mouse users */
+*:focus:not(:focus-visible) {
+  outline: none;
+}

--- a/docs/prototypes/css/components/alerts.css
+++ b/docs/prototypes/css/components/alerts.css
@@ -1,0 +1,127 @@
+/**
+ * Alert Components
+ * Discord Bot Admin UI
+ *
+ * Alert styles for notifications and messages.
+ */
+
+/* ==========================================
+   BASE ALERT
+   ========================================== */
+.alert {
+  padding: 1rem;
+  border-radius: 0.5rem;
+  border-width: 1px;
+  border-style: solid;
+}
+
+.alert-icon {
+  width: 1.25rem;
+  height: 1.25rem;
+  flex-shrink: 0;
+}
+
+.alert-content {
+  gap: 0.75rem;
+}
+
+/* ==========================================
+   ALERT VARIANTS
+   ========================================== */
+
+/* Info Alert */
+.alert-info {
+  background-color: var(--color-info-bg, rgba(6, 182, 212, 0.1));
+  border-color: var(--color-info-border, rgba(6, 182, 212, 0.3));
+  color: var(--color-info, #06b6d4);
+}
+
+/* Success Alert */
+.alert-success {
+  background-color: var(--color-success-bg, rgba(16, 185, 129, 0.1));
+  border-color: var(--color-success-border, rgba(16, 185, 129, 0.3));
+  color: var(--color-success, #10b981);
+}
+
+/* Warning Alert */
+.alert-warning {
+  background-color: var(--color-warning-bg, rgba(245, 158, 11, 0.1));
+  border-color: var(--color-warning-border, rgba(245, 158, 11, 0.3));
+  color: var(--color-warning, #f59e0b);
+}
+
+/* Error Alert */
+.alert-error {
+  background-color: var(--color-error-bg, rgba(239, 68, 68, 0.1));
+  border-color: var(--color-error-border, rgba(239, 68, 68, 0.3));
+  color: var(--color-error, #ef4444);
+}
+
+/* ==========================================
+   ALERT ANIMATIONS
+   ========================================== */
+.alert-slide-in {
+  animation: slideIn 300ms ease-out forwards;
+}
+
+.alert-slide-out {
+  animation: slideOut 300ms ease-out forwards;
+}
+
+/* ==========================================
+   INLINE ALERT (compact)
+   ========================================== */
+.alert-inline {
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+}
+
+.alert-inline .alert-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+/* ==========================================
+   ALERT TITLE
+   ========================================== */
+.alert-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.alert-message {
+  font-size: 0.875rem;
+  opacity: 0.9;
+  margin-top: 0.25rem;
+}
+
+/* ==========================================
+   ALERT DISMISS BUTTON
+   ========================================== */
+.alert-dismiss {
+  padding: 0.25rem;
+  margin-left: 1rem;
+  opacity: 0.7;
+  cursor: pointer;
+  transition: opacity 0.15s ease-out;
+  flex-shrink: 0;
+}
+
+.alert-dismiss:hover {
+  opacity: 1;
+}
+
+.alert-dismiss svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+/* ==========================================
+   BANNER ALERT (full-width)
+   ========================================== */
+.alert-banner {
+  border-radius: 0;
+  border-left: none;
+  border-right: none;
+}

--- a/docs/prototypes/css/components/buttons.css
+++ b/docs/prototypes/css/components/buttons.css
@@ -1,0 +1,151 @@
+/**
+ * Button Components
+ * Discord Bot Admin UI
+ *
+ * Button styles following the design system.
+ */
+
+/* ==========================================
+   BASE BUTTON STYLES
+   ========================================== */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1;
+  border-radius: 0.375rem;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: background-color 0.15s ease-out, border-color 0.15s ease-out, color 0.15s ease-out;
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ==========================================
+   BUTTON VARIANTS
+   ========================================== */
+
+/* Primary Button - Orange accent */
+.btn-primary {
+  background-color: var(--color-accent-orange, #cb4e1b);
+  color: white;
+  border-color: var(--color-accent-orange, #cb4e1b);
+}
+
+.btn-primary:hover:not(:disabled) {
+  background-color: var(--color-accent-orange-hover, #e5591f);
+  border-color: var(--color-accent-orange-hover, #e5591f);
+}
+
+.btn-primary:active:not(:disabled) {
+  background-color: var(--color-accent-orange-active, #b04517);
+  border-color: var(--color-accent-orange-active, #b04517);
+}
+
+/* Secondary Button - Outlined */
+.btn-secondary {
+  background-color: transparent;
+  color: var(--color-text-primary, #d7d3d0);
+  border-color: var(--color-border-primary, #3f4447);
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background-color: var(--color-bg-hover, #363a3e);
+  border-color: var(--color-border-primary, #3f4447);
+}
+
+.btn-secondary:active:not(:disabled) {
+  background-color: var(--color-bg-tertiary, #2f3336);
+}
+
+/* Accent Button - Blue accent */
+.btn-accent {
+  background-color: var(--color-accent-blue, #098ecf);
+  color: white;
+  border-color: var(--color-accent-blue, #098ecf);
+}
+
+.btn-accent:hover:not(:disabled) {
+  background-color: var(--color-accent-blue-hover, #0ba3ea);
+  border-color: var(--color-accent-blue-hover, #0ba3ea);
+}
+
+.btn-accent:active:not(:disabled) {
+  background-color: var(--color-accent-blue-active, #0879b3);
+  border-color: var(--color-accent-blue-active, #0879b3);
+}
+
+/* Danger Button - Error/destructive actions */
+.btn-danger {
+  background-color: var(--color-error, #ef4444);
+  color: white;
+  border-color: var(--color-error, #ef4444);
+}
+
+.btn-danger:hover:not(:disabled) {
+  background-color: #dc2626;
+  border-color: #dc2626;
+}
+
+.btn-danger:active:not(:disabled) {
+  background-color: #b91c1c;
+  border-color: #b91c1c;
+}
+
+/* Ghost Button - No background */
+.btn-ghost {
+  background-color: transparent;
+  color: var(--color-text-secondary, #a8a5a3);
+  border-color: transparent;
+}
+
+.btn-ghost:hover:not(:disabled) {
+  background-color: var(--color-bg-hover, #363a3e);
+  color: var(--color-text-primary, #d7d3d0);
+}
+
+/* ==========================================
+   BUTTON SIZES
+   ========================================== */
+
+/* Small button */
+.btn-sm {
+  padding: 0.375rem 0.75rem;
+  font-size: 0.75rem;
+  gap: 0.375rem;
+}
+
+/* Large button */
+.btn-lg {
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  gap: 0.625rem;
+}
+
+/* ==========================================
+   ICON BUTTON
+   ========================================== */
+.btn-icon {
+  padding: 0.5rem;
+  width: 2.25rem;
+  height: 2.25rem;
+}
+
+.btn-icon.btn-sm {
+  padding: 0.375rem;
+  width: 1.75rem;
+  height: 1.75rem;
+}
+
+.btn-icon.btn-lg {
+  padding: 0.625rem;
+  width: 2.75rem;
+  height: 2.75rem;
+}

--- a/docs/prototypes/css/components/cards.css
+++ b/docs/prototypes/css/components/cards.css
@@ -1,0 +1,94 @@
+/**
+ * Card Components
+ * Discord Bot Admin UI
+ *
+ * Card container styles and variants.
+ */
+
+/* ==========================================
+   BASE CARD
+   ========================================== */
+.card {
+  background-color: var(--color-bg-secondary, #262a2d);
+  border: 1px solid var(--color-border-primary, #3f4447);
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+
+/* ==========================================
+   CARD SECTIONS
+   ========================================== */
+.card-header {
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--color-border-primary, #3f4447);
+}
+
+.card-body {
+  padding: 1.5rem;
+}
+
+.card-footer {
+  padding: 1rem 1.5rem;
+  border-top: 1px solid var(--color-border-primary, #3f4447);
+  background-color: rgba(29, 32, 34, 0.3);
+}
+
+/* ==========================================
+   CARD VARIANTS
+   ========================================== */
+
+/* Interactive card - hover state */
+.card-interactive {
+  cursor: pointer;
+  transition: border-color 0.15s ease-out, box-shadow 0.15s ease-out;
+}
+
+.card-interactive:hover {
+  border-color: var(--color-accent-blue, #098ecf);
+}
+
+.card-interactive:focus-visible {
+  outline: 2px solid var(--color-border-focus, #098ecf);
+  outline-offset: 2px;
+}
+
+/* Elevated card - with shadow */
+.card-elevated {
+  box-shadow: var(--shadow-lg, 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05));
+}
+
+/* Card with primary background */
+.card-primary {
+  background-color: var(--color-bg-primary, #1d2022);
+}
+
+/* ==========================================
+   CARD TITLE
+   ========================================== */
+.card-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--color-text-primary, #d7d3d0);
+  margin: 0;
+}
+
+.card-subtitle {
+  font-size: 0.875rem;
+  color: var(--color-text-secondary, #a8a5a3);
+  margin-top: 0.25rem;
+}
+
+/* ==========================================
+   COMPACT CARD
+   ========================================== */
+.card-compact .card-header {
+  padding: 0.75rem 1rem;
+}
+
+.card-compact .card-body {
+  padding: 1rem;
+}
+
+.card-compact .card-footer {
+  padding: 0.75rem 1rem;
+}

--- a/docs/prototypes/css/components/forms.css
+++ b/docs/prototypes/css/components/forms.css
@@ -1,0 +1,308 @@
+/**
+ * Form Components
+ * Discord Bot Admin UI
+ *
+ * Form input styles, validation states, and form layouts.
+ */
+
+/* ==========================================
+   FORM GROUP
+   ========================================== */
+.form-group {
+  margin-bottom: 1rem;
+}
+
+.form-group:last-child {
+  margin-bottom: 0;
+}
+
+/* ==========================================
+   FORM LABEL
+   ========================================== */
+.form-label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text-primary, #d7d3d0);
+}
+
+/* Required indicator */
+.form-required {
+  color: var(--color-error, #ef4444);
+  margin-left: 0.25rem;
+}
+
+/* Optional indicator */
+.form-optional {
+  color: var(--color-text-tertiary, #7a7876);
+  font-weight: 400;
+  font-size: 0.75rem;
+  margin-left: 0.5rem;
+}
+
+/* ==========================================
+   FORM INPUT
+   ========================================== */
+.form-input {
+  display: block;
+  width: 100%;
+  padding: 0.625rem 0.75rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--color-text-primary, #d7d3d0);
+  background-color: var(--color-bg-primary, #1d2022);
+  border: 1px solid var(--color-border-primary, #3f4447);
+  border-radius: 0.375rem;
+  transition: border-color 0.15s ease-out, box-shadow 0.15s ease-out;
+}
+
+.form-input::placeholder {
+  color: var(--color-text-tertiary, #7a7876);
+}
+
+.form-input:hover:not(:disabled):not(:focus) {
+  border-color: #4a4f52;
+}
+
+.form-input:focus {
+  border-color: var(--color-border-focus, #098ecf);
+  box-shadow: 0 0 0 3px var(--color-accent-blue-muted, rgba(9, 142, 207, 0.2));
+  outline: none;
+}
+
+.form-input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  background-color: var(--color-bg-tertiary, #2f3336);
+}
+
+/* ==========================================
+   FORM SELECT
+   ========================================== */
+.form-select {
+  display: block;
+  width: 100%;
+  padding: 0.625rem 2.5rem 0.625rem 0.75rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--color-text-primary, #d7d3d0);
+  background-color: var(--color-bg-primary, #1d2022);
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%237a7876' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
+  background-position: right 0.5rem center;
+  background-repeat: no-repeat;
+  background-size: 1.5em 1.5em;
+  border: 1px solid var(--color-border-primary, #3f4447);
+  border-radius: 0.375rem;
+  appearance: none;
+  cursor: pointer;
+  transition: border-color 0.15s ease-out, box-shadow 0.15s ease-out;
+}
+
+.form-select:hover:not(:disabled):not(:focus) {
+  border-color: #4a4f52;
+}
+
+.form-select:focus {
+  border-color: var(--color-border-focus, #098ecf);
+  box-shadow: 0 0 0 3px var(--color-accent-blue-muted, rgba(9, 142, 207, 0.2));
+  outline: none;
+}
+
+.form-select:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  background-color: var(--color-bg-tertiary, #2f3336);
+}
+
+/* ==========================================
+   FORM HELP TEXT
+   ========================================== */
+.form-help {
+  display: block;
+  margin-top: 0.375rem;
+  font-size: 0.75rem;
+  color: var(--color-text-tertiary, #7a7876);
+}
+
+/* ==========================================
+   VALIDATION STATES
+   ========================================== */
+
+/* Error state */
+.form-input.form-error,
+.form-select.form-error {
+  border-color: var(--color-error, #ef4444);
+}
+
+.form-input.form-error:focus,
+.form-select.form-error:focus {
+  border-color: var(--color-error, #ef4444);
+  box-shadow: 0 0 0 3px var(--color-error-bg, rgba(239, 68, 68, 0.1));
+}
+
+.form-error-message {
+  display: block;
+  margin-top: 0.375rem;
+  font-size: 0.75rem;
+  color: var(--color-error, #ef4444);
+}
+
+/* Success state */
+.form-input.form-success,
+.form-select.form-success {
+  border-color: var(--color-success, #10b981);
+}
+
+.form-input.form-success:focus,
+.form-select.form-success:focus {
+  border-color: var(--color-success, #10b981);
+  box-shadow: 0 0 0 3px var(--color-success-bg, rgba(16, 185, 129, 0.1));
+}
+
+.form-success-message {
+  display: block;
+  margin-top: 0.375rem;
+  font-size: 0.75rem;
+  color: var(--color-success, #10b981);
+}
+
+/* ==========================================
+   CHECKBOX
+   ========================================== */
+.form-checkbox {
+  width: 1rem;
+  height: 1rem;
+  border: 1px solid var(--color-border-primary, #3f4447);
+  border-radius: 0.25rem;
+  background-color: var(--color-bg-primary, #1d2022);
+  cursor: pointer;
+  appearance: none;
+  transition: background-color 0.15s ease-out, border-color 0.15s ease-out;
+}
+
+.form-checkbox:hover:not(:disabled) {
+  border-color: var(--color-accent-blue, #098ecf);
+}
+
+.form-checkbox:checked {
+  background-color: var(--color-accent-orange, #cb4e1b);
+  border-color: var(--color-accent-orange, #cb4e1b);
+  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
+  background-size: 100% 100%;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.form-checkbox:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--color-accent-blue-muted, rgba(9, 142, 207, 0.2));
+}
+
+.form-checkbox:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ==========================================
+   RADIO BUTTON
+   ========================================== */
+.form-radio {
+  width: 1rem;
+  height: 1rem;
+  border: 1px solid var(--color-border-primary, #3f4447);
+  border-radius: 50%;
+  background-color: var(--color-bg-primary, #1d2022);
+  cursor: pointer;
+  appearance: none;
+  transition: background-color 0.15s ease-out, border-color 0.15s ease-out;
+}
+
+.form-radio:hover:not(:disabled) {
+  border-color: var(--color-accent-blue, #098ecf);
+}
+
+.form-radio:checked {
+  border-color: var(--color-accent-orange, #cb4e1b);
+  background-color: var(--color-bg-primary, #1d2022);
+  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='%23cb4e1b' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='8' cy='8' r='4'/%3e%3c/svg%3e");
+  background-size: 100% 100%;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.form-radio:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--color-accent-blue-muted, rgba(9, 142, 207, 0.2));
+}
+
+.form-radio:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ==========================================
+   TOGGLE SWITCH
+   ========================================== */
+.toggle-switch {
+  position: relative;
+  width: 44px;
+  height: 24px;
+  background-color: var(--color-border-primary, #3f4447);
+  border-radius: 9999px;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.toggle-switch::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  background-color: var(--color-text-primary, #d7d3d0);
+  border-radius: 50%;
+  transition: transform 0.2s ease;
+}
+
+.toggle-switch.active {
+  background-color: var(--color-accent-orange, #cb4e1b);
+}
+
+.toggle-switch.active::after {
+  transform: translateX(20px);
+}
+
+.toggle-switch:focus-visible {
+  outline: 2px solid var(--color-border-focus, #098ecf);
+  outline-offset: 2px;
+}
+
+/* ==========================================
+   TEXTAREA
+   ========================================== */
+.form-textarea {
+  display: block;
+  width: 100%;
+  min-height: 6rem;
+  padding: 0.625rem 0.75rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--color-text-primary, #d7d3d0);
+  background-color: var(--color-bg-primary, #1d2022);
+  border: 1px solid var(--color-border-primary, #3f4447);
+  border-radius: 0.375rem;
+  resize: vertical;
+  transition: border-color 0.15s ease-out, box-shadow 0.15s ease-out;
+}
+
+.form-textarea::placeholder {
+  color: var(--color-text-tertiary, #7a7876);
+}
+
+.form-textarea:focus {
+  border-color: var(--color-border-focus, #098ecf);
+  box-shadow: 0 0 0 3px var(--color-accent-blue-muted, rgba(9, 142, 207, 0.2));
+  outline: none;
+}

--- a/docs/prototypes/css/components/loading.css
+++ b/docs/prototypes/css/components/loading.css
@@ -1,0 +1,301 @@
+/**
+ * Loading Components
+ * Discord Bot Admin UI
+ *
+ * Skeleton loaders, spinners, and progress indicators.
+ */
+
+/* ==========================================
+   SKELETON LOADER
+   ========================================== */
+.skeleton {
+  background: linear-gradient(
+    90deg,
+    var(--color-bg-secondary, #262a2d) 0%,
+    var(--color-bg-hover, #363a3e) 50%,
+    var(--color-bg-secondary, #262a2d) 100%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.5s ease-in-out infinite;
+  border-radius: 0.25rem;
+}
+
+/* Skeleton variants */
+.skeleton-text {
+  height: 1rem;
+  width: 100%;
+}
+
+.skeleton-title {
+  height: 1.5rem;
+  width: 60%;
+}
+
+.skeleton-avatar {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 9999px;
+}
+
+.skeleton-button {
+  height: 2.5rem;
+  width: 6rem;
+  border-radius: 0.375rem;
+}
+
+.skeleton-card {
+  height: 8rem;
+  width: 100%;
+  border-radius: 0.5rem;
+}
+
+/* ==========================================
+   SIMPLE SPINNER
+   Rotating circle animation
+   ========================================== */
+.spinner {
+  border: 3px solid rgba(255, 255, 255, 0.2);
+  border-top-color: var(--color-accent-blue, #098ecf);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+.spinner-sm {
+  width: 24px;
+  height: 24px;
+  border-width: 2px;
+}
+
+.spinner-md {
+  width: 40px;
+  height: 40px;
+  border-width: 3px;
+}
+
+.spinner-lg {
+  width: 64px;
+  height: 64px;
+  border-width: 4px;
+}
+
+/* Spinner color variants */
+.spinner-primary {
+  border-top-color: var(--color-accent-orange, #cb4e1b);
+}
+
+.spinner-white {
+  border-color: rgba(255, 255, 255, 0.3);
+  border-top-color: white;
+}
+
+/* ==========================================
+   DOTS SPINNER
+   Bouncing dots animation
+   ========================================== */
+.dots-spinner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.dots-spinner .dot {
+  background-color: var(--color-accent-blue, #098ecf);
+  border-radius: 50%;
+  animation: bounce-dot 1.4s ease-in-out infinite both;
+}
+
+.dots-spinner .dot:nth-child(1) {
+  animation-delay: -0.32s;
+}
+
+.dots-spinner .dot:nth-child(2) {
+  animation-delay: -0.16s;
+}
+
+.dots-spinner .dot:nth-child(3) {
+  animation-delay: 0s;
+}
+
+.dots-spinner-sm .dot {
+  width: 6px;
+  height: 6px;
+}
+
+.dots-spinner-md .dot {
+  width: 10px;
+  height: 10px;
+}
+
+.dots-spinner-lg .dot {
+  width: 16px;
+  height: 16px;
+}
+
+/* ==========================================
+   PULSE SPINNER
+   Pulsing circle animation
+   ========================================== */
+.pulse-spinner {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.pulse-spinner .ring {
+  position: absolute;
+  border: 3px solid var(--color-accent-blue, #098ecf);
+  border-radius: 50%;
+  animation: pulse-ring 1.5s ease-out infinite;
+}
+
+.pulse-spinner .core {
+  background-color: var(--color-accent-blue, #098ecf);
+  border-radius: 50%;
+  animation: pulse-core 1.5s ease-in-out infinite;
+}
+
+.pulse-spinner-sm .ring {
+  width: 24px;
+  height: 24px;
+  border-width: 2px;
+}
+
+.pulse-spinner-sm .core {
+  width: 12px;
+  height: 12px;
+}
+
+.pulse-spinner-md .ring {
+  width: 40px;
+  height: 40px;
+  border-width: 3px;
+}
+
+.pulse-spinner-md .core {
+  width: 20px;
+  height: 20px;
+}
+
+.pulse-spinner-lg .ring {
+  width: 64px;
+  height: 64px;
+  border-width: 4px;
+}
+
+.pulse-spinner-lg .core {
+  width: 32px;
+  height: 32px;
+}
+
+/* ==========================================
+   PROGRESS BAR
+   ========================================== */
+.progress-bar {
+  height: 4px;
+  background-color: var(--color-border-primary, #3f4447);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.progress-bar-fill {
+  height: 100%;
+  background-color: var(--color-accent-blue, #098ecf);
+  border-radius: 2px;
+  transition: width 0.3s ease;
+}
+
+/* Indeterminate progress */
+.progress-bar-indeterminate .progress-bar-fill {
+  width: 50%;
+  animation: indeterminate-progress 1.5s ease-in-out infinite;
+}
+
+/* Progress bar variants */
+.progress-bar-success .progress-bar-fill {
+  background-color: var(--color-success, #10b981);
+}
+
+.progress-bar-warning .progress-bar-fill {
+  background-color: var(--color-warning, #f59e0b);
+}
+
+.progress-bar-error .progress-bar-fill {
+  background-color: var(--color-error, #ef4444);
+}
+
+/* ==========================================
+   CIRCULAR PROGRESS
+   ========================================== */
+.circular-progress {
+  animation: circular-progress-rotate 2s linear infinite;
+}
+
+.circular-progress-path {
+  stroke: var(--color-accent-blue, #098ecf);
+  stroke-linecap: round;
+  animation: circular-progress-dash 1.5s ease-in-out infinite;
+}
+
+/* ==========================================
+   LOADING OVERLAY
+   ========================================== */
+.loading-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(29, 32, 34, 0.8);
+  z-index: var(--z-tooltip, 1200);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 1rem;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.2s ease, visibility 0.2s ease;
+}
+
+.loading-overlay.active {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* Container-scoped overlay */
+.loading-container {
+  position: relative;
+}
+
+.loading-container-overlay {
+  position: absolute;
+  inset: 0;
+  background-color: rgba(29, 32, 34, 0.8);
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 0.75rem;
+  border-radius: inherit;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.2s ease, visibility 0.2s ease;
+}
+
+.loading-container-overlay.active {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* ==========================================
+   LOADING TEXT
+   ========================================== */
+.loading-text {
+  font-size: 0.875rem;
+  color: var(--color-text-primary, #d7d3d0);
+}
+
+.loading-subtext {
+  font-size: 0.75rem;
+  color: var(--color-text-tertiary, #7a7876);
+}

--- a/docs/prototypes/css/components/modals.css
+++ b/docs/prototypes/css/components/modals.css
@@ -1,0 +1,290 @@
+/**
+ * Modal and Drawer Components
+ * Discord Bot Admin UI
+ *
+ * Modal dialogs and slide-out drawer panels.
+ */
+
+/* ==========================================
+   MODAL BACKDROP
+   z-index: 1000 as per design system
+   ========================================== */
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-modal-backdrop, 1000);
+  background-color: rgba(0, 0, 0, 0.5);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 150ms ease-out, visibility 150ms ease-out;
+}
+
+.modal-backdrop.active {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* ==========================================
+   MODAL CONTAINER
+   z-index: 1001 as per design system
+   ========================================== */
+.modal {
+  position: fixed;
+  z-index: var(--z-modal, 1001);
+  opacity: 0;
+  visibility: hidden;
+  transform: scale(0.95) translateY(-10px);
+  transition: opacity 150ms ease-out, transform 150ms ease-out, visibility 150ms ease-out;
+}
+
+.modal.active {
+  opacity: 1;
+  visibility: visible;
+  transform: scale(1) translateY(0);
+}
+
+/* ==========================================
+   MODAL POSITIONING
+   ========================================== */
+
+/* Centered (default) */
+.modal-centered {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.95);
+}
+
+.modal-centered.active {
+  transform: translate(-50%, -50%) scale(1);
+}
+
+/* Top aligned */
+.modal-top {
+  top: 5rem;
+  left: 50%;
+  transform: translateX(-50%) scale(0.95) translateY(-10px);
+}
+
+.modal-top.active {
+  transform: translateX(-50%) scale(1) translateY(0);
+}
+
+/* ==========================================
+   MODAL SIZE VARIANTS
+   ========================================== */
+.modal-sm {
+  max-width: 400px;
+  width: calc(100% - 2rem);
+}
+
+.modal-md {
+  max-width: 500px;
+  width: calc(100% - 2rem);
+}
+
+.modal-lg {
+  max-width: 600px;
+  width: calc(100% - 2rem);
+}
+
+.modal-xl {
+  max-width: 800px;
+  width: calc(100% - 2rem);
+}
+
+.modal-full {
+  max-width: calc(100% - 3rem);
+  max-height: calc(100% - 3rem);
+  width: calc(100% - 3rem);
+}
+
+/* ==========================================
+   MODAL SECTIONS
+   ========================================== */
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--color-border-primary, #3f4447);
+}
+
+.modal-body {
+  padding: 1.5rem;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 1rem 1.5rem;
+  border-top: 1px solid var(--color-border-primary, #3f4447);
+}
+
+/* Scrollable modal body */
+.modal-body-scroll {
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+/* ==========================================
+   MODAL CLOSE BUTTON
+   ========================================== */
+.modal-close {
+  padding: 0.25rem;
+  color: var(--color-text-tertiary, #7a7876);
+  border-radius: 0.25rem;
+  cursor: pointer;
+  transition: color 0.15s ease-out, background-color 0.15s ease-out;
+}
+
+.modal-close:hover {
+  color: var(--color-text-primary, #d7d3d0);
+  background-color: var(--color-bg-hover, #363a3e);
+}
+
+.modal-close svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+/* ==========================================
+   PREVENT BODY SCROLL
+   ========================================== */
+body.modal-open {
+  overflow: hidden;
+}
+
+/* ==========================================
+   DRAWER COMPONENT
+   ========================================== */
+
+/* Drawer backdrop */
+.drawer-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-modal-backdrop, 1000);
+  background-color: rgba(0, 0, 0, 0.5);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 200ms ease-out, visibility 200ms ease-out;
+}
+
+.drawer-backdrop.active {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* Drawer panel */
+.drawer {
+  position: fixed;
+  z-index: var(--z-modal, 1001);
+  background-color: var(--color-bg-secondary, #262a2d);
+  transition: transform 300ms ease-out;
+}
+
+/* Right drawer (default) */
+.drawer-right {
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 100%;
+  max-width: 400px;
+  transform: translateX(100%);
+  border-left: 1px solid var(--color-border-primary, #3f4447);
+}
+
+.drawer-right.active {
+  transform: translateX(0);
+}
+
+/* Left drawer */
+.drawer-left {
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  max-width: 400px;
+  transform: translateX(-100%);
+  border-right: 1px solid var(--color-border-primary, #3f4447);
+}
+
+.drawer-left.active {
+  transform: translateX(0);
+}
+
+/* Bottom drawer */
+.drawer-bottom {
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: auto;
+  max-height: 80vh;
+  transform: translateY(100%);
+  border-top: 1px solid var(--color-border-primary, #3f4447);
+  border-radius: 1rem 1rem 0 0;
+}
+
+.drawer-bottom.active {
+  transform: translateY(0);
+}
+
+/* Top drawer */
+.drawer-top {
+  top: 0;
+  left: 0;
+  right: 0;
+  height: auto;
+  max-height: 80vh;
+  transform: translateY(-100%);
+  border-bottom: 1px solid var(--color-border-primary, #3f4447);
+  border-radius: 0 0 1rem 1rem;
+}
+
+.drawer-top.active {
+  transform: translateY(0);
+}
+
+/* ==========================================
+   DRAWER SIZE VARIANTS
+   ========================================== */
+.drawer-sm {
+  max-width: 320px;
+}
+
+.drawer-md {
+  max-width: 400px;
+}
+
+.drawer-lg {
+  max-width: 480px;
+}
+
+.drawer-xl {
+  max-width: 640px;
+}
+
+/* ==========================================
+   DRAWER SECTIONS
+   ========================================== */
+.drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--color-border-primary, #3f4447);
+}
+
+.drawer-body {
+  padding: 1.5rem;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.drawer-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 1rem 1.5rem;
+  border-top: 1px solid var(--color-border-primary, #3f4447);
+}

--- a/docs/prototypes/css/components/navigation.css
+++ b/docs/prototypes/css/components/navigation.css
@@ -1,0 +1,222 @@
+/**
+ * Navigation Components
+ * Discord Bot Admin UI
+ *
+ * Navbar, sidebar, and breadcrumb styles.
+ */
+
+/* ==========================================
+   TOP NAVBAR
+   ========================================== */
+.navbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: var(--z-fixed, 300);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 4rem;
+  padding: 0 1rem;
+  background-color: var(--color-bg-secondary, #262a2d);
+  border-bottom: 1px solid var(--color-border-primary, #3f4447);
+}
+
+@media (min-width: 1024px) {
+  .navbar {
+    padding: 0 1.5rem;
+  }
+}
+
+/* ==========================================
+   SIDEBAR
+   ========================================== */
+.sidebar {
+  position: fixed;
+  top: 4rem;
+  left: 0;
+  z-index: var(--z-fixed, 300);
+  width: 16rem;
+  height: calc(100vh - 4rem);
+  background-color: var(--color-bg-secondary, #262a2d);
+  border-right: 1px solid var(--color-border-primary, #3f4447);
+  transform: translateX(-100%);
+  transition: transform 0.3s ease-in-out;
+}
+
+.sidebar.open {
+  transform: translateX(0);
+}
+
+@media (min-width: 1024px) {
+  .sidebar {
+    transform: translateX(0);
+  }
+}
+
+/* Sidebar overlay for mobile */
+.sidebar-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: calc(var(--z-fixed, 300) - 1);
+  background-color: rgba(0, 0, 0, 0.5);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease-in-out, visibility 0.3s ease-in-out;
+}
+
+.sidebar-overlay.active {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* ==========================================
+   SIDEBAR LINKS
+   ========================================== */
+.sidebar-link {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.625rem 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text-secondary, #a8a5a3);
+  border-radius: 0.5rem;
+  transition: background-color 0.15s ease-out, color 0.15s ease-out;
+}
+
+.sidebar-link:hover {
+  color: var(--color-text-primary, #d7d3d0);
+  background-color: var(--color-bg-hover, #363a3e);
+}
+
+.sidebar-link.active {
+  color: var(--color-text-primary, #d7d3d0);
+  background-color: rgba(203, 78, 27, 0.15);
+  border-left: 3px solid var(--color-accent-orange, #cb4e1b);
+}
+
+.sidebar-link svg {
+  width: 1.25rem;
+  height: 1.25rem;
+  flex-shrink: 0;
+}
+
+/* ==========================================
+   SIDEBAR BADGE
+   ========================================== */
+.sidebar-badge {
+  margin-left: auto;
+  padding: 0.125rem 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background-color: var(--color-border-primary, #3f4447);
+  color: var(--color-text-primary, #d7d3d0);
+  border-radius: 9999px;
+}
+
+/* Notification dot */
+.sidebar-badge-dot {
+  margin-left: auto;
+  width: 0.5rem;
+  height: 0.5rem;
+  background-color: var(--color-accent-orange, #cb4e1b);
+  border-radius: 9999px;
+}
+
+/* ==========================================
+   SIDEBAR SECTION
+   ========================================== */
+.sidebar-section {
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--color-text-tertiary, #7a7876);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* ==========================================
+   BREADCRUMB
+   ========================================== */
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+}
+
+.breadcrumb-item {
+  color: var(--color-text-secondary, #a8a5a3);
+  transition: color 0.15s ease-out;
+}
+
+.breadcrumb-item:hover {
+  color: var(--color-text-primary, #d7d3d0);
+}
+
+.breadcrumb-item.active {
+  color: var(--color-text-primary, #d7d3d0);
+}
+
+.breadcrumb-separator {
+  color: var(--color-text-tertiary, #7a7876);
+}
+
+.breadcrumb-separator svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+/* ==========================================
+   DROPDOWN MENU
+   ========================================== */
+.dropdown-menu {
+  display: none;
+  position: absolute;
+  opacity: 0;
+  transform: translateY(-10px);
+  transition: opacity 0.15s ease-in-out, transform 0.15s ease-in-out;
+}
+
+.dropdown-menu.active {
+  display: block;
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* ==========================================
+   STATUS INDICATOR
+   ========================================== */
+.status-pulse {
+  animation: pulse 2s infinite;
+}
+
+/* Bot status in sidebar footer */
+.sidebar-status {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+}
+
+.sidebar-status-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 9999px;
+}
+
+.sidebar-status-dot.online {
+  background-color: var(--color-success, #10b981);
+}
+
+.sidebar-status-dot.offline {
+  background-color: var(--color-text-tertiary, #7a7876);
+}
+
+.sidebar-status-dot.error {
+  background-color: var(--color-error, #ef4444);
+}

--- a/docs/prototypes/css/components/tables.css
+++ b/docs/prototypes/css/components/tables.css
@@ -1,0 +1,212 @@
+/**
+ * Table Components
+ * Discord Bot Admin UI
+ *
+ * Data table styles with sorting, selection, and responsive variants.
+ */
+
+/* ==========================================
+   BASE TABLE
+   ========================================== */
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+/* ==========================================
+   TABLE HEADER
+   ========================================== */
+.table-header {
+  background-color: var(--color-bg-tertiary, #2f3336);
+}
+
+.table-header th {
+  padding: 0.75rem 1.5rem;
+  text-align: left;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--color-text-secondary, #a8a5a3);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* Sortable header */
+.table-header th.sortable {
+  cursor: pointer;
+  user-select: none;
+  transition: color 0.15s ease-out;
+}
+
+.table-header th.sortable:hover {
+  color: var(--color-text-primary, #d7d3d0);
+}
+
+.table-header th.sorted {
+  color: var(--color-accent-blue, #098ecf);
+}
+
+/* ==========================================
+   TABLE BODY
+   ========================================== */
+.table-row {
+  border-bottom: 1px solid var(--color-border-secondary, #2f3336);
+  transition: background-color 0.15s ease-out;
+}
+
+.table-row:hover {
+  background-color: var(--color-bg-hover, #363a3e);
+}
+
+.table-row:last-child {
+  border-bottom: none;
+}
+
+/* Striped rows */
+.table-striped .table-row:nth-child(even) {
+  background-color: rgba(47, 51, 54, 0.3);
+}
+
+/* Selected row */
+.table-row.selected {
+  background-color: var(--color-accent-blue-muted, rgba(9, 142, 207, 0.2));
+}
+
+/* ==========================================
+   TABLE CELL
+   ========================================== */
+.table-cell {
+  padding: 1rem 1.5rem;
+  font-size: 0.875rem;
+  color: var(--color-text-primary, #d7d3d0);
+}
+
+.table-cell-secondary {
+  color: var(--color-text-secondary, #a8a5a3);
+}
+
+/* ==========================================
+   COMPACT TABLE
+   ========================================== */
+.table-compact .table-header th {
+  padding: 0.5rem 1rem;
+}
+
+.table-compact .table-cell {
+  padding: 0.5rem 1rem;
+}
+
+/* ==========================================
+   TABLE CONTAINER
+   ========================================== */
+.table-container {
+  overflow-x: auto;
+  border: 1px solid var(--color-border-primary, #3f4447);
+  border-radius: 0.5rem;
+}
+
+.table-container .table {
+  min-width: 100%;
+}
+
+/* ==========================================
+   TABLE STATES
+   ========================================== */
+
+/* Empty state */
+.table-empty {
+  padding: 3rem 1.5rem;
+  text-align: center;
+}
+
+.table-empty-icon {
+  width: 3rem;
+  height: 3rem;
+  margin: 0 auto 1rem;
+  color: var(--color-text-tertiary, #7a7876);
+}
+
+.table-empty-title {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text-secondary, #a8a5a3);
+}
+
+.table-empty-description {
+  font-size: 0.75rem;
+  color: var(--color-text-tertiary, #7a7876);
+  margin-top: 0.25rem;
+}
+
+/* Loading skeleton row */
+.table-skeleton {
+  height: 1rem;
+  background: linear-gradient(90deg, var(--color-bg-secondary, #262a2d) 0%, var(--color-bg-hover, #363a3e) 50%, var(--color-bg-secondary, #262a2d) 100%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s ease-in-out infinite;
+  border-radius: 0.25rem;
+}
+
+/* Error state */
+.table-error {
+  padding: 3rem 1.5rem;
+  text-align: center;
+  background-color: var(--color-error-bg, rgba(239, 68, 68, 0.1));
+  border: 1px solid var(--color-error-border, rgba(239, 68, 68, 0.3));
+  border-radius: 0.5rem;
+}
+
+.table-error-icon {
+  width: 3rem;
+  height: 3rem;
+  margin: 0 auto 1rem;
+  color: var(--color-error, #ef4444);
+}
+
+.table-error-title {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-error, #ef4444);
+}
+
+/* ==========================================
+   EXPANDABLE ROWS
+   ========================================== */
+.table-row-expandable {
+  cursor: pointer;
+}
+
+.table-row-expanded {
+  background-color: var(--color-bg-primary, #1d2022);
+  border-left: 2px solid var(--color-accent-blue, #098ecf);
+}
+
+.expand-icon {
+  transition: transform 0.15s ease-out;
+}
+
+.expand-icon.rotated {
+  transform: rotate(90deg);
+}
+
+/* ==========================================
+   TABLE PAGINATION
+   ========================================== */
+.table-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  border-top: 1px solid var(--color-border-primary, #3f4447);
+  background-color: var(--color-bg-secondary, #262a2d);
+}
+
+.table-pagination-info {
+  font-size: 0.875rem;
+  color: var(--color-text-secondary, #a8a5a3);
+}
+
+.table-pagination-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}

--- a/docs/prototypes/css/main.css
+++ b/docs/prototypes/css/main.css
@@ -1,0 +1,26 @@
+/**
+ * Main CSS Entry Point
+ * Discord Bot Admin UI
+ *
+ * This file imports all shared styles in the correct order.
+ * Include this file in HTML prototypes to load all design system styles.
+ */
+
+/* Design System Tokens (CSS Custom Properties) */
+@import 'tokens.css';
+
+/* Base styles (reset, scrollbar, focus states) */
+@import 'base.css';
+
+/* Utility classes and animations */
+@import 'utilities.css';
+
+/* Component styles */
+@import 'components/buttons.css';
+@import 'components/forms.css';
+@import 'components/cards.css';
+@import 'components/tables.css';
+@import 'components/alerts.css';
+@import 'components/navigation.css';
+@import 'components/modals.css';
+@import 'components/loading.css';

--- a/docs/prototypes/css/tailwind.config.js
+++ b/docs/prototypes/css/tailwind.config.js
@@ -1,0 +1,74 @@
+/**
+ * Shared Tailwind Configuration
+ * Discord Bot Admin UI
+ *
+ * This file is loaded before Tailwind CDN and provides the design system colors.
+ * Usage in HTML:
+ *   <script src="css/tailwind.config.js"></script>
+ *   <script src="https://cdn.tailwindcss.com"></script>
+ *   <script>tailwind.config = window.tailwindConfig;</script>
+ */
+
+window.tailwindConfig = {
+  theme: {
+    extend: {
+      colors: {
+        bg: {
+          primary: '#1d2022',
+          secondary: '#262a2d',
+          tertiary: '#2f3336',
+          hover: '#363a3e',
+        },
+        text: {
+          primary: '#d7d3d0',
+          secondary: '#a8a5a3',
+          tertiary: '#7a7876',
+          inverse: '#1d2022',
+        },
+        accent: {
+          orange: {
+            DEFAULT: '#cb4e1b',
+            hover: '#e5591f',
+            active: '#b04517',
+            muted: 'rgba(203, 78, 27, 0.2)',
+          },
+          blue: {
+            DEFAULT: '#098ecf',
+            hover: '#0ba3ea',
+            active: '#0879b3',
+            muted: 'rgba(9, 142, 207, 0.2)',
+          },
+        },
+        success: {
+          DEFAULT: '#10b981',
+          bg: 'rgba(16, 185, 129, 0.1)',
+          border: 'rgba(16, 185, 129, 0.3)',
+        },
+        warning: {
+          DEFAULT: '#f59e0b',
+          bg: 'rgba(245, 158, 11, 0.1)',
+          border: 'rgba(245, 158, 11, 0.3)',
+        },
+        error: {
+          DEFAULT: '#ef4444',
+          bg: 'rgba(239, 68, 68, 0.1)',
+          border: 'rgba(239, 68, 68, 0.3)',
+        },
+        info: {
+          DEFAULT: '#06b6d4',
+          bg: 'rgba(6, 182, 212, 0.1)',
+          border: 'rgba(6, 182, 212, 0.3)',
+        },
+        border: {
+          primary: '#3f4447',
+          secondary: '#2f3336',
+          focus: '#098ecf',
+        },
+      },
+      fontFamily: {
+        sans: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', 'sans-serif'],
+        mono: ['ui-monospace', 'SFMono-Regular', '"SF Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
+      },
+    },
+  },
+};

--- a/docs/prototypes/css/tokens.css
+++ b/docs/prototypes/css/tokens.css
@@ -1,0 +1,157 @@
+/**
+ * Design System Tokens
+ * CSS Custom Properties for the Discord Bot Admin UI
+ *
+ * These tokens define the foundational design values used throughout the application.
+ * They are referenced by Tailwind config and can be used directly in CSS.
+ */
+
+:root {
+  /* ==========================================
+     BACKGROUND COLORS
+     ========================================== */
+  --color-bg-primary: #1d2022;
+  --color-bg-secondary: #262a2d;
+  --color-bg-tertiary: #2f3336;
+  --color-bg-hover: #363a3e;
+
+  /* ==========================================
+     TEXT COLORS
+     ========================================== */
+  --color-text-primary: #d7d3d0;
+  --color-text-secondary: #a8a5a3;
+  --color-text-tertiary: #7a7876;
+  --color-text-inverse: #1d2022;
+
+  /* ==========================================
+     ACCENT COLORS - ORANGE
+     ========================================== */
+  --color-accent-orange: #cb4e1b;
+  --color-accent-orange-hover: #e5591f;
+  --color-accent-orange-active: #b04517;
+  --color-accent-orange-muted: rgba(203, 78, 27, 0.2);
+
+  /* ==========================================
+     ACCENT COLORS - BLUE
+     ========================================== */
+  --color-accent-blue: #098ecf;
+  --color-accent-blue-hover: #0ba3ea;
+  --color-accent-blue-active: #0879b3;
+  --color-accent-blue-muted: rgba(9, 142, 207, 0.2);
+
+  /* ==========================================
+     SEMANTIC COLORS - SUCCESS
+     ========================================== */
+  --color-success: #10b981;
+  --color-success-bg: rgba(16, 185, 129, 0.1);
+  --color-success-border: rgba(16, 185, 129, 0.3);
+
+  /* ==========================================
+     SEMANTIC COLORS - WARNING
+     ========================================== */
+  --color-warning: #f59e0b;
+  --color-warning-bg: rgba(245, 158, 11, 0.1);
+  --color-warning-border: rgba(245, 158, 11, 0.3);
+
+  /* ==========================================
+     SEMANTIC COLORS - ERROR
+     ========================================== */
+  --color-error: #ef4444;
+  --color-error-bg: rgba(239, 68, 68, 0.1);
+  --color-error-border: rgba(239, 68, 68, 0.3);
+
+  /* ==========================================
+     SEMANTIC COLORS - INFO
+     ========================================== */
+  --color-info: #06b6d4;
+  --color-info-bg: rgba(6, 182, 212, 0.1);
+  --color-info-border: rgba(6, 182, 212, 0.3);
+
+  /* ==========================================
+     BORDER COLORS
+     ========================================== */
+  --color-border-primary: #3f4447;
+  --color-border-secondary: #2f3336;
+  --color-border-focus: #098ecf;
+
+  /* ==========================================
+     SPACING SCALE
+     Based on 4px grid
+     ========================================== */
+  --space-0: 0;
+  --space-1: 0.25rem;  /* 4px */
+  --space-2: 0.5rem;   /* 8px */
+  --space-3: 0.75rem;  /* 12px */
+  --space-4: 1rem;     /* 16px */
+  --space-5: 1.25rem;  /* 20px */
+  --space-6: 1.5rem;   /* 24px */
+  --space-8: 2rem;     /* 32px */
+  --space-10: 2.5rem;  /* 40px */
+  --space-12: 3rem;    /* 48px */
+  --space-16: 4rem;    /* 64px */
+  --space-20: 5rem;    /* 80px */
+  --space-24: 6rem;    /* 96px */
+
+  /* ==========================================
+     TYPOGRAPHY
+     ========================================== */
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, monospace;
+
+  /* Font Sizes */
+  --text-xs: 0.75rem;    /* 12px */
+  --text-sm: 0.875rem;   /* 14px */
+  --text-base: 1rem;     /* 16px */
+  --text-lg: 1.125rem;   /* 18px */
+  --text-xl: 1.25rem;    /* 20px */
+  --text-2xl: 1.5rem;    /* 24px */
+  --text-3xl: 1.875rem;  /* 30px */
+  --text-4xl: 2.25rem;   /* 36px */
+
+  /* Line Heights */
+  --leading-none: 1;
+  --leading-tight: 1.25;
+  --leading-snug: 1.375;
+  --leading-normal: 1.5;
+  --leading-relaxed: 1.625;
+  --leading-loose: 2;
+
+  /* ==========================================
+     BORDER RADIUS
+     ========================================== */
+  --radius-none: 0;
+  --radius-sm: 0.125rem;  /* 2px */
+  --radius-md: 0.375rem;  /* 6px */
+  --radius-lg: 0.5rem;    /* 8px */
+  --radius-xl: 0.75rem;   /* 12px */
+  --radius-2xl: 1rem;     /* 16px */
+  --radius-full: 9999px;
+
+  /* ==========================================
+     SHADOWS
+     ========================================== */
+  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  --shadow-2xl: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+
+  /* ==========================================
+     TRANSITIONS
+     ========================================== */
+  --transition-fast: 150ms ease-out;
+  --transition-normal: 200ms ease-out;
+  --transition-slow: 300ms ease-out;
+
+  /* ==========================================
+     Z-INDEX SCALE
+     ========================================== */
+  --z-dropdown: 100;
+  --z-sticky: 200;
+  --z-fixed: 300;
+  --z-modal-backdrop: 1000;
+  --z-modal: 1001;
+  --z-popover: 1100;
+  --z-tooltip: 1200;
+  --z-toast: 1300;
+}

--- a/docs/prototypes/css/utilities.css
+++ b/docs/prototypes/css/utilities.css
@@ -1,0 +1,166 @@
+/**
+ * Utility Classes
+ * Discord Bot Admin UI
+ *
+ * Contains utility classes and animation keyframes.
+ */
+
+/* ==========================================
+   SCREEN READER ONLY
+   ========================================== */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+/* ==========================================
+   ANIMATION KEYFRAMES
+   ========================================== */
+
+/* Shimmer animation for skeleton loading */
+@keyframes shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+/* Pulse animation */
+@keyframes pulse {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+/* Slide in from top */
+@keyframes slideIn {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Slide out to top */
+@keyframes slideOut {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+}
+
+/* Fade in */
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+/* Fade out */
+@keyframes fadeOut {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+/* Spin animation for spinners */
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Bounce animation for dots */
+@keyframes bounce-dot {
+  0%, 80%, 100% {
+    transform: scale(0);
+    opacity: 0.5;
+  }
+  40% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+/* Pulse ring animation */
+@keyframes pulse-ring {
+  0% {
+    transform: scale(0.8);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1.4);
+    opacity: 0;
+  }
+}
+
+/* Pulse core animation */
+@keyframes pulse-core {
+  0%, 100% {
+    transform: scale(0.9);
+  }
+  50% {
+    transform: scale(1);
+  }
+}
+
+/* Indeterminate progress bar */
+@keyframes indeterminate-progress {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(200%);
+  }
+}
+
+/* Circular progress rotate */
+@keyframes circular-progress-rotate {
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+/* Circular progress dash */
+@keyframes circular-progress-dash {
+  0% {
+    stroke-dasharray: 1, 200;
+    stroke-dashoffset: 0;
+  }
+  50% {
+    stroke-dasharray: 89, 200;
+    stroke-dashoffset: -35;
+  }
+  100% {
+    stroke-dasharray: 89, 200;
+    stroke-dashoffset: -124;
+  }
+}

--- a/docs/prototypes/dashboard.html
+++ b/docs/prototypes/dashboard.html
@@ -5,127 +5,22 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Discord Bot Admin - Dashboard</title>
 
-  <!-- Tailwind CSS CDN -->
-  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Shared Styles -->
+  <link rel="stylesheet" href="css/main.css">
 
-  <!-- Tailwind Config with Design System -->
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            bg: {
-              primary: '#1d2022',
-              secondary: '#262a2d',
-              tertiary: '#2f3336',
-              hover: '#363a3e',
-            },
-            text: {
-              primary: '#d7d3d0',
-              secondary: '#a8a5a3',
-              tertiary: '#7a7876',
-              inverse: '#1d2022',
-            },
-            accent: {
-              orange: {
-                DEFAULT: '#cb4e1b',
-                hover: '#e5591f',
-                active: '#b04517',
-                muted: 'rgba(203, 78, 27, 0.2)',
-              },
-              blue: {
-                DEFAULT: '#098ecf',
-                hover: '#0ba3ea',
-                active: '#0879b3',
-                muted: 'rgba(9, 142, 207, 0.2)',
-              },
-            },
-            success: {
-              DEFAULT: '#10b981',
-              bg: 'rgba(16, 185, 129, 0.1)',
-              border: 'rgba(16, 185, 129, 0.3)',
-            },
-            warning: {
-              DEFAULT: '#f59e0b',
-              bg: 'rgba(245, 158, 11, 0.1)',
-              border: 'rgba(245, 158, 11, 0.3)',
-            },
-            error: {
-              DEFAULT: '#ef4444',
-              bg: 'rgba(239, 68, 68, 0.1)',
-              border: 'rgba(239, 68, 68, 0.3)',
-            },
-            info: {
-              DEFAULT: '#06b6d4',
-              bg: 'rgba(6, 182, 212, 0.1)',
-              border: 'rgba(6, 182, 212, 0.3)',
-            },
-            border: {
-              primary: '#3f4447',
-              secondary: '#2f3336',
-              focus: '#098ecf',
-            },
-          },
-          fontFamily: {
-            sans: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', 'sans-serif'],
-            mono: ['ui-monospace', 'SFMono-Regular', '"SF Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
-          },
-        },
-      },
-    }
-  </script>
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
 
   <style>
-    /* Custom scrollbar for dark theme */
-    ::-webkit-scrollbar {
-      width: 8px;
-      height: 8px;
-    }
-    ::-webkit-scrollbar-track {
-      background: #1d2022;
-    }
-    ::-webkit-scrollbar-thumb {
-      background: #3f4447;
-      border-radius: 4px;
-    }
-    ::-webkit-scrollbar-thumb:hover {
-      background: #4a4f52;
-    }
-
-    /* Focus states */
-    *:focus-visible {
-      outline: 2px solid #098ecf;
-      outline-offset: 2px;
-    }
-
+    /* Page-specific styles */
     /* Sidebar transition for mobile */
     .sidebar-overlay {
       transition: opacity 0.3s ease-in-out;
     }
     .sidebar-panel {
       transition: transform 0.3s ease-in-out;
-    }
-
-    /* Status indicator pulse animation */
-    @keyframes pulse {
-      0%, 100% { opacity: 1; }
-      50% { opacity: 0.5; }
-    }
-    .status-pulse {
-      animation: pulse 2s infinite;
-    }
-
-    /* Dropdown menu */
-    .dropdown-menu {
-      display: none;
-      opacity: 0;
-      transform: translateY(-10px);
-      transition: opacity 0.15s ease-in-out, transform 0.15s ease-in-out;
-    }
-    .dropdown-menu.active {
-      display: block;
-      opacity: 1;
-      transform: translateY(0);
     }
   </style>
 </head>

--- a/docs/prototypes/feedback-alerts.html
+++ b/docs/prototypes/feedback-alerts.html
@@ -4,109 +4,28 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Alert Components - Feedback Prototype</title>
+
+    <!-- Shared Styles -->
+    <link rel="stylesheet" href="css/main.css">
+
+    <!-- Tailwind CSS CDN with shared config -->
+    <script src="css/tailwind.config.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
-    <script>
-        tailwind.config = {
-            theme: {
-                extend: {
-                    colors: {
-                        dark: {
-                            900: '#0f0f23',
-                            800: '#1a1a2e',
-                            700: '#25253a',
-                            600: '#2d2d44'
-                        }
-                    }
-                }
-            }
-        }
-    </script>
-    <style>
-        /* Alert variant styles */
-        .alert-info {
-            background: rgba(6, 182, 212, 0.1);
-            border-color: rgba(6, 182, 212, 0.3);
-            color: #06b6d4;
-        }
-        .alert-success {
-            background: rgba(16, 185, 129, 0.1);
-            border-color: rgba(16, 185, 129, 0.3);
-            color: #10b981;
-        }
-        .alert-warning {
-            background: rgba(245, 158, 11, 0.1);
-            border-color: rgba(245, 158, 11, 0.3);
-            color: #f59e0b;
-        }
-        .alert-error {
-            background: rgba(239, 68, 68, 0.1);
-            border-color: rgba(239, 68, 68, 0.3);
-            color: #ef4444;
-        }
-
-        /* Slide-in animation */
-        @keyframes slideIn {
-            from {
-                opacity: 0;
-                transform: translateY(-1rem);
-            }
-            to {
-                opacity: 1;
-                transform: translateY(0);
-            }
-        }
-
-        @keyframes slideOut {
-            from {
-                opacity: 1;
-                transform: translateY(0);
-            }
-            to {
-                opacity: 0;
-                transform: translateY(-1rem);
-            }
-        }
-
-        .alert-slide-in {
-            animation: slideIn 300ms ease-out forwards;
-        }
-
-        .alert-slide-out {
-            animation: slideOut 300ms ease-out forwards;
-        }
-
-        /* Alert base styles */
-        .alert {
-            padding: 1rem;
-            border-radius: 0.5rem;
-            border-width: 1px;
-            border-style: solid;
-        }
-
-        .alert-icon {
-            width: 1.25rem;
-            height: 1.25rem;
-            flex-shrink: 0;
-        }
-
-        .alert-content {
-            gap: 0.75rem;
-        }
-    </style>
+    <script>tailwind.config = window.tailwindConfig;</script>
 </head>
-<body class="bg-dark-900 text-gray-100 min-h-screen">
+<body class="bg-bg-primary text-text-primary min-h-screen">
     <!-- Header -->
-    <header class="bg-dark-800 border-b border-dark-600 px-6 py-4">
-        <h1 class="text-2xl font-bold text-white">Alert Components - Feedback Prototype</h1>
-        <p class="text-gray-400 mt-1">Interactive alert component demonstration with multiple variants and behaviors</p>
+    <header class="bg-bg-secondary border-b border-border-primary px-6 py-4">
+        <h1 class="text-2xl font-bold text-text-primary">Alert Components - Feedback Prototype</h1>
+        <p class="text-text-secondary mt-1">Interactive alert component demonstration with multiple variants and behaviors</p>
     </header>
 
     <main class="max-w-5xl mx-auto px-6 py-8 space-y-12">
 
         <!-- Section 1: Static Alerts -->
         <section>
-            <h2 class="text-xl font-semibold text-white mb-4">Section 1: Static Alerts (Basic Message Only)</h2>
-            <p class="text-gray-400 mb-6">All four alert variants displayed with just a message.</p>
+            <h2 class="text-xl font-semibold text-text-primary mb-4">Section 1: Static Alerts (Basic Message Only)</h2>
+            <p class="text-text-secondary mb-6">All four alert variants displayed with just a message.</p>
 
             <div class="space-y-4">
                 <!-- Info Alert -->
@@ -145,8 +64,8 @@
 
         <!-- Section 2: Alerts with Title + Message -->
         <section>
-            <h2 class="text-xl font-semibold text-white mb-4">Section 2: Alerts with Title + Message</h2>
-            <p class="text-gray-400 mb-6">Alerts featuring both a bold title and descriptive message content.</p>
+            <h2 class="text-xl font-semibold text-text-primary mb-4">Section 2: Alerts with Title + Message</h2>
+            <p class="text-text-secondary mb-6">Alerts featuring both a bold title and descriptive message content.</p>
 
             <div class="space-y-4">
                 <!-- Info Alert with Title -->
@@ -197,8 +116,8 @@
 
         <!-- Section 3: Dismissible Alerts -->
         <section>
-            <h2 class="text-xl font-semibold text-white mb-4">Section 3: Dismissible Alerts</h2>
-            <p class="text-gray-400 mb-6">Alerts with close buttons that can be dismissed by the user.</p>
+            <h2 class="text-xl font-semibold text-text-primary mb-4">Section 3: Dismissible Alerts</h2>
+            <p class="text-text-secondary mb-6">Alerts with close buttons that can be dismissed by the user.</p>
 
             <div id="dismissible-alerts" class="space-y-4">
                 <!-- Dismissible Info Alert -->
@@ -274,27 +193,27 @@
                 </div>
             </div>
 
-            <button type="button" class="mt-4 px-4 py-2 bg-dark-700 hover:bg-dark-600 text-white rounded-lg transition-colors text-sm" onclick="resetDismissibleAlerts()">
+            <button type="button" class="mt-4 px-4 py-2 bg-bg-tertiary hover:bg-bg-hover text-text-primary rounded-lg transition-colors text-sm" onclick="resetDismissibleAlerts()">
                 Reset Dismissed Alerts
             </button>
         </section>
 
         <!-- Section 4: Auto-Dismiss Demo -->
         <section>
-            <h2 class="text-xl font-semibold text-white mb-4">Section 4: Auto-Dismiss Demo</h2>
-            <p class="text-gray-400 mb-6">Alerts that automatically dismiss after a configurable timeout.</p>
+            <h2 class="text-xl font-semibold text-text-primary mb-4">Section 4: Auto-Dismiss Demo</h2>
+            <p class="text-text-secondary mb-6">Alerts that automatically dismiss after a configurable timeout.</p>
 
             <div class="flex flex-wrap items-center gap-4 mb-6">
                 <div class="flex items-center gap-2">
-                    <label for="auto-dismiss-duration" class="text-sm text-gray-300">Auto-dismiss after:</label>
-                    <select id="auto-dismiss-duration" class="bg-dark-700 border border-dark-600 text-white rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-cyan-500 focus:border-transparent">
+                    <label for="auto-dismiss-duration" class="text-sm text-text-secondary">Auto-dismiss after:</label>
+                    <select id="auto-dismiss-duration" class="bg-bg-tertiary border border-border-primary text-text-primary rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-accent-blue focus:border-transparent">
                         <option value="2000">2 seconds</option>
                         <option value="3000" selected>3 seconds</option>
                         <option value="5000">5 seconds</option>
                         <option value="10000">10 seconds</option>
                     </select>
                 </div>
-                <button type="button" class="px-4 py-2 bg-cyan-600 hover:bg-cyan-700 text-white rounded-lg transition-colors text-sm" onclick="showAutoDismissAlert()">
+                <button type="button" class="px-4 py-2 bg-accent-blue hover:bg-accent-blue-hover text-white rounded-lg transition-colors text-sm" onclick="showAutoDismissAlert()">
                     Show Auto-Dismiss Alert
                 </button>
             </div>
@@ -306,17 +225,17 @@
 
         <!-- Section 5: Interactive Playground -->
         <section>
-            <h2 class="text-xl font-semibold text-white mb-4">Section 5: Interactive Playground</h2>
-            <p class="text-gray-400 mb-6">Trigger alerts dynamically with customizable options.</p>
+            <h2 class="text-xl font-semibold text-text-primary mb-4">Section 5: Interactive Playground</h2>
+            <p class="text-text-secondary mb-6">Trigger alerts dynamically with customizable options.</p>
 
             <!-- Controls -->
-            <div class="bg-dark-800 rounded-lg p-6 border border-dark-600 mb-6">
-                <h3 class="text-lg font-medium text-white mb-4">Alert Configuration</h3>
+            <div class="bg-bg-secondary rounded-lg p-6 border border-border-primary mb-6">
+                <h3 class="text-lg font-medium text-text-primary mb-4">Alert Configuration</h3>
 
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                     <div>
-                        <label for="alert-variant" class="block text-sm font-medium text-gray-300 mb-2">Variant</label>
-                        <select id="alert-variant" class="w-full bg-dark-700 border border-dark-600 text-white rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-cyan-500 focus:border-transparent">
+                        <label for="alert-variant" class="block text-sm font-medium text-text-secondary mb-2">Variant</label>
+                        <select id="alert-variant" class="w-full bg-bg-tertiary border border-border-primary text-text-primary rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-accent-blue focus:border-transparent">
                             <option value="info">Info</option>
                             <option value="success">Success</option>
                             <option value="warning">Warning</option>
@@ -325,30 +244,30 @@
                     </div>
 
                     <div>
-                        <label for="alert-title" class="block text-sm font-medium text-gray-300 mb-2">Title (optional)</label>
-                        <input type="text" id="alert-title" placeholder="Enter alert title" class="w-full bg-dark-700 border border-dark-600 text-white rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-cyan-500 focus:border-transparent placeholder-gray-500">
+                        <label for="alert-title" class="block text-sm font-medium text-text-secondary mb-2">Title (optional)</label>
+                        <input type="text" id="alert-title" placeholder="Enter alert title" class="w-full bg-bg-tertiary border border-border-primary text-text-primary rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-accent-blue focus:border-transparent placeholder-text-tertiary">
                     </div>
 
                     <div class="md:col-span-2">
-                        <label for="alert-message" class="block text-sm font-medium text-gray-300 mb-2">Message</label>
-                        <textarea id="alert-message" rows="2" placeholder="Enter alert message" class="w-full bg-dark-700 border border-dark-600 text-white rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-cyan-500 focus:border-transparent placeholder-gray-500 resize-none">This is a custom alert message.</textarea>
+                        <label for="alert-message" class="block text-sm font-medium text-text-secondary mb-2">Message</label>
+                        <textarea id="alert-message" rows="2" placeholder="Enter alert message" class="w-full bg-bg-tertiary border border-border-primary text-text-primary rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-accent-blue focus:border-transparent placeholder-text-tertiary resize-none">This is a custom alert message.</textarea>
                     </div>
 
                     <div class="flex items-center gap-6">
                         <label class="flex items-center gap-2 cursor-pointer">
-                            <input type="checkbox" id="alert-dismissible" checked class="w-4 h-4 text-cyan-600 bg-dark-700 border-dark-600 rounded focus:ring-cyan-500">
-                            <span class="text-sm text-gray-300">Dismissible</span>
+                            <input type="checkbox" id="alert-dismissible" checked class="w-4 h-4 text-accent-blue bg-bg-tertiary border-border-primary rounded focus:ring-accent-blue">
+                            <span class="text-sm text-text-secondary">Dismissible</span>
                         </label>
 
                         <label class="flex items-center gap-2 cursor-pointer">
-                            <input type="checkbox" id="alert-auto-dismiss" class="w-4 h-4 text-cyan-600 bg-dark-700 border-dark-600 rounded focus:ring-cyan-500">
-                            <span class="text-sm text-gray-300">Auto-dismiss</span>
+                            <input type="checkbox" id="alert-auto-dismiss" class="w-4 h-4 text-accent-blue bg-bg-tertiary border-border-primary rounded focus:ring-accent-blue">
+                            <span class="text-sm text-text-secondary">Auto-dismiss</span>
                         </label>
                     </div>
 
                     <div>
-                        <label for="alert-auto-duration" class="block text-sm font-medium text-gray-300 mb-2">Auto-dismiss Duration</label>
-                        <select id="alert-auto-duration" class="w-full bg-dark-700 border border-dark-600 text-white rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-cyan-500 focus:border-transparent">
+                        <label for="alert-auto-duration" class="block text-sm font-medium text-text-secondary mb-2">Auto-dismiss Duration</label>
+                        <select id="alert-auto-duration" class="w-full bg-bg-tertiary border border-border-primary text-text-primary rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-accent-blue focus:border-transparent">
                             <option value="2000">2 seconds</option>
                             <option value="3000" selected>3 seconds</option>
                             <option value="5000">5 seconds</option>
@@ -358,29 +277,29 @@
                 </div>
 
                 <div class="flex flex-wrap gap-3 mt-6">
-                    <button type="button" class="px-4 py-2 bg-cyan-600 hover:bg-cyan-700 text-white rounded-lg transition-colors text-sm font-medium" onclick="triggerCustomAlert()">
+                    <button type="button" class="px-4 py-2 bg-accent-blue hover:bg-accent-blue-hover text-white rounded-lg transition-colors text-sm font-medium" onclick="triggerCustomAlert()">
                         Show Alert
                     </button>
-                    <button type="button" class="px-4 py-2 bg-dark-700 hover:bg-dark-600 text-white rounded-lg transition-colors text-sm" onclick="clearPlaygroundAlerts()">
+                    <button type="button" class="px-4 py-2 bg-bg-tertiary hover:bg-bg-hover text-text-primary rounded-lg transition-colors text-sm" onclick="clearPlaygroundAlerts()">
                         Clear All Alerts
                     </button>
                 </div>
             </div>
 
             <!-- Quick Trigger Buttons -->
-            <div class="bg-dark-800 rounded-lg p-6 border border-dark-600 mb-6">
-                <h3 class="text-lg font-medium text-white mb-4">Quick Trigger</h3>
+            <div class="bg-bg-secondary rounded-lg p-6 border border-border-primary mb-6">
+                <h3 class="text-lg font-medium text-text-primary mb-4">Quick Trigger</h3>
                 <div class="flex flex-wrap gap-3">
-                    <button type="button" class="px-4 py-2 bg-cyan-600 hover:bg-cyan-700 text-white rounded-lg transition-colors text-sm" onclick="triggerQuickAlert('info')">
+                    <button type="button" class="px-4 py-2 bg-info hover:opacity-90 text-white rounded-lg transition-colors text-sm" onclick="triggerQuickAlert('info')">
                         Info Alert
                     </button>
-                    <button type="button" class="px-4 py-2 bg-emerald-600 hover:bg-emerald-700 text-white rounded-lg transition-colors text-sm" onclick="triggerQuickAlert('success')">
+                    <button type="button" class="px-4 py-2 bg-success hover:opacity-90 text-white rounded-lg transition-colors text-sm" onclick="triggerQuickAlert('success')">
                         Success Alert
                     </button>
-                    <button type="button" class="px-4 py-2 bg-amber-600 hover:bg-amber-700 text-white rounded-lg transition-colors text-sm" onclick="triggerQuickAlert('warning')">
+                    <button type="button" class="px-4 py-2 bg-warning hover:opacity-90 text-white rounded-lg transition-colors text-sm" onclick="triggerQuickAlert('warning')">
                         Warning Alert
                     </button>
-                    <button type="button" class="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg transition-colors text-sm" onclick="triggerQuickAlert('error')">
+                    <button type="button" class="px-4 py-2 bg-error hover:opacity-90 text-white rounded-lg transition-colors text-sm" onclick="triggerQuickAlert('error')">
                         Error Alert
                     </button>
                 </div>
@@ -395,8 +314,8 @@
     </main>
 
     <!-- Footer -->
-    <footer class="bg-dark-800 border-t border-dark-600 px-6 py-4 mt-12">
-        <p class="text-gray-400 text-sm text-center">Alert Components Prototype - Part of Discord Bot Design System</p>
+    <footer class="bg-bg-secondary border-t border-border-primary px-6 py-4 mt-12">
+        <p class="text-text-secondary text-sm text-center">Alert Components Prototype - Part of Discord Bot Design System</p>
     </footer>
 
     <script>

--- a/docs/prototypes/feedback-confirmation.html
+++ b/docs/prototypes/feedback-confirmation.html
@@ -5,99 +5,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Confirmation Dialogs - Feedback Prototype</title>
 
-  <!-- Tailwind CSS CDN -->
-  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Shared Styles -->
+  <link rel="stylesheet" href="css/main.css">
 
-  <!-- Tailwind Config with Design System -->
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            bg: {
-              primary: '#1d2022',
-              secondary: '#262a2d',
-              tertiary: '#2f3336',
-              hover: '#363a3e',
-            },
-            text: {
-              primary: '#d7d3d0',
-              secondary: '#a8a5a3',
-              tertiary: '#7a7876',
-              inverse: '#1d2022',
-            },
-            accent: {
-              orange: {
-                DEFAULT: '#cb4e1b',
-                hover: '#e5591f',
-                active: '#b04517',
-                muted: 'rgba(203, 78, 27, 0.2)',
-              },
-              blue: {
-                DEFAULT: '#098ecf',
-                hover: '#0ba3ea',
-                active: '#0879b3',
-                muted: 'rgba(9, 142, 207, 0.2)',
-              },
-            },
-            success: {
-              DEFAULT: '#10b981',
-              bg: 'rgba(16, 185, 129, 0.1)',
-              border: 'rgba(16, 185, 129, 0.3)',
-            },
-            warning: {
-              DEFAULT: '#f59e0b',
-              bg: 'rgba(245, 158, 11, 0.1)',
-              border: 'rgba(245, 158, 11, 0.3)',
-            },
-            error: {
-              DEFAULT: '#ef4444',
-              bg: 'rgba(239, 68, 68, 0.1)',
-              border: 'rgba(239, 68, 68, 0.3)',
-            },
-            info: {
-              DEFAULT: '#06b6d4',
-              bg: 'rgba(6, 182, 212, 0.1)',
-              border: 'rgba(6, 182, 212, 0.3)',
-            },
-            border: {
-              primary: '#3f4447',
-              secondary: '#2f3336',
-              focus: '#098ecf',
-            },
-          },
-          fontFamily: {
-            sans: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', 'sans-serif'],
-            mono: ['ui-monospace', 'SFMono-Regular', '"SF Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
-          },
-        },
-      },
-    }
-  </script>
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
 
   <style>
-    /* Custom scrollbar for dark theme */
-    ::-webkit-scrollbar {
-      width: 8px;
-      height: 8px;
-    }
-    ::-webkit-scrollbar-track {
-      background: #1d2022;
-    }
-    ::-webkit-scrollbar-thumb {
-      background: #3f4447;
-      border-radius: 4px;
-    }
-    ::-webkit-scrollbar-thumb:hover {
-      background: #4a4f52;
-    }
-
-    /* Focus states */
-    *:focus-visible {
-      outline: 2px solid #098ecf;
-      outline-offset: 2px;
-    }
-
+    /* Page-specific styles */
     /* Modal backdrop */
     .modal-backdrop {
       z-index: 1000;

--- a/docs/prototypes/feedback-drawers.html
+++ b/docs/prototypes/feedback-drawers.html
@@ -5,103 +5,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Drawer/Sidebar Components - Feedback Prototype</title>
 
-  <!-- Tailwind CSS CDN -->
-  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Shared Styles -->
+  <link rel="stylesheet" href="css/main.css">
 
-  <!-- Tailwind Config with Design System -->
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            bg: {
-              primary: '#1d2022',
-              secondary: '#262a2d',
-              tertiary: '#2f3336',
-              hover: '#363a3e',
-            },
-            text: {
-              primary: '#d7d3d0',
-              secondary: '#a8a5a3',
-              tertiary: '#7a7876',
-              inverse: '#1d2022',
-            },
-            accent: {
-              orange: {
-                DEFAULT: '#cb4e1b',
-                hover: '#e5591f',
-                active: '#b04517',
-                muted: 'rgba(203, 78, 27, 0.2)',
-              },
-              blue: {
-                DEFAULT: '#098ecf',
-                hover: '#0ba3ea',
-                active: '#0879b3',
-                muted: 'rgba(9, 142, 207, 0.2)',
-              },
-            },
-            success: {
-              DEFAULT: '#10b981',
-              bg: 'rgba(16, 185, 129, 0.1)',
-              border: 'rgba(16, 185, 129, 0.3)',
-            },
-            warning: {
-              DEFAULT: '#f59e0b',
-              bg: 'rgba(245, 158, 11, 0.1)',
-              border: 'rgba(245, 158, 11, 0.3)',
-            },
-            error: {
-              DEFAULT: '#ef4444',
-              bg: 'rgba(239, 68, 68, 0.1)',
-              border: 'rgba(239, 68, 68, 0.3)',
-            },
-            info: {
-              DEFAULT: '#06b6d4',
-              bg: 'rgba(6, 182, 212, 0.1)',
-              border: 'rgba(6, 182, 212, 0.3)',
-            },
-            border: {
-              primary: '#3f4447',
-              secondary: '#2f3336',
-              focus: '#098ecf',
-            },
-          },
-          fontFamily: {
-            sans: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', 'sans-serif'],
-            mono: ['ui-monospace', 'SFMono-Regular', '"SF Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
-          },
-          zIndex: {
-            'drawer': '500',
-            'drawer-backdrop': '499',
-          },
-        },
-      },
-    }
-  </script>
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
 
   <style>
-    /* Custom scrollbar for dark theme */
-    ::-webkit-scrollbar {
-      width: 8px;
-      height: 8px;
-    }
-    ::-webkit-scrollbar-track {
-      background: #1d2022;
-    }
-    ::-webkit-scrollbar-thumb {
-      background: #3f4447;
-      border-radius: 4px;
-    }
-    ::-webkit-scrollbar-thumb:hover {
-      background: #4a4f52;
-    }
-
-    /* Focus states */
-    *:focus-visible {
-      outline: 2px solid #098ecf;
-      outline-offset: 2px;
-    }
-
+    /* Page-specific styles */
     /* Drawer backdrop */
     .drawer-backdrop {
       position: fixed;

--- a/docs/prototypes/feedback-empty-states.html
+++ b/docs/prototypes/feedback-empty-states.html
@@ -5,99 +5,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Empty State Components - Feedback Prototype</title>
 
-  <!-- Tailwind CSS CDN -->
-  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Shared Styles -->
+  <link rel="stylesheet" href="css/main.css">
 
-  <!-- Tailwind Config with Design System -->
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            bg: {
-              primary: '#1d2022',
-              secondary: '#262a2d',
-              tertiary: '#2f3336',
-              hover: '#363a3e',
-            },
-            text: {
-              primary: '#d7d3d0',
-              secondary: '#a8a5a3',
-              tertiary: '#7a7876',
-              inverse: '#1d2022',
-            },
-            accent: {
-              orange: {
-                DEFAULT: '#cb4e1b',
-                hover: '#e5591f',
-                active: '#b04517',
-                muted: 'rgba(203, 78, 27, 0.2)',
-              },
-              blue: {
-                DEFAULT: '#098ecf',
-                hover: '#0ba3ea',
-                active: '#0879b3',
-                muted: 'rgba(9, 142, 207, 0.2)',
-              },
-            },
-            success: {
-              DEFAULT: '#10b981',
-              bg: 'rgba(16, 185, 129, 0.1)',
-              border: 'rgba(16, 185, 129, 0.3)',
-            },
-            warning: {
-              DEFAULT: '#f59e0b',
-              bg: 'rgba(245, 158, 11, 0.1)',
-              border: 'rgba(245, 158, 11, 0.3)',
-            },
-            error: {
-              DEFAULT: '#ef4444',
-              bg: 'rgba(239, 68, 68, 0.1)',
-              border: 'rgba(239, 68, 68, 0.3)',
-            },
-            info: {
-              DEFAULT: '#06b6d4',
-              bg: 'rgba(6, 182, 212, 0.1)',
-              border: 'rgba(6, 182, 212, 0.3)',
-            },
-            border: {
-              primary: '#3f4447',
-              secondary: '#2f3336',
-              focus: '#098ecf',
-            },
-          },
-          fontFamily: {
-            sans: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', 'sans-serif'],
-            mono: ['ui-monospace', 'SFMono-Regular', '"SF Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
-          },
-        },
-      },
-    }
-  </script>
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
 
   <style>
-    /* Custom scrollbar for dark theme */
-    ::-webkit-scrollbar {
-      width: 8px;
-      height: 8px;
-    }
-    ::-webkit-scrollbar-track {
-      background: #1d2022;
-    }
-    ::-webkit-scrollbar-thumb {
-      background: #3f4447;
-      border-radius: 4px;
-    }
-    ::-webkit-scrollbar-thumb:hover {
-      background: #4a4f52;
-    }
-
-    /* Focus states */
-    *:focus-visible {
-      outline: 2px solid #098ecf;
-      outline-offset: 2px;
-    }
-
+    /* Page-specific styles */
     /* Button hover transitions */
     .btn {
       transition: all 0.15s ease-in-out;

--- a/docs/prototypes/feedback-loading.html
+++ b/docs/prototypes/feedback-loading.html
@@ -5,99 +5,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Loading States - Feedback Prototype</title>
 
-  <!-- Tailwind CSS CDN -->
-  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Shared Styles -->
+  <link rel="stylesheet" href="css/main.css">
 
-  <!-- Tailwind Config with Design System -->
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            bg: {
-              primary: '#1d2022',
-              secondary: '#262a2d',
-              tertiary: '#2f3336',
-              hover: '#363a3e',
-            },
-            text: {
-              primary: '#d7d3d0',
-              secondary: '#a8a5a3',
-              tertiary: '#7a7876',
-              inverse: '#1d2022',
-            },
-            accent: {
-              orange: {
-                DEFAULT: '#cb4e1b',
-                hover: '#e5591f',
-                active: '#b04517',
-                muted: 'rgba(203, 78, 27, 0.2)',
-              },
-              blue: {
-                DEFAULT: '#098ecf',
-                hover: '#0ba3ea',
-                active: '#0879b3',
-                muted: 'rgba(9, 142, 207, 0.2)',
-              },
-            },
-            success: {
-              DEFAULT: '#10b981',
-              bg: 'rgba(16, 185, 129, 0.1)',
-              border: 'rgba(16, 185, 129, 0.3)',
-            },
-            warning: {
-              DEFAULT: '#f59e0b',
-              bg: 'rgba(245, 158, 11, 0.1)',
-              border: 'rgba(245, 158, 11, 0.3)',
-            },
-            error: {
-              DEFAULT: '#ef4444',
-              bg: 'rgba(239, 68, 68, 0.1)',
-              border: 'rgba(239, 68, 68, 0.3)',
-            },
-            info: {
-              DEFAULT: '#06b6d4',
-              bg: 'rgba(6, 182, 212, 0.1)',
-              border: 'rgba(6, 182, 212, 0.3)',
-            },
-            border: {
-              primary: '#3f4447',
-              secondary: '#2f3336',
-              focus: '#098ecf',
-            },
-          },
-          fontFamily: {
-            sans: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', 'sans-serif'],
-            mono: ['ui-monospace', 'SFMono-Regular', '"SF Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
-          },
-        },
-      },
-    }
-  </script>
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
 
   <style>
-    /* Custom scrollbar for dark theme */
-    ::-webkit-scrollbar {
-      width: 8px;
-      height: 8px;
-    }
-    ::-webkit-scrollbar-track {
-      background: #1d2022;
-    }
-    ::-webkit-scrollbar-thumb {
-      background: #3f4447;
-      border-radius: 4px;
-    }
-    ::-webkit-scrollbar-thumb:hover {
-      background: #4a4f52;
-    }
-
-    /* Focus states */
-    *:focus-visible {
-      outline: 2px solid #098ecf;
-      outline-offset: 2px;
-    }
-
+    /* Page-specific styles */
     /* ==========================================
        SPINNER ANIMATIONS
        ========================================== */

--- a/docs/prototypes/feedback-modals.html
+++ b/docs/prototypes/feedback-modals.html
@@ -5,99 +5,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Modal Components - Feedback Prototype</title>
 
-  <!-- Tailwind CSS CDN -->
-  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Shared Styles -->
+  <link rel="stylesheet" href="css/main.css">
 
-  <!-- Tailwind Config with Design System -->
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            bg: {
-              primary: '#1d2022',
-              secondary: '#262a2d',
-              tertiary: '#2f3336',
-              hover: '#363a3e',
-            },
-            text: {
-              primary: '#d7d3d0',
-              secondary: '#a8a5a3',
-              tertiary: '#7a7876',
-              inverse: '#1d2022',
-            },
-            accent: {
-              orange: {
-                DEFAULT: '#cb4e1b',
-                hover: '#e5591f',
-                active: '#b04517',
-                muted: 'rgba(203, 78, 27, 0.2)',
-              },
-              blue: {
-                DEFAULT: '#098ecf',
-                hover: '#0ba3ea',
-                active: '#0879b3',
-                muted: 'rgba(9, 142, 207, 0.2)',
-              },
-            },
-            success: {
-              DEFAULT: '#10b981',
-              bg: 'rgba(16, 185, 129, 0.1)',
-              border: 'rgba(16, 185, 129, 0.3)',
-            },
-            warning: {
-              DEFAULT: '#f59e0b',
-              bg: 'rgba(245, 158, 11, 0.1)',
-              border: 'rgba(245, 158, 11, 0.3)',
-            },
-            error: {
-              DEFAULT: '#ef4444',
-              bg: 'rgba(239, 68, 68, 0.1)',
-              border: 'rgba(239, 68, 68, 0.3)',
-            },
-            info: {
-              DEFAULT: '#06b6d4',
-              bg: 'rgba(6, 182, 212, 0.1)',
-              border: 'rgba(6, 182, 212, 0.3)',
-            },
-            border: {
-              primary: '#3f4447',
-              secondary: '#2f3336',
-              focus: '#098ecf',
-            },
-          },
-          fontFamily: {
-            sans: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', 'sans-serif'],
-            mono: ['ui-monospace', 'SFMono-Regular', '"SF Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
-          },
-        },
-      },
-    }
-  </script>
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
 
   <style>
-    /* Custom scrollbar for dark theme */
-    ::-webkit-scrollbar {
-      width: 8px;
-      height: 8px;
-    }
-    ::-webkit-scrollbar-track {
-      background: #1d2022;
-    }
-    ::-webkit-scrollbar-thumb {
-      background: #3f4447;
-      border-radius: 4px;
-    }
-    ::-webkit-scrollbar-thumb:hover {
-      background: #4a4f52;
-    }
-
-    /* Focus states */
-    *:focus-visible {
-      outline: 2px solid #098ecf;
-      outline-offset: 2px;
-    }
-
+    /* Page-specific styles */
     /* Modal backdrop - z-index 1000 as per spec */
     .modal-backdrop {
       position: fixed;

--- a/docs/prototypes/feedback-skeletons.html
+++ b/docs/prototypes/feedback-skeletons.html
@@ -5,99 +5,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Skeleton Loaders - Feedback Prototype</title>
 
-  <!-- Tailwind CSS CDN -->
-  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Shared Styles -->
+  <link rel="stylesheet" href="css/main.css">
 
-  <!-- Tailwind Config with Design System -->
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            bg: {
-              primary: '#1d2022',
-              secondary: '#262a2d',
-              tertiary: '#2f3336',
-              hover: '#363a3e',
-            },
-            text: {
-              primary: '#d7d3d0',
-              secondary: '#a8a5a3',
-              tertiary: '#7a7876',
-              inverse: '#1d2022',
-            },
-            accent: {
-              orange: {
-                DEFAULT: '#cb4e1b',
-                hover: '#e5591f',
-                active: '#b04517',
-                muted: 'rgba(203, 78, 27, 0.2)',
-              },
-              blue: {
-                DEFAULT: '#098ecf',
-                hover: '#0ba3ea',
-                active: '#0879b3',
-                muted: 'rgba(9, 142, 207, 0.2)',
-              },
-            },
-            success: {
-              DEFAULT: '#10b981',
-              bg: 'rgba(16, 185, 129, 0.1)',
-              border: 'rgba(16, 185, 129, 0.3)',
-            },
-            warning: {
-              DEFAULT: '#f59e0b',
-              bg: 'rgba(245, 158, 11, 0.1)',
-              border: 'rgba(245, 158, 11, 0.3)',
-            },
-            error: {
-              DEFAULT: '#ef4444',
-              bg: 'rgba(239, 68, 68, 0.1)',
-              border: 'rgba(239, 68, 68, 0.3)',
-            },
-            info: {
-              DEFAULT: '#06b6d4',
-              bg: 'rgba(6, 182, 212, 0.1)',
-              border: 'rgba(6, 182, 212, 0.3)',
-            },
-            border: {
-              primary: '#3f4447',
-              secondary: '#2f3336',
-              focus: '#098ecf',
-            },
-          },
-          fontFamily: {
-            sans: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', 'sans-serif'],
-            mono: ['ui-monospace', 'SFMono-Regular', '"SF Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
-          },
-        },
-      },
-    }
-  </script>
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
 
   <style>
-    /* Custom scrollbar for dark theme */
-    ::-webkit-scrollbar {
-      width: 8px;
-      height: 8px;
-    }
-    ::-webkit-scrollbar-track {
-      background: #1d2022;
-    }
-    ::-webkit-scrollbar-thumb {
-      background: #3f4447;
-      border-radius: 4px;
-    }
-    ::-webkit-scrollbar-thumb:hover {
-      background: #4a4f52;
-    }
-
-    /* Focus states */
-    *:focus-visible {
-      outline: 2px solid #098ecf;
-      outline-offset: 2px;
-    }
-
+    /* Page-specific styles */
     /* Base skeleton styling */
     .skeleton {
       background: linear-gradient(90deg, #2f3336 0%, #3f4447 50%, #2f3336 100%);

--- a/docs/prototypes/feedback-toasts.html
+++ b/docs/prototypes/feedback-toasts.html
@@ -5,99 +5,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Discord Bot Admin - Toast Notifications</title>
 
-  <!-- Tailwind CSS CDN -->
-  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Shared Styles -->
+  <link rel="stylesheet" href="css/main.css">
 
-  <!-- Tailwind Config with Design System -->
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            bg: {
-              primary: '#1d2022',
-              secondary: '#262a2d',
-              tertiary: '#2f3336',
-              hover: '#363a3e',
-            },
-            text: {
-              primary: '#d7d3d0',
-              secondary: '#a8a5a3',
-              tertiary: '#7a7876',
-              inverse: '#1d2022',
-            },
-            accent: {
-              orange: {
-                DEFAULT: '#cb4e1b',
-                hover: '#e5591f',
-                active: '#b04517',
-                muted: 'rgba(203, 78, 27, 0.2)',
-              },
-              blue: {
-                DEFAULT: '#098ecf',
-                hover: '#0ba3ea',
-                active: '#0879b3',
-                muted: 'rgba(9, 142, 207, 0.2)',
-              },
-            },
-            success: {
-              DEFAULT: '#10b981',
-              bg: 'rgba(16, 185, 129, 0.1)',
-              border: 'rgba(16, 185, 129, 0.3)',
-            },
-            warning: {
-              DEFAULT: '#f59e0b',
-              bg: 'rgba(245, 158, 11, 0.1)',
-              border: 'rgba(245, 158, 11, 0.3)',
-            },
-            error: {
-              DEFAULT: '#ef4444',
-              bg: 'rgba(239, 68, 68, 0.1)',
-              border: 'rgba(239, 68, 68, 0.3)',
-            },
-            info: {
-              DEFAULT: '#06b6d4',
-              bg: 'rgba(6, 182, 212, 0.1)',
-              border: 'rgba(6, 182, 212, 0.3)',
-            },
-            border: {
-              primary: '#3f4447',
-              secondary: '#2f3336',
-              focus: '#098ecf',
-            },
-          },
-          fontFamily: {
-            sans: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', 'sans-serif'],
-            mono: ['ui-monospace', 'SFMono-Regular', '"SF Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
-          },
-        },
-      },
-    }
-  </script>
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
 
   <style>
-    /* Custom scrollbar for dark theme */
-    ::-webkit-scrollbar {
-      width: 8px;
-      height: 8px;
-    }
-    ::-webkit-scrollbar-track {
-      background: #1d2022;
-    }
-    ::-webkit-scrollbar-thumb {
-      background: #3f4447;
-      border-radius: 4px;
-    }
-    ::-webkit-scrollbar-thumb:hover {
-      background: #4a4f52;
-    }
-
-    /* Focus states */
-    *:focus-visible {
-      outline: 2px solid #098ecf;
-      outline-offset: 2px;
-    }
-
+    /* Page-specific styles */
     /* Toast Container Positions */
     .toast-container {
       position: fixed;

--- a/docs/prototypes/feedback-tooltips.html
+++ b/docs/prototypes/feedback-tooltips.html
@@ -5,99 +5,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Tooltips & Popovers - Feedback Prototype</title>
 
-  <!-- Tailwind CSS CDN -->
-  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Shared Styles -->
+  <link rel="stylesheet" href="css/main.css">
 
-  <!-- Tailwind Config with Design System -->
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            bg: {
-              primary: '#1d2022',
-              secondary: '#262a2d',
-              tertiary: '#2f3336',
-              hover: '#363a3e',
-            },
-            text: {
-              primary: '#d7d3d0',
-              secondary: '#a8a5a3',
-              tertiary: '#7a7876',
-              inverse: '#1d2022',
-            },
-            accent: {
-              orange: {
-                DEFAULT: '#cb4e1b',
-                hover: '#e5591f',
-                active: '#b04517',
-                muted: 'rgba(203, 78, 27, 0.2)',
-              },
-              blue: {
-                DEFAULT: '#098ecf',
-                hover: '#0ba3ea',
-                active: '#0879b3',
-                muted: 'rgba(9, 142, 207, 0.2)',
-              },
-            },
-            success: {
-              DEFAULT: '#10b981',
-              bg: 'rgba(16, 185, 129, 0.1)',
-              border: 'rgba(16, 185, 129, 0.3)',
-            },
-            warning: {
-              DEFAULT: '#f59e0b',
-              bg: 'rgba(245, 158, 11, 0.1)',
-              border: 'rgba(245, 158, 11, 0.3)',
-            },
-            error: {
-              DEFAULT: '#ef4444',
-              bg: 'rgba(239, 68, 68, 0.1)',
-              border: 'rgba(239, 68, 68, 0.3)',
-            },
-            info: {
-              DEFAULT: '#06b6d4',
-              bg: 'rgba(6, 182, 212, 0.1)',
-              border: 'rgba(6, 182, 212, 0.3)',
-            },
-            border: {
-              primary: '#3f4447',
-              secondary: '#2f3336',
-              focus: '#098ecf',
-            },
-          },
-          fontFamily: {
-            sans: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', 'sans-serif'],
-            mono: ['ui-monospace', 'SFMono-Regular', '"SF Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
-          },
-        },
-      },
-    }
-  </script>
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
 
   <style>
-    /* Custom scrollbar for dark theme */
-    ::-webkit-scrollbar {
-      width: 8px;
-      height: 8px;
-    }
-    ::-webkit-scrollbar-track {
-      background: #1d2022;
-    }
-    ::-webkit-scrollbar-thumb {
-      background: #3f4447;
-      border-radius: 4px;
-    }
-    ::-webkit-scrollbar-thumb:hover {
-      background: #4a4f52;
-    }
-
-    /* Focus states */
-    *:focus-visible {
-      outline: 2px solid #098ecf;
-      outline-offset: 2px;
-    }
-
+    /* Page-specific styles */
     /* ==================== */
     /* TOOLTIP STYLES       */
     /* ==================== */

--- a/docs/prototypes/forms/components/01-text-input.html
+++ b/docs/prototypes/forms/components/01-text-input.html
@@ -5,99 +5,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Text Input - Form Components Library</title>
 
-  <!-- Tailwind CSS CDN -->
-  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Shared Styles -->
+  <link rel="stylesheet" href="../../css/main.css">
 
-  <!-- Tailwind Config (Design System) -->
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            bg: {
-              primary: '#1d2022',
-              secondary: '#262a2d',
-              tertiary: '#2f3336',
-              hover: '#363a3e',
-            },
-            text: {
-              primary: '#d7d3d0',
-              secondary: '#a8a5a3',
-              tertiary: '#7a7876',
-              inverse: '#1d2022',
-            },
-            accent: {
-              orange: {
-                DEFAULT: '#cb4e1b',
-                hover: '#e5591f',
-                active: '#b04517',
-                muted: 'rgba(203, 78, 27, 0.2)',
-              },
-              blue: {
-                DEFAULT: '#098ecf',
-                hover: '#0ba3ea',
-                active: '#0879b3',
-                muted: 'rgba(9, 142, 207, 0.2)',
-              },
-            },
-            success: {
-              DEFAULT: '#10b981',
-              bg: 'rgba(16, 185, 129, 0.1)',
-              border: 'rgba(16, 185, 129, 0.3)',
-            },
-            warning: {
-              DEFAULT: '#f59e0b',
-              bg: 'rgba(245, 158, 11, 0.1)',
-              border: 'rgba(245, 158, 11, 0.3)',
-            },
-            error: {
-              DEFAULT: '#ef4444',
-              bg: 'rgba(239, 68, 68, 0.1)',
-              border: 'rgba(239, 68, 68, 0.3)',
-            },
-            info: {
-              DEFAULT: '#06b6d4',
-              bg: 'rgba(6, 182, 212, 0.1)',
-              border: 'rgba(6, 182, 212, 0.3)',
-            },
-            border: {
-              primary: '#3f4447',
-              secondary: '#2f3336',
-              focus: '#098ecf',
-            },
-          },
-          fontFamily: {
-            sans: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', 'sans-serif'],
-            mono: ['ui-monospace', 'SFMono-Regular', '"SF Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
-          },
-        },
-      },
-    }
-  </script>
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="../../css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
 
   <style>
     /* ========================================
-       FORM COMPONENT STYLES
+       PAGE-SPECIFIC FORM COMPONENT STYLES
        ======================================== */
-
-    /* Focus states */
-    *:focus-visible {
-      outline: 2px solid #098ecf;
-      outline-offset: 2px;
-    }
-
-    /* Screen reader only */
-    .sr-only {
-      position: absolute;
-      width: 1px;
-      height: 1px;
-      padding: 0;
-      margin: -1px;
-      overflow: hidden;
-      clip: rect(0, 0, 0, 0);
-      white-space: nowrap;
-      border: 0;
-    }
 
     /* ----------------------------------------
        Form Group

--- a/docs/prototypes/forms/components/02-validation-states.html
+++ b/docs/prototypes/forms/components/02-validation-states.html
@@ -5,99 +5,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Validation States - Form Components Library</title>
 
-  <!-- Tailwind CSS CDN -->
-  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Shared Styles -->
+  <link rel="stylesheet" href="../../css/main.css">
 
-  <!-- Tailwind Config (Design System) -->
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            bg: {
-              primary: '#1d2022',
-              secondary: '#262a2d',
-              tertiary: '#2f3336',
-              hover: '#363a3e',
-            },
-            text: {
-              primary: '#d7d3d0',
-              secondary: '#a8a5a3',
-              tertiary: '#7a7876',
-              inverse: '#1d2022',
-            },
-            accent: {
-              orange: {
-                DEFAULT: '#cb4e1b',
-                hover: '#e5591f',
-                active: '#b04517',
-                muted: 'rgba(203, 78, 27, 0.2)',
-              },
-              blue: {
-                DEFAULT: '#098ecf',
-                hover: '#0ba3ea',
-                active: '#0879b3',
-                muted: 'rgba(9, 142, 207, 0.2)',
-              },
-            },
-            success: {
-              DEFAULT: '#10b981',
-              bg: 'rgba(16, 185, 129, 0.1)',
-              border: 'rgba(16, 185, 129, 0.3)',
-            },
-            warning: {
-              DEFAULT: '#f59e0b',
-              bg: 'rgba(245, 158, 11, 0.1)',
-              border: 'rgba(245, 158, 11, 0.3)',
-            },
-            error: {
-              DEFAULT: '#ef4444',
-              bg: 'rgba(239, 68, 68, 0.1)',
-              border: 'rgba(239, 68, 68, 0.3)',
-            },
-            info: {
-              DEFAULT: '#06b6d4',
-              bg: 'rgba(6, 182, 212, 0.1)',
-              border: 'rgba(6, 182, 212, 0.3)',
-            },
-            border: {
-              primary: '#3f4447',
-              secondary: '#2f3336',
-              focus: '#098ecf',
-            },
-          },
-          fontFamily: {
-            sans: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', 'sans-serif'],
-            mono: ['ui-monospace', 'SFMono-Regular', '"SF Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
-          },
-        },
-      },
-    }
-  </script>
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="../../css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
 
   <style>
     /* ========================================
-       FORM COMPONENT STYLES
+       PAGE-SPECIFIC FORM COMPONENT STYLES
        ======================================== */
-
-    /* Focus states */
-    *:focus-visible {
-      outline: 2px solid #098ecf;
-      outline-offset: 2px;
-    }
-
-    /* Screen reader only */
-    .sr-only {
-      position: absolute;
-      width: 1px;
-      height: 1px;
-      padding: 0;
-      margin: -1px;
-      overflow: hidden;
-      clip: rect(0, 0, 0, 0);
-      white-space: nowrap;
-      border: 0;
-    }
 
     /* ----------------------------------------
        Form Group

--- a/docs/prototypes/forms/components/03-select-dropdown.html
+++ b/docs/prototypes/forms/components/03-select-dropdown.html
@@ -5,99 +5,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Select Dropdown - Form Components Library</title>
 
-  <!-- Tailwind CSS CDN -->
-  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Shared Styles -->
+  <link rel="stylesheet" href="../../css/main.css">
 
-  <!-- Tailwind Config (Design System) -->
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            bg: {
-              primary: '#1d2022',
-              secondary: '#262a2d',
-              tertiary: '#2f3336',
-              hover: '#363a3e',
-            },
-            text: {
-              primary: '#d7d3d0',
-              secondary: '#a8a5a3',
-              tertiary: '#7a7876',
-              inverse: '#1d2022',
-            },
-            accent: {
-              orange: {
-                DEFAULT: '#cb4e1b',
-                hover: '#e5591f',
-                active: '#b04517',
-                muted: 'rgba(203, 78, 27, 0.2)',
-              },
-              blue: {
-                DEFAULT: '#098ecf',
-                hover: '#0ba3ea',
-                active: '#0879b3',
-                muted: 'rgba(9, 142, 207, 0.2)',
-              },
-            },
-            success: {
-              DEFAULT: '#10b981',
-              bg: 'rgba(16, 185, 129, 0.1)',
-              border: 'rgba(16, 185, 129, 0.3)',
-            },
-            warning: {
-              DEFAULT: '#f59e0b',
-              bg: 'rgba(245, 158, 11, 0.1)',
-              border: 'rgba(245, 158, 11, 0.3)',
-            },
-            error: {
-              DEFAULT: '#ef4444',
-              bg: 'rgba(239, 68, 68, 0.1)',
-              border: 'rgba(239, 68, 68, 0.3)',
-            },
-            info: {
-              DEFAULT: '#06b6d4',
-              bg: 'rgba(6, 182, 212, 0.1)',
-              border: 'rgba(6, 182, 212, 0.3)',
-            },
-            border: {
-              primary: '#3f4447',
-              secondary: '#2f3336',
-              focus: '#098ecf',
-            },
-          },
-          fontFamily: {
-            sans: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', 'sans-serif'],
-            mono: ['ui-monospace', 'SFMono-Regular', '"SF Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
-          },
-        },
-      },
-    }
-  </script>
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="../../css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
 
   <style>
     /* ========================================
-       FORM COMPONENT STYLES
+       PAGE-SPECIFIC FORM COMPONENT STYLES
        ======================================== */
-
-    /* Focus states */
-    *:focus-visible {
-      outline: 2px solid #098ecf;
-      outline-offset: 2px;
-    }
-
-    /* Screen reader only */
-    .sr-only {
-      position: absolute;
-      width: 1px;
-      height: 1px;
-      padding: 0;
-      margin: -1px;
-      overflow: hidden;
-      clip: rect(0, 0, 0, 0);
-      white-space: nowrap;
-      border: 0;
-    }
 
     /* ----------------------------------------
        Form Group

--- a/docs/prototypes/forms/components/04-checkbox.html
+++ b/docs/prototypes/forms/components/04-checkbox.html
@@ -5,99 +5,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Checkbox - Form Components Library</title>
 
-  <!-- Tailwind CSS CDN -->
-  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Shared Styles -->
+  <link rel="stylesheet" href="../../css/main.css">
 
-  <!-- Tailwind Config (Design System) -->
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            bg: {
-              primary: '#1d2022',
-              secondary: '#262a2d',
-              tertiary: '#2f3336',
-              hover: '#363a3e',
-            },
-            text: {
-              primary: '#d7d3d0',
-              secondary: '#a8a5a3',
-              tertiary: '#7a7876',
-              inverse: '#1d2022',
-            },
-            accent: {
-              orange: {
-                DEFAULT: '#cb4e1b',
-                hover: '#e5591f',
-                active: '#b04517',
-                muted: 'rgba(203, 78, 27, 0.2)',
-              },
-              blue: {
-                DEFAULT: '#098ecf',
-                hover: '#0ba3ea',
-                active: '#0879b3',
-                muted: 'rgba(9, 142, 207, 0.2)',
-              },
-            },
-            success: {
-              DEFAULT: '#10b981',
-              bg: 'rgba(16, 185, 129, 0.1)',
-              border: 'rgba(16, 185, 129, 0.3)',
-            },
-            warning: {
-              DEFAULT: '#f59e0b',
-              bg: 'rgba(245, 158, 11, 0.1)',
-              border: 'rgba(245, 158, 11, 0.3)',
-            },
-            error: {
-              DEFAULT: '#ef4444',
-              bg: 'rgba(239, 68, 68, 0.1)',
-              border: 'rgba(239, 68, 68, 0.3)',
-            },
-            info: {
-              DEFAULT: '#06b6d4',
-              bg: 'rgba(6, 182, 212, 0.1)',
-              border: 'rgba(6, 182, 212, 0.3)',
-            },
-            border: {
-              primary: '#3f4447',
-              secondary: '#2f3336',
-              focus: '#098ecf',
-            },
-          },
-          fontFamily: {
-            sans: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', 'sans-serif'],
-            mono: ['ui-monospace', 'SFMono-Regular', '"SF Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
-          },
-        },
-      },
-    }
-  </script>
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="../../css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
 
   <style>
     /* ========================================
-       FORM COMPONENT STYLES
+       PAGE-SPECIFIC FORM COMPONENT STYLES
        ======================================== */
-
-    /* Focus states */
-    *:focus-visible {
-      outline: 2px solid #098ecf;
-      outline-offset: 2px;
-    }
-
-    /* Screen reader only */
-    .sr-only {
-      position: absolute;
-      width: 1px;
-      height: 1px;
-      padding: 0;
-      margin: -1px;
-      overflow: hidden;
-      clip: rect(0, 0, 0, 0);
-      white-space: nowrap;
-      border: 0;
-    }
 
     /* ----------------------------------------
        Form Group

--- a/docs/prototypes/forms/components/05-radio-button.html
+++ b/docs/prototypes/forms/components/05-radio-button.html
@@ -5,99 +5,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Radio Button - Form Components Library</title>
 
-  <!-- Tailwind CSS CDN -->
-  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Shared Styles -->
+  <link rel="stylesheet" href="../../css/main.css">
 
-  <!-- Tailwind Config (Design System) -->
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            bg: {
-              primary: '#1d2022',
-              secondary: '#262a2d',
-              tertiary: '#2f3336',
-              hover: '#363a3e',
-            },
-            text: {
-              primary: '#d7d3d0',
-              secondary: '#a8a5a3',
-              tertiary: '#7a7876',
-              inverse: '#1d2022',
-            },
-            accent: {
-              orange: {
-                DEFAULT: '#cb4e1b',
-                hover: '#e5591f',
-                active: '#b04517',
-                muted: 'rgba(203, 78, 27, 0.2)',
-              },
-              blue: {
-                DEFAULT: '#098ecf',
-                hover: '#0ba3ea',
-                active: '#0879b3',
-                muted: 'rgba(9, 142, 207, 0.2)',
-              },
-            },
-            success: {
-              DEFAULT: '#10b981',
-              bg: 'rgba(16, 185, 129, 0.1)',
-              border: 'rgba(16, 185, 129, 0.3)',
-            },
-            warning: {
-              DEFAULT: '#f59e0b',
-              bg: 'rgba(245, 158, 11, 0.1)',
-              border: 'rgba(245, 158, 11, 0.3)',
-            },
-            error: {
-              DEFAULT: '#ef4444',
-              bg: 'rgba(239, 68, 68, 0.1)',
-              border: 'rgba(239, 68, 68, 0.3)',
-            },
-            info: {
-              DEFAULT: '#06b6d4',
-              bg: 'rgba(6, 182, 212, 0.1)',
-              border: 'rgba(6, 182, 212, 0.3)',
-            },
-            border: {
-              primary: '#3f4447',
-              secondary: '#2f3336',
-              focus: '#098ecf',
-            },
-          },
-          fontFamily: {
-            sans: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', 'sans-serif'],
-            mono: ['ui-monospace', 'SFMono-Regular', '"SF Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
-          },
-        },
-      },
-    }
-  </script>
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="../../css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
 
   <style>
     /* ========================================
-       FORM COMPONENT STYLES
+       PAGE-SPECIFIC FORM COMPONENT STYLES
        ======================================== */
-
-    /* Focus states */
-    *:focus-visible {
-      outline: 2px solid #098ecf;
-      outline-offset: 2px;
-    }
-
-    /* Screen reader only */
-    .sr-only {
-      position: absolute;
-      width: 1px;
-      height: 1px;
-      padding: 0;
-      margin: -1px;
-      overflow: hidden;
-      clip: rect(0, 0, 0, 0);
-      white-space: nowrap;
-      border: 0;
-    }
 
     /* ----------------------------------------
        Form Group

--- a/docs/prototypes/forms/components/06-toggle-switch.html
+++ b/docs/prototypes/forms/components/06-toggle-switch.html
@@ -5,99 +5,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Toggle Switch - Form Components Library</title>
 
-  <!-- Tailwind CSS CDN -->
-  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Shared Styles -->
+  <link rel="stylesheet" href="../../css/main.css">
 
-  <!-- Tailwind Config (Design System) -->
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            bg: {
-              primary: '#1d2022',
-              secondary: '#262a2d',
-              tertiary: '#2f3336',
-              hover: '#363a3e',
-            },
-            text: {
-              primary: '#d7d3d0',
-              secondary: '#a8a5a3',
-              tertiary: '#7a7876',
-              inverse: '#1d2022',
-            },
-            accent: {
-              orange: {
-                DEFAULT: '#cb4e1b',
-                hover: '#e5591f',
-                active: '#b04517',
-                muted: 'rgba(203, 78, 27, 0.2)',
-              },
-              blue: {
-                DEFAULT: '#098ecf',
-                hover: '#0ba3ea',
-                active: '#0879b3',
-                muted: 'rgba(9, 142, 207, 0.2)',
-              },
-            },
-            success: {
-              DEFAULT: '#10b981',
-              bg: 'rgba(16, 185, 129, 0.1)',
-              border: 'rgba(16, 185, 129, 0.3)',
-            },
-            warning: {
-              DEFAULT: '#f59e0b',
-              bg: 'rgba(245, 158, 11, 0.1)',
-              border: 'rgba(245, 158, 11, 0.3)',
-            },
-            error: {
-              DEFAULT: '#ef4444',
-              bg: 'rgba(239, 68, 68, 0.1)',
-              border: 'rgba(239, 68, 68, 0.3)',
-            },
-            info: {
-              DEFAULT: '#06b6d4',
-              bg: 'rgba(6, 182, 212, 0.1)',
-              border: 'rgba(6, 182, 212, 0.3)',
-            },
-            border: {
-              primary: '#3f4447',
-              secondary: '#2f3336',
-              focus: '#098ecf',
-            },
-          },
-          fontFamily: {
-            sans: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', 'sans-serif'],
-            mono: ['ui-monospace', 'SFMono-Regular', '"SF Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
-          },
-        },
-      },
-    }
-  </script>
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="../../css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
 
   <style>
     /* ========================================
-       FORM COMPONENT STYLES
+       PAGE-SPECIFIC FORM COMPONENT STYLES
        ======================================== */
-
-    /* Focus states */
-    *:focus-visible {
-      outline: 2px solid #098ecf;
-      outline-offset: 2px;
-    }
-
-    /* Screen reader only */
-    .sr-only {
-      position: absolute;
-      width: 1px;
-      height: 1px;
-      padding: 0;
-      margin: -1px;
-      overflow: hidden;
-      clip: rect(0, 0, 0, 0);
-      white-space: nowrap;
-      border: 0;
-    }
 
     /* ----------------------------------------
        Form Group

--- a/docs/prototypes/forms/components/07-form-group.html
+++ b/docs/prototypes/forms/components/07-form-group.html
@@ -5,99 +5,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Form Group - Form Components Library</title>
 
-  <!-- Tailwind CSS CDN -->
-  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Shared Styles -->
+  <link rel="stylesheet" href="../../css/main.css">
 
-  <!-- Tailwind Config (Design System) -->
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            bg: {
-              primary: '#1d2022',
-              secondary: '#262a2d',
-              tertiary: '#2f3336',
-              hover: '#363a3e',
-            },
-            text: {
-              primary: '#d7d3d0',
-              secondary: '#a8a5a3',
-              tertiary: '#7a7876',
-              inverse: '#1d2022',
-            },
-            accent: {
-              orange: {
-                DEFAULT: '#cb4e1b',
-                hover: '#e5591f',
-                active: '#b04517',
-                muted: 'rgba(203, 78, 27, 0.2)',
-              },
-              blue: {
-                DEFAULT: '#098ecf',
-                hover: '#0ba3ea',
-                active: '#0879b3',
-                muted: 'rgba(9, 142, 207, 0.2)',
-              },
-            },
-            success: {
-              DEFAULT: '#10b981',
-              bg: 'rgba(16, 185, 129, 0.1)',
-              border: 'rgba(16, 185, 129, 0.3)',
-            },
-            warning: {
-              DEFAULT: '#f59e0b',
-              bg: 'rgba(245, 158, 11, 0.1)',
-              border: 'rgba(245, 158, 11, 0.3)',
-            },
-            error: {
-              DEFAULT: '#ef4444',
-              bg: 'rgba(239, 68, 68, 0.1)',
-              border: 'rgba(239, 68, 68, 0.3)',
-            },
-            info: {
-              DEFAULT: '#06b6d4',
-              bg: 'rgba(6, 182, 212, 0.1)',
-              border: 'rgba(6, 182, 212, 0.3)',
-            },
-            border: {
-              primary: '#3f4447',
-              secondary: '#2f3336',
-              focus: '#098ecf',
-            },
-          },
-          fontFamily: {
-            sans: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', 'sans-serif'],
-            mono: ['ui-monospace', 'SFMono-Regular', '"SF Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
-          },
-        },
-      },
-    }
-  </script>
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="../../css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
 
   <style>
     /* ========================================
-       FORM COMPONENT STYLES
+       PAGE-SPECIFIC FORM COMPONENT STYLES
        ======================================== */
-
-    /* Focus states */
-    *:focus-visible {
-      outline: 2px solid #098ecf;
-      outline-offset: 2px;
-    }
-
-    /* Screen reader only */
-    .sr-only {
-      position: absolute;
-      width: 1px;
-      height: 1px;
-      padding: 0;
-      margin: -1px;
-      overflow: hidden;
-      clip: rect(0, 0, 0, 0);
-      white-space: nowrap;
-      border: 0;
-    }
 
     /* ----------------------------------------
        Form Group

--- a/docs/prototypes/forms/components/08-date-time.html
+++ b/docs/prototypes/forms/components/08-date-time.html
@@ -5,99 +5,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Date &amp; Time Input - Form Components Library</title>
 
-  <!-- Tailwind CSS CDN -->
-  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Shared Styles -->
+  <link rel="stylesheet" href="../../css/main.css">
 
-  <!-- Tailwind Config (Design System) -->
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            bg: {
-              primary: '#1d2022',
-              secondary: '#262a2d',
-              tertiary: '#2f3336',
-              hover: '#363a3e',
-            },
-            text: {
-              primary: '#d7d3d0',
-              secondary: '#a8a5a3',
-              tertiary: '#7a7876',
-              inverse: '#1d2022',
-            },
-            accent: {
-              orange: {
-                DEFAULT: '#cb4e1b',
-                hover: '#e5591f',
-                active: '#b04517',
-                muted: 'rgba(203, 78, 27, 0.2)',
-              },
-              blue: {
-                DEFAULT: '#098ecf',
-                hover: '#0ba3ea',
-                active: '#0879b3',
-                muted: 'rgba(9, 142, 207, 0.2)',
-              },
-            },
-            success: {
-              DEFAULT: '#10b981',
-              bg: 'rgba(16, 185, 129, 0.1)',
-              border: 'rgba(16, 185, 129, 0.3)',
-            },
-            warning: {
-              DEFAULT: '#f59e0b',
-              bg: 'rgba(245, 158, 11, 0.1)',
-              border: 'rgba(245, 158, 11, 0.3)',
-            },
-            error: {
-              DEFAULT: '#ef4444',
-              bg: 'rgba(239, 68, 68, 0.1)',
-              border: 'rgba(239, 68, 68, 0.3)',
-            },
-            info: {
-              DEFAULT: '#06b6d4',
-              bg: 'rgba(6, 182, 212, 0.1)',
-              border: 'rgba(6, 182, 212, 0.3)',
-            },
-            border: {
-              primary: '#3f4447',
-              secondary: '#2f3336',
-              focus: '#098ecf',
-            },
-          },
-          fontFamily: {
-            sans: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', 'sans-serif'],
-            mono: ['ui-monospace', 'SFMono-Regular', '"SF Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
-          },
-        },
-      },
-    }
-  </script>
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="../../css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
 
   <style>
     /* ========================================
-       FORM COMPONENT STYLES
+       PAGE-SPECIFIC FORM COMPONENT STYLES
        ======================================== */
-
-    /* Focus states */
-    *:focus-visible {
-      outline: 2px solid #098ecf;
-      outline-offset: 2px;
-    }
-
-    /* Screen reader only */
-    .sr-only {
-      position: absolute;
-      width: 1px;
-      height: 1px;
-      padding: 0;
-      margin: -1px;
-      overflow: hidden;
-      clip: rect(0, 0, 0, 0);
-      white-space: nowrap;
-      border: 0;
-    }
 
     /* ----------------------------------------
        Form Group

--- a/docs/prototypes/forms/components/09-number-input.html
+++ b/docs/prototypes/forms/components/09-number-input.html
@@ -5,99 +5,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Number Input - Form Components Library</title>
 
-  <!-- Tailwind CSS CDN -->
-  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Shared Styles -->
+  <link rel="stylesheet" href="../../css/main.css">
 
-  <!-- Tailwind Config (Design System) -->
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            bg: {
-              primary: '#1d2022',
-              secondary: '#262a2d',
-              tertiary: '#2f3336',
-              hover: '#363a3e',
-            },
-            text: {
-              primary: '#d7d3d0',
-              secondary: '#a8a5a3',
-              tertiary: '#7a7876',
-              inverse: '#1d2022',
-            },
-            accent: {
-              orange: {
-                DEFAULT: '#cb4e1b',
-                hover: '#e5591f',
-                active: '#b04517',
-                muted: 'rgba(203, 78, 27, 0.2)',
-              },
-              blue: {
-                DEFAULT: '#098ecf',
-                hover: '#0ba3ea',
-                active: '#0879b3',
-                muted: 'rgba(9, 142, 207, 0.2)',
-              },
-            },
-            success: {
-              DEFAULT: '#10b981',
-              bg: 'rgba(16, 185, 129, 0.1)',
-              border: 'rgba(16, 185, 129, 0.3)',
-            },
-            warning: {
-              DEFAULT: '#f59e0b',
-              bg: 'rgba(245, 158, 11, 0.1)',
-              border: 'rgba(245, 158, 11, 0.3)',
-            },
-            error: {
-              DEFAULT: '#ef4444',
-              bg: 'rgba(239, 68, 68, 0.1)',
-              border: 'rgba(239, 68, 68, 0.3)',
-            },
-            info: {
-              DEFAULT: '#06b6d4',
-              bg: 'rgba(6, 182, 212, 0.1)',
-              border: 'rgba(6, 182, 212, 0.3)',
-            },
-            border: {
-              primary: '#3f4447',
-              secondary: '#2f3336',
-              focus: '#098ecf',
-            },
-          },
-          fontFamily: {
-            sans: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', 'sans-serif'],
-            mono: ['ui-monospace', 'SFMono-Regular', '"SF Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
-          },
-        },
-      },
-    }
-  </script>
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="../../css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
 
   <style>
     /* ========================================
-       FORM COMPONENT STYLES
+       PAGE-SPECIFIC FORM COMPONENT STYLES
        ======================================== */
-
-    /* Focus states */
-    *:focus-visible {
-      outline: 2px solid #098ecf;
-      outline-offset: 2px;
-    }
-
-    /* Screen reader only */
-    .sr-only {
-      position: absolute;
-      width: 1px;
-      height: 1px;
-      padding: 0;
-      margin: -1px;
-      overflow: hidden;
-      clip: rect(0, 0, 0, 0);
-      white-space: nowrap;
-      border: 0;
-    }
 
     /* ----------------------------------------
        Form Group

--- a/docs/prototypes/forms/components/10-file-upload.html
+++ b/docs/prototypes/forms/components/10-file-upload.html
@@ -5,99 +5,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>File Upload - Form Components Library</title>
 
-  <!-- Tailwind CSS CDN -->
-  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Shared Styles -->
+  <link rel="stylesheet" href="../../css/main.css">
 
-  <!-- Tailwind Config (Design System) -->
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            bg: {
-              primary: '#1d2022',
-              secondary: '#262a2d',
-              tertiary: '#2f3336',
-              hover: '#363a3e',
-            },
-            text: {
-              primary: '#d7d3d0',
-              secondary: '#a8a5a3',
-              tertiary: '#7a7876',
-              inverse: '#1d2022',
-            },
-            accent: {
-              orange: {
-                DEFAULT: '#cb4e1b',
-                hover: '#e5591f',
-                active: '#b04517',
-                muted: 'rgba(203, 78, 27, 0.2)',
-              },
-              blue: {
-                DEFAULT: '#098ecf',
-                hover: '#0ba3ea',
-                active: '#0879b3',
-                muted: 'rgba(9, 142, 207, 0.2)',
-              },
-            },
-            success: {
-              DEFAULT: '#10b981',
-              bg: 'rgba(16, 185, 129, 0.1)',
-              border: 'rgba(16, 185, 129, 0.3)',
-            },
-            warning: {
-              DEFAULT: '#f59e0b',
-              bg: 'rgba(245, 158, 11, 0.1)',
-              border: 'rgba(245, 158, 11, 0.3)',
-            },
-            error: {
-              DEFAULT: '#ef4444',
-              bg: 'rgba(239, 68, 68, 0.1)',
-              border: 'rgba(239, 68, 68, 0.3)',
-            },
-            info: {
-              DEFAULT: '#06b6d4',
-              bg: 'rgba(6, 182, 212, 0.1)',
-              border: 'rgba(6, 182, 212, 0.3)',
-            },
-            border: {
-              primary: '#3f4447',
-              secondary: '#2f3336',
-              focus: '#098ecf',
-            },
-          },
-          fontFamily: {
-            sans: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', 'sans-serif'],
-            mono: ['ui-monospace', 'SFMono-Regular', '"SF Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
-          },
-        },
-      },
-    }
-  </script>
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="../../css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
 
   <style>
     /* ========================================
-       FORM COMPONENT STYLES
+       PAGE-SPECIFIC FORM COMPONENT STYLES
        ======================================== */
-
-    /* Focus states */
-    *:focus-visible {
-      outline: 2px solid #098ecf;
-      outline-offset: 2px;
-    }
-
-    /* Screen reader only */
-    .sr-only {
-      position: absolute;
-      width: 1px;
-      height: 1px;
-      padding: 0;
-      margin: -1px;
-      overflow: hidden;
-      clip: rect(0, 0, 0, 0);
-      white-space: nowrap;
-      border: 0;
-    }
 
     /* ----------------------------------------
        Form Group

--- a/docs/prototypes/forms/index.html
+++ b/docs/prototypes/forms/index.html
@@ -5,86 +5,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Form Components Library - Discord Bot Admin</title>
 
-  <!-- Tailwind CSS CDN -->
-  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Shared Styles -->
+  <link rel="stylesheet" href="../css/main.css">
 
-  <!-- Tailwind Config (Design System) -->
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            bg: {
-              primary: '#1d2022',
-              secondary: '#262a2d',
-              tertiary: '#2f3336',
-              hover: '#363a3e',
-            },
-            text: {
-              primary: '#d7d3d0',
-              secondary: '#a8a5a3',
-              tertiary: '#7a7876',
-              inverse: '#1d2022',
-            },
-            accent: {
-              orange: {
-                DEFAULT: '#cb4e1b',
-                hover: '#e5591f',
-                active: '#b04517',
-                muted: 'rgba(203, 78, 27, 0.2)',
-              },
-              blue: {
-                DEFAULT: '#098ecf',
-                hover: '#0ba3ea',
-                active: '#0879b3',
-                muted: 'rgba(9, 142, 207, 0.2)',
-              },
-            },
-            success: {
-              DEFAULT: '#10b981',
-              bg: 'rgba(16, 185, 129, 0.1)',
-              border: 'rgba(16, 185, 129, 0.3)',
-            },
-            warning: {
-              DEFAULT: '#f59e0b',
-              bg: 'rgba(245, 158, 11, 0.1)',
-              border: 'rgba(245, 158, 11, 0.3)',
-            },
-            error: {
-              DEFAULT: '#ef4444',
-              bg: 'rgba(239, 68, 68, 0.1)',
-              border: 'rgba(239, 68, 68, 0.3)',
-            },
-            info: {
-              DEFAULT: '#06b6d4',
-              bg: 'rgba(6, 182, 212, 0.1)',
-              border: 'rgba(6, 182, 212, 0.3)',
-            },
-            border: {
-              primary: '#3f4447',
-              secondary: '#2f3336',
-              focus: '#098ecf',
-            },
-          },
-          fontFamily: {
-            sans: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', 'sans-serif'],
-            mono: ['ui-monospace', 'SFMono-Regular', '"SF Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
-          },
-        },
-      },
-    }
-  </script>
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="../css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
 
   <style>
     /* ========================================
        INDEX PAGE STYLES
        ======================================== */
-
-    /* Focus states */
-    *:focus-visible {
-      outline: 2px solid #098ecf;
-      outline-offset: 2px;
-    }
 
     /* Component Card */
     .component-card {


### PR DESCRIPTION
## Summary
- Creates `docs/prototypes/css/` directory with modular CSS architecture
- Extracts ~2,500 lines of duplicate inline styles from 27 prototype files into shared components
- Adds design tokens (`tokens.css`), base styles, utilities, and 8 component CSS files
- Refactors all prototype HTML files to import shared styles via relative paths
- Fixes `feedback-alerts.html` to use design system colors (was using inconsistent dark-900/dark-800)

## Architecture
```
docs/prototypes/css/
├── main.css              # Import manifest
├── tokens.css            # Design tokens as CSS custom properties
├── tailwind.config.js    # Shared Tailwind CDN configuration
├── base.css              # Reset, scrollbar, focus states
├── utilities.css         # Utility classes and animations
└── components/           # Component-specific styles
    ├── buttons.css
    ├── forms.css
    ├── cards.css
    ├── tables.css
    ├── alerts.css
    ├── navigation.css
    ├── modals.css
    └── loading.css
```

## Test plan
- [ ] Open `docs/prototypes/dashboard.html` in browser and verify styling renders correctly
- [ ] Open a nested prototype like `docs/prototypes/forms/components/01-text-input.html` and verify CSS loads
- [ ] Check `docs/prototypes/feedback-alerts.html` uses correct design system colors
- [ ] Verify hover/focus states work on buttons and form inputs

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)