### PR TITLE
fix: Align chart data serialization with JavaScript expectations (fixes #171)

### DIFF
--- a/src/DiscordBot.Bot/Pages/CommandLogs/Analytics.cshtml
+++ b/src/DiscordBot.Bot/Pages/CommandLogs/Analytics.cshtml
@@ -367,9 +367,20 @@
     @{
         var chartData = new {
             usageOverTime = Model.ViewModel.UsageOverTime.Select(u => new { date = u.Date.ToString("yyyy-MM-dd"), count = u.Count }),
-            topCommands = Model.ViewModel.TopCommands,
-            successRate = new { success = Model.ViewModel.SuccessRateData.SuccessCount, failure = Model.ViewModel.SuccessRateData.FailureCount },
-            performance = Model.ViewModel.PerformanceData.Select(p => new { command = p.CommandName, avgMs = p.AvgResponseTimeMs })
+            topCommands = Model.ViewModel.TopCommands.Select(kvp => new {
+                commandName = kvp.Key,
+                count = kvp.Value,
+                percentage = Model.ViewModel.TotalCommands > 0 ? (double)kvp.Value / Model.ViewModel.TotalCommands * 100 : 0
+            }),
+            successRate = new {
+                successCount = Model.ViewModel.SuccessRateData.SuccessCount,
+                failureCount = Model.ViewModel.SuccessRateData.FailureCount,
+                successRate = Model.ViewModel.SuccessRateData.SuccessRate
+            },
+            responseTime = Model.ViewModel.PerformanceData.Select(p => new {
+                commandName = p.CommandName,
+                avgResponseTimeMs = p.AvgResponseTimeMs
+            })
         };
         var chartDataJson = System.Text.Json.JsonSerializer.Serialize(chartData);
     }


### PR DESCRIPTION
## Summary

Fixes the Command Analytics page (`/CommandLogs/Analytics`) where only the "Usage Over Time" chart was rendering while the other three charts were empty.

### Root Cause
Property name mismatches between the server-side JSON serialization in `Analytics.cshtml` and the client-side JavaScript in `command-analytics.js`:

| Chart | Server Property | Expected by JavaScript |
|-------|-----------------|----------------------|
| Top Commands | `Dictionary<string, int>` | `[{commandName, count, percentage}]` |
| Success Rate | `{success, failure}` | `{successCount, failureCount, successRate}` |
| Response Time | `performance: [{command, avgMs}]` | `responseTime: [{commandName, avgResponseTimeMs}]` |

### Changes Made
- `topCommands`: Transform Dictionary to array of objects with `commandName`, `count`, and `percentage` properties
- `successRate`: Rename `success` → `successCount`, `failure` → `failureCount`, and add `successRate` property
- `responseTime`: Rename `performance` → `responseTime`, with `commandName` and `avgResponseTimeMs` properties

## Test Plan
- [x] Build succeeds
- [x] All tests pass (665 passed)
- [ ] Verify all four charts render when data is available
- [ ] Verify charts handle empty data gracefully (show "No data available" message)

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)