### PR TITLE
Add ViewModels for Razor Pages (closes #62)

### DIFF
--- a/src/DiscordBot.Bot/ViewModels/Pages/BotStatusViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Pages/BotStatusViewModel.cs
@@ -1,0 +1,83 @@
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Bot.ViewModels.Pages;
+
+/// <summary>
+/// View model for displaying bot status information on the dashboard.
+/// </summary>
+public record BotStatusViewModel
+{
+    /// <summary>
+    /// Gets the bot's formatted uptime string.
+    /// </summary>
+    public string UptimeFormatted { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the number of guilds the bot is connected to.
+    /// </summary>
+    public int GuildCount { get; init; }
+
+    /// <summary>
+    /// Gets the bot's current latency in milliseconds.
+    /// </summary>
+    public int LatencyMs { get; init; }
+
+    /// <summary>
+    /// Gets the time when the bot started.
+    /// </summary>
+    public DateTime StartTime { get; init; }
+
+    /// <summary>
+    /// Gets the bot's username.
+    /// </summary>
+    public string BotUsername { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the bot's connection state.
+    /// </summary>
+    public string ConnectionState { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets whether the bot is currently online.
+    /// </summary>
+    public bool IsOnline { get; init; }
+
+    /// <summary>
+    /// Creates a <see cref="BotStatusViewModel"/> from a <see cref="BotStatusDto"/>.
+    /// </summary>
+    /// <param name="dto">The bot status DTO to map from.</param>
+    /// <returns>A new <see cref="BotStatusViewModel"/> instance.</returns>
+    public static BotStatusViewModel FromDto(BotStatusDto dto)
+    {
+        return new BotStatusViewModel
+        {
+            UptimeFormatted = FormatUptime(dto.Uptime),
+            GuildCount = dto.GuildCount,
+            LatencyMs = dto.LatencyMs,
+            StartTime = dto.StartTime,
+            BotUsername = dto.BotUsername,
+            ConnectionState = dto.ConnectionState,
+            IsOnline = dto.ConnectionState.Equals("Connected", StringComparison.OrdinalIgnoreCase)
+        };
+    }
+
+    /// <summary>
+    /// Formats a TimeSpan into a human-readable uptime string.
+    /// </summary>
+    /// <param name="uptime">The uptime duration.</param>
+    /// <returns>Formatted uptime string (e.g., "2d 5h 30m" or "3h 45m" or "25m").</returns>
+    private static string FormatUptime(TimeSpan uptime)
+    {
+        if (uptime.TotalDays >= 1)
+        {
+            return $"{(int)uptime.TotalDays}d {uptime.Hours}h {uptime.Minutes}m";
+        }
+
+        if (uptime.TotalHours >= 1)
+        {
+            return $"{uptime.Hours}h {uptime.Minutes}m";
+        }
+
+        return $"{uptime.Minutes}m";
+    }
+}

--- a/src/DiscordBot.Bot/ViewModels/Pages/CommandLogListViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Pages/CommandLogListViewModel.cs
@@ -1,0 +1,183 @@
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Bot.ViewModels.Pages;
+
+/// <summary>
+/// View model for displaying a paginated list of command logs.
+/// </summary>
+public record CommandLogListViewModel
+{
+    /// <summary>
+    /// Gets the collection of command log items for the current page.
+    /// </summary>
+    public IReadOnlyList<CommandLogListItem> Logs { get; init; } = Array.Empty<CommandLogListItem>();
+
+    /// <summary>
+    /// Gets the current page number (1-based).
+    /// </summary>
+    public int CurrentPage { get; init; } = 1;
+
+    /// <summary>
+    /// Gets the total number of pages.
+    /// </summary>
+    public int TotalPages { get; init; } = 1;
+
+    /// <summary>
+    /// Gets the total number of command log entries across all pages.
+    /// </summary>
+    public int TotalCount { get; init; }
+
+    /// <summary>
+    /// Gets the page size (number of items per page).
+    /// </summary>
+    public int PageSize { get; init; } = 25;
+
+    /// <summary>
+    /// Gets whether there is a next page available.
+    /// </summary>
+    public bool HasNextPage => CurrentPage < TotalPages;
+
+    /// <summary>
+    /// Gets whether there is a previous page available.
+    /// </summary>
+    public bool HasPreviousPage => CurrentPage > 1;
+
+    /// <summary>
+    /// Gets the filter options applied to the command log list.
+    /// </summary>
+    public CommandLogFilterOptions Filters { get; init; } = new();
+
+    /// <summary>
+    /// Creates a <see cref="CommandLogListViewModel"/> from a paginated response.
+    /// </summary>
+    /// <param name="paginatedResponse">The paginated command log response.</param>
+    /// <param name="filters">Optional filter options.</param>
+    /// <returns>A new <see cref="CommandLogListViewModel"/> instance.</returns>
+    public static CommandLogListViewModel FromPaginatedDto(
+        PaginatedResponseDto<CommandLogDto> paginatedResponse,
+        CommandLogFilterOptions? filters = null)
+    {
+        return new CommandLogListViewModel
+        {
+            Logs = paginatedResponse.Items.Select(CommandLogListItem.FromDto).ToList(),
+            CurrentPage = paginatedResponse.Page,
+            TotalPages = paginatedResponse.TotalPages,
+            TotalCount = paginatedResponse.TotalCount,
+            PageSize = paginatedResponse.PageSize,
+            Filters = filters ?? new CommandLogFilterOptions()
+        };
+    }
+}
+
+/// <summary>
+/// Represents a command log entry for list display.
+/// </summary>
+public record CommandLogListItem
+{
+    /// <summary>
+    /// Gets the unique identifier for the command log entry.
+    /// </summary>
+    public Guid Id { get; init; }
+
+    /// <summary>
+    /// Gets the guild name where the command was executed.
+    /// </summary>
+    public string GuildName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the username of the user who executed the command.
+    /// </summary>
+    public string Username { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the name of the command that was executed.
+    /// </summary>
+    public string CommandName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the timestamp when the command was executed.
+    /// </summary>
+    public DateTime ExecutedAt { get; init; }
+
+    /// <summary>
+    /// Gets whether the command executed successfully.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the response time in milliseconds.
+    /// </summary>
+    public int ResponseTimeMs { get; init; }
+
+    /// <summary>
+    /// Gets the error message if the command failed.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// Creates a <see cref="CommandLogListItem"/> from a <see cref="CommandLogDto"/>.
+    /// </summary>
+    /// <param name="dto">The command log DTO to map from.</param>
+    /// <returns>A new <see cref="CommandLogListItem"/> instance.</returns>
+    public static CommandLogListItem FromDto(CommandLogDto dto)
+    {
+        return new CommandLogListItem
+        {
+            Id = dto.Id,
+            GuildName = dto.GuildName ?? "Direct Message",
+            Username = dto.Username ?? "Unknown",
+            CommandName = dto.CommandName,
+            ExecutedAt = dto.ExecutedAt,
+            Success = dto.Success,
+            ResponseTimeMs = dto.ResponseTimeMs,
+            ErrorMessage = dto.ErrorMessage
+        };
+    }
+}
+
+/// <summary>
+/// Represents filter options for command log queries.
+/// </summary>
+public record CommandLogFilterOptions
+{
+    /// <summary>
+    /// Gets the guild ID filter. Null means no filter.
+    /// </summary>
+    public ulong? GuildId { get; init; }
+
+    /// <summary>
+    /// Gets the user ID filter. Null means no filter.
+    /// </summary>
+    public ulong? UserId { get; init; }
+
+    /// <summary>
+    /// Gets the command name filter. Null or empty means no filter.
+    /// </summary>
+    public string? CommandName { get; init; }
+
+    /// <summary>
+    /// Gets the start date for date range filter. Null means no start date limit.
+    /// </summary>
+    public DateTime? StartDate { get; init; }
+
+    /// <summary>
+    /// Gets the end date for date range filter. Null means no end date limit.
+    /// </summary>
+    public DateTime? EndDate { get; init; }
+
+    /// <summary>
+    /// Gets whether to filter for successful commands only. Null means no success filter.
+    /// </summary>
+    public bool? SuccessOnly { get; init; }
+
+    /// <summary>
+    /// Gets whether any filters are currently applied.
+    /// </summary>
+    public bool HasActiveFilters =>
+        GuildId.HasValue ||
+        UserId.HasValue ||
+        !string.IsNullOrWhiteSpace(CommandName) ||
+        StartDate.HasValue ||
+        EndDate.HasValue ||
+        SuccessOnly.HasValue;
+}

--- a/src/DiscordBot.Bot/ViewModels/Pages/GuildDetailViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Pages/GuildDetailViewModel.cs
@@ -1,0 +1,136 @@
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Bot.ViewModels.Pages;
+
+/// <summary>
+/// View model for displaying detailed guild information.
+/// </summary>
+public record GuildDetailViewModel
+{
+    /// <summary>
+    /// Gets the guild's Discord snowflake ID.
+    /// </summary>
+    public ulong Id { get; init; }
+
+    /// <summary>
+    /// Gets the guild name.
+    /// </summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the member count.
+    /// </summary>
+    public int MemberCount { get; init; }
+
+    /// <summary>
+    /// Gets the guild icon URL.
+    /// </summary>
+    public string? IconUrl { get; init; }
+
+    /// <summary>
+    /// Gets whether the guild is active.
+    /// </summary>
+    public bool IsActive { get; init; }
+
+    /// <summary>
+    /// Gets the date when the bot joined the guild.
+    /// </summary>
+    public DateTime JoinedAt { get; init; }
+
+    /// <summary>
+    /// Gets the custom command prefix for the guild.
+    /// </summary>
+    public string? Prefix { get; init; }
+
+    /// <summary>
+    /// Gets the guild settings as JSON.
+    /// </summary>
+    public string? Settings { get; init; }
+
+    /// <summary>
+    /// Gets the list of recent command logs for this guild.
+    /// </summary>
+    public IReadOnlyList<RecentCommandLogItem> RecentCommandLogs { get; init; } = Array.Empty<RecentCommandLogItem>();
+
+    /// <summary>
+    /// Creates a <see cref="GuildDetailViewModel"/> from a <see cref="GuildDto"/>.
+    /// </summary>
+    /// <param name="dto">The guild DTO to map from.</param>
+    /// <param name="recentLogs">Optional collection of recent command logs for the guild.</param>
+    /// <returns>A new <see cref="GuildDetailViewModel"/> instance.</returns>
+    public static GuildDetailViewModel FromDto(GuildDto dto, IEnumerable<CommandLogDto>? recentLogs = null)
+    {
+        return new GuildDetailViewModel
+        {
+            Id = dto.Id,
+            Name = dto.Name,
+            MemberCount = dto.MemberCount ?? 0,
+            IconUrl = dto.IconUrl,
+            IsActive = dto.IsActive,
+            JoinedAt = dto.JoinedAt,
+            Prefix = dto.Prefix,
+            Settings = dto.Settings,
+            RecentCommandLogs = recentLogs?.Select(RecentCommandLogItem.FromDto).ToList() ?? (IReadOnlyList<RecentCommandLogItem>)Array.Empty<RecentCommandLogItem>()
+        };
+    }
+}
+
+/// <summary>
+/// Represents a recent command log entry for guild detail display.
+/// </summary>
+public record RecentCommandLogItem
+{
+    /// <summary>
+    /// Gets the unique identifier for the command log entry.
+    /// </summary>
+    public Guid Id { get; init; }
+
+    /// <summary>
+    /// Gets the username of the user who executed the command.
+    /// </summary>
+    public string Username { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the name of the command that was executed.
+    /// </summary>
+    public string CommandName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the timestamp when the command was executed.
+    /// </summary>
+    public DateTime ExecutedAt { get; init; }
+
+    /// <summary>
+    /// Gets the response time in milliseconds.
+    /// </summary>
+    public int ResponseTimeMs { get; init; }
+
+    /// <summary>
+    /// Gets whether the command executed successfully.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the error message if the command failed.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// Creates a <see cref="RecentCommandLogItem"/> from a <see cref="CommandLogDto"/>.
+    /// </summary>
+    /// <param name="dto">The command log DTO to map from.</param>
+    /// <returns>A new <see cref="RecentCommandLogItem"/> instance.</returns>
+    public static RecentCommandLogItem FromDto(CommandLogDto dto)
+    {
+        return new RecentCommandLogItem
+        {
+            Id = dto.Id,
+            Username = dto.Username ?? "Unknown",
+            CommandName = dto.CommandName,
+            ExecutedAt = dto.ExecutedAt,
+            ResponseTimeMs = dto.ResponseTimeMs,
+            Success = dto.Success,
+            ErrorMessage = dto.ErrorMessage
+        };
+    }
+}

--- a/src/DiscordBot.Bot/ViewModels/Pages/GuildListViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Pages/GuildListViewModel.cs
@@ -1,0 +1,102 @@
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Bot.ViewModels.Pages;
+
+/// <summary>
+/// View model for displaying a list of guilds.
+/// </summary>
+public record GuildListViewModel
+{
+    /// <summary>
+    /// Gets the collection of guild summary items.
+    /// </summary>
+    public IReadOnlyList<GuildSummaryItem> Guilds { get; init; } = Array.Empty<GuildSummaryItem>();
+
+    /// <summary>
+    /// Gets the total number of guilds.
+    /// </summary>
+    public int TotalCount { get; init; }
+
+    /// <summary>
+    /// Creates a <see cref="GuildListViewModel"/> from a collection of <see cref="GuildDto"/>.
+    /// </summary>
+    /// <param name="dtos">The guild DTOs to map from.</param>
+    /// <returns>A new <see cref="GuildListViewModel"/> instance.</returns>
+    public static GuildListViewModel FromDtos(IEnumerable<GuildDto> dtos)
+    {
+        var guildList = dtos.ToList();
+        return new GuildListViewModel
+        {
+            Guilds = guildList.Select(GuildSummaryItem.FromDto).ToList(),
+            TotalCount = guildList.Count
+        };
+    }
+
+    /// <summary>
+    /// Creates a <see cref="GuildListViewModel"/> from a paginated response.
+    /// </summary>
+    /// <param name="paginatedResponse">The paginated guild response.</param>
+    /// <returns>A new <see cref="GuildListViewModel"/> instance.</returns>
+    public static GuildListViewModel FromPaginatedDto(PaginatedResponseDto<GuildDto> paginatedResponse)
+    {
+        return new GuildListViewModel
+        {
+            Guilds = paginatedResponse.Items.Select(GuildSummaryItem.FromDto).ToList(),
+            TotalCount = paginatedResponse.TotalCount
+        };
+    }
+}
+
+/// <summary>
+/// Represents a summary of guild information for list display.
+/// </summary>
+public record GuildSummaryItem
+{
+    /// <summary>
+    /// Gets the guild's Discord snowflake ID.
+    /// </summary>
+    public ulong Id { get; init; }
+
+    /// <summary>
+    /// Gets the guild name.
+    /// </summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the member count.
+    /// </summary>
+    public int MemberCount { get; init; }
+
+    /// <summary>
+    /// Gets the guild icon URL.
+    /// </summary>
+    public string? IconUrl { get; init; }
+
+    /// <summary>
+    /// Gets whether the guild is active.
+    /// </summary>
+    public bool IsActive { get; init; }
+
+    /// <summary>
+    /// Gets the date when the bot joined the guild.
+    /// </summary>
+    public DateTime JoinedAt { get; init; }
+
+    /// <summary>
+    /// Creates a <see cref="GuildSummaryItem"/> from a <see cref="GuildDto"/>.
+    /// </summary>
+    /// <param name="dto">The guild DTO to map from.</param>
+    /// <returns>A new <see cref="GuildSummaryItem"/> instance.</returns>
+    public static GuildSummaryItem FromDto(GuildDto dto)
+    {
+        return new GuildSummaryItem
+        {
+            Id = dto.Id,
+            Name = dto.Name,
+            MemberCount = dto.MemberCount ?? 0,
+            IconUrl = dto.IconUrl,
+            IsActive = dto.IsActive,
+            JoinedAt = dto.JoinedAt
+        };
+    }
+}


### PR DESCRIPTION
## Summary
Implements Feature 1.5: API Client Service Layer by creating page-specific ViewModels that enable Razor Pages to consume data from the existing service layer (IBotService, IGuildService, ICommandLogService).

## Changes
- Created `ViewModels/Pages/` folder structure in DiscordBot.Bot
- **BotStatusViewModel**: Dashboard status display with formatted uptime
- **GuildListViewModel**: Guild list page with support for both simple and paginated collections  
- **GuildDetailViewModel**: Guild detail page with nested recent command logs
- **CommandLogListViewModel**: Command logs page with pagination and filtering support

## Key Features
- Static factory methods (`FromDto`, `FromPaginatedDto`) for easy DTO mapping
- Immutable record types for thread safety
- Read-only collections for data integrity  
- Comprehensive XML documentation
- Pagination helpers (HasNextPage, HasPreviousPage)
- Filter options for command log queries

## Technical Details
Since the Razor Pages UI is hosted in the same project as the Web API, pages can inject services directly rather than making HTTP calls. This improves performance and simplifies the architecture:

- **Before**: Razor Pages → HTTP → API Controllers → Services
- **After**: Razor Pages → Services (direct injection)

The API endpoints remain available for external consumers, but the internal UI uses services directly.

## Testing
- All 175 existing tests pass
- No new tests needed as these are simple DTO mapping models
- ViewModels will be tested implicitly through Razor Page integration tests in future PRs

## Related Issues
- Closes #62 (Feature 1.5: API Client Service Layer)
- Part of Epic #57 (Foundation and Project Setup)
- Depends on existing service layer from previous features

## Next Steps
After this PR merges, the next task will be implementing the actual Razor Pages (Dashboard, Guild List, Guild Detail, Command Logs) that consume these ViewModels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)