### PR TITLE
feat: Add toast notification system (#87)

### DIFF
--- a/src/DiscordBot.Bot/Extensions/TempDataExtensions.cs
+++ b/src/DiscordBot.Bot/Extensions/TempDataExtensions.cs
@@ -1,0 +1,72 @@
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+
+namespace DiscordBot.Bot.Extensions;
+
+/// <summary>
+/// Extension methods for TempData to provide toast notification support.
+/// Toast messages set via these methods will be automatically displayed
+/// when the _ToastContainer partial is rendered in the layout.
+/// </summary>
+public static class TempDataExtensions
+{
+    /// <summary>
+    /// Sets a success toast message to be displayed on the next page load.
+    /// </summary>
+    /// <param name="tempData">The TempData dictionary.</param>
+    /// <param name="message">The message to display.</param>
+    /// <param name="title">Optional title for the toast.</param>
+    public static void SetSuccessToast(this ITempDataDictionary tempData, string message, string? title = null)
+    {
+        tempData["ToastSuccess"] = message;
+        if (title != null)
+        {
+            tempData["ToastSuccessTitle"] = title;
+        }
+    }
+
+    /// <summary>
+    /// Sets an error toast message to be displayed on the next page load.
+    /// Error toasts display for longer (10 seconds by default).
+    /// </summary>
+    /// <param name="tempData">The TempData dictionary.</param>
+    /// <param name="message">The message to display.</param>
+    /// <param name="title">Optional title for the toast.</param>
+    public static void SetErrorToast(this ITempDataDictionary tempData, string message, string? title = null)
+    {
+        tempData["ToastError"] = message;
+        if (title != null)
+        {
+            tempData["ToastErrorTitle"] = title;
+        }
+    }
+
+    /// <summary>
+    /// Sets a warning toast message to be displayed on the next page load.
+    /// </summary>
+    /// <param name="tempData">The TempData dictionary.</param>
+    /// <param name="message">The message to display.</param>
+    /// <param name="title">Optional title for the toast.</param>
+    public static void SetWarningToast(this ITempDataDictionary tempData, string message, string? title = null)
+    {
+        tempData["ToastWarning"] = message;
+        if (title != null)
+        {
+            tempData["ToastWarningTitle"] = title;
+        }
+    }
+
+    /// <summary>
+    /// Sets an info toast message to be displayed on the next page load.
+    /// </summary>
+    /// <param name="tempData">The TempData dictionary.</param>
+    /// <param name="message">The message to display.</param>
+    /// <param name="title">Optional title for the toast.</param>
+    public static void SetInfoToast(this ITempDataDictionary tempData, string message, string? title = null)
+    {
+        tempData["ToastInfo"] = message;
+        if (title != null)
+        {
+            tempData["ToastInfoTitle"] = title;
+        }
+    }
+}

--- a/src/DiscordBot.Bot/Pages/Shared/_Layout.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/_Layout.cshtml
@@ -32,8 +32,13 @@
         </div>
     </main>
 
+    <!-- Toast Notifications Container -->
+    @await Html.PartialAsync("_ToastContainer")
+
     <!-- JavaScript for Navigation -->
     <script src="~/js/navigation.js" asp-append-version="true"></script>
+    <!-- JavaScript for Toast Notifications -->
+    <script src="~/js/toast.js" asp-append-version="true"></script>
 
     @await RenderSectionAsync("Scripts", required: false)
 </body>

--- a/src/DiscordBot.Bot/Pages/Shared/_ToastContainer.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/_ToastContainer.cshtml
@@ -1,0 +1,71 @@
+@*
+    Toast Notification Container
+    Include this partial in _Layout.cshtml to enable toast notifications.
+
+    Usage from JavaScript:
+        ToastManager.show('success', 'Your changes have been saved.');
+        ToastManager.show('error', 'Something went wrong.', { title: 'Error', duration: 10000 });
+        ToastManager.show('warning', 'Rate limit approaching.');
+        ToastManager.show('info', 'New features available.');
+*@
+
+<!-- Toast Container -->
+<div id="toastContainer"
+     class="fixed top-16 right-4 z-[1100] flex flex-col gap-2 pointer-events-none max-h-[calc(100vh-32px)] overflow-hidden"
+     role="region"
+     aria-label="Notifications">
+    <!-- Accessible live region for screen readers -->
+    <div id="toastLiveRegion" class="sr-only" aria-live="polite" aria-atomic="true"></div>
+</div>
+
+@* Render any TempData toasts passed from server-side *@
+@{
+    var toastSuccess = TempData["ToastSuccess"]?.ToString();
+    var toastSuccessTitle = TempData["ToastSuccessTitle"]?.ToString();
+    var toastError = TempData["ToastError"]?.ToString();
+    var toastErrorTitle = TempData["ToastErrorTitle"]?.ToString();
+    var toastWarning = TempData["ToastWarning"]?.ToString();
+    var toastWarningTitle = TempData["ToastWarningTitle"]?.ToString();
+    var toastInfo = TempData["ToastInfo"]?.ToString();
+    var toastInfoTitle = TempData["ToastInfoTitle"]?.ToString();
+}
+@if (!string.IsNullOrEmpty(toastSuccess) || !string.IsNullOrEmpty(toastError) || !string.IsNullOrEmpty(toastWarning) || !string.IsNullOrEmpty(toastInfo))
+{
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            @if (!string.IsNullOrEmpty(toastSuccess))
+            {
+                <text>
+                ToastManager.show('success', @Html.Raw(Json.Serialize(toastSuccess)), {
+                    title: @Html.Raw(Json.Serialize(toastSuccessTitle))
+                });
+                </text>
+            }
+            @if (!string.IsNullOrEmpty(toastError))
+            {
+                <text>
+                ToastManager.show('error', @Html.Raw(Json.Serialize(toastError)), {
+                    title: @Html.Raw(Json.Serialize(toastErrorTitle)),
+                    duration: 10000
+                });
+                </text>
+            }
+            @if (!string.IsNullOrEmpty(toastWarning))
+            {
+                <text>
+                ToastManager.show('warning', @Html.Raw(Json.Serialize(toastWarning)), {
+                    title: @Html.Raw(Json.Serialize(toastWarningTitle))
+                });
+                </text>
+            }
+            @if (!string.IsNullOrEmpty(toastInfo))
+            {
+                <text>
+                ToastManager.show('info', @Html.Raw(Json.Serialize(toastInfo)), {
+                    title: @Html.Raw(Json.Serialize(toastInfoTitle))
+                });
+                </text>
+            }
+        });
+    </script>
+}

--- a/src/DiscordBot.Bot/wwwroot/js/toast.js
+++ b/src/DiscordBot.Bot/wwwroot/js/toast.js
@@ -56,6 +56,34 @@ const ToastManager = {
 
     // Insert at beginning (newest on top)
     this.container.insertBefore(toastData.element, this.container.firstChild);
+
+    // Announce to screen readers via live region
+    this.announceToScreenReader(type, message, title);
+  },
+
+  /**
+   * Announce toast message to screen readers
+   * @private
+   */
+  announceToScreenReader(type, message, title) {
+    const liveRegion = document.getElementById('toastLiveRegion');
+    if (liveRegion) {
+      const typeLabels = {
+        success: 'Success',
+        error: 'Error',
+        warning: 'Warning',
+        info: 'Information'
+      };
+      const announcement = title
+        ? `${typeLabels[type]}: ${title}. ${message}`
+        : `${typeLabels[type]}: ${message}`;
+      liveRegion.textContent = announcement;
+
+      // Clear after a short delay to allow for repeated announcements
+      setTimeout(() => {
+        liveRegion.textContent = '';
+      }, 1000);
+    }
   },
 
   /**


### PR DESCRIPTION
## Summary
- Add global toast notification system with success, error, warning, and info variants
- Create `_ToastContainer.cshtml` partial with accessible aria-live region for screen reader announcements
- Add `TempDataExtensions` helper for server-side toast messages on page redirects
- Update `ToastManager` JavaScript module with screen reader accessibility support

## Changes Made
| File | Description |
|------|-------------|
| `_ToastContainer.cshtml` | New partial view containing toast container with aria-live region |
| `_Layout.cshtml` | Include toast container partial and toast.js script |
| `TempDataExtensions.cs` | Extension methods for setting success/error/warning/info toasts via TempData |
| `toast.js` | Add screen reader announcement functionality |

## Features
- Success, error, warning, info toast variants per design system
- Auto-dismiss after configurable duration (5s default, 10s for errors)
- Manual dismiss via close button
- Queue up to 5 notifications with oldest removed first
- Hover-to-pause timer functionality
- Progress bar countdown indicator
- Accessible announcements via aria-live region
- Server-side support via TempData for post-redirect-get pattern

## Usage

### JavaScript (Client-side)
```javascript
ToastManager.show('success', 'Your changes have been saved.');
ToastManager.show('error', 'Something went wrong.', { title: 'Error', duration: 10000 });
ToastManager.show('warning', 'Rate limit approaching.');
ToastManager.show('info', 'New features available.', { title: 'Update' });
```

### C# (Server-side)
```csharp
using DiscordBot.Bot.Extensions;

TempData.SetSuccessToast("Settings saved successfully!", "Success");
TempData.SetErrorToast("Failed to save settings.", "Error");
return RedirectToPage();
```

## Test Plan
- [x] Build succeeds with 0 warnings
- [x] All 677 tests pass
- [ ] Manual test: Trigger each toast variant from JavaScript console
- [ ] Manual test: Verify auto-dismiss timer works
- [ ] Manual test: Verify hover pauses timer
- [ ] Manual test: Verify close button dismisses toast
- [ ] Manual test: Verify multiple toasts queue properly
- [ ] Screen reader test: Verify announcements work

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)