### PR TITLE
fix: Optimize CommandLogService database filtering (closes #107)

### DIFF
--- a/src/DiscordBot.Core/Interfaces/ICommandLogRepository.cs
+++ b/src/DiscordBot.Core/Interfaces/ICommandLogRepository.cs
@@ -93,4 +93,30 @@ public interface ICommandLogRepository : IRepository<CommandLog>
         ulong? guildId = null,
         int limit = 10,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets command logs with filters applied at the database level with pagination.
+    /// </summary>
+    /// <param name="searchTerm">Search term for multi-field search across command name, username, and guild name.</param>
+    /// <param name="guildId">Optional guild ID filter.</param>
+    /// <param name="userId">Optional user ID filter.</param>
+    /// <param name="commandName">Optional command name filter.</param>
+    /// <param name="startDate">Optional start date filter.</param>
+    /// <param name="endDate">Optional end date filter.</param>
+    /// <param name="successOnly">Optional filter for success status.</param>
+    /// <param name="page">Page number (1-based).</param>
+    /// <param name="pageSize">Number of items per page.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Paginated result containing filtered command logs and total count.</returns>
+    Task<(IReadOnlyList<CommandLog> Items, int TotalCount)> GetFilteredLogsAsync(
+        string? searchTerm = null,
+        ulong? guildId = null,
+        ulong? userId = null,
+        string? commandName = null,
+        DateTime? startDate = null,
+        DateTime? endDate = null,
+        bool? successOnly = null,
+        int page = 1,
+        int pageSize = 50,
+        CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
## Summary

This PR moves command log filtering from in-memory to database level for better performance and scalability. The previous implementation loaded all logs into memory and then filtered, which would fail at scale with 100,000+ logs.

### Changes
- Add `GetFilteredLogsAsync()` to `ICommandLogRepository` interface
- Implement database-level filtering in `CommandLogRepository` using IQueryable
- Support all filter parameters:
  - `searchTerm` (searches across command name, username, guild name)
  - `guildId`, `userId`, `commandName` (exact match filters)
  - `startDate`, `endDate` (date range filters)
  - `successOnly` (boolean filter)
  - `page`, `pageSize` (pagination at database level)
- Update `CommandLogService` to use new repository method
- Add performance logging with query execution time
- Log warning when query exceeds 500ms threshold
- Remove in-memory filtering code and TODO comment

### Files Modified
- `src/DiscordBot.Core/Interfaces/ICommandLogRepository.cs` - Added new interface method
- `src/DiscordBot.Infrastructure/Data/Repositories/CommandLogRepository.cs` - Implemented filtering
- `src/DiscordBot.Bot/Services/CommandLogService.cs` - Updated to use new method
- `tests/DiscordBot.Tests/Data/Repositories/CommandLogRepositoryTests.cs` - Added 20 new tests
- `tests/DiscordBot.Tests/Services/CommandLogServiceTests.cs` - Updated tests for new mock pattern

## Test plan

- [x] All existing tests updated to use new repository method
- [x] 20 new repository tests for `GetFilteredLogsAsync` covering:
  - No filters (returns all paginated)
  - Each individual filter (guildId, userId, commandName, date range, success)
  - Case-insensitive search
  - Search across multiple fields (command name, username, guild name)
  - Multiple filters combined
  - Pagination (correct page, correct order)
  - Empty/whitespace search terms
- [x] All 938 tests pass (926 passed, 12 pre-existing skips)
- [ ] Manual testing with large dataset (100,000+ logs)

## Impact

Without this fix:
- Memory usage grows unbounded with log volume
- API response times degrade with scale
- Potential OOM errors in production

With this fix:
- Database handles filtering efficiently
- Memory footprint stays constant regardless of total log count
- Performance is logged for monitoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)