### PR TITLE
fix: Remove placeholder links from login page (#164)

### DIFF
--- a/src/DiscordBot.Bot/Pages/Account/Login.cshtml
+++ b/src/DiscordBot.Bot/Pages/Account/Login.cshtml
@@ -69,14 +69,9 @@
 
                 <!-- Password Field -->
                 <div>
-                    <div class="flex items-center justify-between mb-2">
-                        <label asp-for="Input.Password" class="block text-sm font-semibold text-text-primary">
-                            Password
-                        </label>
-                        <a href="#" class="text-xs text-accent-blue hover:text-accent-blue-hover transition-colors" tabindex="-1" aria-disabled="true" title="Coming soon">
-                            Forgot password?
-                        </a>
-                    </div>
+                    <label asp-for="Input.Password" class="block text-sm font-semibold text-text-primary mb-2">
+                        Password
+                    </label>
                     <input
                         asp-for="Input.Password"
                         type="password"
@@ -136,14 +131,6 @@
                 </form>
             }
         </div>
-
-        <!-- Footer Note -->
-        <p class="text-center text-xs text-text-tertiary mt-6">
-            By signing in, you agree to our
-            <a href="#" class="text-accent-blue hover:text-accent-blue-hover transition-colors">Terms of Service</a>
-            and
-            <a href="#" class="text-accent-blue hover:text-accent-blue-hover transition-colors">Privacy Policy</a>.
-        </p>
     </div>
 
     @section Scripts {


### PR DESCRIPTION
## Summary

- Removed non-functional "Forgot password?" link from the password field
- Removed the Terms of Service/Privacy Policy footer containing placeholder links
- These features will be re-added when properly implemented

## Changes

| Link Removed | Location | Reason |
|--------------|----------|--------|
| Forgot password? | Password field | Feature not implemented |
| Terms of Service | Footer | No document exists |
| Privacy Policy | Footer | No document exists |

## Test plan

- [ ] Login page loads without errors
- [ ] Password field displays correctly without the forgot password link
- [ ] No broken links remain on the login page
- [ ] Build completes successfully

Fixes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)