### PR TITLE
feat: Add log sanitization and rate limit violation logging (fixes #102, #103)

### DIFF
--- a/src/DiscordBot.Bot/Services/CommandExecutionLogger.cs
+++ b/src/DiscordBot.Bot/Services/CommandExecutionLogger.cs
@@ -1,6 +1,7 @@
 using Discord;
 using Discord.Interactions;
 using DiscordBot.Core.Interfaces;
+using DiscordBot.Core.Utilities;
 
 namespace DiscordBot.Bot.Services;
 
@@ -75,14 +76,18 @@ public class CommandExecutionLogger : ICommandExecutionLogger
                 executionTimeMs,
                 correlationId);
 
+            // Sanitize parameters to prevent sensitive data from being stored in logs
+            var sanitizedParameters = LogSanitizer.SanitizeString(parameters);
+            var sanitizedErrorMessage = LogSanitizer.SanitizeString(errorMessage);
+
             await commandLogRepository.LogCommandAsync(
                 context.Guild?.Id,
                 context.User.Id,
                 commandName,
-                parameters,
+                sanitizedParameters,
                 executionTimeMs,
                 success,
-                errorMessage,
+                sanitizedErrorMessage,
                 correlationId,
                 cancellationToken);
 

--- a/src/DiscordBot.Bot/Services/GuildService.cs
+++ b/src/DiscordBot.Bot/Services/GuildService.cs
@@ -2,6 +2,7 @@ using Discord.WebSocket;
 using DiscordBot.Core.DTOs;
 using DiscordBot.Core.Entities;
 using DiscordBot.Core.Interfaces;
+using DiscordBot.Core.Utilities;
 
 namespace DiscordBot.Bot.Services;
 
@@ -174,6 +175,10 @@ public class GuildService : IGuildService
         if (request.Settings != null)
         {
             dbGuild.Settings = request.Settings;
+            _logger.LogDebug(
+                "Guild {GuildId} settings updated: {SanitizedSettings}",
+                guildId,
+                LogSanitizer.SanitizeString(request.Settings));
         }
 
         if (request.IsActive.HasValue)

--- a/src/DiscordBot.Bot/appsettings.json
+++ b/src/DiscordBot.Bot/appsettings.json
@@ -6,6 +6,11 @@
     "SlowQueryThresholdMs": 100,
     "LogQueryParameters": true
   },
+  "LogSanitization": {
+    "Enabled": true,
+    "CustomPatterns": {},
+    "AdditionalSensitiveKeys": []
+  },
   "Discord": {
     "Token": "",
     "TestGuildId": null,

--- a/src/DiscordBot.Core/Utilities/LogSanitizationOptions.cs
+++ b/src/DiscordBot.Core/Utilities/LogSanitizationOptions.cs
@@ -1,0 +1,46 @@
+namespace DiscordBot.Core.Utilities;
+
+/// <summary>
+/// Configuration options for log sanitization.
+/// </summary>
+public class LogSanitizationOptions
+{
+    /// <summary>
+    /// Configuration section name.
+    /// </summary>
+    public const string SectionName = "LogSanitization";
+
+    /// <summary>
+    /// Gets or sets whether log sanitization is enabled.
+    /// Defaults to true.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets additional custom regex patterns for sanitization.
+    /// Key is the pattern name, value is the regex pattern.
+    /// </summary>
+    public Dictionary<string, CustomPattern> CustomPatterns { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets additional sensitive key names to redact.
+    /// Values in dictionary keys matching these names will be fully redacted.
+    /// </summary>
+    public List<string> AdditionalSensitiveKeys { get; set; } = new();
+}
+
+/// <summary>
+/// Represents a custom sanitization pattern.
+/// </summary>
+public class CustomPattern
+{
+    /// <summary>
+    /// Gets or sets the regex pattern to match.
+    /// </summary>
+    public string Pattern { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the replacement marker.
+    /// </summary>
+    public string Replacement { get; set; } = "[REDACTED]";
+}

--- a/src/DiscordBot.Core/Utilities/LogSanitizer.cs
+++ b/src/DiscordBot.Core/Utilities/LogSanitizer.cs
@@ -1,0 +1,207 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace DiscordBot.Core.Utilities;
+
+/// <summary>
+/// Provides methods for sanitizing sensitive data from log entries.
+/// This is a security-critical utility for GDPR/privacy compliance.
+/// </summary>
+public static partial class LogSanitizer
+{
+    /// <summary>
+    /// Replacement markers for sanitized data.
+    /// </summary>
+    public static class Markers
+    {
+        public const string Email = "[EMAIL]";
+        public const string Phone = "[PHONE]";
+        public const string CreditCard = "[CARD]";
+        public const string Token = "[TOKEN]";
+        public const string Password = "[PASSWORD]";
+        public const string DiscordToken = "[DISCORD_TOKEN]";
+        public const string ApiKey = "[API_KEY]";
+    }
+
+    // Email pattern: standard email format
+    [GeneratedRegex(@"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}", RegexOptions.Compiled)]
+    private static partial Regex EmailRegex();
+
+    // Phone patterns: various formats including international
+    [GeneratedRegex(@"(?:\+?1[-.\s]?)?\(?[0-9]{3}\)?[-.\s]?[0-9]{3}[-.\s]?[0-9]{4}", RegexOptions.Compiled)]
+    private static partial Regex PhoneRegex();
+
+    // Credit card patterns: 13-19 digits with optional separators
+    [GeneratedRegex(@"\b(?:\d[-\s]?){13,19}\b", RegexOptions.Compiled)]
+    private static partial Regex CreditCardRegex();
+
+    // Discord tokens: Bot tokens and user tokens (Base64-like with dots)
+    [GeneratedRegex(@"[MN][A-Za-z\d]{23,}\.[\w-]{6}\.[\w-]{27,}", RegexOptions.Compiled)]
+    private static partial Regex DiscordTokenRegex();
+
+    // Bearer tokens: Authorization header format
+    [GeneratedRegex(@"Bearer\s+[A-Za-z0-9\-_]+\.?[A-Za-z0-9\-_]*\.?[A-Za-z0-9\-_]*", RegexOptions.Compiled | RegexOptions.IgnoreCase)]
+    private static partial Regex BearerTokenRegex();
+
+    // API keys: Common patterns (alphanumeric with dashes, 20+ chars)
+    [GeneratedRegex(@"(?:api[_-]?key|apikey|api_secret|secret[_-]?key)[""']?\s*[:=]\s*[""']?([A-Za-z0-9\-_]{20,})[""']?", RegexOptions.Compiled | RegexOptions.IgnoreCase)]
+    private static partial Regex ApiKeyRegex();
+
+    // Password patterns: password fields in various formats
+    [GeneratedRegex(@"(?:password|passwd|pwd|secret)[""']?\s*[:=]\s*[""']?([^""'\s,}\]]{1,})[""']?", RegexOptions.Compiled | RegexOptions.IgnoreCase)]
+    private static partial Regex PasswordRegex();
+
+    // Generic secret/token patterns in key-value format
+    [GeneratedRegex(@"(?:token|auth|secret|credential)[""']?\s*[:=]\s*[""']?([A-Za-z0-9\-_\.]{10,})[""']?", RegexOptions.Compiled | RegexOptions.IgnoreCase)]
+    private static partial Regex GenericSecretRegex();
+
+    /// <summary>
+    /// Sanitizes a string by redacting sensitive data patterns.
+    /// </summary>
+    /// <param name="input">The string to sanitize.</param>
+    /// <returns>The sanitized string with sensitive data replaced by markers, or null if input was null.</returns>
+    public static string? SanitizeString(string? input)
+    {
+        if (input == null)
+        {
+            return null;
+        }
+
+        if (input.Length == 0)
+        {
+            return input;
+        }
+
+        var result = input;
+
+        // Order matters: more specific patterns first
+        result = DiscordTokenRegex().Replace(result, Markers.DiscordToken);
+        result = BearerTokenRegex().Replace(result, Markers.Token);
+        result = CreditCardRegex().Replace(result, Markers.CreditCard);
+        result = EmailRegex().Replace(result, Markers.Email);
+        result = PhoneRegex().Replace(result, Markers.Phone);
+        result = ApiKeyRegex().Replace(result, m =>
+        {
+            if (m.Groups.Count > 1 && m.Groups[1].Success)
+            {
+                return m.Value.Replace(m.Groups[1].Value, Markers.ApiKey);
+            }
+            return m.Value;
+        });
+        result = PasswordRegex().Replace(result, m =>
+        {
+            if (m.Groups.Count > 1 && m.Groups[1].Success)
+            {
+                return m.Value.Replace(m.Groups[1].Value, Markers.Password);
+            }
+            return m.Value;
+        });
+        result = GenericSecretRegex().Replace(result, m =>
+        {
+            if (m.Groups.Count > 1 && m.Groups[1].Success)
+            {
+                return m.Value.Replace(m.Groups[1].Value, Markers.Token);
+            }
+            return m.Value;
+        });
+
+        return result;
+    }
+
+    /// <summary>
+    /// Sanitizes an object by serializing to JSON, sanitizing, and returning the sanitized string.
+    /// </summary>
+    /// <param name="obj">The object to sanitize.</param>
+    /// <param name="options">Optional JSON serializer options.</param>
+    /// <returns>The sanitized JSON string representation.</returns>
+    public static string SanitizeObject(object? obj, JsonSerializerOptions? options = null)
+    {
+        if (obj == null)
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var json = JsonSerializer.Serialize(obj, options ?? DefaultJsonOptions);
+            return SanitizeString(json);
+        }
+        catch (JsonException)
+        {
+            // If serialization fails, try ToString
+            return SanitizeString(obj.ToString());
+        }
+    }
+
+    /// <summary>
+    /// Sanitizes a dictionary by redacting sensitive values.
+    /// Keys that match sensitive patterns will have their values redacted.
+    /// </summary>
+    /// <param name="dictionary">The dictionary to sanitize.</param>
+    /// <returns>A new dictionary with sensitive values redacted.</returns>
+    public static IDictionary<string, string?> SanitizeDictionary(IDictionary<string, string?>? dictionary)
+    {
+        if (dictionary == null || dictionary.Count == 0)
+        {
+            return new Dictionary<string, string?>();
+        }
+
+        var result = new Dictionary<string, string?>(dictionary.Count);
+
+        foreach (var kvp in dictionary)
+        {
+            var sanitizedValue = IsSensitiveKey(kvp.Key)
+                ? GetMarkerForKey(kvp.Key)
+                : SanitizeString(kvp.Value);
+
+            result[kvp.Key] = sanitizedValue;
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Determines if a key name indicates sensitive data.
+    /// </summary>
+    private static bool IsSensitiveKey(string key)
+    {
+        var lowerKey = key.ToLowerInvariant();
+        return lowerKey.Contains("password") ||
+               lowerKey.Contains("passwd") ||
+               lowerKey.Contains("secret") ||
+               lowerKey.Contains("token") ||
+               lowerKey.Contains("apikey") ||
+               lowerKey.Contains("api_key") ||
+               lowerKey.Contains("api-key") ||
+               lowerKey.Contains("auth") ||
+               lowerKey.Contains("credential") ||
+               lowerKey.Contains("credit") ||
+               lowerKey.Contains("card");
+    }
+
+    /// <summary>
+    /// Gets the appropriate marker for a sensitive key.
+    /// </summary>
+    private static string GetMarkerForKey(string key)
+    {
+        var lowerKey = key.ToLowerInvariant();
+
+        if (lowerKey.Contains("password") || lowerKey.Contains("passwd"))
+            return Markers.Password;
+        if (lowerKey.Contains("discord") && lowerKey.Contains("token"))
+            return Markers.DiscordToken;
+        if (lowerKey.Contains("token"))
+            return Markers.Token;
+        if (lowerKey.Contains("apikey") || lowerKey.Contains("api_key") || lowerKey.Contains("api-key"))
+            return Markers.ApiKey;
+        if (lowerKey.Contains("credit") || lowerKey.Contains("card"))
+            return Markers.CreditCard;
+
+        return Markers.Token; // Default for other sensitive keys
+    }
+
+    private static readonly JsonSerializerOptions DefaultJsonOptions = new()
+    {
+        WriteIndented = false
+    };
+}

--- a/tests/DiscordBot.Tests/Core/Utilities/LogSanitizerTests.cs
+++ b/tests/DiscordBot.Tests/Core/Utilities/LogSanitizerTests.cs
@@ -1,0 +1,355 @@
+using DiscordBot.Core.Utilities;
+using FluentAssertions;
+
+namespace DiscordBot.Tests.Core.Utilities;
+
+/// <summary>
+/// Unit tests for <see cref="LogSanitizer"/>.
+/// </summary>
+public class LogSanitizerTests
+{
+    #region SanitizeString Tests
+
+    [Fact]
+    public void SanitizeString_NullInput_ReturnsNull()
+    {
+        // Act
+        var result = LogSanitizer.SanitizeString(null);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void SanitizeString_EmptyInput_ReturnsEmptyString()
+    {
+        // Act
+        var result = LogSanitizer.SanitizeString(string.Empty);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SanitizeString_NoSensitiveData_ReturnsUnchanged()
+    {
+        // Arrange
+        var input = "This is a regular log message with no sensitive data";
+
+        // Act
+        var result = LogSanitizer.SanitizeString(input);
+
+        // Assert
+        result.Should().Be(input);
+    }
+
+    [Theory]
+    [InlineData("test@example.com")]
+    [InlineData("user.name+tag@domain.co.uk")]
+    [InlineData("john.doe@company.org")]
+    public void SanitizeString_EmailAddresses_AreRedacted(string email)
+    {
+        // Arrange
+        var input = $"User email is {email}";
+
+        // Act
+        var result = LogSanitizer.SanitizeString(input);
+
+        // Assert
+        result.Should().Contain(LogSanitizer.Markers.Email);
+        result.Should().NotContain(email);
+    }
+
+    [Theory]
+    [InlineData("123-456-7890")]
+    [InlineData("(123) 456-7890")]
+    [InlineData("+1 123 456 7890")]
+    [InlineData("1234567890")]
+    public void SanitizeString_PhoneNumbers_AreRedacted(string phone)
+    {
+        // Arrange
+        var input = $"Contact phone: {phone}";
+
+        // Act
+        var result = LogSanitizer.SanitizeString(input);
+
+        // Assert
+        result.Should().Contain(LogSanitizer.Markers.Phone);
+        result.Should().NotContain(phone);
+    }
+
+    [Theory]
+    [InlineData("4111111111111111")]
+    [InlineData("4111-1111-1111-1111")]
+    [InlineData("4111 1111 1111 1111")]
+    [InlineData("5500000000000004")]
+    public void SanitizeString_CreditCardNumbers_AreRedacted(string card)
+    {
+        // Arrange
+        var input = $"Card number: {card}";
+
+        // Act
+        var result = LogSanitizer.SanitizeString(input);
+
+        // Assert
+        result.Should().Contain(LogSanitizer.Markers.CreditCard);
+        result.Should().NotContain(card);
+    }
+
+    [Theory]
+    [InlineData("Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U")]
+    [InlineData("bearer abc123xyz456")]
+    public void SanitizeString_BearerTokens_AreRedacted(string token)
+    {
+        // Arrange
+        var input = $"Authorization: {token}";
+
+        // Act
+        var result = LogSanitizer.SanitizeString(input);
+
+        // Assert
+        result.Should().Contain(LogSanitizer.Markers.Token);
+        result.Should().NotContain(token.Split(' ')[1]); // Check the token part is redacted
+    }
+
+    [Fact]
+    public void SanitizeString_DiscordTokens_AreRedacted()
+    {
+        // Arrange - Use clearly fake token pattern that matches Discord format
+        // Format: base64(user_id).timestamp.hmac - starts with M or N
+        var fakeToken = "MTEST" + new string('x', 20) + ".XXXXXX.XXXXXXXXXXXXXXXXXXXXXXXXXXX";
+        var input = $"Discord token: {fakeToken}";
+
+        // Act
+        var result = LogSanitizer.SanitizeString(input);
+
+        // Assert
+        result.Should().Contain(LogSanitizer.Markers.DiscordToken);
+        result.Should().NotContain(fakeToken);
+    }
+
+    [Theory]
+    [InlineData("password=MySecretPassword123")]
+    [InlineData("password: supersecret")]
+    [InlineData("\"password\": \"hunter2\"")]
+    [InlineData("pwd=admin123")]
+    public void SanitizeString_Passwords_AreRedacted(string passwordField)
+    {
+        // Arrange
+        var input = $"Config: {passwordField}";
+
+        // Act
+        var result = LogSanitizer.SanitizeString(input);
+
+        // Assert
+        result.Should().Contain(LogSanitizer.Markers.Password);
+    }
+
+    [Theory]
+    [InlineData("api_key=sk_live_abcdefghijklmnopqrstuv", "[API_KEY]")]
+    [InlineData("apikey: AIzaSyABCDEFGHIJKLMNOPQRSTU", "[API_KEY]")]
+    [InlineData("\"api_key\": \"super_secret_abcdefghijkl\"", "[API_KEY]")]
+    public void SanitizeString_ApiKeys_AreRedacted(string apiKeyField, string expectedMarker)
+    {
+        // Arrange
+        var input = $"Settings: {apiKeyField}";
+
+        // Act
+        var result = LogSanitizer.SanitizeString(input);
+
+        // Assert
+        result.Should().Contain(expectedMarker);
+    }
+
+    [Fact]
+    public void SanitizeString_MultipleSensitiveDataTypes_AllAreRedacted()
+    {
+        // Arrange
+        var input = "User test@example.com called from 123-456-7890 with password=secret123";
+
+        // Act
+        var result = LogSanitizer.SanitizeString(input);
+
+        // Assert
+        result.Should().Contain(LogSanitizer.Markers.Email);
+        result.Should().Contain(LogSanitizer.Markers.Phone);
+        result.Should().Contain(LogSanitizer.Markers.Password);
+        result.Should().NotContain("test@example.com");
+        result.Should().NotContain("123-456-7890");
+        result.Should().NotContain("secret123");
+    }
+
+    [Fact]
+    public void SanitizeString_Performance_UnderFiveMilliseconds()
+    {
+        // Arrange - Large string with multiple patterns
+        var input = string.Join(" ", Enumerable.Range(0, 100).Select(i =>
+            $"User user{i}@example.com phone 123-456-{i:D4} password=secret{i}"));
+
+        // Act - Warm up the regex cache
+        _ = LogSanitizer.SanitizeString(input);
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        for (int i = 0; i < 100; i++)
+        {
+            _ = LogSanitizer.SanitizeString(input);
+        }
+        sw.Stop();
+
+        // Assert - Average should be well under 5ms (allowing for CI/CD variance)
+        var averageMs = sw.ElapsedMilliseconds / 100.0;
+        averageMs.Should().BeLessThan(5, "sanitization should be performant");
+    }
+
+    #endregion
+
+    #region SanitizeObject Tests
+
+    [Fact]
+    public void SanitizeObject_NullObject_ReturnsEmptyString()
+    {
+        // Act
+        var result = LogSanitizer.SanitizeObject(null);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SanitizeObject_SimpleObject_SanitizesSensitiveFields()
+    {
+        // Arrange
+        var obj = new { Email = "test@example.com", Name = "John" };
+
+        // Act
+        var result = LogSanitizer.SanitizeObject(obj);
+
+        // Assert
+        result.Should().Contain(LogSanitizer.Markers.Email);
+        result.Should().NotContain("test@example.com");
+        result.Should().Contain("John");
+    }
+
+    [Fact]
+    public void SanitizeObject_ObjectWithPassword_SanitizesPassword()
+    {
+        // Arrange
+        var obj = new Dictionary<string, string>
+        {
+            { "username", "admin" },
+            { "password", "secretpassword123" }
+        };
+
+        // Act
+        var result = LogSanitizer.SanitizeObject(obj);
+
+        // Assert
+        result.Should().NotContain("secretpassword123");
+        result.Should().Contain("admin");
+    }
+
+    #endregion
+
+    #region SanitizeDictionary Tests
+
+    [Fact]
+    public void SanitizeDictionary_NullDictionary_ReturnsEmptyDictionary()
+    {
+        // Act
+        var result = LogSanitizer.SanitizeDictionary(null);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SanitizeDictionary_EmptyDictionary_ReturnsEmptyDictionary()
+    {
+        // Arrange
+        var dict = new Dictionary<string, string?>();
+
+        // Act
+        var result = LogSanitizer.SanitizeDictionary(dict);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SanitizeDictionary_SensitiveKeys_AreFullyRedacted()
+    {
+        // Arrange
+        var dict = new Dictionary<string, string?>
+        {
+            { "password", "supersecret" },
+            { "apikey", "sk_live_123456" },
+            { "token", "eyJhbGc..." },
+            { "username", "testuser" }
+        };
+
+        // Act
+        var result = LogSanitizer.SanitizeDictionary(dict);
+
+        // Assert
+        result["password"].Should().Be(LogSanitizer.Markers.Password);
+        result["apikey"].Should().Be(LogSanitizer.Markers.ApiKey);
+        result["token"].Should().Be(LogSanitizer.Markers.Token);
+        result["username"].Should().Be("testuser");
+    }
+
+    [Fact]
+    public void SanitizeDictionary_NonSensitiveKeysWithSensitiveValues_ValuesSanitized()
+    {
+        // Arrange
+        var dict = new Dictionary<string, string?>
+        {
+            { "message", "Contact me at test@example.com" },
+            { "details", "Call 123-456-7890" }
+        };
+
+        // Act
+        var result = LogSanitizer.SanitizeDictionary(dict);
+
+        // Assert
+        result["message"].Should().Contain(LogSanitizer.Markers.Email);
+        result["details"].Should().Contain(LogSanitizer.Markers.Phone);
+    }
+
+    #endregion
+
+    #region Markers Tests
+
+    [Fact]
+    public void Markers_AllHaveBracketFormat()
+    {
+        // Assert - All markers should be in [MARKER] format
+        LogSanitizer.Markers.Email.Should().StartWith("[").And.EndWith("]");
+        LogSanitizer.Markers.Phone.Should().StartWith("[").And.EndWith("]");
+        LogSanitizer.Markers.CreditCard.Should().StartWith("[").And.EndWith("]");
+        LogSanitizer.Markers.Token.Should().StartWith("[").And.EndWith("]");
+        LogSanitizer.Markers.Password.Should().StartWith("[").And.EndWith("]");
+        LogSanitizer.Markers.DiscordToken.Should().StartWith("[").And.EndWith("]");
+        LogSanitizer.Markers.ApiKey.Should().StartWith("[").And.EndWith("]");
+    }
+
+    [Fact]
+    public void Markers_AreDistinct()
+    {
+        // Arrange
+        var markers = new[]
+        {
+            LogSanitizer.Markers.Email,
+            LogSanitizer.Markers.Phone,
+            LogSanitizer.Markers.CreditCard,
+            LogSanitizer.Markers.Token,
+            LogSanitizer.Markers.Password,
+            LogSanitizer.Markers.DiscordToken,
+            LogSanitizer.Markers.ApiKey
+        };
+
+        // Assert
+        markers.Should().OnlyHaveUniqueItems();
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

- **Log Sanitization (#102):** Implements `LogSanitizer` utility class that redacts sensitive data patterns (emails, phone numbers, credit cards, tokens, passwords, API keys) from log entries before storage. This protects PII for GDPR/privacy compliance.

- **Rate Limit Logging (#103):** Adds Warning level logging when rate limits are exceeded, including user ID, command name, rate limit parameters, and reset time. Trace level logging added for successful checks.

## Changes

### New Files
- `src/DiscordBot.Core/Utilities/LogSanitizer.cs` - Static sanitization methods with regex patterns
- `src/DiscordBot.Core/Utilities/LogSanitizationOptions.cs` - Configuration for custom patterns
- `tests/DiscordBot.Tests/Core/Utilities/LogSanitizerTests.cs` - 35 unit tests

### Modified Files
- `src/DiscordBot.Bot/Preconditions/RateLimitAttribute.cs` - Added ILogger injection and warning/trace logging
- `src/DiscordBot.Bot/Services/CommandExecutionLogger.cs` - Sanitizes parameters and error messages
- `src/DiscordBot.Bot/Services/GuildService.cs` - Sanitizes settings before debug logging
- `src/DiscordBot.Bot/appsettings.json` - Added LogSanitization config section
- `tests/DiscordBot.Tests/Preconditions/RateLimitAttributeTests.cs` - 4 new logging tests

## Sanitization Patterns

| Pattern | Marker |
|---------|--------|
| Email addresses | `[EMAIL]` |
| Phone numbers | `[PHONE]` |
| Credit card numbers | `[CARD]` |
| Bearer tokens | `[TOKEN]` |
| Discord tokens | `[DISCORD_TOKEN]` |
| Passwords | `[PASSWORD]` |
| API keys | `[API_KEY]` |

## Test plan

- [x] All 35 LogSanitizer tests pass
- [x] All 4 RateLimitAttribute logging tests pass
- [x] All 765 existing tests pass
- [x] Build succeeds with no errors
- [ ] Manual verification: Rate limit violations appear in logs at Warning level
- [ ] Manual verification: Sensitive data in command parameters is redacted in database

Fixes #102, fixes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)