### PR TITLE
Epic: Interactivity & Advanced Features (Phase 5)

### DIFF
--- a/docs/interactive-components.md
+++ b/docs/interactive-components.md
@@ -1,0 +1,758 @@
+# Interactive Components
+
+This document provides comprehensive documentation for Discord component interactions in the bot, including buttons and future support for select menus. Interactive components enable rich user experiences with confirmation dialogs, pagination, and multi-step workflows.
+
+## Overview
+
+The bot currently supports the following Discord component types:
+
+| Component Type | Status | Use Cases |
+|----------------|--------|-----------|
+| Buttons | ✓ Implemented | Confirmations, pagination, action triggers |
+| Select Menus | Planned | Category selection, option filtering, multi-choice workflows |
+| Modals | Future | Text input forms, configuration wizards |
+
+All interactive components use a standardized ID convention and state management system to maintain context across user interactions.
+
+---
+
+## Component ID Convention
+
+Discord component custom IDs follow a structured format to ensure proper routing, security, and state management.
+
+### Format Specification
+
+```
+{handler}:{action}:{userId}:{correlationId}:{data}
+```
+
+**Segment Breakdown:**
+
+| Segment | Required | Description | Example |
+|---------|----------|-------------|---------|
+| `handler` | Yes | The component handler module (routes to specific handler method) | `shutdown`, `guilds`, `help` |
+| `action` | Yes | The action to perform within the handler | `confirm`, `cancel`, `page`, `next`, `prev` |
+| `userId` | Yes | The Discord user ID who can interact with this component (security) | `123456789012345678` |
+| `correlationId` | Yes | An 8-character identifier for state lookup | `a7b3c9d1` |
+| `data` | No | Optional additional data for the action | `next`, `prev`, `5` (page number) |
+
+### Example Component IDs
+
+```
+shutdown:confirm:123456789012345678:a7b3c9d1:
+shutdown:cancel:123456789012345678:a7b3c9d1:
+guilds:page:123456789012345678:b4f8e2a6:next
+guilds:page:123456789012345678:b4f8e2a6:prev
+help:select:123456789012345678:c3d7f1b9:admin
+```
+
+### Purpose of Each Segment
+
+#### Handler
+The handler segment routes the component interaction to the appropriate module class. Discord.NET matches this against `[ComponentInteraction]` attribute patterns.
+
+**Usage:**
+- Must be unique across all component handlers
+- Use lowercase, no spaces
+- Represents the feature or command group
+
+#### Action
+The action segment specifies what operation to perform within the handler. This allows a single handler to manage multiple related actions.
+
+**Usage:**
+- Describes the specific operation (e.g., `confirm`, `cancel`, `page`)
+- Multiple actions can share the same handler
+- Use descriptive, action-oriented names
+
+#### User ID
+The user ID segment provides built-in security by restricting component interactions to the original command invoker.
+
+**Security Implications:**
+- Prevents unauthorized users from clicking someone else's buttons
+- Validated in every component handler before processing
+- Reduces risk of accidental or malicious interaction hijacking
+
+**Validation Example:**
+```csharp
+if (parts.UserId != Context.User.Id)
+{
+    await RespondAsync("You cannot interact with this component.", ephemeral: true);
+    return;
+}
+```
+
+#### Correlation ID
+The correlation ID is an 8-character unique identifier used to retrieve interaction state from the state service.
+
+**Format:** First 8 characters of a GUID (lowercase, no hyphens)
+
+**Generation:**
+```csharp
+Guid.NewGuid().ToString("N")[..8]  // Example: "a7b3c9d1"
+```
+
+**Purpose:**
+- Links component clicks to stored state data
+- Enables complex multi-step workflows
+- Prevents state pollution with short, unique IDs
+- Automatically expires with state expiration
+
+**Security Note:** Correlation IDs are not cryptographically secure tokens. They rely on state expiration and user ID validation for security.
+
+#### Data (Optional)
+The data segment carries additional context-specific information for the action.
+
+**Common Use Cases:**
+- Pagination direction: `next`, `prev`
+- Page numbers: `1`, `2`, `3`
+- Selection values: `admin`, `general`, `moderation`
+- Entity IDs: `5`, `guild123`
+
+**Handling Empty Data:**
+```csharp
+// ComponentIdBuilder automatically handles null/empty data
+var id = ComponentIdBuilder.Build("handler", "action", userId, correlationId);
+// Result: "handler:action:123456789012345678:a7b3c9d1:"
+
+// With data
+var id = ComponentIdBuilder.Build("handler", "action", userId, correlationId, "next");
+// Result: "handler:action:123456789012345678:a7b3c9d1:next"
+```
+
+---
+
+## State Management
+
+Interactive workflows require maintaining state across multiple interactions. The bot uses an in-memory state service to store temporary data associated with component interactions.
+
+### Architecture
+
+The state management system consists of three core components:
+
+| Component | Type | Responsibility |
+|-----------|------|----------------|
+| `IInteractionStateService` | Interface | State service contract |
+| `InteractionStateService` | Service | In-memory state storage and retrieval |
+| `InteractionStateCleanupService` | Hosted Service | Background cleanup of expired states |
+
+### Storage Mechanism
+
+**Technology:** `ConcurrentDictionary<string, object>` for thread-safe in-memory storage
+
+**Key Structure:**
+- Key: 8-character correlation ID
+- Value: `InteractionState<T>` wrapper containing state data
+
+**Example State Wrapper:**
+```csharp
+public class InteractionState<T>
+{
+    public string CorrelationId { get; set; }
+    public ulong UserId { get; set; }
+    public T Data { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime ExpiresAt { get; set; }
+    public bool IsExpired => DateTime.UtcNow >= ExpiresAt;
+}
+```
+
+### State Expiration
+
+**Default Expiration:** 15 minutes from creation
+
+**Expiration Behavior:**
+- State is checked for expiration on every retrieval attempt
+- Expired state is automatically removed when accessed
+- Background cleanup service runs every 1 minute to remove orphaned expired states
+
+**Custom Expiration:**
+```csharp
+// Use default 15-minute expiration
+var correlationId = _stateService.CreateState(userId, state);
+
+// Use custom 5-minute expiration
+var correlationId = _stateService.CreateState(userId, state, TimeSpan.FromMinutes(5));
+```
+
+### Background Cleanup
+
+The `InteractionStateCleanupService` is a background hosted service that periodically removes expired state entries.
+
+**Cleanup Interval:** Every 1 minute
+
+**Process:**
+1. Iterate through all state entries
+2. Check `ExpiresAt` property via reflection
+3. Remove expired entries
+4. Log cleanup results at TRACE level
+
+**Why Background Cleanup?**
+- Prevents memory leaks from expired but unaccessed states
+- Handles edge cases where users never interact after component expiration
+- Maintains predictable memory usage
+
+### State Persistence
+
+**Important:** State is stored in-memory only and is **not persisted** to disk or database.
+
+**Implications:**
+- State is lost on bot restart
+- State is not shared across multiple bot instances
+- Acceptable trade-off for temporary interaction workflows
+
+**Mitigations:**
+- Commands can be re-run to generate new state
+- Critical operations (like shutdown) require re-confirmation after restart
+- Long-term data is stored in the database via repositories
+
+---
+
+## Adding New Interactive Commands
+
+This section provides a step-by-step guide for developers implementing new interactive workflows.
+
+### Step 1: Create State DTO
+
+Define a class to represent the state data for your interactive workflow.
+
+**Location:** `src/DiscordBot.Bot/Models/`
+
+**Example:**
+```csharp
+namespace DiscordBot.Bot.Models;
+
+/// <summary>
+/// State data for shutdown confirmation interactions.
+/// </summary>
+public class ShutdownState
+{
+    /// <summary>
+    /// The timestamp when the shutdown was requested.
+    /// </summary>
+    public DateTime RequestedAt { get; set; }
+}
+```
+
+**Best Practices:**
+- Keep state classes simple and focused
+- Include only data needed for the interaction workflow
+- Use descriptive property names with XML documentation
+- Avoid storing large objects or collections when possible
+
+### Step 2: Create State in Command Handler
+
+When responding to a slash command, create the state and store it in the state service.
+
+**Example:**
+```csharp
+[SlashCommand("shutdown", "Gracefully shut down the bot")]
+[RequireOwner]
+public async Task ShutdownAsync()
+{
+    // Create state
+    var state = new ShutdownState
+    {
+        RequestedAt = DateTime.UtcNow
+    };
+
+    // Store state and get correlation ID
+    var correlationId = _stateService.CreateState(Context.User.Id, state);
+
+    // Build component IDs
+    var confirmId = ComponentIdBuilder.Build("shutdown", "confirm", Context.User.Id, correlationId);
+    var cancelId = ComponentIdBuilder.Build("shutdown", "cancel", Context.User.Id, correlationId);
+
+    // Build buttons
+    var components = new ComponentBuilder()
+        .WithButton("Confirm Shutdown", confirmId, ButtonStyle.Danger)
+        .WithButton("Cancel", cancelId, ButtonStyle.Secondary)
+        .Build();
+
+    // Send response with buttons
+    await RespondAsync(
+        embed: embedBuilder.Build(),
+        components: components,
+        ephemeral: true);
+}
+```
+
+### Step 3: Create Component Handler
+
+Create a handler method to process component interactions.
+
+**Location:** `src/DiscordBot.Bot/Commands/AdminComponentModule.cs` (or create new module)
+
+**Example:**
+```csharp
+/// <summary>
+/// Handles the shutdown confirmation button interaction.
+/// </summary>
+[ComponentInteraction("shutdown:confirm:*:*:")]
+[RequireOwner]
+public async Task HandleShutdownConfirmAsync()
+{
+    var customId = ((SocketMessageComponent)Context.Interaction).Data.CustomId;
+
+    // Parse component ID
+    if (!ComponentIdBuilder.TryParse(customId, out var parts))
+    {
+        await RespondAsync("This interaction is invalid or has expired.", ephemeral: true);
+        _logger.LogWarning("Invalid component ID format: {CustomId}", customId);
+        return;
+    }
+
+    // Validate user
+    if (parts.UserId != Context.User.Id)
+    {
+        await RespondAsync("You cannot interact with this component.", ephemeral: true);
+        _logger.LogWarning(
+            "User {ActualUserId} attempted to interact with component for user {ExpectedUserId}",
+            Context.User.Id,
+            parts.UserId);
+        return;
+    }
+
+    // Retrieve state
+    if (!_stateService.TryGetState<ShutdownState>(parts.CorrelationId, out var state) || state == null)
+    {
+        await RespondAsync("This interaction has expired. Please run the command again.", ephemeral: true);
+        _logger.LogDebug("Expired or missing state for correlation ID {CorrelationId}", parts.CorrelationId);
+        return;
+    }
+
+    // Remove state (cleanup)
+    _stateService.TryRemoveState(parts.CorrelationId);
+
+    // Perform action
+    var originalMessage = (SocketMessageComponent)Context.Interaction;
+    await originalMessage.UpdateAsync(msg =>
+    {
+        msg.Content = "Shutdown confirmed. The bot is shutting down...";
+        msg.Components = new ComponentBuilder().Build();  // Remove buttons
+    });
+
+    _logger.LogInformation("Shutdown confirmed by user {UserId}", Context.User.Id);
+
+    // Execute business logic
+    _applicationLifetime.StopApplication();
+}
+```
+
+### Step 4: Handle Component Patterns
+
+The `[ComponentInteraction]` attribute uses pattern matching with wildcards (`*`).
+
+**Pattern Examples:**
+
+| Pattern | Matches |
+|---------|---------|
+| `"shutdown:confirm:*:*:"` | Any user, any correlation ID, no data |
+| `"guilds:page:*:*:*"` | Any user, any correlation ID, any data |
+| `"help:select:123:*:*"` | Specific user, any correlation ID, any data |
+
+**Best Practice:** Use wildcards for user ID, correlation ID, and data segments to allow flexible matching.
+
+### Step 5: Update Message (Optional)
+
+Component handlers can update the original message to reflect the interaction result.
+
+**Update Message Content:**
+```csharp
+var originalMessage = (SocketMessageComponent)Context.Interaction;
+await originalMessage.UpdateAsync(msg =>
+{
+    msg.Content = "Operation completed successfully!";
+    msg.Components = new ComponentBuilder().Build();  // Remove buttons
+});
+```
+
+**Update Embed:**
+```csharp
+await originalMessage.UpdateAsync(msg =>
+{
+    msg.Embed = newEmbedBuilder.Build();
+    msg.Components = newComponentBuilder.Build();
+});
+```
+
+---
+
+## Pagination Pattern
+
+Pagination is a common interactive workflow for displaying large datasets across multiple pages.
+
+### Implementation Example
+
+**Command Handler:**
+```csharp
+[SlashCommand("guilds", "List all guilds the bot is connected to")]
+public async Task GuildsAsync()
+{
+    var guilds = _client.Guilds
+        .OrderByDescending(g => g.MemberCount)
+        .Select(g => new GuildDto { /* ... */ })
+        .ToList();
+
+    // Set up pagination
+    const int pageSize = 5;
+    var totalPages = (int)Math.Ceiling(guilds.Count / (double)pageSize);
+    var currentPage = 0;
+
+    var state = new GuildsPaginationState
+    {
+        Guilds = guilds,
+        CurrentPage = currentPage,
+        PageSize = pageSize,
+        TotalPages = totalPages
+    };
+
+    var correlationId = _stateService.CreateState(Context.User.Id, state);
+
+    // Build first page
+    var pageGuilds = guilds.Take(pageSize).ToList();
+    var embed = new EmbedBuilder()
+        .WithTitle($"Connected Guilds (Page 1/{totalPages})")
+        .WithDescription(string.Join("\n", pageGuilds.Select(g => $"**{g.Name}** (ID: {g.Id})")))
+        .WithColor(Color.Blue)
+        .WithFooter($"Total: {guilds.Count} guilds")
+        .Build();
+
+    // Build pagination buttons
+    var components = new ComponentBuilder();
+    if (totalPages > 1)
+    {
+        var nextId = ComponentIdBuilder.Build("guilds", "page", Context.User.Id, correlationId, "next");
+        components.WithButton("Next", nextId, ButtonStyle.Primary);
+    }
+
+    await RespondAsync(embed: embed, components: components.Build(), ephemeral: true);
+}
+```
+
+**Pagination Handler:**
+```csharp
+[ComponentInteraction("guilds:page:*:*:*")]
+public async Task HandleGuildsPageAsync()
+{
+    var customId = ((SocketMessageComponent)Context.Interaction).Data.CustomId;
+
+    if (!ComponentIdBuilder.TryParse(customId, out var parts))
+    {
+        await RespondAsync("This interaction is invalid or has expired.", ephemeral: true);
+        return;
+    }
+
+    // Validate user
+    if (parts.UserId != Context.User.Id)
+    {
+        await RespondAsync("You cannot interact with this component.", ephemeral: true);
+        return;
+    }
+
+    // Retrieve state
+    if (!_stateService.TryGetState<GuildsPaginationState>(parts.CorrelationId, out var state) || state == null)
+    {
+        await RespondAsync("This interaction has expired. Please run the command again.", ephemeral: true);
+        return;
+    }
+
+    // Update page based on direction
+    var direction = parts.Data;
+    if (direction == "next" && state.CurrentPage < state.TotalPages - 1)
+    {
+        state.CurrentPage++;
+    }
+    else if (direction == "prev" && state.CurrentPage > 0)
+    {
+        state.CurrentPage--;
+    }
+
+    // Create new state with updated page
+    _stateService.TryRemoveState(parts.CorrelationId);
+    var newCorrelationId = _stateService.CreateState(Context.User.Id, state);
+
+    // Build page content
+    var pageGuilds = state.Guilds
+        .Skip(state.CurrentPage * state.PageSize)
+        .Take(state.PageSize)
+        .ToList();
+
+    var embed = new EmbedBuilder()
+        .WithTitle($"Connected Guilds (Page {state.CurrentPage + 1}/{state.TotalPages})")
+        .WithDescription(string.Join("\n", pageGuilds.Select(g => $"**{g.Name}** (ID: {g.Id})")))
+        .WithColor(Color.Blue)
+        .WithFooter($"Total: {state.Guilds.Count} guilds")
+        .Build();
+
+    // Build pagination buttons
+    var components = new ComponentBuilder();
+
+    if (state.CurrentPage > 0)
+    {
+        var prevId = ComponentIdBuilder.Build("guilds", "page", Context.User.Id, newCorrelationId, "prev");
+        components.WithButton("Previous", prevId, ButtonStyle.Primary);
+    }
+
+    if (state.CurrentPage < state.TotalPages - 1)
+    {
+        var nextId = ComponentIdBuilder.Build("guilds", "page", Context.User.Id, newCorrelationId, "next");
+        components.WithButton("Next", nextId, ButtonStyle.Primary);
+    }
+
+    // Update message
+    var originalMessage = (SocketMessageComponent)Context.Interaction;
+    await originalMessage.UpdateAsync(msg =>
+    {
+        msg.Embed = embed;
+        msg.Components = components.Build();
+    });
+}
+```
+
+### Pagination State DTO
+
+```csharp
+namespace DiscordBot.Bot.Models;
+
+public class GuildsPaginationState
+{
+    public required List<GuildDto> Guilds { get; set; }
+    public int CurrentPage { get; set; }
+    public int PageSize { get; set; }
+    public int TotalPages { get; set; }
+}
+```
+
+---
+
+## Timeout Behavior
+
+Component interactions have a built-in timeout mechanism to prevent stale interactions and memory leaks.
+
+### Default Timeout
+
+**Duration:** 15 minutes from state creation
+
+**What Happens on Timeout:**
+1. State expires in the state service
+2. Component interaction attempts return "This interaction has expired" error
+3. Background cleanup service removes the state entry within 1 minute
+4. Discord buttons become unresponsive (no visual change)
+
+### User Experience
+
+When a user clicks an expired button:
+
+```
+This interaction has expired. Please run the command again.
+```
+
+**Ephemeral Response:** The error message is only visible to the user who clicked the button.
+
+### Preventing Timeout Issues
+
+**Best Practices:**
+1. **Set Appropriate Expiration Times:**
+   - Short workflows: 5 minutes
+   - Standard workflows: 15 minutes (default)
+   - Long workflows: 30 minutes (max recommended)
+
+2. **Provide Clear Instructions:**
+   - Inform users of timeout duration in embed footer
+   - Suggest re-running command if timeout occurs
+
+3. **Handle Gracefully:**
+   - Always check for state existence before processing
+   - Provide helpful error messages with re-run instructions
+
+**Example Footer:**
+```csharp
+var embed = new EmbedBuilder()
+    .WithFooter("This interaction will expire in 15 minutes. Run the command again if it expires.")
+    .Build();
+```
+
+### Discord Component Timeout
+
+**Discord Limit:** Discord.NET components remain interactive for up to 15 minutes by default.
+
+**Alignment:** Our state expiration matches Discord's component timeout to ensure consistent behavior.
+
+---
+
+## Security Considerations
+
+Interactive components introduce security challenges that must be addressed to prevent unauthorized access and malicious behavior.
+
+### User Validation
+
+**Mechanism:** Every component ID includes the user ID of the command invoker.
+
+**Enforcement:**
+```csharp
+// Validate user
+if (parts.UserId != Context.User.Id)
+{
+    await RespondAsync("You cannot interact with this component.", ephemeral: true);
+    _logger.LogWarning(
+        "User {ActualUserId} attempted to interact with component for user {ExpectedUserId}",
+        Context.User.Id,
+        parts.UserId);
+    return;
+}
+```
+
+**Why This Matters:**
+- Prevents users from clicking buttons meant for someone else
+- Reduces risk of accidental or malicious hijacking
+- Ensures only the command invoker can complete the workflow
+
+**Logging:** All unauthorized interaction attempts are logged at WARNING level for security monitoring.
+
+### Permission Re-validation
+
+For sensitive operations, permissions are re-validated when the component is clicked, not just when the command is invoked.
+
+**Example: Shutdown Confirmation**
+```csharp
+[ComponentInteraction("shutdown:confirm:*:*:")]
+[RequireOwner]  // Re-validates owner status
+public async Task HandleShutdownConfirmAsync()
+{
+    // Handler logic
+}
+```
+
+**Why Re-validate?**
+- Permissions may change between command invocation and button click
+- User roles may be revoked
+- Prevents delayed attacks after permission loss
+
+**Best Practice:** Always apply the same precondition attributes to both the slash command and component handlers.
+
+### State Data Integrity
+
+**Threat Model:**
+- Correlation IDs are not cryptographically secure
+- Attackers could theoretically guess correlation IDs (8 characters = 4.3 billion combinations)
+- State data could be accessed or modified by malicious code
+
+**Mitigations:**
+1. **User ID Binding:** State is always associated with a specific user ID
+2. **Short Expiration:** 15-minute default limits window for brute-force attacks
+3. **Validation at Retrieval:** State type is validated on retrieval
+4. **Logging:** State access is logged for audit trails
+
+**Future Enhancements:**
+- Increase correlation ID length for higher entropy
+- Add HMAC signature validation
+- Implement rate limiting on component interactions
+
+### Sensitive Data in State
+
+**Warning:** Avoid storing sensitive data (passwords, tokens, PII) in interaction state.
+
+**Rationale:**
+- State is in-memory and could be logged or dumped
+- State is not encrypted at rest
+- Correlation IDs could be guessed
+
+**Best Practice:** Store only the minimum data needed for the workflow. Reference entities by ID and retrieve from database when needed.
+
+**Example:**
+```csharp
+// BAD: Storing sensitive data
+public class BadState
+{
+    public string UserPassword { get; set; }
+    public string ApiToken { get; set; }
+}
+
+// GOOD: Storing only IDs
+public class GoodState
+{
+    public ulong UserId { get; set; }
+    public DateTime RequestedAt { get; set; }
+}
+```
+
+---
+
+## Testing Interactive Components
+
+### Unit Testing State DTOs
+
+**Example:**
+```csharp
+[Fact]
+public void ShutdownState_ShouldStoreRequestedAt()
+{
+    var state = new ShutdownState
+    {
+        RequestedAt = DateTime.UtcNow
+    };
+
+    Assert.NotEqual(default, state.RequestedAt);
+}
+```
+
+### Integration Testing Component Handlers
+
+**Example:**
+```csharp
+[Fact]
+public async Task HandleShutdownConfirmAsync_WithValidState_ShouldStopApplication()
+{
+    // Arrange
+    var stateService = new InteractionStateService(logger);
+    var state = new ShutdownState { RequestedAt = DateTime.UtcNow };
+    var correlationId = stateService.CreateState(userId, state);
+
+    // Act
+    // Simulate button click with valid correlation ID
+
+    // Assert
+    // Verify application lifetime StopApplication was called
+}
+```
+
+### Testing ComponentIdBuilder
+
+**Example:**
+```csharp
+[Fact]
+public void ComponentIdBuilder_Build_ShouldGenerateValidId()
+{
+    var id = ComponentIdBuilder.Build("shutdown", "confirm", 123456789, "a7b3c9d1");
+
+    Assert.Equal("shutdown:confirm:123456789:a7b3c9d1:", id);
+}
+
+[Fact]
+public void ComponentIdBuilder_Parse_ShouldExtractParts()
+{
+    var id = "guilds:page:123456789:b4f8e2a6:next";
+
+    var parts = ComponentIdBuilder.Parse(id);
+
+    Assert.Equal("guilds", parts.Handler);
+    Assert.Equal("page", parts.Action);
+    Assert.Equal(123456789ul, parts.UserId);
+    Assert.Equal("b4f8e2a6", parts.CorrelationId);
+    Assert.Equal("next", parts.Data);
+}
+```
+
+---
+
+## Related Documentation
+
+- [Admin Commands](admin-commands.md) - Slash command reference including interactive `/shutdown` and `/guilds`
+- [MVP Plan](mvp-plan.md) - Phase 5 implementation details and acceptance criteria
+- [Permissions System](permissions.md) - Precondition attributes used in component handlers
+
+---
+
+*Document Version: 1.0*
+*Last Updated: December 2025*
+*Status: Phase 5 Implementation Complete*

--- a/docs/mvp-plan.md
+++ b/docs/mvp-plan.md
@@ -403,10 +403,16 @@ CommandLog
 - Interactive workflows complete
 
 **Acceptance Criteria:**
-- [ ] Shutdown requires confirmation button
-- [ ] Guild list paginates with buttons
-- [ ] Components timeout after 15 minutes
-- [ ] Unknown component clicks handled gracefully
+- [x] Shutdown requires confirmation button
+- [x] Guild list paginates with buttons
+- [x] Components timeout after 15 minutes
+- [x] Unknown component clicks handled gracefully
+
+**Status:** ✓ COMPLETED
+
+**Documentation:**
+- [Interactive Components](interactive-components.md) - Component interactions, state management, and developer guide
+- [Admin Commands](admin-commands.md) - Updated with interactive `/shutdown` and `/guilds` workflows
 
 ---
 

--- a/src/DiscordBot.Bot/Commands/AdminComponentModule.cs
+++ b/src/DiscordBot.Bot/Commands/AdminComponentModule.cs
@@ -1,0 +1,224 @@
+using Discord;
+using Discord.Interactions;
+using Discord.WebSocket;
+using DiscordBot.Bot.Components;
+using DiscordBot.Bot.Models;
+using DiscordBot.Bot.Preconditions;
+using DiscordBot.Core.Interfaces;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace DiscordBot.Bot.Commands;
+
+/// <summary>
+/// Module for handling component interactions (button clicks) for admin commands.
+/// </summary>
+public class AdminComponentModule : InteractionModuleBase<SocketInteractionContext>
+{
+    private readonly IInteractionStateService _stateService;
+    private readonly IHostApplicationLifetime _applicationLifetime;
+    private readonly ILogger<AdminComponentModule> _logger;
+
+    public AdminComponentModule(
+        IInteractionStateService stateService,
+        IHostApplicationLifetime applicationLifetime,
+        ILogger<AdminComponentModule> logger)
+    {
+        _stateService = stateService;
+        _applicationLifetime = applicationLifetime;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Handles the shutdown confirmation button interaction.
+    /// </summary>
+    [ComponentInteraction("shutdown:confirm:*:*:")]
+    [Preconditions.RequireOwner]
+    public async Task HandleShutdownConfirmAsync()
+    {
+        var customId = ((SocketMessageComponent)Context.Interaction).Data.CustomId;
+
+        if (!ComponentIdBuilder.TryParse(customId, out var parts))
+        {
+            await RespondAsync("This interaction is invalid or has expired.", ephemeral: true);
+            _logger.LogWarning("Invalid component ID format: {CustomId}", customId);
+            return;
+        }
+
+        // Validate user
+        if (parts.UserId != Context.User.Id)
+        {
+            await RespondAsync("You cannot interact with this component.", ephemeral: true);
+            _logger.LogWarning(
+                "User {ActualUserId} attempted to interact with component for user {ExpectedUserId}",
+                Context.User.Id,
+                parts.UserId);
+            return;
+        }
+
+        // Retrieve state
+        if (!_stateService.TryGetState<ShutdownState>(parts.CorrelationId, out var state) || state == null)
+        {
+            await RespondAsync("This interaction has expired. Please run the command again.", ephemeral: true);
+            _logger.LogDebug("Expired or missing state for correlation ID {CorrelationId}", parts.CorrelationId);
+            return;
+        }
+
+        // Remove state
+        _stateService.TryRemoveState(parts.CorrelationId);
+
+        // Update the original message to remove buttons
+        var originalMessage = (SocketMessageComponent)Context.Interaction;
+        await originalMessage.UpdateAsync(msg =>
+        {
+            msg.Content = "Shutdown confirmed. The bot is shutting down...";
+            msg.Components = new ComponentBuilder().Build();
+        });
+
+        _logger.LogInformation(
+            "Shutdown confirmed by user {UserId} ({Username}), initiating shutdown",
+            Context.User.Id,
+            Context.User.Username);
+
+        // Initiate shutdown
+        _applicationLifetime.StopApplication();
+    }
+
+    /// <summary>
+    /// Handles the shutdown cancel button interaction.
+    /// </summary>
+    [ComponentInteraction("shutdown:cancel:*:*:")]
+    public async Task HandleShutdownCancelAsync()
+    {
+        var customId = ((SocketMessageComponent)Context.Interaction).Data.CustomId;
+
+        if (!ComponentIdBuilder.TryParse(customId, out var parts))
+        {
+            await RespondAsync("This interaction is invalid or has expired.", ephemeral: true);
+            _logger.LogWarning("Invalid component ID format: {CustomId}", customId);
+            return;
+        }
+
+        // Validate user
+        if (parts.UserId != Context.User.Id)
+        {
+            await RespondAsync("You cannot interact with this component.", ephemeral: true);
+            _logger.LogWarning(
+                "User {ActualUserId} attempted to interact with component for user {ExpectedUserId}",
+                Context.User.Id,
+                parts.UserId);
+            return;
+        }
+
+        // Retrieve state (optional, just to clean up)
+        if (_stateService.TryGetState<ShutdownState>(parts.CorrelationId, out _))
+        {
+            _stateService.TryRemoveState(parts.CorrelationId);
+        }
+
+        // Update the original message to remove buttons
+        var originalMessage = (SocketMessageComponent)Context.Interaction;
+        await originalMessage.UpdateAsync(msg =>
+        {
+            msg.Content = "Shutdown cancelled.";
+            msg.Components = new ComponentBuilder().Build();
+        });
+
+        _logger.LogInformation(
+            "Shutdown cancelled by user {UserId} ({Username})",
+            Context.User.Id,
+            Context.User.Username);
+    }
+
+    /// <summary>
+    /// Handles the guilds pagination button interaction.
+    /// </summary>
+    [ComponentInteraction("guilds:page:*:*:*")]
+    public async Task HandleGuildsPageAsync()
+    {
+        var customId = ((SocketMessageComponent)Context.Interaction).Data.CustomId;
+
+        if (!ComponentIdBuilder.TryParse(customId, out var parts))
+        {
+            await RespondAsync("This interaction is invalid or has expired.", ephemeral: true);
+            _logger.LogWarning("Invalid component ID format: {CustomId}", customId);
+            return;
+        }
+
+        // Validate user
+        if (parts.UserId != Context.User.Id)
+        {
+            await RespondAsync("You cannot interact with this component.", ephemeral: true);
+            _logger.LogWarning(
+                "User {ActualUserId} attempted to interact with component for user {ExpectedUserId}",
+                Context.User.Id,
+                parts.UserId);
+            return;
+        }
+
+        // Retrieve state
+        if (!_stateService.TryGetState<GuildsPaginationState>(parts.CorrelationId, out var state) || state == null)
+        {
+            await RespondAsync("This interaction has expired. Please run the command again.", ephemeral: true);
+            _logger.LogDebug("Expired or missing state for correlation ID {CorrelationId}", parts.CorrelationId);
+            return;
+        }
+
+        // Parse page direction from data
+        var direction = parts.Data;
+        if (direction == "next" && state.CurrentPage < state.TotalPages - 1)
+        {
+            state.CurrentPage++;
+        }
+        else if (direction == "prev" && state.CurrentPage > 0)
+        {
+            state.CurrentPage--;
+        }
+
+        // Update state in service
+        _stateService.TryRemoveState(parts.CorrelationId);
+        var newCorrelationId = _stateService.CreateState(Context.User.Id, state);
+
+        // Build the page content
+        var pageGuilds = state.Guilds
+            .Skip(state.CurrentPage * state.PageSize)
+            .Take(state.PageSize)
+            .ToList();
+
+        var embed = new EmbedBuilder()
+            .WithTitle($"Connected Guilds (Page {state.CurrentPage + 1}/{state.TotalPages})")
+            .WithDescription(string.Join("\n", pageGuilds.Select(g => $"**{g.Name}** (ID: {g.Id})")))
+            .WithColor(Color.Blue)
+            .WithFooter($"Total: {state.Guilds.Count} guilds")
+            .Build();
+
+        // Build buttons
+        var components = new ComponentBuilder();
+
+        if (state.CurrentPage > 0)
+        {
+            var prevId = ComponentIdBuilder.Build("guilds", "page", Context.User.Id, newCorrelationId, "prev");
+            components.WithButton("Previous", prevId, ButtonStyle.Primary);
+        }
+
+        if (state.CurrentPage < state.TotalPages - 1)
+        {
+            var nextId = ComponentIdBuilder.Build("guilds", "page", Context.User.Id, newCorrelationId, "next");
+            components.WithButton("Next", nextId, ButtonStyle.Primary);
+        }
+
+        // Update the original message
+        var originalMessage = (SocketMessageComponent)Context.Interaction;
+        await originalMessage.UpdateAsync(msg =>
+        {
+            msg.Embed = embed;
+            msg.Components = components.Build();
+        });
+
+        _logger.LogDebug(
+            "Updated guilds pagination for user {UserId}, page {Page} of {TotalPages}",
+            Context.User.Id,
+            state.CurrentPage + 1,
+            state.TotalPages);
+    }
+}

--- a/src/DiscordBot.Bot/Components/ComponentIdBuilder.cs
+++ b/src/DiscordBot.Bot/Components/ComponentIdBuilder.cs
@@ -1,0 +1,122 @@
+namespace DiscordBot.Bot.Components;
+
+/// <summary>
+/// Utility class for building and parsing Discord component custom IDs.
+/// Format: {handler}:{action}:{userId}:{correlationId}:{data}
+/// </summary>
+public static class ComponentIdBuilder
+{
+    private const char Separator = ':';
+    private const int MinParts = 4; // handler, action, userId, correlationId (data is optional)
+
+    /// <summary>
+    /// Builds a component custom ID from the provided parts.
+    /// </summary>
+    /// <param name="handler">The handler name (e.g., "shutdown", "guilds")</param>
+    /// <param name="action">The action name (e.g., "confirm", "cancel", "page")</param>
+    /// <param name="userId">The user ID who can interact with this component</param>
+    /// <param name="correlationId">The correlation ID for state lookup</param>
+    /// <param name="data">Optional additional data</param>
+    /// <returns>A formatted component custom ID string</returns>
+    public static string Build(string handler, string action, ulong userId, string correlationId, string? data = null)
+    {
+        if (string.IsNullOrWhiteSpace(handler))
+            throw new ArgumentException("Handler cannot be null or whitespace.", nameof(handler));
+        if (string.IsNullOrWhiteSpace(action))
+            throw new ArgumentException("Action cannot be null or whitespace.", nameof(action));
+        if (string.IsNullOrWhiteSpace(correlationId))
+            throw new ArgumentException("Correlation ID cannot be null or whitespace.", nameof(correlationId));
+
+        var parts = new List<string> { handler, action, userId.ToString(), correlationId };
+
+        if (!string.IsNullOrEmpty(data))
+        {
+            parts.Add(data);
+        }
+        else
+        {
+            parts.Add(string.Empty);
+        }
+
+        return string.Join(Separator, parts);
+    }
+
+    /// <summary>
+    /// Parses a component custom ID into its constituent parts.
+    /// </summary>
+    /// <param name="customId">The component custom ID to parse</param>
+    /// <returns>The parsed component ID parts</returns>
+    /// <exception cref="FormatException">Thrown when the custom ID format is invalid</exception>
+    public static ComponentIdParts Parse(string customId)
+    {
+        if (!TryParse(customId, out var parts))
+        {
+            throw new FormatException($"Invalid component custom ID format: {customId}");
+        }
+
+        return parts;
+    }
+
+    /// <summary>
+    /// Attempts to parse a component custom ID into its constituent parts.
+    /// </summary>
+    /// <param name="customId">The component custom ID to parse</param>
+    /// <param name="parts">The parsed component ID parts, or default if parsing fails</param>
+    /// <returns>True if parsing succeeded, false otherwise</returns>
+    public static bool TryParse(string customId, out ComponentIdParts parts)
+    {
+        parts = default!;
+
+        if (string.IsNullOrWhiteSpace(customId))
+            return false;
+
+        var segments = customId.Split(Separator);
+        if (segments.Length < MinParts)
+            return false;
+
+        if (!ulong.TryParse(segments[2], out var userId))
+            return false;
+
+        parts = new ComponentIdParts
+        {
+            Handler = segments[0],
+            Action = segments[1],
+            UserId = userId,
+            CorrelationId = segments[3],
+            Data = segments.Length > 4 && !string.IsNullOrEmpty(segments[4]) ? segments[4] : null
+        };
+
+        return true;
+    }
+}
+
+/// <summary>
+/// Represents the parsed parts of a component custom ID.
+/// </summary>
+public record ComponentIdParts
+{
+    /// <summary>
+    /// The handler name (e.g., "shutdown", "guilds")
+    /// </summary>
+    public required string Handler { get; init; }
+
+    /// <summary>
+    /// The action name (e.g., "confirm", "cancel", "page")
+    /// </summary>
+    public required string Action { get; init; }
+
+    /// <summary>
+    /// The user ID who can interact with this component
+    /// </summary>
+    public required ulong UserId { get; init; }
+
+    /// <summary>
+    /// The correlation ID for state lookup
+    /// </summary>
+    public required string CorrelationId { get; init; }
+
+    /// <summary>
+    /// Optional additional data
+    /// </summary>
+    public string? Data { get; init; }
+}

--- a/src/DiscordBot.Bot/Extensions/DiscordServiceExtensions.cs
+++ b/src/DiscordBot.Bot/Extensions/DiscordServiceExtensions.cs
@@ -3,6 +3,7 @@ using Discord.Interactions;
 using Discord.WebSocket;
 using DiscordBot.Bot.Handlers;
 using DiscordBot.Bot.Services;
+using DiscordBot.Core.Interfaces;
 
 namespace DiscordBot.Bot.Extensions;
 
@@ -56,8 +57,14 @@ public static class DiscordServiceExtensions
         // Register CommandExecutionLogger as singleton
         services.AddSingleton<ICommandExecutionLogger, CommandExecutionLogger>();
 
+        // Register InteractionStateService as singleton
+        services.AddSingleton<IInteractionStateService, InteractionStateService>();
+
         // Register BotHostedService as hosted service
         services.AddHostedService<BotHostedService>();
+
+        // Register InteractionStateCleanupService as hosted service
+        services.AddHostedService<InteractionStateCleanupService>();
 
         return services;
     }

--- a/src/DiscordBot.Bot/Models/GuildsPaginationState.cs
+++ b/src/DiscordBot.Bot/Models/GuildsPaginationState.cs
@@ -1,0 +1,29 @@
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Bot.Models;
+
+/// <summary>
+/// State data for guilds pagination interactions.
+/// </summary>
+public class GuildsPaginationState
+{
+    /// <summary>
+    /// The list of all guilds to paginate through.
+    /// </summary>
+    public required List<GuildDto> Guilds { get; set; }
+
+    /// <summary>
+    /// The current page number (0-based).
+    /// </summary>
+    public int CurrentPage { get; set; }
+
+    /// <summary>
+    /// The number of items per page.
+    /// </summary>
+    public int PageSize { get; set; }
+
+    /// <summary>
+    /// The total number of pages.
+    /// </summary>
+    public int TotalPages { get; set; }
+}

--- a/src/DiscordBot.Bot/Models/ShutdownState.cs
+++ b/src/DiscordBot.Bot/Models/ShutdownState.cs
@@ -1,0 +1,12 @@
+namespace DiscordBot.Bot.Models;
+
+/// <summary>
+/// State data for shutdown confirmation interactions.
+/// </summary>
+public class ShutdownState
+{
+    /// <summary>
+    /// The timestamp when the shutdown was requested.
+    /// </summary>
+    public DateTime RequestedAt { get; set; }
+}

--- a/src/DiscordBot.Bot/Services/InteractionState.cs
+++ b/src/DiscordBot.Bot/Services/InteractionState.cs
@@ -1,0 +1,38 @@
+namespace DiscordBot.Bot.Services;
+
+/// <summary>
+/// Represents a stored state entry for a Discord component interaction.
+/// </summary>
+/// <typeparam name="T">The type of state data stored</typeparam>
+public class InteractionState<T>
+{
+    /// <summary>
+    /// The unique correlation ID for this state entry.
+    /// </summary>
+    public required string CorrelationId { get; init; }
+
+    /// <summary>
+    /// The user ID associated with this state.
+    /// </summary>
+    public required ulong UserId { get; init; }
+
+    /// <summary>
+    /// The state data.
+    /// </summary>
+    public required T Data { get; init; }
+
+    /// <summary>
+    /// The timestamp when this state was created.
+    /// </summary>
+    public DateTime CreatedAt { get; init; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// The timestamp when this state expires.
+    /// </summary>
+    public DateTime ExpiresAt { get; init; }
+
+    /// <summary>
+    /// Gets whether this state entry has expired.
+    /// </summary>
+    public bool IsExpired => DateTime.UtcNow >= ExpiresAt;
+}

--- a/src/DiscordBot.Bot/Services/InteractionStateCleanupService.cs
+++ b/src/DiscordBot.Bot/Services/InteractionStateCleanupService.cs
@@ -1,0 +1,58 @@
+using DiscordBot.Core.Interfaces;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace DiscordBot.Bot.Services;
+
+/// <summary>
+/// Background service that periodically cleans up expired interaction states.
+/// Runs every 1 minute to remove expired state entries.
+/// </summary>
+public class InteractionStateCleanupService : BackgroundService
+{
+    private readonly IInteractionStateService _stateService;
+    private readonly ILogger<InteractionStateCleanupService> _logger;
+    private static readonly TimeSpan CleanupInterval = TimeSpan.FromMinutes(1);
+
+    public InteractionStateCleanupService(
+        IInteractionStateService stateService,
+        ILogger<InteractionStateCleanupService> logger)
+    {
+        _stateService = stateService;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation(
+            "Interaction state cleanup service started, cleanup interval: {Interval}",
+            CleanupInterval);
+
+        using var timer = new PeriodicTimer(CleanupInterval);
+
+        try
+        {
+            while (await timer.WaitForNextTickAsync(stoppingToken))
+            {
+                try
+                {
+                    var removedCount = _stateService.CleanupExpired();
+                    var activeCount = _stateService.ActiveStateCount;
+
+                    _logger.LogTrace(
+                        "Cleanup completed: removed {RemovedCount} expired states, {ActiveCount} active states remaining",
+                        removedCount,
+                        activeCount);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error occurred during interaction state cleanup");
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation("Interaction state cleanup service is stopping");
+        }
+    }
+}

--- a/src/DiscordBot.Bot/Services/InteractionStateService.cs
+++ b/src/DiscordBot.Bot/Services/InteractionStateService.cs
@@ -1,0 +1,168 @@
+using System.Collections.Concurrent;
+using DiscordBot.Core.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace DiscordBot.Bot.Services;
+
+/// <summary>
+/// Service for managing temporary state data for Discord component interactions.
+/// Uses an in-memory concurrent dictionary with automatic expiration.
+/// </summary>
+public class InteractionStateService : IInteractionStateService
+{
+    private readonly ConcurrentDictionary<string, object> _states = new();
+    private readonly ILogger<InteractionStateService> _logger;
+    private static readonly TimeSpan DefaultExpiry = TimeSpan.FromMinutes(15);
+
+    public InteractionStateService(ILogger<InteractionStateService> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public string CreateState<T>(ulong userId, T data, TimeSpan? expiry = null)
+    {
+        var correlationId = GenerateCorrelationId();
+        var expiryDuration = expiry ?? DefaultExpiry;
+
+        var state = new InteractionState<T>
+        {
+            CorrelationId = correlationId,
+            UserId = userId,
+            Data = data,
+            CreatedAt = DateTime.UtcNow,
+            ExpiresAt = DateTime.UtcNow.Add(expiryDuration)
+        };
+
+        if (_states.TryAdd(correlationId, state))
+        {
+            _logger.LogDebug(
+                "Created interaction state {CorrelationId} for user {UserId}, expires at {ExpiresAt}",
+                correlationId,
+                userId,
+                state.ExpiresAt);
+            return correlationId;
+        }
+
+        _logger.LogWarning(
+            "Failed to create interaction state {CorrelationId} for user {UserId} - correlation ID collision",
+            correlationId,
+            userId);
+        throw new InvalidOperationException($"Failed to create state with correlation ID {correlationId}");
+    }
+
+    /// <inheritdoc />
+    public bool TryGetState<T>(string correlationId, out T? state)
+    {
+        state = default;
+
+        if (string.IsNullOrWhiteSpace(correlationId))
+        {
+            _logger.LogTrace("TryGetState called with null/empty correlation ID");
+            return false;
+        }
+
+        if (!_states.TryGetValue(correlationId, out var obj))
+        {
+            _logger.LogTrace("State not found for correlation ID {CorrelationId}", correlationId);
+            return false;
+        }
+
+        if (obj is not InteractionState<T> interactionState)
+        {
+            _logger.LogWarning(
+                "State type mismatch for correlation ID {CorrelationId}: expected {ExpectedType}, got {ActualType}",
+                correlationId,
+                typeof(T).Name,
+                obj.GetType().Name);
+            return false;
+        }
+
+        if (interactionState.IsExpired)
+        {
+            _logger.LogDebug(
+                "State expired for correlation ID {CorrelationId} (expired at {ExpiresAt})",
+                correlationId,
+                interactionState.ExpiresAt);
+            _states.TryRemove(correlationId, out _);
+            return false;
+        }
+
+        state = interactionState.Data;
+        _logger.LogTrace("Retrieved state for correlation ID {CorrelationId}", correlationId);
+        return true;
+    }
+
+    /// <inheritdoc />
+    public bool TryRemoveState(string correlationId)
+    {
+        if (string.IsNullOrWhiteSpace(correlationId))
+        {
+            _logger.LogTrace("TryRemoveState called with null/empty correlation ID");
+            return false;
+        }
+
+        if (_states.TryRemove(correlationId, out _))
+        {
+            _logger.LogDebug("Removed state for correlation ID {CorrelationId}", correlationId);
+            return true;
+        }
+
+        _logger.LogTrace("State not found for removal, correlation ID {CorrelationId}", correlationId);
+        return false;
+    }
+
+    /// <inheritdoc />
+    public int CleanupExpired()
+    {
+        var expiredKeys = new List<string>();
+        var now = DateTime.UtcNow;
+
+        foreach (var kvp in _states)
+        {
+            // Check if the value has an ExpiresAt property using reflection or dynamic typing
+            var stateType = kvp.Value.GetType();
+            var expiresAtProperty = stateType.GetProperty("ExpiresAt");
+
+            if (expiresAtProperty != null)
+            {
+                var expiresAt = (DateTime?)expiresAtProperty.GetValue(kvp.Value);
+                if (expiresAt.HasValue && now >= expiresAt.Value)
+                {
+                    expiredKeys.Add(kvp.Key);
+                }
+            }
+        }
+
+        var removedCount = 0;
+        foreach (var key in expiredKeys)
+        {
+            if (_states.TryRemove(key, out _))
+            {
+                removedCount++;
+            }
+        }
+
+        if (removedCount > 0)
+        {
+            _logger.LogDebug("Cleaned up {Count} expired interaction states", removedCount);
+        }
+        else
+        {
+            _logger.LogTrace("No expired interaction states to clean up");
+        }
+
+        return removedCount;
+    }
+
+    /// <inheritdoc />
+    public int ActiveStateCount => _states.Count;
+
+    /// <summary>
+    /// Generates an 8-character correlation ID.
+    /// </summary>
+    private static string GenerateCorrelationId()
+    {
+        return Guid.NewGuid().ToString("N")[..8];
+    }
+}

--- a/src/DiscordBot.Core/Interfaces/IInteractionStateService.cs
+++ b/src/DiscordBot.Core/Interfaces/IInteractionStateService.cs
@@ -1,0 +1,44 @@
+namespace DiscordBot.Core.Interfaces;
+
+/// <summary>
+/// Service for managing temporary state data for Discord component interactions.
+/// </summary>
+public interface IInteractionStateService
+{
+    /// <summary>
+    /// Creates a new state entry and returns a correlation ID.
+    /// </summary>
+    /// <typeparam name="T">The type of state data</typeparam>
+    /// <param name="userId">The user ID associated with this state</param>
+    /// <param name="data">The state data to store</param>
+    /// <param name="expiry">Optional custom expiry duration (defaults to 15 minutes)</param>
+    /// <returns>An 8-character correlation ID for state lookup</returns>
+    string CreateState<T>(ulong userId, T data, TimeSpan? expiry = null);
+
+    /// <summary>
+    /// Attempts to retrieve state data by correlation ID.
+    /// </summary>
+    /// <typeparam name="T">The expected type of state data</typeparam>
+    /// <param name="correlationId">The correlation ID to lookup</param>
+    /// <param name="state">The retrieved state data, or default if not found</param>
+    /// <returns>True if state was found and is valid, false otherwise</returns>
+    bool TryGetState<T>(string correlationId, out T? state);
+
+    /// <summary>
+    /// Attempts to remove state data by correlation ID.
+    /// </summary>
+    /// <param name="correlationId">The correlation ID to remove</param>
+    /// <returns>True if state was found and removed, false otherwise</returns>
+    bool TryRemoveState(string correlationId);
+
+    /// <summary>
+    /// Removes all expired state entries.
+    /// </summary>
+    /// <returns>The number of expired entries removed</returns>
+    int CleanupExpired();
+
+    /// <summary>
+    /// Gets the number of active (non-expired) state entries.
+    /// </summary>
+    int ActiveStateCount { get; }
+}

--- a/tests/DiscordBot.Tests/Components/ComponentIdBuilderTests.cs
+++ b/tests/DiscordBot.Tests/Components/ComponentIdBuilderTests.cs
@@ -1,0 +1,294 @@
+using DiscordBot.Bot.Components;
+using FluentAssertions;
+
+namespace DiscordBot.Tests.Components;
+
+/// <summary>
+/// Unit tests for <see cref="ComponentIdBuilder"/>.
+/// </summary>
+public class ComponentIdBuilderTests
+{
+    [Fact]
+    public void Build_WithAllParameters_ReturnsCorrectFormat()
+    {
+        // Arrange
+        const string handler = "shutdown";
+        const string action = "confirm";
+        const ulong userId = 123456789UL;
+        const string correlationId = "abc123de";
+        const string data = "extraData";
+
+        // Act
+        var result = ComponentIdBuilder.Build(handler, action, userId, correlationId, data);
+
+        // Assert
+        result.Should().Be("shutdown:confirm:123456789:abc123de:extraData",
+            "the component ID should be formatted with all parts separated by colons");
+    }
+
+    [Fact]
+    public void Build_WithoutData_OmitsDataSegment()
+    {
+        // Arrange
+        const string handler = "guilds";
+        const string action = "page";
+        const ulong userId = 987654321UL;
+        const string correlationId = "xyz789ab";
+
+        // Act
+        var result = ComponentIdBuilder.Build(handler, action, userId, correlationId);
+
+        // Assert
+        result.Should().Be("guilds:page:987654321:xyz789ab:",
+            "the component ID should have an empty data segment when data is not provided");
+    }
+
+    [Fact]
+    public void Build_WithEmptyData_HasEmptyDataSegment()
+    {
+        // Arrange
+        const string handler = "test";
+        const string action = "action";
+        const ulong userId = 111222333UL;
+        const string correlationId = "corr1234";
+        const string data = "";
+
+        // Act
+        var result = ComponentIdBuilder.Build(handler, action, userId, correlationId, data);
+
+        // Assert
+        result.Should().Be("test:action:111222333:corr1234:",
+            "the component ID should have an empty data segment when data is empty string");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Build_WithInvalidHandler_ThrowsArgumentException(string? invalidHandler)
+    {
+        // Arrange
+        const string action = "action";
+        const ulong userId = 123456789UL;
+        const string correlationId = "abc123de";
+
+        // Act & Assert
+        FluentActions.Invoking(() => ComponentIdBuilder.Build(invalidHandler!, action, userId, correlationId))
+            .Should().Throw<ArgumentException>()
+            .WithMessage("*Handler cannot be null or whitespace*",
+                "handler is a required parameter");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Build_WithInvalidAction_ThrowsArgumentException(string? invalidAction)
+    {
+        // Arrange
+        const string handler = "handler";
+        const ulong userId = 123456789UL;
+        const string correlationId = "abc123de";
+
+        // Act & Assert
+        FluentActions.Invoking(() => ComponentIdBuilder.Build(handler, invalidAction!, userId, correlationId))
+            .Should().Throw<ArgumentException>()
+            .WithMessage("*Action cannot be null or whitespace*",
+                "action is a required parameter");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Build_WithInvalidCorrelationId_ThrowsArgumentException(string? invalidCorrelationId)
+    {
+        // Arrange
+        const string handler = "handler";
+        const string action = "action";
+        const ulong userId = 123456789UL;
+
+        // Act & Assert
+        FluentActions.Invoking(() => ComponentIdBuilder.Build(handler, action, userId, invalidCorrelationId!))
+            .Should().Throw<ArgumentException>()
+            .WithMessage("*Correlation ID cannot be null or whitespace*",
+                "correlation ID is a required parameter");
+    }
+
+    [Fact]
+    public void Parse_ValidId_ReturnsAllParts()
+    {
+        // Arrange
+        const string customId = "shutdown:confirm:123456789:abc123de:extraData";
+
+        // Act
+        var result = ComponentIdBuilder.Parse(customId);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Handler.Should().Be("shutdown");
+        result.Action.Should().Be("confirm");
+        result.UserId.Should().Be(123456789UL);
+        result.CorrelationId.Should().Be("abc123de");
+        result.Data.Should().Be("extraData");
+    }
+
+    [Fact]
+    public void Parse_ValidIdWithoutData_ReturnsEmptyData()
+    {
+        // Arrange
+        const string customId = "guilds:page:987654321:xyz789ab:";
+
+        // Act
+        var result = ComponentIdBuilder.Parse(customId);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Handler.Should().Be("guilds");
+        result.Action.Should().Be("page");
+        result.UserId.Should().Be(987654321UL);
+        result.CorrelationId.Should().Be("xyz789ab");
+        result.Data.Should().BeNull("empty data segment should result in null data");
+    }
+
+    [Fact]
+    public void Parse_ValidIdWithMinimumParts_ReturnsNullData()
+    {
+        // Arrange
+        const string customId = "handler:action:111222333:corr1234";
+
+        // Act
+        var result = ComponentIdBuilder.Parse(customId);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Handler.Should().Be("handler");
+        result.Action.Should().Be("action");
+        result.UserId.Should().Be(111222333UL);
+        result.CorrelationId.Should().Be("corr1234");
+        result.Data.Should().BeNull("missing data segment should result in null data");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("only:three:parts")]
+    [InlineData("invalid:user:id:corr")]
+    [InlineData("handler:action:notanumber:corr")]
+    public void Parse_InvalidFormat_ThrowsFormatException(string invalidCustomId)
+    {
+        // Act & Assert
+        FluentActions.Invoking(() => ComponentIdBuilder.Parse(invalidCustomId))
+            .Should().Throw<FormatException>()
+            .WithMessage("*Invalid component custom ID format*",
+                "malformed custom IDs should throw a format exception");
+    }
+
+    [Fact]
+    public void TryParse_ValidId_ReturnsTrueAndParts()
+    {
+        // Arrange
+        const string customId = "shutdown:confirm:123456789:abc123de:extraData";
+
+        // Act
+        var success = ComponentIdBuilder.TryParse(customId, out var result);
+
+        // Assert
+        success.Should().BeTrue("parsing should succeed for valid custom ID");
+        result.Should().NotBeNull();
+        result.Handler.Should().Be("shutdown");
+        result.Action.Should().Be("confirm");
+        result.UserId.Should().Be(123456789UL);
+        result.CorrelationId.Should().Be("abc123de");
+        result.Data.Should().Be("extraData");
+    }
+
+    [Fact]
+    public void TryParse_ValidIdWithoutData_ReturnsTrueAndNullData()
+    {
+        // Arrange
+        const string customId = "guilds:page:987654321:xyz789ab";
+
+        // Act
+        var success = ComponentIdBuilder.TryParse(customId, out var result);
+
+        // Assert
+        success.Should().BeTrue("parsing should succeed for valid custom ID without data");
+        result.Should().NotBeNull();
+        result.Data.Should().BeNull("missing data segment should result in null data");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("only:three:parts")]
+    [InlineData("invalid:user:id:corr")]
+    [InlineData("handler:action:notanumber:corr")]
+    [InlineData("handler:action:99999999999999999999:corr")] // ulong overflow
+    public void TryParse_InvalidFormat_ReturnsFalseAndNull(string? invalidCustomId)
+    {
+        // Act
+        var success = ComponentIdBuilder.TryParse(invalidCustomId!, out var result);
+
+        // Assert
+        success.Should().BeFalse("parsing should fail for invalid custom ID");
+    }
+
+    [Fact]
+    public void Parse_AndBuild_RoundTrip_ProducesOriginalId()
+    {
+        // Arrange
+        const string handler = "shutdown";
+        const string action = "confirm";
+        const ulong userId = 123456789UL;
+        const string correlationId = "abc123de";
+        const string data = "extraData";
+
+        // Act
+        var builtId = ComponentIdBuilder.Build(handler, action, userId, correlationId, data);
+        var parsed = ComponentIdBuilder.Parse(builtId);
+        var rebuiltId = ComponentIdBuilder.Build(
+            parsed.Handler,
+            parsed.Action,
+            parsed.UserId,
+            parsed.CorrelationId,
+            parsed.Data);
+
+        // Assert
+        rebuiltId.Should().Be(builtId,
+            "building and parsing should be reversible operations");
+    }
+
+    [Fact]
+    public void Build_WithColonInData_CreatesIdWithMultipleParts()
+    {
+        // Arrange
+        const string handler = "test";
+        const string action = "action";
+        const ulong userId = 123456789UL;
+        const string correlationId = "abc123de";
+        const string data = "value:with:colons";
+
+        // Act
+        var result = ComponentIdBuilder.Build(handler, action, userId, correlationId, data);
+
+        // Assert
+        result.Should().Be("test:action:123456789:abc123de:value:with:colons",
+            "colons in data should be preserved in the component ID");
+    }
+
+    [Fact]
+    public void Parse_WithColonInData_ExtractsOnlyFirstDataSegment()
+    {
+        // Arrange
+        const string customId = "test:action:123456789:abc123de:value:with:colons";
+
+        // Act
+        var result = ComponentIdBuilder.Parse(customId);
+
+        // Assert
+        result.Data.Should().Be("value",
+            "only the first data segment is extracted when data contains colons");
+    }
+}

--- a/tests/DiscordBot.Tests/Services/InteractionStateServiceTests.cs
+++ b/tests/DiscordBot.Tests/Services/InteractionStateServiceTests.cs
@@ -1,0 +1,511 @@
+using DiscordBot.Bot.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace DiscordBot.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="InteractionStateService"/>.
+/// </summary>
+public class InteractionStateServiceTests
+{
+    private readonly Mock<ILogger<InteractionStateService>> _mockLogger;
+    private readonly InteractionStateService _service;
+
+    public InteractionStateServiceTests()
+    {
+        _mockLogger = new Mock<ILogger<InteractionStateService>>();
+        _service = new InteractionStateService(_mockLogger.Object);
+    }
+
+    [Fact]
+    public void CreateState_ReturnsUniqueCorrelationId()
+    {
+        // Arrange
+        const ulong userId = 123456789UL;
+        var data = new TestStateData { Message = "Test data" };
+
+        // Act
+        var correlationId1 = _service.CreateState(userId, data);
+        var correlationId2 = _service.CreateState(userId, data);
+        var correlationId3 = _service.CreateState(userId, data);
+
+        // Assert
+        correlationId1.Should().NotBe(correlationId2,
+            "each CreateState call should generate a unique correlation ID");
+        correlationId2.Should().NotBe(correlationId3,
+            "each CreateState call should generate a unique correlation ID");
+        correlationId1.Should().NotBe(correlationId3,
+            "each CreateState call should generate a unique correlation ID");
+    }
+
+    [Fact]
+    public void CreateState_GeneratesEightCharacterId()
+    {
+        // Arrange
+        const ulong userId = 123456789UL;
+        var data = new TestStateData { Message = "Test data" };
+
+        // Act
+        var correlationId = _service.CreateState(userId, data);
+
+        // Assert
+        correlationId.Should().HaveLength(8,
+            "the correlation ID should be exactly 8 characters long");
+        correlationId.Should().MatchRegex("^[a-f0-9]{8}$",
+            "the correlation ID should contain only hexadecimal characters");
+    }
+
+    [Fact]
+    public void CreateState_WithDefaultExpiry_CreatesStateWithFifteenMinuteExpiry()
+    {
+        // Arrange
+        const ulong userId = 123456789UL;
+        var data = new TestStateData { Message = "Test data" };
+        var beforeCreate = DateTime.UtcNow;
+
+        // Act
+        var correlationId = _service.CreateState(userId, data);
+
+        // Assert
+        var afterCreate = DateTime.UtcNow;
+        _service.TryGetState<TestStateData>(correlationId, out var retrievedData)
+            .Should().BeTrue("the state should be immediately retrievable after creation");
+        retrievedData.Should().BeEquivalentTo(data,
+            "the retrieved data should match the original data");
+
+        // Verify state was created (indirectly by checking active count increased)
+        _service.ActiveStateCount.Should().BeGreaterThan(0,
+            "active state count should include the newly created state");
+    }
+
+    [Fact]
+    public void CreateState_WithCustomExpiry_CreatesStateWithSpecifiedExpiry()
+    {
+        // Arrange
+        const ulong userId = 123456789UL;
+        var data = new TestStateData { Message = "Test data" };
+        var customExpiry = TimeSpan.FromMinutes(5);
+
+        // Act
+        var correlationId = _service.CreateState(userId, data, customExpiry);
+
+        // Assert
+        _service.TryGetState<TestStateData>(correlationId, out var retrievedData)
+            .Should().BeTrue("the state should be retrievable with custom expiry");
+        retrievedData.Should().BeEquivalentTo(data);
+    }
+
+    [Fact]
+    public void TryGetState_ExistingState_ReturnsTrueAndState()
+    {
+        // Arrange
+        const ulong userId = 123456789UL;
+        var data = new TestStateData { Message = "Test message", Value = 42 };
+        var correlationId = _service.CreateState(userId, data);
+
+        // Act
+        var success = _service.TryGetState<TestStateData>(correlationId, out var retrievedData);
+
+        // Assert
+        success.Should().BeTrue("the state should be successfully retrieved");
+        retrievedData.Should().NotBeNull();
+        retrievedData.Should().BeEquivalentTo(data,
+            "the retrieved data should match the original data");
+    }
+
+    [Fact]
+    public void TryGetState_NonExistentState_ReturnsFalse()
+    {
+        // Arrange
+        const string nonExistentCorrelationId = "abcd1234";
+
+        // Act
+        var success = _service.TryGetState<TestStateData>(nonExistentCorrelationId, out var retrievedData);
+
+        // Assert
+        success.Should().BeFalse("the state should not be found");
+        retrievedData.Should().BeNull("no data should be returned for non-existent state");
+    }
+
+    [Fact]
+    public void TryGetState_ExpiredState_ReturnsFalse()
+    {
+        // Arrange
+        const ulong userId = 123456789UL;
+        var data = new TestStateData { Message = "Test data" };
+        // Create state with very short expiry
+        var correlationId = _service.CreateState(userId, data, TimeSpan.FromMilliseconds(1));
+
+        // Wait for expiration
+        Thread.Sleep(50);
+
+        // Act
+        var success = _service.TryGetState<TestStateData>(correlationId, out var retrievedData);
+
+        // Assert
+        success.Should().BeFalse("expired state should not be retrievable");
+        retrievedData.Should().BeNull("no data should be returned for expired state");
+    }
+
+    [Fact]
+    public void TryGetState_ExpiredState_RemovesFromDictionary()
+    {
+        // Arrange
+        const ulong userId = 123456789UL;
+        var data = new TestStateData { Message = "Test data" };
+        var correlationId = _service.CreateState(userId, data, TimeSpan.FromMilliseconds(1));
+        var initialCount = _service.ActiveStateCount;
+
+        // Wait for expiration
+        Thread.Sleep(50);
+
+        // Act
+        _service.TryGetState<TestStateData>(correlationId, out _);
+
+        // Assert
+        _service.ActiveStateCount.Should().BeLessThan(initialCount,
+            "expired state should be removed from the dictionary when accessed");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void TryGetState_WithNullOrEmptyCorrelationId_ReturnsFalse(string? correlationId)
+    {
+        // Act
+        var success = _service.TryGetState<TestStateData>(correlationId!, out var retrievedData);
+
+        // Assert
+        success.Should().BeFalse("null or empty correlation ID should return false");
+        retrievedData.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryGetState_WithWrongType_ReturnsFalse()
+    {
+        // Arrange
+        const ulong userId = 123456789UL;
+        var data = new TestStateData { Message = "Test data" };
+        var correlationId = _service.CreateState(userId, data);
+
+        // Act - try to retrieve with wrong type
+        var success = _service.TryGetState<AlternateStateData>(correlationId, out var retrievedData);
+
+        // Assert
+        success.Should().BeFalse("type mismatch should return false");
+        retrievedData.Should().BeNull("no data should be returned for type mismatch");
+    }
+
+    [Fact]
+    public void TryRemoveState_ExistingState_ReturnsTrue()
+    {
+        // Arrange
+        const ulong userId = 123456789UL;
+        var data = new TestStateData { Message = "Test data" };
+        var correlationId = _service.CreateState(userId, data);
+
+        // Act
+        var success = _service.TryRemoveState(correlationId);
+
+        // Assert
+        success.Should().BeTrue("removing existing state should succeed");
+        _service.TryGetState<TestStateData>(correlationId, out _)
+            .Should().BeFalse("state should no longer be retrievable after removal");
+    }
+
+    [Fact]
+    public void TryRemoveState_NonExistentState_ReturnsFalse()
+    {
+        // Arrange
+        const string nonExistentCorrelationId = "abcd1234";
+
+        // Act
+        var success = _service.TryRemoveState(nonExistentCorrelationId);
+
+        // Assert
+        success.Should().BeFalse("removing non-existent state should return false");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void TryRemoveState_WithNullOrEmptyCorrelationId_ReturnsFalse(string? correlationId)
+    {
+        // Act
+        var success = _service.TryRemoveState(correlationId!);
+
+        // Assert
+        success.Should().BeFalse("null or empty correlation ID should return false");
+    }
+
+    [Fact]
+    public void CleanupExpired_RemovesOnlyExpiredStates()
+    {
+        // Arrange
+        const ulong userId = 123456789UL;
+
+        // Create some states with very short expiry
+        var expiredId1 = _service.CreateState(userId, new TestStateData { Message = "Expired 1" }, TimeSpan.FromMilliseconds(1));
+        var expiredId2 = _service.CreateState(userId, new TestStateData { Message = "Expired 2" }, TimeSpan.FromMilliseconds(1));
+
+        // Wait for expiration
+        Thread.Sleep(50);
+
+        // Create some states that won't expire
+        var validId1 = _service.CreateState(userId, new TestStateData { Message = "Valid 1" }, TimeSpan.FromMinutes(10));
+        var validId2 = _service.CreateState(userId, new TestStateData { Message = "Valid 2" }, TimeSpan.FromMinutes(10));
+
+        // Act
+        var removedCount = _service.CleanupExpired();
+
+        // Assert
+        removedCount.Should().Be(2, "exactly 2 expired states should be removed");
+
+        // Verify expired states are gone
+        _service.TryGetState<TestStateData>(expiredId1, out _)
+            .Should().BeFalse("expired state 1 should be removed");
+        _service.TryGetState<TestStateData>(expiredId2, out _)
+            .Should().BeFalse("expired state 2 should be removed");
+
+        // Verify valid states remain
+        _service.TryGetState<TestStateData>(validId1, out _)
+            .Should().BeTrue("valid state 1 should remain");
+        _service.TryGetState<TestStateData>(validId2, out _)
+            .Should().BeTrue("valid state 2 should remain");
+    }
+
+    [Fact]
+    public void CleanupExpired_LeavesNonExpiredStates()
+    {
+        // Arrange
+        const ulong userId = 123456789UL;
+        var data1 = new TestStateData { Message = "Data 1" };
+        var data2 = new TestStateData { Message = "Data 2" };
+
+        var correlationId1 = _service.CreateState(userId, data1, TimeSpan.FromHours(1));
+        var correlationId2 = _service.CreateState(userId, data2, TimeSpan.FromHours(1));
+
+        // Act
+        var removedCount = _service.CleanupExpired();
+
+        // Assert
+        removedCount.Should().Be(0, "no states should be removed as none are expired");
+        _service.TryGetState<TestStateData>(correlationId1, out _)
+            .Should().BeTrue("non-expired state 1 should remain");
+        _service.TryGetState<TestStateData>(correlationId2, out _)
+            .Should().BeTrue("non-expired state 2 should remain");
+    }
+
+    [Fact]
+    public void CleanupExpired_WithNoStates_ReturnsZero()
+    {
+        // Arrange
+        var freshService = new InteractionStateService(_mockLogger.Object);
+
+        // Act
+        var removedCount = freshService.CleanupExpired();
+
+        // Assert
+        removedCount.Should().Be(0, "no states should be removed when dictionary is empty");
+    }
+
+    [Fact]
+    public void ActiveStateCount_ReturnsCorrectCount()
+    {
+        // Arrange
+        const ulong userId = 123456789UL;
+        var initialCount = _service.ActiveStateCount;
+
+        // Act - Add states
+        _service.CreateState(userId, new TestStateData { Message = "State 1" });
+        _service.CreateState(userId, new TestStateData { Message = "State 2" });
+        _service.CreateState(userId, new TestStateData { Message = "State 3" });
+
+        // Assert
+        _service.ActiveStateCount.Should().Be(initialCount + 3,
+            "active state count should increase by 3");
+    }
+
+    [Fact]
+    public void ActiveStateCount_DecreasesAfterRemoval()
+    {
+        // Arrange
+        const ulong userId = 123456789UL;
+        var correlationId = _service.CreateState(userId, new TestStateData { Message = "Test" });
+        var countBeforeRemoval = _service.ActiveStateCount;
+
+        // Act
+        _service.TryRemoveState(correlationId);
+
+        // Assert
+        _service.ActiveStateCount.Should().Be(countBeforeRemoval - 1,
+            "active state count should decrease after removal");
+    }
+
+    [Fact]
+    public void CreateState_LogsDebugMessage()
+    {
+        // Arrange
+        const ulong userId = 123456789UL;
+        var data = new TestStateData { Message = "Test data" };
+
+        // Act
+        _service.CreateState(userId, data);
+
+        // Assert
+        _mockLogger.Verify(
+            l => l.Log(
+                LogLevel.Debug,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Created interaction state")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once,
+            "creating state should log a debug message");
+    }
+
+    [Fact]
+    public void TryGetState_WithExpiredState_LogsDebugMessage()
+    {
+        // Arrange
+        const ulong userId = 123456789UL;
+        var correlationId = _service.CreateState(userId, new TestStateData { Message = "Test" }, TimeSpan.FromMilliseconds(1));
+
+        // Wait for expiration
+        Thread.Sleep(50);
+
+        // Act
+        _service.TryGetState<TestStateData>(correlationId, out _);
+
+        // Assert
+        _mockLogger.Verify(
+            l => l.Log(
+                LogLevel.Debug,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("State expired")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once,
+            "accessing expired state should log a debug message");
+    }
+
+    [Fact]
+    public void TryRemoveState_LogsDebugMessageOnSuccess()
+    {
+        // Arrange
+        const ulong userId = 123456789UL;
+        var correlationId = _service.CreateState(userId, new TestStateData { Message = "Test" });
+
+        // Reset the mock to clear the CreateState log
+        _mockLogger.Invocations.Clear();
+
+        // Act
+        _service.TryRemoveState(correlationId);
+
+        // Assert
+        _mockLogger.Verify(
+            l => l.Log(
+                LogLevel.Debug,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Removed state")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once,
+            "removing state should log a debug message");
+    }
+
+    [Fact]
+    public void CleanupExpired_WithExpiredStates_LogsDebugMessage()
+    {
+        // Arrange
+        const ulong userId = 123456789UL;
+        _service.CreateState(userId, new TestStateData { Message = "Expired" }, TimeSpan.FromMilliseconds(1));
+
+        // Wait for expiration
+        Thread.Sleep(50);
+
+        // Reset the mock to clear the CreateState log
+        _mockLogger.Invocations.Clear();
+
+        // Act
+        _service.CleanupExpired();
+
+        // Assert
+        _mockLogger.Verify(
+            l => l.Log(
+                LogLevel.Debug,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Cleaned up")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once,
+            "cleaning up expired states should log a debug message");
+    }
+
+    [Fact]
+    public void CreateState_WithDifferentDataTypes_WorksCorrectly()
+    {
+        // Arrange
+        const ulong userId = 123456789UL;
+        var stringData = "Simple string data";
+        var intData = 42;
+        var complexData = new TestStateData { Message = "Complex", Value = 100 };
+
+        // Act
+        var stringId = _service.CreateState(userId, stringData);
+        var intId = _service.CreateState(userId, intData);
+        var complexId = _service.CreateState(userId, complexData);
+
+        // Assert
+        _service.TryGetState<string>(stringId, out var retrievedString)
+            .Should().BeTrue();
+        retrievedString.Should().Be(stringData);
+
+        _service.TryGetState<int>(intId, out var retrievedInt)
+            .Should().BeTrue();
+        retrievedInt.Should().Be(intData);
+
+        _service.TryGetState<TestStateData>(complexId, out var retrievedComplex)
+            .Should().BeTrue();
+        retrievedComplex.Should().BeEquivalentTo(complexData);
+    }
+
+    [Fact]
+    public void CreateState_StoresCorrectUserId()
+    {
+        // Arrange
+        const ulong userId1 = 111111111UL;
+        const ulong userId2 = 222222222UL;
+        var data1 = new TestStateData { Message = "User 1 data" };
+        var data2 = new TestStateData { Message = "User 2 data" };
+
+        // Act
+        var id1 = _service.CreateState(userId1, data1);
+        var id2 = _service.CreateState(userId2, data2);
+
+        // Assert
+        _service.TryGetState<TestStateData>(id1, out var retrieved1)
+            .Should().BeTrue();
+        retrieved1.Should().BeEquivalentTo(data1);
+
+        _service.TryGetState<TestStateData>(id2, out var retrieved2)
+            .Should().BeTrue();
+        retrieved2.Should().BeEquivalentTo(data2);
+    }
+
+    // Test helper classes
+    private class TestStateData
+    {
+        public string Message { get; set; } = string.Empty;
+        public int Value { get; set; }
+    }
+
+    private class AlternateStateData
+    {
+        public string DifferentProperty { get; set; } = string.Empty;
+    }
+}


### PR DESCRIPTION
## Summary
- Implements Discord component interactivity (buttons) for enhanced user workflows
- Adds shutdown confirmation dialog to prevent accidental bot shutdowns
- Adds pagination to /guilds command for better UX with large server counts
- Introduces interaction state management with automatic 15-minute expiration
- Includes comprehensive unit test coverage (60 new tests)

## Key Changes
- **ComponentIdBuilder**: Utility for structured component custom IDs with user validation
- **InteractionStateService**: In-memory state storage with configurable expiration
- **InteractionStateCleanupService**: Background service for expired state cleanup (runs every minute)
- **AdminComponentModule**: Handles button click interactions for shutdown confirmation and pagination
- **Enhanced AdminModule**: `/shutdown` and `/guilds` commands now use interactive components

## Acceptance Criteria
- [x] Shutdown requires confirmation button
- [x] Guild list paginates with buttons (5 per page)
- [x] Components timeout after 15 minutes
- [x] Unknown component clicks handled gracefully
- [x] Only original user can interact with buttons

## Test Plan
- [x] Run `dotnet test` - all 175 tests pass (60 new tests added)
- [ ] Manual testing: Execute `/shutdown` command, verify buttons appear, click Cancel
- [ ] Manual testing: Execute `/shutdown` command, click Confirm, verify bot shuts down
- [ ] Manual testing: Execute `/guilds` in a server with 10+ guilds, verify pagination works
- [ ] Manual testing: Wait 16 minutes and click a button, verify expiration message

## Documentation
- Created `docs/interactive-components.md` - Developer guide for adding new interactive workflows
- Updated `docs/admin-commands.md` - Documents new confirmation and pagination features
- Updated `docs/mvp-plan.md` - Marked Phase 5 as COMPLETED

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)