### PR TITLE
feat: Add Correlation ID middleware for API request tracing

### DIFF
--- a/src/DiscordBot.Bot/Controllers/BotController.cs
+++ b/src/DiscordBot.Bot/Controllers/BotController.cs
@@ -1,3 +1,4 @@
+using DiscordBot.Bot.Extensions;
 using DiscordBot.Core.DTOs;
 using DiscordBot.Core.Interfaces;
 using Microsoft.AspNetCore.Mvc;
@@ -86,7 +87,7 @@ public class BotController : ControllerBase
                 Message = "Restart operation is not supported",
                 Detail = ex.Message,
                 StatusCode = StatusCodes.Status500InternalServerError,
-                TraceId = HttpContext.TraceIdentifier
+                TraceId = HttpContext.GetCorrelationId()
             });
         }
     }

--- a/src/DiscordBot.Bot/Controllers/CommandLogsController.cs
+++ b/src/DiscordBot.Bot/Controllers/CommandLogsController.cs
@@ -1,3 +1,4 @@
+using DiscordBot.Bot.Extensions;
 using DiscordBot.Core.DTOs;
 using DiscordBot.Core.Interfaces;
 using Microsoft.AspNetCore.Mvc;
@@ -71,7 +72,7 @@ public class CommandLogsController : ControllerBase
                 Message = "Invalid date range",
                 Detail = "Start date cannot be after end date.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.TraceIdentifier
+                TraceId = HttpContext.GetCorrelationId()
             });
         }
 

--- a/src/DiscordBot.Bot/Controllers/GuildsController.cs
+++ b/src/DiscordBot.Bot/Controllers/GuildsController.cs
@@ -1,3 +1,4 @@
+using DiscordBot.Bot.Extensions;
 using DiscordBot.Core.DTOs;
 using DiscordBot.Core.Interfaces;
 using Microsoft.AspNetCore.Mvc;
@@ -67,7 +68,7 @@ public class GuildsController : ControllerBase
                 Message = "Guild not found",
                 Detail = $"No guild with ID {id} exists in the database.",
                 StatusCode = StatusCodes.Status404NotFound,
-                TraceId = HttpContext.TraceIdentifier
+                TraceId = HttpContext.GetCorrelationId()
             });
         }
 
@@ -103,7 +104,7 @@ public class GuildsController : ControllerBase
                 Message = "Invalid request",
                 Detail = "Request body cannot be null.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.TraceIdentifier
+                TraceId = HttpContext.GetCorrelationId()
             });
         }
 
@@ -118,7 +119,7 @@ public class GuildsController : ControllerBase
                 Message = "Guild not found",
                 Detail = $"No guild with ID {id} exists in the database.",
                 StatusCode = StatusCodes.Status404NotFound,
-                TraceId = HttpContext.TraceIdentifier
+                TraceId = HttpContext.GetCorrelationId()
             });
         }
 
@@ -151,7 +152,7 @@ public class GuildsController : ControllerBase
                 Message = "Guild not found",
                 Detail = $"No guild with ID {id} is connected to the bot.",
                 StatusCode = StatusCodes.Status404NotFound,
-                TraceId = HttpContext.TraceIdentifier
+                TraceId = HttpContext.GetCorrelationId()
             });
         }
 

--- a/src/DiscordBot.Bot/Extensions/HttpContextExtensions.cs
+++ b/src/DiscordBot.Bot/Extensions/HttpContextExtensions.cs
@@ -1,0 +1,33 @@
+using DiscordBot.Bot.Middleware;
+
+namespace DiscordBot.Bot.Extensions;
+
+/// <summary>
+/// Extension methods for <see cref="HttpContext"/> to simplify access to request context data.
+/// </summary>
+public static class HttpContextExtensions
+{
+    /// <summary>
+    /// Retrieves the correlation ID for the current request.
+    /// </summary>
+    /// <param name="context">The HTTP context.</param>
+    /// <returns>
+    /// The correlation ID if available in HttpContext.Items; otherwise, falls back to HttpContext.TraceIdentifier.
+    /// </returns>
+    /// <remarks>
+    /// This method should be used in controllers and services to retrieve the correlation ID for logging
+    /// and error responses. The correlation ID is set by <see cref="CorrelationIdMiddleware"/> and stored
+    /// in HttpContext.Items for the duration of the request.
+    /// </remarks>
+    public static string GetCorrelationId(this HttpContext context)
+    {
+        if (context.Items.TryGetValue(CorrelationIdMiddleware.ItemKey, out var correlationId)
+            && correlationId is string id)
+        {
+            return id;
+        }
+
+        // Fallback to TraceIdentifier if correlation ID is not set
+        return context.TraceIdentifier;
+    }
+}

--- a/src/DiscordBot.Bot/Middleware/CorrelationIdMiddleware.cs
+++ b/src/DiscordBot.Bot/Middleware/CorrelationIdMiddleware.cs
@@ -1,0 +1,86 @@
+using Serilog.Context;
+
+namespace DiscordBot.Bot.Middleware;
+
+/// <summary>
+/// Middleware that extracts or generates correlation IDs for API requests and propagates them through logs and response headers.
+/// </summary>
+/// <remarks>
+/// The middleware performs the following operations:
+/// <list type="number">
+/// <item>Extracts the X-Correlation-ID header from the incoming request, or generates a new 16-character hex ID if not present</item>
+/// <item>Stores the correlation ID in HttpContext.Items for access by other middleware and controllers</item>
+/// <item>Adds the X-Correlation-ID header to the response</item>
+/// <item>Pushes the correlation ID to Serilog's LogContext for structured logging</item>
+/// </list>
+/// This enables end-to-end request tracing across the application and facilitates troubleshooting.
+/// </remarks>
+public class CorrelationIdMiddleware
+{
+    /// <summary>
+    /// The header name used for correlation ID in requests and responses.
+    /// </summary>
+    public const string HeaderName = "X-Correlation-ID";
+
+    /// <summary>
+    /// The key used to store the correlation ID in HttpContext.Items.
+    /// </summary>
+    public const string ItemKey = "CorrelationId";
+
+    private readonly RequestDelegate _next;
+    private readonly ILogger<CorrelationIdMiddleware> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CorrelationIdMiddleware"/> class.
+    /// </summary>
+    /// <param name="next">The next middleware in the pipeline.</param>
+    /// <param name="logger">The logger instance.</param>
+    public CorrelationIdMiddleware(RequestDelegate next, ILogger<CorrelationIdMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Processes the HTTP request and manages correlation ID extraction, generation, and propagation.
+    /// </summary>
+    /// <param name="context">The HTTP context for the current request.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public async Task InvokeAsync(HttpContext context)
+    {
+        // Extract correlation ID from request headers or generate a new one
+        var correlationId = context.Request.Headers[HeaderName].FirstOrDefault();
+
+        if (string.IsNullOrWhiteSpace(correlationId))
+        {
+            correlationId = GenerateCorrelationId();
+            _logger.LogTrace("Generated new correlation ID: {CorrelationId}", correlationId);
+        }
+        else
+        {
+            _logger.LogTrace("Using existing correlation ID from request: {CorrelationId}", correlationId);
+        }
+
+        // Store correlation ID in HttpContext.Items for access by controllers and other middleware
+        context.Items[ItemKey] = correlationId;
+
+        // Add correlation ID to response headers
+        context.Response.Headers[HeaderName] = correlationId;
+
+        // Push correlation ID to Serilog LogContext for structured logging
+        // The using statement ensures the property is disposed after the request completes
+        using (LogContext.PushProperty("CorrelationId", correlationId))
+        {
+            await _next(context);
+        }
+    }
+
+    /// <summary>
+    /// Generates a new correlation ID as a 16-character hexadecimal string.
+    /// </summary>
+    /// <returns>A new correlation ID.</returns>
+    private static string GenerateCorrelationId()
+    {
+        return Guid.NewGuid().ToString("N")[..16]; // 16-char hex string
+    }
+}

--- a/src/DiscordBot.Bot/Middleware/CorrelationIdMiddlewareExtensions.cs
+++ b/src/DiscordBot.Bot/Middleware/CorrelationIdMiddlewareExtensions.cs
@@ -1,0 +1,22 @@
+namespace DiscordBot.Bot.Middleware;
+
+/// <summary>
+/// Extension methods for registering <see cref="CorrelationIdMiddleware"/> in the application pipeline.
+/// </summary>
+public static class CorrelationIdMiddlewareExtensions
+{
+    /// <summary>
+    /// Adds the correlation ID middleware to the application pipeline.
+    /// </summary>
+    /// <param name="builder">The application builder.</param>
+    /// <returns>The application builder for chaining.</returns>
+    /// <remarks>
+    /// This middleware should be registered early in the pipeline, ideally before logging middleware
+    /// (such as Serilog request logging) to ensure the correlation ID is available for all subsequent
+    /// middleware and logging operations.
+    /// </remarks>
+    public static IApplicationBuilder UseCorrelationId(this IApplicationBuilder builder)
+    {
+        return builder.UseMiddleware<CorrelationIdMiddleware>();
+    }
+}

--- a/src/DiscordBot.Bot/Program.cs
+++ b/src/DiscordBot.Bot/Program.cs
@@ -1,5 +1,6 @@
 using DiscordBot.Bot.Authorization;
 using DiscordBot.Bot.Extensions;
+using DiscordBot.Bot.Middleware;
 using DiscordBot.Bot.Services;
 using DiscordBot.Core.Entities;
 using DiscordBot.Core.Interfaces;
@@ -193,6 +194,9 @@ try
     var app = builder.Build();
 
     // Configure middleware pipeline
+    // Add correlation ID middleware (must be before Serilog request logging)
+    app.UseCorrelationId();
+
     app.UseSerilogRequestLogging();
 
     // Configure error handling

--- a/tests/DiscordBot.Tests/Middleware/CorrelationIdMiddlewareTests.cs
+++ b/tests/DiscordBot.Tests/Middleware/CorrelationIdMiddlewareTests.cs
@@ -1,0 +1,352 @@
+using DiscordBot.Bot.Middleware;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Text.RegularExpressions;
+
+namespace DiscordBot.Tests.Middleware;
+
+/// <summary>
+/// Unit tests for <see cref="CorrelationIdMiddleware"/>.
+/// </summary>
+public class CorrelationIdMiddlewareTests
+{
+    private readonly Mock<ILogger<CorrelationIdMiddleware>> _mockLogger;
+
+    public CorrelationIdMiddlewareTests()
+    {
+        _mockLogger = new Mock<ILogger<CorrelationIdMiddleware>>();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WithExistingHeader_UsesProvidedCorrelationId()
+    {
+        // Arrange
+        const string expectedCorrelationId = "test-correlation-id-abc123";
+        var context = new DefaultHttpContext();
+        context.Request.Headers[CorrelationIdMiddleware.HeaderName] = expectedCorrelationId;
+
+        var nextCalled = false;
+        RequestDelegate next = (ctx) =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        };
+
+        var middleware = new CorrelationIdMiddleware(next, _mockLogger.Object);
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert
+        context.Items.Should().ContainKey(CorrelationIdMiddleware.ItemKey,
+            "the correlation ID should be stored in HttpContext.Items");
+        context.Items[CorrelationIdMiddleware.ItemKey].Should().Be(expectedCorrelationId,
+            "the provided correlation ID should be used");
+        context.Response.Headers.Should().ContainKey(CorrelationIdMiddleware.HeaderName,
+            "the correlation ID should be added to response headers");
+        context.Response.Headers[CorrelationIdMiddleware.HeaderName].ToString().Should().Be(expectedCorrelationId,
+            "the response header should match the provided correlation ID");
+        nextCalled.Should().BeTrue("the next middleware should be called");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WithoutHeader_GeneratesNewCorrelationId()
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+
+        var nextCalled = false;
+        RequestDelegate next = (ctx) =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        };
+
+        var middleware = new CorrelationIdMiddleware(next, _mockLogger.Object);
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert
+        context.Items.Should().ContainKey(CorrelationIdMiddleware.ItemKey,
+            "a correlation ID should be stored in HttpContext.Items");
+        context.Items[CorrelationIdMiddleware.ItemKey].Should().NotBeNull(
+            "a correlation ID should be generated");
+
+        var correlationId = context.Items[CorrelationIdMiddleware.ItemKey] as string;
+        correlationId.Should().NotBeNullOrWhiteSpace("the correlation ID should not be empty");
+        correlationId!.Length.Should().Be(16, "the generated correlation ID should be 16 characters");
+        correlationId.Should().MatchRegex("^[0-9a-f]{16}$",
+            "the correlation ID should be a 16-character hexadecimal string");
+
+        context.Response.Headers.Should().ContainKey(CorrelationIdMiddleware.HeaderName,
+            "the correlation ID should be added to response headers");
+        context.Response.Headers[CorrelationIdMiddleware.HeaderName].ToString().Should().Be(correlationId,
+            "the response header should match the generated correlation ID");
+        nextCalled.Should().BeTrue("the next middleware should be called");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_AlwaysAddsResponseHeader()
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+
+        RequestDelegate next = (ctx) => Task.CompletedTask;
+        var middleware = new CorrelationIdMiddleware(next, _mockLogger.Object);
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert
+        context.Response.Headers.Should().ContainKey(CorrelationIdMiddleware.HeaderName,
+            "the X-Correlation-ID header should always be added to the response");
+        context.Response.Headers[CorrelationIdMiddleware.HeaderName].Should().NotBeEmpty(
+            "the response header should have a value");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_CallsNextDelegate()
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+
+        var nextCalled = false;
+        var nextCalledWithCorrectContext = false;
+
+        RequestDelegate next = (ctx) =>
+        {
+            nextCalled = true;
+            nextCalledWithCorrectContext = ctx == context;
+            return Task.CompletedTask;
+        };
+
+        var middleware = new CorrelationIdMiddleware(next, _mockLogger.Object);
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert
+        nextCalled.Should().BeTrue("the next middleware delegate should be invoked");
+        nextCalledWithCorrectContext.Should().BeTrue(
+            "the next middleware should be called with the same HttpContext");
+    }
+
+    [Fact]
+    public async Task GeneratedCorrelationId_IsValid16CharHex()
+    {
+        // Arrange
+        var generatedIds = new List<string>();
+        var context1 = new DefaultHttpContext();
+        var context2 = new DefaultHttpContext();
+        var context3 = new DefaultHttpContext();
+
+        RequestDelegate next = (ctx) => Task.CompletedTask;
+        var middleware = new CorrelationIdMiddleware(next, _mockLogger.Object);
+
+        // Act - Generate multiple correlation IDs
+        await middleware.InvokeAsync(context1);
+        await middleware.InvokeAsync(context2);
+        await middleware.InvokeAsync(context3);
+
+        generatedIds.Add(context1.Items[CorrelationIdMiddleware.ItemKey] as string ?? "");
+        generatedIds.Add(context2.Items[CorrelationIdMiddleware.ItemKey] as string ?? "");
+        generatedIds.Add(context3.Items[CorrelationIdMiddleware.ItemKey] as string ?? "");
+
+        // Assert - All generated IDs should be valid
+        generatedIds.Should().AllSatisfy(id =>
+        {
+            id.Should().NotBeNullOrWhiteSpace("each correlation ID should be generated");
+            id.Length.Should().Be(16, "each correlation ID should be exactly 16 characters");
+            id.Should().MatchRegex("^[0-9a-f]{16}$",
+                "each correlation ID should contain only hexadecimal characters (0-9, a-f)");
+        });
+
+        // Assert - Generated IDs should be unique
+        generatedIds.Distinct().Should().HaveCount(3,
+            "each generated correlation ID should be unique");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    public async Task InvokeAsync_WithWhitespaceHeader_GeneratesNewCorrelationId(string whitespaceValue)
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        context.Request.Headers[CorrelationIdMiddleware.HeaderName] = whitespaceValue;
+
+        RequestDelegate next = (ctx) => Task.CompletedTask;
+        var middleware = new CorrelationIdMiddleware(next, _mockLogger.Object);
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert
+        var correlationId = context.Items[CorrelationIdMiddleware.ItemKey] as string;
+        correlationId.Should().NotBeNullOrWhiteSpace(
+            "a new correlation ID should be generated when header is whitespace");
+        correlationId.Should().MatchRegex("^[0-9a-f]{16}$",
+            "the generated correlation ID should be a valid 16-character hex string");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WithMultipleHeaderValues_UsesFirstValue()
+    {
+        // Arrange
+        const string firstValue = "first-correlation-id";
+        const string secondValue = "second-correlation-id";
+        var context = new DefaultHttpContext();
+        context.Request.Headers.Append(CorrelationIdMiddleware.HeaderName, firstValue);
+        context.Request.Headers.Append(CorrelationIdMiddleware.HeaderName, secondValue);
+
+        RequestDelegate next = (ctx) => Task.CompletedTask;
+        var middleware = new CorrelationIdMiddleware(next, _mockLogger.Object);
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert
+        var correlationId = context.Items[CorrelationIdMiddleware.ItemKey] as string;
+        correlationId.Should().Be(firstValue,
+            "the first header value should be used when multiple values are present");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WithExistingHeader_LogsTraceMessage()
+    {
+        // Arrange
+        const string correlationId = "existing-correlation-id";
+        var context = new DefaultHttpContext();
+        context.Request.Headers[CorrelationIdMiddleware.HeaderName] = correlationId;
+
+        RequestDelegate next = (ctx) => Task.CompletedTask;
+        var middleware = new CorrelationIdMiddleware(next, _mockLogger.Object);
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert
+        _mockLogger.Verify(
+            l => l.Log(
+                LogLevel.Trace,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Using existing correlation ID from request")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once,
+            "a trace log should be written when using an existing correlation ID");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WithoutHeader_LogsTraceMessage()
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+
+        RequestDelegate next = (ctx) => Task.CompletedTask;
+        var middleware = new CorrelationIdMiddleware(next, _mockLogger.Object);
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert
+        _mockLogger.Verify(
+            l => l.Log(
+                LogLevel.Trace,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Generated new correlation ID")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once,
+            "a trace log should be written when generating a new correlation ID");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_StoresCorrelationIdBeforeCallingNext()
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        string? correlationIdInNext = null;
+
+        RequestDelegate next = (ctx) =>
+        {
+            correlationIdInNext = ctx.Items[CorrelationIdMiddleware.ItemKey] as string;
+            return Task.CompletedTask;
+        };
+
+        var middleware = new CorrelationIdMiddleware(next, _mockLogger.Object);
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert
+        correlationIdInNext.Should().NotBeNullOrWhiteSpace(
+            "the correlation ID should be available to downstream middleware");
+        correlationIdInNext.Should().Be(context.Items[CorrelationIdMiddleware.ItemKey] as string,
+            "the same correlation ID should be used throughout the request pipeline");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_PreservesCustomCorrelationIdFormat()
+    {
+        // Arrange
+        const string customCorrelationId = "MY-CUSTOM-FORMAT-12345";
+        var context = new DefaultHttpContext();
+        context.Request.Headers[CorrelationIdMiddleware.HeaderName] = customCorrelationId;
+
+        RequestDelegate next = (ctx) => Task.CompletedTask;
+        var middleware = new CorrelationIdMiddleware(next, _mockLogger.Object);
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert
+        var correlationId = context.Items[CorrelationIdMiddleware.ItemKey] as string;
+        correlationId.Should().Be(customCorrelationId,
+            "the middleware should accept and preserve custom correlation ID formats");
+        context.Response.Headers[CorrelationIdMiddleware.HeaderName].ToString().Should().Be(customCorrelationId,
+            "the custom correlation ID should be echoed in the response");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_PropagatesExceptionsFromNext()
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        var expectedException = new InvalidOperationException("Test exception");
+
+        RequestDelegate next = (ctx) => throw expectedException;
+        var middleware = new CorrelationIdMiddleware(next, _mockLogger.Object);
+
+        // Act & Assert
+        var act = async () => await middleware.InvokeAsync(context);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Test exception",
+                "exceptions from downstream middleware should propagate");
+
+        // Verify correlation ID was still set before the exception
+        context.Items.Should().ContainKey(CorrelationIdMiddleware.ItemKey,
+            "the correlation ID should be set even if downstream middleware throws");
+    }
+
+    [Fact]
+    public void HeaderName_IsCorrect()
+    {
+        // Assert
+        CorrelationIdMiddleware.HeaderName.Should().Be("X-Correlation-ID",
+            "the header name constant should match the expected value");
+    }
+
+    [Fact]
+    public void ItemKey_IsCorrect()
+    {
+        // Assert
+        CorrelationIdMiddleware.ItemKey.Should().Be("CorrelationId",
+            "the items key constant should match the expected value");
+    }
+}


### PR DESCRIPTION
## Summary

- Implements `CorrelationIdMiddleware` to extract `X-Correlation-ID` from request headers or generate a new 16-char hex ID
- Stores correlation ID in `HttpContext.Items` and adds to response headers for end-to-end request tracing
- Pushes correlation ID to Serilog's `LogContext` so all logs during a request include the correlation ID
- Updates all API controllers to use `GetCorrelationId()` extension method in error responses

## Test plan

- [x] Build succeeds with no errors
- [x] All 693 tests pass (includes 16 new middleware tests)
- [x] Middleware tests verify:
  - Existing correlation IDs from headers are preserved
  - New correlation IDs are generated when missing
  - Response headers always include X-Correlation-ID
  - Generated IDs are valid 16-char hex strings
  - Edge cases like empty/whitespace headers and multiple header values

Fixes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)