### PR TITLE
fix: Restrict Components showcase page to admins (#167)

### DIFF
--- a/src/DiscordBot.Bot/Pages/Components.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Components.cshtml.cs
@@ -9,7 +9,7 @@ namespace DiscordBot.Bot.Pages;
 /// PageModel for the component showcase page.
 /// Creates sample ViewModels for all UI components to demonstrate their various states and variants.
 /// </summary>
-[Authorize(Policy = "RequireViewer")]
+[Authorize(Policy = "RequireAdmin")]
 public class ComponentsModel : PageModel
 {
     // Buttons

--- a/src/DiscordBot.Bot/Pages/Shared/_Sidebar.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/_Sidebar.cshtml
@@ -90,19 +90,21 @@
       <div class="my-4 border-t border-border-secondary" role="separator"></div>
     </authorize>
 
-    <!-- Developer Tools -->
-    <div class="space-y-1" role="group" aria-labelledby="dev-nav-heading">
-      <h2 id="dev-nav-heading" class="sidebar-section">Developer</h2>
-      <a href="/Components" class="sidebar-link @(ViewContext.RouteData.Values["page"]?.ToString() == "/Components" ? "active" : "")">
-        <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
-        </svg>
-        Components
-      </a>
-    </div>
+    <!-- Developer Tools - visible to Admin+ -->
+    <authorize policy="RequireAdmin">
+      <div class="space-y-1" role="group" aria-labelledby="dev-nav-heading">
+        <h2 id="dev-nav-heading" class="sidebar-section">Developer</h2>
+        <a href="/Components" class="sidebar-link @(ViewContext.RouteData.Values["page"]?.ToString() == "/Components" ? "active" : "")">
+          <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
+          </svg>
+          Components
+        </a>
+      </div>
 
-    <!-- Divider -->
-    <div class="my-4 border-t border-border-secondary" role="separator"></div>
+      <!-- Divider -->
+      <div class="my-4 border-t border-border-secondary" role="separator"></div>
+    </authorize>
 
     <!-- Secondary Navigation (Coming Soon) -->
     <div class="space-y-1" role="group" aria-labelledby="support-nav-heading">


### PR DESCRIPTION
## Summary

- Wraps the Developer section in the sidebar with `<authorize policy="RequireAdmin">` so only admins see it
- Updates the Components page authorization from `RequireViewer` to `RequireAdmin` to prevent direct URL access
- Regular users (Viewer, Moderator) no longer see the Developer section or can access the Components page

## Test plan

- [ ] Log in as a Viewer or Moderator user - Developer section should not appear in sidebar
- [ ] Try to access `/Components` directly as a non-admin - should be denied
- [ ] Log in as Admin or SuperAdmin - Developer section should be visible and Components page accessible

Fixes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)