### PR TITLE
Fix placeholder links in user dropdown menu

### DIFF
--- a/src/DiscordBot.Bot/Pages/Shared/_Navbar.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/_Navbar.cshtml
@@ -101,20 +101,7 @@
             <p class="text-sm font-medium text-text-primary">@displayName</p>
             <p class="text-xs text-text-secondary">@user?.Email</p>
           </div>
-          <a href="#" role="menuitem" class="flex items-center gap-2 px-4 py-2 text-sm text-text-secondary hover:bg-bg-hover hover:text-text-primary transition-colors">
-            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-            </svg>
-            Profile
-          </a>
-          <a href="#" role="menuitem" class="flex items-center gap-2 px-4 py-2 text-sm text-text-secondary hover:bg-bg-hover hover:text-text-primary transition-colors">
-            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-            </svg>
-            Settings
-          </a>
-          <div class="border-t border-border-primary mt-1 pt-1">
+          <div class="pt-1">
             <form asp-page="/Account/Logout" asp-page-handler="Post" method="post" class="block">
               <button type="submit" role="menuitem" class="w-full text-left flex items-center gap-2 px-4 py-2 text-sm text-error hover:bg-bg-hover transition-colors">
                 <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">


### PR DESCRIPTION
## Summary

- Remove non-functional Profile and Settings links from user dropdown menu that pointed to `#`
- Keep Sign out functionality intact
- Clean up redundant border styling after removing menu items

Closes #162

## Test plan

- [ ] Log in to admin UI
- [ ] Click user avatar/dropdown in navbar
- [ ] Verify only Sign out option appears (no Profile or Settings)
- [ ] Verify Sign out still works correctly
- [ ] Verify dropdown displays correctly without visual issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)