### PR TITLE
Set default date filter on Command Analytics page

### DIFF
--- a/src/DiscordBot.Bot/Pages/CommandLogs/Analytics.cshtml
+++ b/src/DiscordBot.Bot/Pages/CommandLogs/Analytics.cshtml
@@ -78,14 +78,24 @@
                     <!-- Quick Date Presets -->
                     <div class="mb-4">
                         <label class="block text-sm font-medium text-text-primary mb-2">Quick Date Range</label>
+                        @{
+                            var today = DateTime.UtcNow.Date;
+                            var isToday = Model.StartDate?.Date == today && Model.EndDate?.Date == today;
+                            var is7Days = Model.StartDate?.Date == today.AddDays(-7) && Model.EndDate?.Date == today;
+                            var is30Days = Model.StartDate?.Date == today.AddDays(-30) && Model.EndDate?.Date == today;
+
+                            string GetPresetClass(bool isActive) => isActive
+                                ? "px-3 py-1.5 text-xs font-medium bg-accent-blue text-white border border-accent-blue rounded-md hover:bg-accent-blue/90 transition-colors"
+                                : "px-3 py-1.5 text-xs font-medium bg-bg-tertiary text-text-secondary border border-border-primary rounded-md hover:bg-bg-hover transition-colors";
+                        }
                         <div class="flex flex-wrap gap-2">
-                            <button type="button" onclick="setDatePreset('today')" class="px-3 py-1.5 text-xs font-medium bg-bg-tertiary text-text-secondary border border-border-primary rounded-md hover:bg-bg-hover transition-colors">
+                            <button type="button" onclick="setDatePreset('today')" class="@GetPresetClass(isToday)">
                                 Today
                             </button>
-                            <button type="button" onclick="setDatePreset('7days')" class="px-3 py-1.5 text-xs font-medium bg-bg-tertiary text-text-secondary border border-border-primary rounded-md hover:bg-bg-hover transition-colors">
+                            <button type="button" onclick="setDatePreset('7days')" class="@GetPresetClass(is7Days)">
                                 Last 7 Days
                             </button>
-                            <button type="button" onclick="setDatePreset('30days')" class="px-3 py-1.5 text-xs font-medium bg-bg-tertiary text-text-secondary border border-border-primary rounded-md hover:bg-bg-hover transition-colors">
+                            <button type="button" onclick="setDatePreset('30days')" class="@GetPresetClass(is30Days)">
                                 Last 30 Days
                             </button>
                         </div>

--- a/src/DiscordBot.Bot/Pages/CommandLogs/Analytics.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/CommandLogs/Analytics.cshtml.cs
@@ -51,9 +51,12 @@ public class AnalyticsModel : PageModel
 
     public async Task<IActionResult> OnGetAsync(CancellationToken cancellationToken = default)
     {
-        // Default to last 30 days if no dates specified
-        var start = StartDate ?? DateTime.UtcNow.AddDays(-30).Date;
-        var end = EndDate ?? DateTime.UtcNow.Date.AddDays(1); // End of today
+        // Set defaults if not specified (so UI shows the actual filter values)
+        StartDate ??= DateTime.UtcNow.AddDays(-30).Date;
+        EndDate ??= DateTime.UtcNow.Date;
+
+        var start = StartDate.Value;
+        var end = EndDate.Value.AddDays(1); // End of the selected day
 
         _logger.LogDebug("Loading analytics for {Start} to {End}, GuildId: {GuildId}", start, end, GuildId);
 


### PR DESCRIPTION
## Summary
- Pre-populate date filter inputs with default values (last 30 days) so users immediately see what date range the analytics cover
- Highlight the active quick date preset button to indicate current selection

Fixes #180

## Changes Made
- `Analytics.cshtml.cs`: Set `StartDate` and `EndDate` properties to default values when not provided via query string
- `Analytics.cshtml`: Added logic to highlight the matching quick date preset button (Today, Last 7 Days, Last 30 Days) based on current filter state

## Before
- Date inputs appeared empty on page load
- Users didn't know what date range was being displayed
- Filter badge showed "0 active" despite 30-day default being applied

## After
- Date inputs show the default date range (last 30 days)
- "Last 30 Days" preset button is highlighted on initial load
- Filter badge correctly shows "2 active" filters for dates

## Test plan
- [ ] Visit `/CommandLogs/Analytics` - date inputs should show last 30 days, "Last 30 Days" button should be highlighted
- [ ] Click "Today" preset - dates should update, "Today" button should become highlighted
- [ ] Click "Last 7 Days" preset - dates should update, button should become highlighted
- [ ] Manually enter custom dates - no preset button should be highlighted
- [ ] Verify filter badge shows correct count

🤖 Generated with [Claude Code](https://claude.com/claude-code)