### PR TITLE
Remove or replace decorative notifications bell

### DIFF
--- a/src/DiscordBot.Bot/Pages/Shared/_Navbar.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/_Navbar.cshtml
@@ -53,14 +53,6 @@
       </svg>
     </button>
 
-    <!-- Notifications -->
-    <button class="relative p-2 rounded-md text-text-secondary hover:text-text-primary hover:bg-bg-hover transition-colors" aria-label="Notifications">
-      <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
-      </svg>
-      <span class="absolute top-1 right-1 w-2 h-2 bg-accent-orange rounded-full"></span>
-    </button>
-
     <!-- Authentication Section -->
     @if (SignInManager.IsSignedIn(User))
     {


### PR DESCRIPTION
## Summary

- Remove non-functional notifications bell from navbar that was misleading users
- The bell had a red indicator dot suggesting unread notifications, but no notification system exists
- Will be re-added when a proper notification system is implemented

## Test plan

- [ ] Verify navbar displays correctly without the notifications bell
- [ ] Verify no broken layout or spacing issues in the right section of navbar

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)