### PR TITLE
fix: Make bot version in sidebar dynamic (#165)

### DIFF
--- a/src/DiscordBot.Bot/Pages/Shared/_Sidebar.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/_Sidebar.cshtml
@@ -1,3 +1,4 @@
+@inject DiscordBot.Core.Interfaces.IVersionService VersionService
 <!-- Sidebar Navigation -->
 <aside
   id="sidebar"
@@ -127,7 +128,7 @@
       <div class="sidebar-status">
         <span class="sidebar-status-dot online status-pulse"></span>
         <span class="text-success font-medium">Bot Online</span>
-        <span class="ml-auto text-xs text-text-tertiary">v2.1.0</span>
+        <span class="ml-auto text-xs text-text-tertiary">@VersionService.GetVersion()</span>
       </div>
     </div>
   </nav>

--- a/src/DiscordBot.Bot/Program.cs
+++ b/src/DiscordBot.Bot/Program.cs
@@ -140,6 +140,7 @@ try
     builder.Services.AddScoped<IClaimsTransformation, DiscordClaimsTransformation>();
 
     // Add application services
+    builder.Services.AddSingleton<IVersionService, VersionService>();
     builder.Services.AddScoped<IBotService, BotService>();
     builder.Services.AddScoped<IGuildService, GuildService>();
     builder.Services.AddScoped<ICommandLogService, CommandLogService>();

--- a/src/DiscordBot.Bot/Services/VersionService.cs
+++ b/src/DiscordBot.Bot/Services/VersionService.cs
@@ -1,0 +1,35 @@
+using System.Reflection;
+using DiscordBot.Core.Interfaces;
+
+namespace DiscordBot.Bot.Services;
+
+/// <summary>
+/// Service for retrieving application version information.
+/// </summary>
+public class VersionService : IVersionService
+{
+    private readonly string _version;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VersionService"/> class.
+    /// </summary>
+    public VersionService()
+    {
+        var assembly = Assembly.GetEntryAssembly();
+        var version = assembly?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? assembly?.GetName().Version?.ToString()
+            ?? "0.0.0";
+
+        // Strip any metadata suffix (e.g., "+abc123" from semantic versioning)
+        var plusIndex = version.IndexOf('+');
+        if (plusIndex >= 0)
+        {
+            version = version[..plusIndex];
+        }
+
+        _version = $"v{version}";
+    }
+
+    /// <inheritdoc/>
+    public string GetVersion() => _version;
+}

--- a/src/DiscordBot.Core/Interfaces/IVersionService.cs
+++ b/src/DiscordBot.Core/Interfaces/IVersionService.cs
@@ -1,0 +1,13 @@
+namespace DiscordBot.Core.Interfaces;
+
+/// <summary>
+/// Service interface for retrieving application version information.
+/// </summary>
+public interface IVersionService
+{
+    /// <summary>
+    /// Gets the current application version string.
+    /// </summary>
+    /// <returns>The version string (e.g., "v1.0.0"), or a fallback value if unavailable.</returns>
+    string GetVersion();
+}


### PR DESCRIPTION
## Summary
- Adds `IVersionService` interface and `VersionService` implementation to dynamically read the application version from assembly metadata
- Updates the sidebar footer to display the version dynamically instead of the hardcoded "v2.1.0"
- Version is sourced from `AssemblyInformationalVersionAttribute` with fallbacks to `AssemblyVersion` and finally "0.0.0"

## Test plan
- [ ] Build succeeds without errors
- [ ] Run the application and verify the version displays correctly in the sidebar footer
- [ ] Verify version updates when assembly version changes

Fixes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)