### PR TITLE
feat: Add Bot Control Panel for lifecycle management (#83)

### DIFF
--- a/docs/implementation-plans/issue-83-bot-control-panel.md
+++ b/docs/implementation-plans/issue-83-bot-control-panel.md
@@ -1,0 +1,975 @@
+# Issue #83 - Bot Control Panel
+
+## Implementation Plan
+
+**Document Version:** 1.0
+**Date:** 2025-12-23
+**Issue Reference:** GitHub Issue #83
+**Dependencies:**
+- Feature 3.1: Bot Status Widget (#68) - COMPLETED
+- Feature 2.2: Authorization Policies (#65) - COMPLETED
+
+---
+
+## 1. Requirement Summary
+
+Create a dedicated Bot Control Panel page at `/Admin/BotControl` for bot lifecycle management. The page will provide administrators with:
+
+- **Restart Bot** - With simple confirmation modal
+- **Shutdown Bot** - With typed confirmation requiring "SHUTDOWN" to be entered
+- **View Bot Configuration** - Read-only display with masked sensitive values (tokens show as masked)
+- **Real-time Status Updates** - JavaScript polling to keep status indicator current
+
+This is an Admin-only feature that provides direct control over the bot's lifecycle from the web UI.
+
+---
+
+## 2. Architectural Considerations
+
+### 2.1 Existing System Components
+
+| Component | Location | Purpose |
+|-----------|----------|---------|
+| `IBotService` | `src/DiscordBot.Core/Interfaces/IBotService.cs` | Service interface with `RestartAsync()` and `ShutdownAsync()` |
+| `BotService` | `src/DiscordBot.Bot/Services/BotService.cs` | Implementation using `IHostApplicationLifetime` |
+| `BotController` | `src/DiscordBot.Bot/Controllers/BotController.cs` | REST API for `/api/bot/status`, `/api/bot/restart`, `/api/bot/shutdown` |
+| `BotStatusDto` | `src/DiscordBot.Core/DTOs/BotStatusDto.cs` | DTO for bot status information |
+| `BotStatusViewModel` | `src/DiscordBot.Bot/ViewModels/Pages/BotStatusViewModel.cs` | ViewModel for dashboard status card |
+| `_ConfirmationModal.cshtml` | `src/DiscordBot.Bot/Pages/Shared/Components/` | Existing modal component |
+| `ConfirmationModalViewModel` | `src/DiscordBot.Bot/ViewModels/Components/` | Modal configuration record |
+| `quick-actions.js` | `src/DiscordBot.Bot/wwwroot/js/` | Modal handling, AJAX submissions, toast notifications |
+| `bot-status-refresh.js` | `src/DiscordBot.Bot/wwwroot/js/` | Status polling (30-second interval) |
+
+### 2.2 Integration Requirements
+
+1. **Authorization**
+   - Page requires `[Authorize(Policy = "RequireAdmin")]`
+   - OnPost handlers must verify admin role before executing actions
+
+2. **Existing Modal Limitations**
+   - Current `_ConfirmationModal.cshtml` does not support typed confirmation
+   - Will need to create enhanced `_TypedConfirmationModal.cshtml` component for shutdown
+
+3. **API Usage**
+   - REST API endpoints already exist at `/api/bot/restart` and `/api/bot/shutdown`
+   - Can use either API or Razor Page handlers for actions
+   - Recommend Razor Page handlers for consistency with existing patterns (see `Index.cshtml.cs`)
+
+4. **Configuration Access**
+   - Need new service method to expose safe configuration values
+   - Must mask sensitive values (tokens, secrets)
+
+### 2.3 Architectural Patterns to Follow
+
+Based on existing codebase patterns:
+
+```
+Pattern: Razor Page with OnPost handlers for AJAX actions
+Example: Pages/Index.cshtml.cs - OnPostRestartBotAsync(), OnPostSyncAllGuildsAsync()
+
+Pattern: Shared components with ViewModels
+Example: _ConfirmationModal.cshtml + ConfirmationModalViewModel
+
+Pattern: JavaScript modules for client-side functionality
+Example: quick-actions.js, bot-status-refresh.js
+```
+
+### 2.4 Security Considerations
+
+| Risk | Mitigation |
+|------|------------|
+| Unauthorized restart/shutdown | `[Authorize(Policy = "RequireAdmin")]` + handler-level role check |
+| CSRF attacks | Anti-forgery tokens (default in Razor Pages) |
+| Accidental shutdown | Typed confirmation requiring "SHUTDOWN" |
+| Token exposure | Mask sensitive configuration values in display |
+| Audit trail | Log all administrative actions with user ID and timestamp |
+
+### 2.5 Current RestartAsync Limitation
+
+**Important:** The current `BotService.RestartAsync()` throws `NotSupportedException`:
+
+```csharp
+public Task RestartAsync(CancellationToken cancellationToken = default)
+{
+    _logger.LogWarning("Restart requested but not implemented - this feature requires external process management");
+    throw new NotSupportedException("Bot restart is not currently supported. Use an external process manager for restart capabilities.");
+}
+```
+
+**Options:**
+1. **Soft Restart** - Disconnect and reconnect the Discord client (preferred)
+2. **Application Restart** - Requires external process manager (systemd, Docker, etc.)
+3. **Disable Feature** - Show restart as unavailable with explanation
+
+**Recommendation:** Implement soft restart (disconnect/reconnect Discord client) as it can be done within the application.
+
+---
+
+## 3. Data Models
+
+### 3.1 New DTOs
+
+#### `BotConfigurationDto.cs`
+
+**Location:** `src/DiscordBot.Core/DTOs/BotConfigurationDto.cs`
+
+```csharp
+namespace DiscordBot.Core.DTOs;
+
+/// <summary>
+/// Read-only bot configuration for display purposes.
+/// Sensitive values are masked.
+/// </summary>
+public class BotConfigurationDto
+{
+    /// <summary>
+    /// Gets the bot token (masked, shows only last 4 characters).
+    /// </summary>
+    public string TokenMasked { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the test guild ID if configured.
+    /// </summary>
+    public ulong? TestGuildId { get; set; }
+
+    /// <summary>
+    /// Gets whether a test guild is configured.
+    /// </summary>
+    public bool HasTestGuild { get; set; }
+
+    /// <summary>
+    /// Gets the OAuth client ID (masked).
+    /// </summary>
+    public string OAuthClientIdMasked { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets whether OAuth is configured.
+    /// </summary>
+    public bool IsOAuthConfigured { get; set; }
+
+    /// <summary>
+    /// Gets the database provider name.
+    /// </summary>
+    public string DatabaseProvider { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the Discord.NET version.
+    /// </summary>
+    public string DiscordNetVersion { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the application version.
+    /// </summary>
+    public string AppVersion { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the .NET runtime version.
+    /// </summary>
+    public string RuntimeVersion { get; set; } = string.Empty;
+}
+```
+
+### 3.2 Interface Extension
+
+Add to `IBotService.cs`:
+
+```csharp
+/// <summary>
+/// Gets the bot configuration with sensitive values masked.
+/// </summary>
+/// <returns>Bot configuration information safe for display.</returns>
+BotConfigurationDto GetConfiguration();
+```
+
+---
+
+## 4. ViewModels
+
+### 4.1 Bot Control Page ViewModel
+
+**Location:** `src/DiscordBot.Bot/ViewModels/Pages/BotControlViewModel.cs`
+
+```csharp
+namespace DiscordBot.Bot.ViewModels.Pages;
+
+/// <summary>
+/// View model for the Bot Control Panel page.
+/// </summary>
+public class BotControlViewModel
+{
+    /// <summary>
+    /// Gets the current bot status.
+    /// </summary>
+    public BotStatusViewModel Status { get; set; } = null!;
+
+    /// <summary>
+    /// Gets the bot configuration (with masked sensitive values).
+    /// </summary>
+    public BotConfigurationDto Configuration { get; set; } = null!;
+
+    /// <summary>
+    /// Gets whether restart is available.
+    /// </summary>
+    public bool CanRestart { get; set; }
+
+    /// <summary>
+    /// Gets the reason restart is unavailable (if applicable).
+    /// </summary>
+    public string? RestartUnavailableReason { get; set; }
+
+    /// <summary>
+    /// Gets whether shutdown is available.
+    /// </summary>
+    public bool CanShutdown { get; set; }
+
+    /// <summary>
+    /// Gets the last action result message (for success/error display).
+    /// </summary>
+    public string? LastActionMessage { get; set; }
+
+    /// <summary>
+    /// Gets whether the last action was successful.
+    /// </summary>
+    public bool? LastActionSuccess { get; set; }
+}
+```
+
+### 4.2 Typed Confirmation Modal ViewModel
+
+**Location:** `src/DiscordBot.Bot/ViewModels/Components/TypedConfirmationModalViewModel.cs`
+
+```csharp
+namespace DiscordBot.Bot.ViewModels.Components;
+
+/// <summary>
+/// View model for typed confirmation modal dialogs.
+/// User must type a specific phrase to enable the confirm button.
+/// </summary>
+public record TypedConfirmationModalViewModel
+{
+    /// <summary>
+    /// Gets the unique identifier for the modal.
+    /// </summary>
+    public string Id { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the title of the confirmation dialog.
+    /// </summary>
+    public string Title { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the message explaining the action and consequences.
+    /// </summary>
+    public string Message { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the exact text the user must type to confirm.
+    /// </summary>
+    public string RequiredText { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the label for the input field.
+    /// </summary>
+    public string InputLabel { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the text for the confirm button.
+    /// </summary>
+    public string ConfirmText { get; init; } = "Confirm";
+
+    /// <summary>
+    /// Gets the text for the cancel button.
+    /// </summary>
+    public string CancelText { get; init; } = "Cancel";
+
+    /// <summary>
+    /// Gets the visual variant of the confirmation dialog.
+    /// </summary>
+    public ConfirmationVariant Variant { get; init; } = ConfirmationVariant.Danger;
+
+    /// <summary>
+    /// Gets the form action URL for POST submissions.
+    /// </summary>
+    public string? FormAction { get; init; }
+
+    /// <summary>
+    /// Gets the Razor Page handler name for the form.
+    /// </summary>
+    public string? FormHandler { get; init; }
+}
+```
+
+---
+
+## 5. Service Layer Changes
+
+### 5.1 IBotService Extension
+
+Add new method to `src/DiscordBot.Core/Interfaces/IBotService.cs`:
+
+```csharp
+/// <summary>
+/// Gets the bot configuration with sensitive values masked.
+/// </summary>
+/// <returns>Bot configuration information safe for display.</returns>
+BotConfigurationDto GetConfiguration();
+```
+
+### 5.2 BotService Implementation Updates
+
+Update `src/DiscordBot.Bot/Services/BotService.cs`:
+
+1. Add `GetConfiguration()` implementation
+2. Modify `RestartAsync()` to perform soft restart (disconnect/reconnect)
+
+```csharp
+/// <inheritdoc/>
+public BotConfigurationDto GetConfiguration()
+{
+    var token = _config.Token ?? string.Empty;
+    var maskedToken = token.Length > 4
+        ? $"{new string('\u2022', 20)}{token[^4..]}"
+        : new string('\u2022', 24);
+
+    return new BotConfigurationDto
+    {
+        TokenMasked = maskedToken,
+        TestGuildId = _config.TestGuildId,
+        HasTestGuild = _config.TestGuildId.HasValue,
+        OAuthClientIdMasked = MaskClientId(_config.OAuth?.ClientId),
+        IsOAuthConfigured = !string.IsNullOrEmpty(_config.OAuth?.ClientId),
+        DatabaseProvider = GetDatabaseProvider(),
+        DiscordNetVersion = GetDiscordNetVersion(),
+        AppVersion = GetAppVersion(),
+        RuntimeVersion = Environment.Version.ToString()
+    };
+}
+
+/// <inheritdoc/>
+public async Task RestartAsync(CancellationToken cancellationToken = default)
+{
+    _logger.LogWarning("Bot soft restart requested");
+
+    // Disconnect from Discord
+    await _client.StopAsync();
+    await _client.LogoutAsync();
+
+    _logger.LogInformation("Bot disconnected, waiting before reconnect...");
+
+    // Brief delay to ensure clean disconnect
+    await Task.Delay(2000, cancellationToken);
+
+    // Reconnect
+    await _client.LoginAsync(TokenType.Bot, _config.Token);
+    await _client.StartAsync();
+
+    _logger.LogInformation("Bot reconnected successfully");
+}
+```
+
+---
+
+## 6. Razor Pages Structure
+
+### 6.1 Page Overview
+
+| Page | Route | Purpose |
+|------|-------|---------|
+| BotControl | `/Admin/BotControl` | Bot lifecycle management and configuration view |
+
+### 6.2 File Structure
+
+```
+src/DiscordBot.Bot/
+├── Pages/
+│   └── Admin/
+│       ├── BotControl.cshtml
+│       └── BotControl.cshtml.cs
+├── ViewModels/
+│   ├── Pages/
+│   │   └── BotControlViewModel.cs
+│   └── Components/
+│       └── TypedConfirmationModalViewModel.cs
+├── wwwroot/
+│   └── js/
+│       └── bot-control.js
+└── Pages/Shared/Components/
+    └── _TypedConfirmationModal.cshtml
+```
+
+### 6.3 BotControl Page Specification
+
+**Files:**
+- `src/DiscordBot.Bot/Pages/Admin/BotControl.cshtml`
+- `src/DiscordBot.Bot/Pages/Admin/BotControl.cshtml.cs`
+
+**Page Layout:**
+
+```
++------------------------------------------------------------------+
+| Bot Control Panel                                                 |
+| Manage your bot's lifecycle and view configuration               |
++------------------------------------------------------------------+
+
++----------------------------------+  +----------------------------------+
+| Bot Status                       |  | Actions                          |
+| [Status Card with real-time      |  | [Restart Bot] (warning button)   |
+|  updates - polls every 5 sec]    |  | [Shutdown Bot] (danger button)   |
+|  - Connection State              |  |                                  |
+|  - Uptime                        |  | Note: Restart will briefly       |
+|  - Latency                       |  | disconnect the bot from all      |
+|  - Guild Count                   |  | servers.                         |
++----------------------------------+  +----------------------------------+
+
++------------------------------------------------------------------+
+| Configuration                                                     |
++------------------------------------------------------------------+
+| Token              | ••••••••••••••••••••abcd                     |
+| Test Guild ID      | 1234567890123456789 (or "Not configured")    |
+| OAuth Client ID    | ••••••••••••1234                             |
+| Database Provider  | SQLite                                       |
+| Discord.NET        | 3.18.0                                       |
+| App Version        | 2.1.0                                        |
+| .NET Runtime       | 8.0.0                                        |
++------------------------------------------------------------------+
+
++------------------------------------------------------------------+
+| Danger Zone                                                       |
++------------------------------------------------------------------+
+| [!] Shutdown Bot                                                  |
+| Shutting down the bot will stop all functionality. The bot will  |
+| need to be manually restarted from the server.                   |
+|                                                [Shutdown Bot]     |
++------------------------------------------------------------------+
+```
+
+**PageModel Implementation:**
+
+```csharp
+namespace DiscordBot.Bot.Pages.Admin;
+
+[Authorize(Policy = "RequireAdmin")]
+public class BotControlModel : PageModel
+{
+    private readonly IBotService _botService;
+    private readonly ILogger<BotControlModel> _logger;
+
+    public BotControlViewModel ViewModel { get; set; } = new();
+
+    public async Task<IActionResult> OnGetAsync()
+    {
+        LoadViewModel();
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostRestartBotAsync()
+    {
+        if (!User.IsInRole("Admin") && !User.IsInRole("SuperAdmin"))
+        {
+            _logger.LogWarning("Non-admin user {UserId} attempted to restart bot", User.Identity?.Name);
+            return Forbid();
+        }
+
+        _logger.LogWarning("Bot restart requested by user {UserId}", User.Identity?.Name);
+
+        try
+        {
+            await _botService.RestartAsync();
+            return new JsonResult(new { success = true, message = "Bot is restarting..." });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to restart bot");
+            return new JsonResult(new { success = false, message = "Failed to restart bot." })
+            {
+                StatusCode = 500
+            };
+        }
+    }
+
+    public async Task<IActionResult> OnPostShutdownBotAsync()
+    {
+        if (!User.IsInRole("Admin") && !User.IsInRole("SuperAdmin"))
+        {
+            _logger.LogWarning("Non-admin user {UserId} attempted to shutdown bot", User.Identity?.Name);
+            return Forbid();
+        }
+
+        _logger.LogCritical("Bot SHUTDOWN requested by user {UserId}", User.Identity?.Name);
+
+        try
+        {
+            await _botService.ShutdownAsync();
+            return new JsonResult(new { success = true, message = "Bot is shutting down..." });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to shutdown bot");
+            return new JsonResult(new { success = false, message = "Failed to shutdown bot." })
+            {
+                StatusCode = 500
+            };
+        }
+    }
+
+    private void LoadViewModel()
+    {
+        var status = _botService.GetStatus();
+        var config = _botService.GetConfiguration();
+
+        ViewModel = new BotControlViewModel
+        {
+            Status = BotStatusViewModel.FromDto(status),
+            Configuration = config,
+            CanRestart = true,
+            CanShutdown = true
+        };
+    }
+}
+```
+
+---
+
+## 7. Shared Components
+
+### 7.1 Typed Confirmation Modal
+
+**Location:** `src/DiscordBot.Bot/Pages/Shared/Components/_TypedConfirmationModal.cshtml`
+
+This component extends the existing `_ConfirmationModal` pattern with typed confirmation:
+
+- Text input field
+- Validation that disables button until exact text is entered
+- JavaScript for real-time validation
+- Same visual styling as existing modal
+
+**Key Features:**
+- Input field with placeholder showing required text
+- Confirm button disabled by default
+- Button enables only when input matches required text exactly
+- Form submits via AJAX like existing quick actions
+
+---
+
+## 8. JavaScript Implementation
+
+### 8.1 Bot Control Module
+
+**Location:** `src/DiscordBot.Bot/wwwroot/js/bot-control.js`
+
+```javascript
+// Bot Control Panel Module
+// Handles typed confirmation, status polling, and action submissions
+
+(function() {
+    'use strict';
+
+    // Configuration
+    const STATUS_POLL_INTERVAL_MS = 5000; // 5 seconds for control panel
+    const API_ENDPOINT = '/api/bot/status';
+
+    /**
+     * Initialize typed confirmation modal functionality
+     */
+    function initTypedConfirmation(modalId, inputId, confirmBtnId, requiredText) {
+        const input = document.getElementById(inputId);
+        const confirmBtn = document.getElementById(confirmBtnId);
+
+        if (!input || !confirmBtn) return;
+
+        input.addEventListener('input', function() {
+            confirmBtn.disabled = input.value !== requiredText;
+        });
+
+        // Reset on modal close
+        const modal = document.getElementById(modalId);
+        if (modal) {
+            const observer = new MutationObserver(function(mutations) {
+                mutations.forEach(function(mutation) {
+                    if (mutation.attributeName === 'class' && modal.classList.contains('hidden')) {
+                        input.value = '';
+                        confirmBtn.disabled = true;
+                    }
+                });
+            });
+            observer.observe(modal, { attributes: true });
+        }
+    }
+
+    /**
+     * Submit shutdown action via AJAX
+     */
+    async function submitShutdown(handler) {
+        const token = document.querySelector('input[name="__RequestVerificationToken"]')?.value;
+        if (!token) {
+            window.quickActions?.showToast('Security token not found. Please refresh.', 'error');
+            return;
+        }
+
+        try {
+            const response = await fetch(`?handler=${handler}`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                    'RequestVerificationToken': token
+                },
+                body: `__RequestVerificationToken=${encodeURIComponent(token)}`
+            });
+
+            const data = await response.json();
+
+            if (response.ok && data.success) {
+                window.quickActions?.showToast(data.message, 'success');
+                // Close modal
+                window.quickActions?.hideConfirmationModal('shutdownModal');
+            } else {
+                window.quickActions?.showToast(data.message || 'Action failed.', 'error');
+            }
+        } catch (error) {
+            console.error('Shutdown error:', error);
+            window.quickActions?.showToast('An error occurred.', 'error');
+        }
+    }
+
+    /**
+     * Enhanced status polling for control panel (faster interval)
+     */
+    async function refreshStatus() {
+        const statusContainer = document.querySelector('[data-bot-control-status]');
+        if (!statusContainer) return;
+
+        try {
+            const response = await fetch(API_ENDPOINT);
+            if (!response.ok) throw new Error('Status fetch failed');
+
+            const data = await response.json();
+
+            // Update status elements
+            updateStatusElement('[data-connection-state]', data.connectionState);
+            updateStatusElement('[data-latency]', data.latencyMs + 'ms');
+            updateStatusElement('[data-guild-count]', data.guildCount);
+            updateStatusElement('[data-uptime]', formatUptime(data.uptime));
+            updateStatusIndicator(data.connectionState);
+
+        } catch (error) {
+            console.error('Status refresh failed:', error);
+        }
+    }
+
+    function updateStatusElement(selector, value) {
+        const el = document.querySelector(selector);
+        if (el) el.textContent = value;
+    }
+
+    function updateStatusIndicator(state) {
+        const indicator = document.querySelector('[data-status-indicator]');
+        if (!indicator) return;
+
+        const isOnline = state.toUpperCase() === 'CONNECTED';
+        indicator.classList.toggle('bg-success', isOnline);
+        indicator.classList.toggle('bg-error', !isOnline);
+    }
+
+    function formatUptime(timeSpanString) {
+        // Parse TimeSpan format and return human-readable string
+        // (Reuse logic from bot-status-refresh.js)
+        // ... implementation ...
+        return timeSpanString; // Placeholder
+    }
+
+    // Initialize on DOM ready
+    function init() {
+        // Init typed confirmation for shutdown
+        initTypedConfirmation('shutdownModal', 'shutdownConfirmInput', 'shutdownConfirmBtn', 'SHUTDOWN');
+
+        // Start enhanced status polling
+        const statusContainer = document.querySelector('[data-bot-control-status]');
+        if (statusContainer) {
+            refreshStatus();
+            setInterval(refreshStatus, STATUS_POLL_INTERVAL_MS);
+        }
+    }
+
+    // Expose public API
+    window.botControl = {
+        initTypedConfirmation,
+        submitShutdown,
+        refreshStatus
+    };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();
+```
+
+---
+
+## 9. Sidebar Navigation Update
+
+Add Bot Control link to `_Sidebar.cshtml` under Administration section:
+
+```razor
+<!-- Bot Control - Admin only -->
+<a asp-page="/Admin/BotControl" class="sidebar-link @(ViewContext.RouteData.Values["page"]?.ToString() == "/Admin/BotControl" ? "active" : "")">
+    <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+    </svg>
+    Bot Control
+</a>
+```
+
+---
+
+## 10. Implementation Sequence
+
+### Phase 1: Foundation (Tasks 6.1.1)
+
+1. Create `BotConfigurationDto.cs` in Core DTOs
+2. Extend `IBotService` interface with `GetConfiguration()`
+3. Implement `GetConfiguration()` in `BotService`
+4. Update `RestartAsync()` to perform soft restart (disconnect/reconnect)
+5. Create `BotControlViewModel.cs`
+
+### Phase 2: Components (Task 6.1.2, 6.1.3)
+
+6. Create `TypedConfirmationModalViewModel.cs`
+7. Create `_TypedConfirmationModal.cshtml` component
+8. Create `bot-control.js` JavaScript module
+
+### Phase 3: Page Implementation (Tasks 6.1.1 - 6.1.5)
+
+9. Create `Pages/Admin/BotControl.cshtml.cs` with handlers
+10. Create `Pages/Admin/BotControl.cshtml` with layout
+11. Add restart confirmation modal (simple)
+12. Add shutdown confirmation modal (typed)
+13. Add configuration display section
+14. Add real-time status polling
+
+### Phase 4: Navigation and Polish (Task 6.1.6)
+
+15. Update `_Sidebar.cshtml` with Bot Control link
+16. Add logging for administrative actions
+17. Test all functionality
+
+---
+
+## 11. Subagent Task Plan
+
+### 11.1 design-specialist
+
+Not required - uses existing design system components and patterns from prototypes.
+
+### 11.2 html-prototyper
+
+Not required - page can be built directly using existing Razor components and prototype patterns.
+
+### 11.3 dotnet-specialist
+
+**Primary implementer for all tasks:**
+
+| Task | Description | Estimated Effort |
+|------|-------------|------------------|
+| 6.1.1-a | Create `BotConfigurationDto.cs` | 30 min |
+| 6.1.1-b | Extend `IBotService` interface | 15 min |
+| 6.1.1-c | Implement `GetConfiguration()` in `BotService` | 45 min |
+| 6.1.1-d | Update `RestartAsync()` for soft restart | 30 min |
+| 6.1.1-e | Create `BotControlViewModel.cs` | 30 min |
+| 6.1.2 | Create `TypedConfirmationModalViewModel.cs` | 20 min |
+| 6.1.2 | Create `_TypedConfirmationModal.cshtml` component | 45 min |
+| 6.1.2 | Implement restart with simple confirmation | 30 min |
+| 6.1.3 | Implement shutdown with typed confirmation ("SHUTDOWN") | 45 min |
+| 6.1.4 | Create configuration display section | 30 min |
+| 6.1.5 | Create `bot-control.js` with status polling | 1 hour |
+| 6.1.5 | Wire up real-time status updates | 30 min |
+| 6.1.6 | Add logging for administrative actions | 30 min |
+| 6.1.1 | Create `BotControl.cshtml` page | 1.5 hours |
+| 6.1.1 | Create `BotControl.cshtml.cs` PageModel | 1 hour |
+| - | Update `_Sidebar.cshtml` navigation | 15 min |
+
+**Total Estimated Effort:** ~9 hours
+
+### 11.4 docs-writer
+
+| Task | Description | Estimated Effort |
+|------|-------------|------------------|
+| - | Document Bot Control Panel in admin guide | 1 hour |
+
+---
+
+## 12. Timeline / Dependency Map
+
+```
+Phase 1: Foundation (Day 1, Morning)
+├── BotConfigurationDto (no dependencies)
+├── IBotService extension (no dependencies)
+├── BotService updates (depends on DTO and interface)
+└── BotControlViewModel (depends on DTO)
+
+Phase 2: Components (Day 1, Afternoon)
+├── TypedConfirmationModalViewModel (no dependencies)
+├── _TypedConfirmationModal.cshtml (depends on ViewModel)
+└── bot-control.js (no dependencies)
+
+Phase 3: Page Implementation (Day 2)
+├── BotControl.cshtml.cs (depends on service, viewmodels)
+├── BotControl.cshtml (depends on PageModel, components)
+└── Wire up modals and polling (depends on page)
+
+Phase 4: Integration (Day 2, Afternoon)
+├── Update sidebar navigation
+├── Add logging
+└── Testing and polish
+```
+
+**Parallelization Opportunities:**
+- DTOs and ViewModels can be created simultaneously
+- JavaScript can be developed in parallel with Razor components
+- Documentation can begin once page is functional
+
+---
+
+## 13. Acceptance Criteria
+
+### 13.1 Page Access (Task 6.1.1)
+
+- [ ] Bot Control Panel page exists at `/Admin/BotControl`
+- [ ] Page requires Admin or SuperAdmin role
+- [ ] Non-authenticated users redirected to login
+- [ ] Non-admin users receive 403 Forbidden
+- [ ] Page is accessible from sidebar under "Administration" section
+
+### 13.2 Restart Functionality (Task 6.1.2)
+
+- [ ] "Restart Bot" button is visible on the page
+- [ ] Clicking button shows confirmation modal
+- [ ] Confirmation modal has Warning variant styling
+- [ ] Clicking "Cancel" closes modal without action
+- [ ] Clicking "Restart Bot" initiates restart
+- [ ] Success toast displayed after restart initiated
+- [ ] Error toast displayed if restart fails
+- [ ] Action is logged with user ID and timestamp
+
+### 13.3 Shutdown Functionality (Task 6.1.3)
+
+- [ ] "Shutdown Bot" button is in "Danger Zone" section
+- [ ] Clicking button shows typed confirmation modal
+- [ ] Modal shows Danger variant styling (red)
+- [ ] Text input field is present with label
+- [ ] Confirm button is disabled by default
+- [ ] Typing anything other than "SHUTDOWN" keeps button disabled
+- [ ] Typing exactly "SHUTDOWN" enables confirm button
+- [ ] Clicking "Cancel" closes modal and resets input
+- [ ] Clicking "Shutdown Bot" when enabled initiates shutdown
+- [ ] Success toast displayed after shutdown initiated
+- [ ] Action is logged at CRITICAL level with user ID
+
+### 13.4 Configuration Display (Task 6.1.4)
+
+- [ ] Configuration section shows read-only values
+- [ ] Bot token is masked (shows dots + last 4 characters)
+- [ ] OAuth Client ID is masked (if configured)
+- [ ] Test Guild ID is displayed (or "Not configured")
+- [ ] Database provider is displayed
+- [ ] Discord.NET version is displayed
+- [ ] Application version is displayed
+- [ ] .NET runtime version is displayed
+
+### 13.5 Real-time Status (Task 6.1.5)
+
+- [ ] Status section shows connection state
+- [ ] Status section shows uptime
+- [ ] Status section shows latency
+- [ ] Status section shows guild count
+- [ ] Status updates automatically every 5 seconds
+- [ ] Visual indicator reflects connection state (green/red)
+
+### 13.6 Logging (Task 6.1.6)
+
+- [ ] Restart attempts are logged at Warning level
+- [ ] Successful restarts are logged at Information level
+- [ ] Failed restarts are logged at Error level
+- [ ] Shutdown attempts are logged at Critical level
+- [ ] Logs include user ID of the actor
+- [ ] Logs include timestamp
+
+---
+
+## 14. Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Restart fails to reconnect | Medium | High | Implement timeout and error handling; consider external process manager |
+| Shutdown leaves bot unrecoverable | Low | Critical | Typed confirmation; clear warning messages; require external restart |
+| Status polling overloads API | Low | Medium | 5-second interval is reasonable; use caching if needed |
+| Token exposure in configuration | Low | Critical | Mask to show only last 4 characters |
+| Unauthorized access bypass | Low | High | Server-side role verification in handlers |
+| AJAX failure on slow networks | Medium | Low | Show loading states; timeout handling; retry logic |
+
+---
+
+## 15. File Summary
+
+### New Files to Create
+
+**Core Layer (`src/DiscordBot.Core/`):**
+- `DTOs/BotConfigurationDto.cs`
+
+**Bot Layer (`src/DiscordBot.Bot/`):**
+- `ViewModels/Pages/BotControlViewModel.cs`
+- `ViewModels/Components/TypedConfirmationModalViewModel.cs`
+- `Pages/Admin/BotControl.cshtml`
+- `Pages/Admin/BotControl.cshtml.cs`
+- `Pages/Shared/Components/_TypedConfirmationModal.cshtml`
+- `wwwroot/js/bot-control.js`
+
+### Files to Modify
+
+- `src/DiscordBot.Core/Interfaces/IBotService.cs` - Add `GetConfiguration()` method
+- `src/DiscordBot.Bot/Services/BotService.cs` - Implement `GetConfiguration()`, update `RestartAsync()`
+- `src/DiscordBot.Bot/Pages/Shared/_Sidebar.cshtml` - Add Bot Control navigation link
+
+---
+
+## 16. Testing Considerations
+
+### Unit Tests
+
+- `BotService.GetConfiguration()` masks tokens correctly
+- `BotService.RestartAsync()` calls disconnect and reconnect in order
+- `BotControlViewModel` correctly maps from DTOs
+
+### Integration Tests
+
+- Page requires authentication
+- Page requires Admin role
+- Restart handler returns correct JSON response
+- Shutdown handler returns correct JSON response
+- Configuration display does not expose full tokens
+
+### Manual Testing
+
+- Restart confirmation modal opens and closes correctly
+- Shutdown typed confirmation validates input correctly
+- Status updates in real-time
+- Toast notifications appear for success/error
+- Navigation link highlights when on page
+- Mobile responsive layout works correctly
+
+---
+
+## 17. Prototype Reference
+
+The typed confirmation modal pattern is demonstrated in:
+- `docs/prototypes/feedback-confirmation.html` - Section 3: Typed Confirmation
+
+The danger zone styling pattern is demonstrated in:
+- `docs/prototypes/pages/settings.html` - `.danger-zone` CSS class
+
+---
+
+*Document prepared by: Systems Architect Agent*
+*Review status: Ready for implementation*

--- a/src/DiscordBot.Bot/Pages/Admin/BotControl.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/BotControl.cshtml
@@ -1,0 +1,203 @@
+@page
+@model DiscordBot.Bot.Pages.Admin.BotControlModel
+@{
+    ViewData["Title"] = "Bot Control";
+}
+
+<!-- Page Header -->
+<div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+    <div>
+        <h1 class="text-2xl lg:text-3xl font-bold text-text-primary">Bot Control</h1>
+        <p class="text-text-secondary mt-1">Manage your bot's lifecycle and view configuration</p>
+    </div>
+</div>
+
+<!-- Main Content Grid -->
+<div class="grid grid-cols-1 lg:grid-cols-3 gap-6" data-bot-control-status>
+    <!-- Bot Status Card -->
+    <div class="lg:col-span-2">
+        <div class="bg-bg-secondary border border-border-primary rounded-lg">
+            <div class="px-6 py-4 border-b border-border-primary">
+                <h2 class="text-lg font-semibold text-text-primary">Bot Status</h2>
+                <p class="text-sm text-text-secondary mt-1">Real-time bot connection status</p>
+            </div>
+            <div class="p-6">
+                <div class="grid grid-cols-2 md:grid-cols-4 gap-6">
+                    <!-- Connection State -->
+                    <div>
+                        <p class="text-sm font-medium text-text-tertiary mb-1">Status</p>
+                        <div class="flex items-center gap-2">
+                            <span class="w-2.5 h-2.5 rounded-full @(Model.ViewModel.Status.ConnectionState == "Connected" ? "bg-success animate-pulse" : "bg-error")" data-status-indicator></span>
+                            <span class="text-lg font-semibold text-text-primary" data-connection-state>@Model.ViewModel.Status.ConnectionState</span>
+                        </div>
+                    </div>
+
+                    <!-- Uptime -->
+                    <div>
+                        <p class="text-sm font-medium text-text-tertiary mb-1">Uptime</p>
+                        <span class="text-lg font-semibold text-text-primary" data-uptime>@Model.ViewModel.Status.UptimeFormatted</span>
+                    </div>
+
+                    <!-- Latency -->
+                    <div>
+                        <p class="text-sm font-medium text-text-tertiary mb-1">Latency</p>
+                        <span class="text-lg font-semibold text-text-primary" data-latency>@Model.ViewModel.Status.LatencyMs ms</span>
+                    </div>
+
+                    <!-- Guild Count -->
+                    <div>
+                        <p class="text-sm font-medium text-text-tertiary mb-1">Servers</p>
+                        <span class="text-lg font-semibold text-text-primary" data-guild-count>@Model.ViewModel.Status.GuildCount</span>
+                    </div>
+                </div>
+
+                <!-- Last Updated -->
+                <div class="mt-4 pt-4 border-t border-border-primary">
+                    <p class="text-xs text-text-tertiary">
+                        Status updates every 5 seconds. Last updated: <span data-last-updated>@DateTime.UtcNow.ToString("HH:mm:ss") UTC</span>
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Quick Actions Card -->
+    <div>
+        <div class="bg-bg-secondary border border-border-primary rounded-lg">
+            <div class="px-6 py-4 border-b border-border-primary">
+                <h2 class="text-lg font-semibold text-text-primary">Actions</h2>
+                <p class="text-sm text-text-secondary mt-1">Bot lifecycle controls</p>
+            </div>
+            <div class="p-6 space-y-4">
+                <!-- Restart Button -->
+                <button type="button"
+                        onclick="window.quickActions?.showConfirmationModal('restartModal')"
+                        class="w-full flex items-center justify-center gap-2 px-4 py-3 bg-warning hover:bg-amber-600 active:bg-amber-700 text-text-inverse font-semibold text-sm rounded-lg transition-colors">
+                    <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                    </svg>
+                    Restart Bot
+                </button>
+
+                <p class="text-xs text-text-tertiary text-center">
+                    Restarts the Discord connection without stopping the application.
+                </p>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Configuration Card -->
+<div class="mt-6">
+    <div class="bg-bg-secondary border border-border-primary rounded-lg">
+        <div class="px-6 py-4 border-b border-border-primary">
+            <h2 class="text-lg font-semibold text-text-primary">Configuration</h2>
+            <p class="text-sm text-text-secondary mt-1">Current bot configuration (read-only)</p>
+        </div>
+        <div class="p-6">
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <!-- Token (Masked) -->
+                <div class="space-y-1">
+                    <p class="text-sm font-medium text-text-tertiary">Bot Token</p>
+                    <p class="text-sm font-mono text-text-primary bg-bg-primary px-3 py-2 rounded-md border border-border-primary">
+                        @Model.ViewModel.Configuration.TokenMasked
+                    </p>
+                </div>
+
+                <!-- Test Guild ID -->
+                <div class="space-y-1">
+                    <p class="text-sm font-medium text-text-tertiary">Test Guild ID</p>
+                    <p class="text-sm font-mono text-text-primary bg-bg-primary px-3 py-2 rounded-md border border-border-primary">
+                        @(Model.ViewModel.Configuration.HasTestGuild ? Model.ViewModel.Configuration.TestGuildId.ToString() : "Not configured")
+                    </p>
+                </div>
+
+                <!-- Database Provider -->
+                <div class="space-y-1">
+                    <p class="text-sm font-medium text-text-tertiary">Database Provider</p>
+                    <p class="text-sm text-text-primary bg-bg-primary px-3 py-2 rounded-md border border-border-primary">
+                        @Model.ViewModel.Configuration.DatabaseProvider
+                    </p>
+                </div>
+
+                <!-- Rate Limits -->
+                <div class="space-y-1">
+                    <p class="text-sm font-medium text-text-tertiary">Default Rate Limit</p>
+                    <p class="text-sm text-text-primary bg-bg-primary px-3 py-2 rounded-md border border-border-primary">
+                        @Model.ViewModel.Configuration.DefaultRateLimitInvokes invokes / @Model.ViewModel.Configuration.DefaultRateLimitPeriodSeconds seconds
+                    </p>
+                </div>
+
+                <!-- Discord.NET Version -->
+                <div class="space-y-1">
+                    <p class="text-sm font-medium text-text-tertiary">Discord.NET Version</p>
+                    <p class="text-sm text-text-primary bg-bg-primary px-3 py-2 rounded-md border border-border-primary">
+                        @Model.ViewModel.Configuration.DiscordNetVersion
+                    </p>
+                </div>
+
+                <!-- Application Version -->
+                <div class="space-y-1">
+                    <p class="text-sm font-medium text-text-tertiary">Application Version</p>
+                    <p class="text-sm text-text-primary bg-bg-primary px-3 py-2 rounded-md border border-border-primary">
+                        @Model.ViewModel.Configuration.AppVersion
+                    </p>
+                </div>
+
+                <!-- .NET Runtime -->
+                <div class="space-y-1">
+                    <p class="text-sm font-medium text-text-tertiary">.NET Runtime</p>
+                    <p class="text-sm text-text-primary bg-bg-primary px-3 py-2 rounded-md border border-border-primary">
+                        @Model.ViewModel.Configuration.RuntimeVersion
+                    </p>
+                </div>
+
+                <!-- Start Time -->
+                <div class="space-y-1">
+                    <p class="text-sm font-medium text-text-tertiary">Started At</p>
+                    <p class="text-sm text-text-primary bg-bg-primary px-3 py-2 rounded-md border border-border-primary">
+                        @Model.ViewModel.Status.StartTime.ToString("yyyy-MM-dd HH:mm:ss") UTC
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Danger Zone -->
+<div class="mt-6">
+    <div class="border-2 border-error rounded-lg p-6 bg-error/5">
+        <div class="flex items-start gap-4">
+            <div class="flex-shrink-0 w-10 h-10 rounded-full bg-error/20 flex items-center justify-center">
+                <svg class="w-5 h-5 text-error" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                </svg>
+            </div>
+            <div class="flex-1">
+                <h3 class="text-lg font-semibold text-error">Danger Zone</h3>
+                <p class="text-sm text-text-secondary mt-1">
+                    Shutting down the bot will stop all functionality. The bot will need to be manually restarted from the server.
+                    This action is irreversible and requires typing confirmation.
+                </p>
+                <div class="mt-4">
+                    <button type="button"
+                            onclick="window.botControl?.showTypedModal('shutdownModal')"
+                            class="flex items-center gap-2 px-4 py-2.5 bg-error hover:bg-red-600 active:bg-red-700 text-white font-semibold text-sm rounded-lg transition-colors">
+                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
+                        </svg>
+                        Shutdown Bot
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Modals -->
+<partial name="Components/_ConfirmationModal" model="Model.RestartModal" />
+<partial name="Components/_TypedConfirmationModal" model="Model.ShutdownModal" />
+
+@section Scripts {
+    <script src="~/js/bot-control.js"></script>
+}

--- a/src/DiscordBot.Bot/Pages/Admin/BotControl.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Admin/BotControl.cshtml.cs
@@ -1,0 +1,173 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using DiscordBot.Core.Interfaces;
+using DiscordBot.Bot.ViewModels.Pages;
+using DiscordBot.Bot.ViewModels.Components;
+
+namespace DiscordBot.Bot.Pages.Admin;
+
+/// <summary>
+/// Page model for the Bot Control Panel.
+/// Provides lifecycle management controls for the bot.
+/// </summary>
+[Authorize(Policy = "RequireAdmin")]
+public class BotControlModel : PageModel
+{
+    private readonly IBotService _botService;
+    private readonly ILogger<BotControlModel> _logger;
+
+    /// <summary>
+    /// Gets the view model for the page.
+    /// </summary>
+    public BotControlViewModel ViewModel { get; private set; } = new();
+
+    /// <summary>
+    /// Gets the restart confirmation modal configuration.
+    /// </summary>
+    public ConfirmationModalViewModel RestartModal { get; private set; } = null!;
+
+    /// <summary>
+    /// Gets the shutdown typed confirmation modal configuration.
+    /// </summary>
+    public TypedConfirmationModalViewModel ShutdownModal { get; private set; } = null!;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BotControlModel"/> class.
+    /// </summary>
+    public BotControlModel(
+        IBotService botService,
+        ILogger<BotControlModel> logger)
+    {
+        _botService = botService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Handles GET requests for the Bot Control page.
+    /// </summary>
+    public void OnGet()
+    {
+        _logger.LogDebug("Bot Control page accessed by user {UserId}", User.Identity?.Name);
+        LoadViewModel();
+    }
+
+    /// <summary>
+    /// Handles POST requests to restart the bot.
+    /// </summary>
+    public async Task<IActionResult> OnPostRestartBotAsync()
+    {
+        if (!User.IsInRole("Admin") && !User.IsInRole("SuperAdmin"))
+        {
+            _logger.LogWarning("Non-admin user {UserId} attempted to restart bot", User.Identity?.Name);
+            return Forbid();
+        }
+
+        _logger.LogWarning("Bot restart requested by user {UserId}", User.Identity?.Name);
+
+        try
+        {
+            await _botService.RestartAsync();
+            _logger.LogInformation("Bot restart completed successfully, initiated by {UserId}", User.Identity?.Name);
+
+            return new JsonResult(new
+            {
+                success = true,
+                message = "Bot is restarting..."
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to restart bot, requested by {UserId}", User.Identity?.Name);
+
+            return new JsonResult(new
+            {
+                success = false,
+                message = "Failed to restart bot. Please check logs for details."
+            })
+            {
+                StatusCode = 500
+            };
+        }
+    }
+
+    /// <summary>
+    /// Handles POST requests to shutdown the bot.
+    /// </summary>
+    public async Task<IActionResult> OnPostShutdownBotAsync()
+    {
+        if (!User.IsInRole("Admin") && !User.IsInRole("SuperAdmin"))
+        {
+            _logger.LogWarning("Non-admin user {UserId} attempted to shutdown bot", User.Identity?.Name);
+            return Forbid();
+        }
+
+        _logger.LogCritical("Bot SHUTDOWN requested by user {UserId}", User.Identity?.Name);
+
+        try
+        {
+            await _botService.ShutdownAsync();
+            _logger.LogCritical("Bot shutdown initiated by {UserId}", User.Identity?.Name);
+
+            return new JsonResult(new
+            {
+                success = true,
+                message = "Bot is shutting down..."
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to shutdown bot, requested by {UserId}", User.Identity?.Name);
+
+            return new JsonResult(new
+            {
+                success = false,
+                message = "Failed to shutdown bot. Please check logs for details."
+            })
+            {
+                StatusCode = 500
+            };
+        }
+    }
+
+    private void LoadViewModel()
+    {
+        var status = _botService.GetStatus();
+        var config = _botService.GetConfiguration();
+
+        ViewModel = new BotControlViewModel
+        {
+            Status = BotStatusViewModel.FromDto(status),
+            Configuration = config,
+            CanRestart = true,
+            CanShutdown = true
+        };
+
+        RestartModal = new ConfirmationModalViewModel
+        {
+            Id = "restartModal",
+            Title = "Restart Bot",
+            Message = "Are you sure you want to restart the bot? This will briefly disconnect the bot from all servers. The bot will automatically reconnect after a few seconds.",
+            ConfirmText = "Restart Bot",
+            CancelText = "Cancel",
+            Variant = ConfirmationVariant.Warning,
+            FormHandler = "RestartBot"
+        };
+
+        ShutdownModal = new TypedConfirmationModalViewModel
+        {
+            Id = "shutdownModal",
+            Title = "Shutdown Bot",
+            Message = "This action will completely shut down the bot. The bot will NOT restart automatically and will need to be manually started from the server. This action is critical and should only be used when necessary.",
+            RequiredText = "SHUTDOWN",
+            InputLabel = "Type SHUTDOWN to confirm",
+            ConfirmText = "Shutdown Bot",
+            CancelText = "Cancel",
+            Variant = ConfirmationVariant.Danger,
+            FormHandler = "ShutdownBot"
+        };
+
+        _logger.LogDebug("Bot Control ViewModel loaded: ConnectionState={ConnectionState}, GuildCount={GuildCount}",
+            ViewModel.Status.ConnectionState, ViewModel.Status.GuildCount);
+    }
+}

--- a/src/DiscordBot.Bot/Pages/Shared/Components/_TypedConfirmationModal.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/Components/_TypedConfirmationModal.cshtml
@@ -1,0 +1,106 @@
+@model DiscordBot.Bot.ViewModels.Components.TypedConfirmationModalViewModel
+@using DiscordBot.Bot.ViewModels.Components
+
+<!-- Typed Confirmation Modal -->
+<div id="@Model.Id" class="hidden fixed inset-0 z-50" role="alertdialog" aria-modal="true" aria-labelledby="@(Model.Id)Title" aria-describedby="@(Model.Id)Desc">
+    <!-- Backdrop -->
+    <div class="fixed inset-0 bg-black/70 backdrop-blur-sm" onclick="window.botControl?.hideTypedModal('@Model.Id')"></div>
+
+    <!-- Modal Dialog -->
+    <div class="fixed inset-0 flex items-center justify-center p-4">
+        <div class="bg-bg-tertiary border border-border-primary rounded-lg shadow-xl max-w-md w-full" role="document">
+            <!-- Modal Content -->
+            <div class="p-6">
+                <div class="flex items-start gap-4">
+                    <!-- Icon -->
+                    <div class="flex-shrink-0 w-10 h-10 rounded-full bg-@GetVariantColorClass(Model.Variant)/20 flex items-center justify-center">
+                        <svg class="w-5 h-5 text-@GetVariantColorClass(Model.Variant)" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@GetDefaultIconPath(Model.Variant)" />
+                        </svg>
+                    </div>
+
+                    <!-- Text Content -->
+                    <div class="flex-1">
+                        <h3 id="@(Model.Id)Title" class="text-lg font-semibold text-text-primary">@Model.Title</h3>
+                        <p id="@(Model.Id)Desc" class="mt-2 text-sm text-text-secondary">@Model.Message</p>
+
+                        <!-- Typed Input -->
+                        <div class="mt-4">
+                            <label for="@(Model.Id)Input" class="block text-sm font-medium text-text-primary mb-2">
+                                @Model.InputLabel
+                            </label>
+                            <input
+                                type="text"
+                                id="@(Model.Id)Input"
+                                class="w-full px-3 py-2 text-sm bg-bg-primary border border-error rounded-md text-text-primary placeholder-text-tertiary focus:border-error focus:ring-1 focus:ring-error transition-colors"
+                                placeholder="@Model.RequiredText"
+                                autocomplete="off"
+                                data-required-text="@Model.RequiredText"
+                                data-confirm-btn="@(Model.Id)ConfirmBtn"
+                                oninput="window.botControl?.validateTypedInput(this)"
+                            />
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Modal Footer -->
+            <div class="flex justify-end gap-3 px-6 py-4 bg-bg-secondary border-t border-border-primary rounded-b-lg">
+                <button type="button"
+                        onclick="window.botControl?.hideTypedModal('@Model.Id')"
+                        class="px-4 py-2 bg-bg-tertiary hover:bg-bg-hover border border-border-primary text-text-primary font-medium text-sm rounded-md transition-colors">
+                    @Model.CancelText
+                </button>
+
+                <form method="post" action="@Model.FormAction" class="inline-block" id="@(Model.Id)Form">
+                    @Html.AntiForgeryToken()
+                    <input type="hidden" name="handler" value="@Model.FormHandler" />
+                    <button type="submit"
+                            id="@(Model.Id)ConfirmBtn"
+                            disabled
+                            class="px-4 py-2 @GetConfirmButtonClass(Model.Variant) text-white font-medium text-sm rounded-md transition-colors min-w-[100px] flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed">
+                        <span class="confirm-btn-text">@Model.ConfirmText</span>
+                        <svg class="hidden w-4 h-4 animate-spin confirm-btn-spinner" fill="none" viewBox="0 0 24 24">
+                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                        </svg>
+                    </button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+@functions {
+    private string GetVariantColorClass(ConfirmationVariant variant)
+    {
+        return variant switch
+        {
+            ConfirmationVariant.Info => "accent-blue",
+            ConfirmationVariant.Warning => "warning",
+            ConfirmationVariant.Danger => "error",
+            _ => "warning"
+        };
+    }
+
+    private string GetConfirmButtonClass(ConfirmationVariant variant)
+    {
+        return variant switch
+        {
+            ConfirmationVariant.Info => "bg-accent-blue hover:bg-accent-blue-hover active:bg-accent-blue-active disabled:hover:bg-accent-blue",
+            ConfirmationVariant.Warning => "bg-warning hover:bg-amber-600 active:bg-amber-700 disabled:hover:bg-warning",
+            ConfirmationVariant.Danger => "bg-error hover:bg-red-600 active:bg-red-700 disabled:hover:bg-error",
+            _ => "bg-accent-orange hover:bg-accent-orange-hover active:bg-accent-orange-active disabled:hover:bg-accent-orange"
+        };
+    }
+
+    private string GetDefaultIconPath(ConfirmationVariant variant)
+    {
+        return variant switch
+        {
+            ConfirmationVariant.Info => "M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z",
+            ConfirmationVariant.Danger => "M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z",
+            _ => "M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+        };
+    }
+}

--- a/src/DiscordBot.Bot/Pages/Shared/_Sidebar.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/_Sidebar.cshtml
@@ -75,6 +75,13 @@
           </svg>
           Users
         </a>
+        <a href="/Admin/BotControl" class="sidebar-link @(ViewContext.RouteData.Values["page"]?.ToString() == "/Admin/BotControl" ? "active" : "")">
+          <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+          </svg>
+          Bot Control
+        </a>
       </div>
       <div class="my-4 border-t border-border-secondary"></div>
     </authorize>

--- a/src/DiscordBot.Bot/ViewModels/Components/TypedConfirmationModalViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Components/TypedConfirmationModalViewModel.cs
@@ -1,0 +1,58 @@
+namespace DiscordBot.Bot.ViewModels.Components;
+
+/// <summary>
+/// View model for typed confirmation modal dialogs.
+/// User must type a specific phrase to enable the confirm button.
+/// </summary>
+public record TypedConfirmationModalViewModel
+{
+    /// <summary>
+    /// Gets the unique identifier for the modal.
+    /// </summary>
+    public string Id { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the title of the confirmation dialog.
+    /// </summary>
+    public string Title { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the message explaining the action and consequences.
+    /// </summary>
+    public string Message { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the exact text the user must type to confirm.
+    /// </summary>
+    public string RequiredText { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the label for the input field.
+    /// </summary>
+    public string InputLabel { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the text for the confirm button.
+    /// </summary>
+    public string ConfirmText { get; init; } = "Confirm";
+
+    /// <summary>
+    /// Gets the text for the cancel button.
+    /// </summary>
+    public string CancelText { get; init; } = "Cancel";
+
+    /// <summary>
+    /// Gets the visual variant of the confirmation dialog.
+    /// </summary>
+    public ConfirmationVariant Variant { get; init; } = ConfirmationVariant.Danger;
+
+    /// <summary>
+    /// Gets the form action URL for POST submissions.
+    /// </summary>
+    public string? FormAction { get; init; }
+
+    /// <summary>
+    /// Gets the Razor Page handler name for the form.
+    /// </summary>
+    public string? FormHandler { get; init; }
+}

--- a/src/DiscordBot.Bot/ViewModels/Pages/BotControlViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Pages/BotControlViewModel.cs
@@ -1,0 +1,29 @@
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Bot.ViewModels.Pages;
+
+/// <summary>
+/// View model for the Bot Control Panel page.
+/// </summary>
+public class BotControlViewModel
+{
+    /// <summary>
+    /// Gets or sets the current bot status.
+    /// </summary>
+    public BotStatusViewModel Status { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets the bot configuration (with masked sensitive values).
+    /// </summary>
+    public BotConfigurationDto Configuration { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets whether restart is available.
+    /// </summary>
+    public bool CanRestart { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets whether shutdown is available.
+    /// </summary>
+    public bool CanShutdown { get; set; } = true;
+}

--- a/src/DiscordBot.Bot/wwwroot/js/bot-control.js
+++ b/src/DiscordBot.Bot/wwwroot/js/bot-control.js
@@ -1,0 +1,302 @@
+/**
+ * Bot Control Panel Module
+ * Handles typed confirmation, status polling, and action submissions
+ */
+(function() {
+    'use strict';
+
+    // Configuration
+    const STATUS_POLL_INTERVAL_MS = 5000; // 5 seconds for control panel
+    const API_ENDPOINT = '/api/bot/status';
+
+    let statusPollInterval = null;
+
+    /**
+     * Show a typed confirmation modal
+     * @param {string} modalId - The modal element ID
+     */
+    function showTypedModal(modalId) {
+        const modal = document.getElementById(modalId);
+        if (!modal) return;
+
+        // Reset input and button state
+        const input = modal.querySelector('input[type="text"]');
+        const confirmBtn = modal.querySelector('button[type="submit"]');
+
+        if (input) {
+            input.value = '';
+        }
+        if (confirmBtn) {
+            confirmBtn.disabled = true;
+        }
+
+        modal.classList.remove('hidden');
+        document.body.classList.add('overflow-hidden');
+
+        // Focus the input
+        if (input) {
+            setTimeout(() => input.focus(), 100);
+        }
+
+        // Setup form submission handler
+        const form = modal.querySelector('form');
+        if (form && !form.dataset.handlerAttached) {
+            form.dataset.handlerAttached = 'true';
+            form.addEventListener('submit', handleTypedFormSubmit);
+        }
+    }
+
+    /**
+     * Hide a typed confirmation modal
+     * @param {string} modalId - The modal element ID
+     */
+    function hideTypedModal(modalId) {
+        const modal = document.getElementById(modalId);
+        if (!modal) return;
+
+        modal.classList.add('hidden');
+        document.body.classList.remove('overflow-hidden');
+
+        // Reset input
+        const input = modal.querySelector('input[type="text"]');
+        if (input) {
+            input.value = '';
+        }
+
+        // Reset button
+        const confirmBtn = modal.querySelector('button[type="submit"]');
+        if (confirmBtn) {
+            confirmBtn.disabled = true;
+            const btnText = confirmBtn.querySelector('.confirm-btn-text');
+            const spinner = confirmBtn.querySelector('.confirm-btn-spinner');
+            if (btnText) btnText.classList.remove('hidden');
+            if (spinner) spinner.classList.add('hidden');
+        }
+    }
+
+    /**
+     * Validate typed input and enable/disable confirm button
+     * @param {HTMLInputElement} input - The input element
+     */
+    function validateTypedInput(input) {
+        const requiredText = input.dataset.requiredText;
+        const confirmBtnId = input.dataset.confirmBtn;
+        const confirmBtn = document.getElementById(confirmBtnId);
+
+        if (confirmBtn) {
+            confirmBtn.disabled = input.value !== requiredText;
+        }
+    }
+
+    /**
+     * Handle typed confirmation form submission via AJAX
+     * @param {Event} e - The submit event
+     */
+    async function handleTypedFormSubmit(e) {
+        e.preventDefault();
+
+        const form = e.target;
+        const modal = form.closest('[role="alertdialog"]');
+        const confirmBtn = form.querySelector('button[type="submit"]');
+        const btnText = confirmBtn?.querySelector('.confirm-btn-text');
+        const spinner = confirmBtn?.querySelector('.confirm-btn-spinner');
+
+        // Show loading state
+        if (confirmBtn) confirmBtn.disabled = true;
+        if (btnText) btnText.classList.add('hidden');
+        if (spinner) spinner.classList.remove('hidden');
+
+        try {
+            const formData = new FormData(form);
+            const handler = formData.get('handler');
+            const token = formData.get('__RequestVerificationToken');
+
+            const response = await fetch(`?handler=${handler}`, {
+                method: 'POST',
+                headers: {
+                    'RequestVerificationToken': token
+                },
+                body: formData
+            });
+
+            const data = await response.json();
+
+            if (response.ok && data.success) {
+                window.quickActions?.showToast(data.message, 'success');
+                if (modal) {
+                    hideTypedModal(modal.id);
+                }
+            } else {
+                window.quickActions?.showToast(data.message || 'Action failed.', 'error');
+                // Reset button state
+                if (confirmBtn) confirmBtn.disabled = false;
+                if (btnText) btnText.classList.remove('hidden');
+                if (spinner) spinner.classList.add('hidden');
+            }
+        } catch (error) {
+            console.error('Form submission error:', error);
+            window.quickActions?.showToast('An error occurred. Please try again.', 'error');
+            // Reset button state
+            if (confirmBtn) confirmBtn.disabled = false;
+            if (btnText) btnText.classList.remove('hidden');
+            if (spinner) spinner.classList.add('hidden');
+        }
+    }
+
+    /**
+     * Refresh bot status via API
+     */
+    async function refreshStatus() {
+        const statusContainer = document.querySelector('[data-bot-control-status]');
+        if (!statusContainer) return;
+
+        try {
+            const response = await fetch(API_ENDPOINT);
+            if (!response.ok) throw new Error('Status fetch failed');
+
+            const data = await response.json();
+
+            // Update status elements
+            updateStatusElement('[data-connection-state]', data.connectionState);
+            updateStatusElement('[data-latency]', data.latencyMs + ' ms');
+            updateStatusElement('[data-guild-count]', data.guildCount);
+            updateStatusElement('[data-uptime]', formatUptime(data.uptime));
+            updateStatusElement('[data-last-updated]', new Date().toISOString().substr(11, 8) + ' UTC');
+            updateStatusIndicator(data.connectionState);
+
+        } catch (error) {
+            console.error('Status refresh failed:', error);
+        }
+    }
+
+    /**
+     * Update a status element with a new value
+     * @param {string} selector - CSS selector
+     * @param {string} value - New value
+     */
+    function updateStatusElement(selector, value) {
+        const el = document.querySelector(selector);
+        if (el) el.textContent = value;
+    }
+
+    /**
+     * Update the status indicator color
+     * @param {string} state - Connection state
+     */
+    function updateStatusIndicator(state) {
+        const indicator = document.querySelector('[data-status-indicator]');
+        if (!indicator) return;
+
+        const isOnline = state.toUpperCase() === 'CONNECTED';
+
+        // Remove existing classes
+        indicator.classList.remove('bg-success', 'bg-error', 'animate-pulse');
+
+        // Add appropriate classes
+        if (isOnline) {
+            indicator.classList.add('bg-success', 'animate-pulse');
+        } else {
+            indicator.classList.add('bg-error');
+        }
+    }
+
+    /**
+     * Format a TimeSpan string to human-readable format
+     * @param {string} timeSpanString - TimeSpan in format "d.hh:mm:ss" or "hh:mm:ss"
+     * @returns {string} Formatted uptime string
+     */
+    function formatUptime(timeSpanString) {
+        if (!timeSpanString) return '0s';
+
+        // Parse the TimeSpan string
+        const parts = timeSpanString.split(':');
+        let days = 0, hours = 0, minutes = 0, seconds = 0;
+
+        if (parts.length === 3) {
+            // Format: "hh:mm:ss" or "d.hh:mm:ss"
+            const hourPart = parts[0];
+            if (hourPart.includes('.')) {
+                const dayHour = hourPart.split('.');
+                days = parseInt(dayHour[0], 10);
+                hours = parseInt(dayHour[1], 10);
+            } else {
+                hours = parseInt(hourPart, 10);
+            }
+            minutes = parseInt(parts[1], 10);
+            seconds = parseInt(parts[2].split('.')[0], 10); // Remove fractional seconds
+        }
+
+        // Build human-readable string
+        if (days > 0) {
+            return `${days}d ${hours}h ${minutes}m`;
+        } else if (hours > 0) {
+            return `${hours}h ${minutes}m ${seconds}s`;
+        } else if (minutes > 0) {
+            return `${minutes}m ${seconds}s`;
+        } else {
+            return `${seconds}s`;
+        }
+    }
+
+    /**
+     * Start status polling
+     */
+    function startPolling() {
+        const statusContainer = document.querySelector('[data-bot-control-status]');
+        if (!statusContainer) return;
+
+        // Initial refresh
+        refreshStatus();
+
+        // Start interval polling
+        statusPollInterval = setInterval(refreshStatus, STATUS_POLL_INTERVAL_MS);
+    }
+
+    /**
+     * Stop status polling
+     */
+    function stopPolling() {
+        if (statusPollInterval) {
+            clearInterval(statusPollInterval);
+            statusPollInterval = null;
+        }
+    }
+
+    /**
+     * Initialize the module
+     */
+    function init() {
+        // Start status polling
+        startPolling();
+
+        // Handle escape key to close modals
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape') {
+                const openModal = document.querySelector('[role="alertdialog"]:not(.hidden)');
+                if (openModal) {
+                    hideTypedModal(openModal.id);
+                }
+            }
+        });
+
+        // Clean up on page unload
+        window.addEventListener('beforeunload', stopPolling);
+    }
+
+    // Expose public API
+    window.botControl = {
+        showTypedModal,
+        hideTypedModal,
+        validateTypedInput,
+        refreshStatus,
+        startPolling,
+        stopPolling
+    };
+
+    // Initialize on DOM ready
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/src/DiscordBot.Core/DTOs/BotConfigurationDto.cs
+++ b/src/DiscordBot.Core/DTOs/BotConfigurationDto.cs
@@ -1,0 +1,53 @@
+namespace DiscordBot.Core.DTOs;
+
+/// <summary>
+/// Read-only bot configuration for display purposes.
+/// Sensitive values are masked for security.
+/// </summary>
+public class BotConfigurationDto
+{
+    /// <summary>
+    /// Gets or sets the bot token (masked, shows only last 4 characters).
+    /// </summary>
+    public string TokenMasked { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the test guild ID if configured.
+    /// </summary>
+    public ulong? TestGuildId { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether a test guild is configured.
+    /// </summary>
+    public bool HasTestGuild { get; set; }
+
+    /// <summary>
+    /// Gets or sets the database provider name.
+    /// </summary>
+    public string DatabaseProvider { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the Discord.NET version.
+    /// </summary>
+    public string DiscordNetVersion { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the application version.
+    /// </summary>
+    public string AppVersion { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the .NET runtime version.
+    /// </summary>
+    public string RuntimeVersion { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the default rate limit invokes.
+    /// </summary>
+    public int DefaultRateLimitInvokes { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default rate limit period in seconds.
+    /// </summary>
+    public double DefaultRateLimitPeriodSeconds { get; set; }
+}

--- a/src/DiscordBot.Core/Interfaces/IBotService.cs
+++ b/src/DiscordBot.Core/Interfaces/IBotService.cs
@@ -32,4 +32,10 @@ public interface IBotService
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     Task ShutdownAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the bot configuration with sensitive values masked.
+    /// </summary>
+    /// <returns>Bot configuration information safe for display.</returns>
+    BotConfigurationDto GetConfiguration();
 }


### PR DESCRIPTION
## Summary

- Add dedicated Bot Control page at `/Admin/BotControl` for bot lifecycle management
- Implement soft restart functionality that disconnects and reconnects the Discord client
- Add shutdown with typed confirmation requiring users to type "SHUTDOWN" to confirm
- Display read-only configuration with masked sensitive values (token, OAuth client ID)
- Real-time status updates via 5-second polling of the `/api/bot/status` endpoint

## Changes

### New Files
- `Pages/Admin/BotControl.cshtml` / `.cs` - Bot Control Panel page
- `Pages/Shared/Components/_TypedConfirmationModal.cshtml` - Reusable typed confirmation modal
- `ViewModels/Components/TypedConfirmationModalViewModel.cs` - Typed modal configuration
- `ViewModels/Pages/BotControlViewModel.cs` - Page view model
- `wwwroot/js/bot-control.js` - Client-side functionality
- `Core/DTOs/BotConfigurationDto.cs` - Configuration DTO with masked values

### Modified Files
- `IBotService.cs` - Added `GetConfiguration()` method
- `BotService.cs` - Implemented `GetConfiguration()` and updated `RestartAsync()` for soft restart
- `_Sidebar.cshtml` - Added Bot Control navigation link
- `BotServiceTests.cs` - Updated tests for new constructor parameter

## Test plan

- [ ] Navigate to `/Admin/BotControl` as an admin user
- [ ] Verify bot status displays correctly with real-time updates
- [ ] Verify configuration displays with masked token
- [ ] Click "Restart Bot" and confirm - verify bot disconnects and reconnects
- [ ] Click "Shutdown Bot" and verify typed confirmation modal appears
- [ ] Verify shutdown button is disabled until "SHUTDOWN" is typed exactly
- [ ] Verify non-admin users cannot access the page
- [ ] Run `dotnet test --filter BotServiceTests` - all tests should pass

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)