### PR TITLE
feat: Add consent web UI management page (closes #134)

### DIFF
--- a/src/DiscordBot.Bot/Pages/Account/Privacy.cshtml
+++ b/src/DiscordBot.Bot/Pages/Account/Privacy.cshtml
@@ -1,0 +1,341 @@
+@page
+@model PrivacyModel
+@{
+    ViewData["Title"] = "Privacy & Consent";
+}
+
+<!-- Page Header -->
+<div class="mb-8">
+    <h1 class="text-3xl font-bold text-text-primary mb-2">Privacy & Consent</h1>
+    <p class="text-text-secondary">Manage your data privacy preferences and consent settings for the Discord bot</p>
+</div>
+
+<!-- Status Message -->
+@if (!string.IsNullOrEmpty(Model.StatusMessage))
+{
+    <div class="mb-6 p-4 rounded-lg flex items-start gap-3 @(Model.IsSuccess ? "bg-success-bg border border-success-border" : "bg-error-bg border border-error-border")" role="alert">
+        @if (Model.IsSuccess)
+        {
+            <!-- Success Icon -->
+            <svg class="w-5 h-5 text-success flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
+            </svg>
+        }
+        else
+        {
+            <!-- Error Icon -->
+            <svg class="w-5 h-5 text-error flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
+            </svg>
+        }
+        <div>
+            <p class="text-sm font-semibold @(Model.IsSuccess ? "text-success" : "text-error")">
+                @(Model.IsSuccess ? "Success" : "Error")
+            </p>
+            <p class="text-sm @(Model.IsSuccess ? "text-success" : "text-error") mt-1">
+                @Model.StatusMessage
+            </p>
+        </div>
+    </div>
+}
+
+@if (!Model.IsDiscordLinked)
+{
+    <!-- Discord Not Linked State -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg p-6 shadow-lg">
+        <div class="p-4 bg-warning-bg border border-warning-border rounded-md mb-6">
+            <div class="flex items-start gap-3">
+                <svg class="w-5 h-5 text-warning flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                    <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
+                </svg>
+                <div>
+                    <p class="text-sm font-semibold text-warning">Discord Account Required</p>
+                    <p class="text-sm text-warning/90 mt-1">
+                        You need to link your Discord account before managing consent preferences. Your consent settings are tied to your Discord user ID.
+                    </p>
+                </div>
+            </div>
+        </div>
+
+        <div class="text-center py-8">
+            <div class="inline-flex items-center justify-center w-16 h-16 bg-bg-tertiary rounded-xl mb-4">
+                <svg class="w-10 h-10 text-text-secondary" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M20.317 4.492c-1.53-.69-3.17-1.2-4.885-1.49a.075.075 0 0 0-.079.036c-.21.369-.444.85-.608 1.23a18.566 18.566 0 0 0-5.487 0 12.36 12.36 0 0 0-.617-1.23A.077.077 0 0 0 8.562 3c-1.714.29-3.354.8-4.885 1.491a.07.07 0 0 0-.032.027C.533 9.093-.32 13.555.099 17.961a.08.08 0 0 0 .031.055 20.03 20.03 0 0 0 5.993 2.98.078.078 0 0 0 .084-.026 13.83 13.83 0 0 0 1.226-1.963.074.074 0 0 0-.041-.104 13.201 13.201 0 0 1-1.872-.878.075.075 0 0 1-.008-.125c.126-.093.252-.19.372-.287a.075.075 0 0 1 .078-.01c3.927 1.764 8.18 1.764 12.061 0a.075.075 0 0 1 .079.009c.12.098.245.195.372.288a.075.075 0 0 1-.006.125c-.598.344-1.22.635-1.873.877a.075.075 0 0 0-.041.105c.36.687.772 1.341 1.225 1.962a.077.077 0 0 0 .084.028 19.963 19.963 0 0 0 6.002-2.981.076.076 0 0 0 .032-.054c.5-5.094-.838-9.52-3.549-13.442a.06.06 0 0 0-.031-.028zM8.02 15.278c-1.182 0-2.157-1.069-2.157-2.38 0-1.312.956-2.38 2.157-2.38 1.21 0 2.176 1.077 2.157 2.38 0 1.312-.956 2.38-2.157 2.38zm7.975 0c-1.183 0-2.157-1.069-2.157-2.38 0-1.312.955-2.38 2.157-2.38 1.21 0 2.176 1.077 2.157 2.38 0 1.312-.946 2.38-2.157 2.38z"/>
+                </svg>
+            </div>
+            <h2 class="text-xl font-semibold text-text-primary mb-2">Link Your Discord Account</h2>
+            <p class="text-text-secondary text-sm mb-6 max-w-md mx-auto">
+                To manage your privacy preferences, please link your Discord account first.
+            </p>
+
+            <a asp-page="./LinkDiscord" class="inline-flex items-center justify-center gap-2.5 py-2.5 px-6 text-sm font-semibold text-white bg-discord border border-discord rounded-md transition-colors hover:bg-discord-hover hover:border-discord-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-discord focus-visible:ring-offset-2 focus-visible:ring-offset-bg-secondary">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/>
+                </svg>
+                Link Discord Account
+            </a>
+        </div>
+    </div>
+}
+else
+{
+    <!-- Discord Linked State -->
+    <!-- Connected Discord Account Info -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg p-6 shadow-lg mb-6">
+        <div class="flex items-center gap-4 pb-4 border-b border-border-primary mb-4">
+            <div class="w-12 h-12 rounded-full bg-bg-tertiary border-2 border-accent-blue flex items-center justify-center">
+                <svg class="w-6 h-6 text-text-secondary" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M20.317 4.492c-1.53-.69-3.17-1.2-4.885-1.49a.075.075 0 0 0-.079.036c-.21.369-.444.85-.608 1.23a18.566 18.566 0 0 0-5.487 0 12.36 12.36 0 0 0-.617-1.23A.077.077 0 0 0 8.562 3c-1.714.29-3.354.8-4.885 1.491a.07.07 0 0 0-.032.027C.533 9.093-.32 13.555.099 17.961a.08.08 0 0 0 .031.055 20.03 20.03 0 0 0 5.993 2.98.078.078 0 0 0 .084-.026 13.83 13.83 0 0 0 1.226-1.963.074.074 0 0 0-.041-.104 13.201 13.201 0 0 1-1.872-.878.075.075 0 0 1-.008-.125c.126-.093.252-.19.372-.287a.075.075 0 0 1 .078-.01c3.927 1.764 8.18 1.764 12.061 0a.075.075 0 0 1 .079.009c.12.098.245.195.372.288a.075.075 0 0 1-.006.125c-.598.344-1.22.635-1.873.877a.075.075 0 0 0-.041.105c.36.687.772 1.341 1.225 1.962a.077.077 0 0 0 .084.028 19.963 19.963 0 0 0 6.002-2.981.076.076 0 0 0 .032-.054c.5-5.094-.838-9.52-3.549-13.442a.06.06 0 0 0-.031-.028zM8.02 15.278c-1.182 0-2.157-1.069-2.157-2.38 0-1.312.956-2.38 2.157-2.38 1.21 0 2.176 1.077 2.157 2.38 0 1.312-.956 2.38-2.157 2.38zm7.975 0c-1.183 0-2.157-1.069-2.157-2.38 0-1.312.955-2.38 2.157-2.38 1.21 0 2.176 1.077 2.157 2.38 0 1.312-.946 2.38-2.157 2.38z"/>
+                </svg>
+            </div>
+            <div class="flex-1">
+                <div class="flex items-center gap-2">
+                    <h2 class="text-lg font-semibold text-text-primary">@(Model.DiscordUsername ?? "Discord User")</h2>
+                    <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-success-bg text-success border border-success-border">
+                        Linked
+                    </span>
+                </div>
+                @if (Model.DiscordUserId.HasValue)
+                {
+                    <p class="text-sm text-text-secondary font-mono">ID: @Model.DiscordUserId.Value</p>
+                }
+            </div>
+        </div>
+        <p class="text-sm text-text-secondary">
+            Your consent preferences are managed for this Discord account. Changes will apply to all servers where the bot is present.
+        </p>
+    </div>
+
+    @if (Model.ConsentStatuses.Any())
+    {
+        <!-- Consent Settings Card -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg shadow-lg mb-6">
+            <div class="flex items-center justify-between px-6 py-4 border-b border-border-primary">
+                <div>
+                    <h3 class="text-lg font-semibold text-text-primary">Consent Settings</h3>
+                    <p class="text-sm text-text-secondary mt-1">Control what data the bot can collect and process</p>
+                </div>
+            </div>
+
+            <div class="p-6 space-y-6">
+                @foreach (var consent in Model.ConsentStatuses)
+                {
+                    <!-- Consent Item -->
+                    <div class="flex items-start gap-4 p-4 bg-bg-primary rounded-lg border border-border-secondary">
+                        <label class="form-toggle cursor-pointer flex-shrink-0 pt-1">
+                            <form method="post" asp-page-handler="ToggleConsent" asp-route-type="@consent.Type" asp-route-grant="@(!consent.IsGranted)" onsubmit="return confirm('@(consent.IsGranted ? "Are you sure you want to revoke consent for " + consent.TypeDisplayName + "?" : "Are you sure you want to grant consent for " + consent.TypeDisplayName + "?")');">
+                                <input type="checkbox" class="form-toggle-input" checked="@consent.IsGranted" onchange="this.form.submit()" />
+                                <span class="form-toggle-track">
+                                    <span class="form-toggle-thumb"></span>
+                                </span>
+                            </form>
+                        </label>
+
+                        <div class="flex-1">
+                            <div class="flex items-start justify-between gap-4">
+                                <div>
+                                    <label class="block text-base font-semibold text-text-primary cursor-pointer">
+                                        @consent.TypeDisplayName
+                                    </label>
+                                    <p class="text-sm text-text-secondary mt-1">
+                                        @consent.Description
+                                    </p>
+                                </div>
+                            </div>
+                            <div class="mt-3 flex items-center gap-2">
+                                @if (consent.IsGranted)
+                                {
+                                    <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-success-bg text-success border border-success-border">
+                                        Enabled
+                                    </span>
+                                    @if (consent.GrantedAt.HasValue)
+                                    {
+                                        <span class="text-xs text-text-tertiary">Since @consent.GrantedAt.Value.ToLocalTime().ToString("MMM d, yyyy")</span>
+                                    }
+                                }
+                                else
+                                {
+                                    <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-bg-tertiary text-text-secondary border border-border-primary">
+                                        Disabled
+                                    </span>
+                                    <span class="text-xs text-text-tertiary">Never enabled</span>
+                                }
+                            </div>
+                        </div>
+                    </div>
+                }
+            </div>
+        </div>
+    }
+    else
+    {
+        <!-- Empty State - No Consents -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-12 text-center mb-6">
+            <div class="inline-flex items-center justify-center w-16 h-16 bg-bg-tertiary rounded-xl mb-4">
+                <svg class="w-10 h-10 text-text-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+                </svg>
+            </div>
+            <h3 class="text-xl font-semibold text-text-primary mb-2">No Consent Preferences</h3>
+            <p class="text-text-secondary text-sm max-w-md mx-auto">
+                You haven't set any consent preferences yet. Consent preferences will appear here once you interact with bot features that require consent.
+            </p>
+        </div>
+    }
+
+    @if (Model.ConsentHistory.Any())
+    {
+        <!-- Consent History Card -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg shadow-lg">
+            <div class="flex items-center justify-between px-6 py-4 border-b border-border-primary">
+                <div>
+                    <h3 class="text-lg font-semibold text-text-primary">Consent History</h3>
+                    <p class="text-sm text-text-secondary mt-1">A record of all consent changes for your account</p>
+                </div>
+            </div>
+
+            <div class="p-6">
+                <div class="space-y-0">
+                    @{
+                        var historyList = Model.ConsentHistory.ToList();
+                        for (int i = 0; i < historyList.Count; i++)
+                        {
+                            var entry = historyList[i];
+                            var isGranted = entry.Action.Equals("Granted", StringComparison.OrdinalIgnoreCase);
+                            var isLast = i == historyList.Count - 1;
+
+                            <!-- Timeline Item -->
+                            <div class="timeline-item relative pl-10 @(isLast ? "pb-0" : "pb-6")">
+                                <div class="absolute left-0 top-1 w-8 h-8 rounded-full @(isGranted ? "bg-success-bg border border-success-border" : "bg-error-bg border border-error-border") flex items-center justify-center">
+                                    @if (isGranted)
+                                    {
+                                        <svg class="w-4 h-4 text-success" fill="currentColor" viewBox="0 0 20 20">
+                                            <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
+                                        </svg>
+                                    }
+                                    else
+                                    {
+                                        <svg class="w-4 h-4 text-error" fill="currentColor" viewBox="0 0 20 20">
+                                            <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
+                                        </svg>
+                                    }
+                                </div>
+                                <div>
+                                    <div class="flex items-center gap-2 mb-1">
+                                        <span class="text-sm font-semibold text-text-primary">@entry.TypeDisplayName</span>
+                                        <span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium @(isGranted ? "bg-success-bg text-success" : "bg-error-bg text-error")">
+                                            @entry.Action
+                                        </span>
+                                    </div>
+                                    <p class="text-xs text-text-tertiary">@entry.Timestamp.ToLocalTime().ToString("MMMM d, yyyy 'at' h:mm tt")</p>
+                                    <p class="text-sm text-text-secondary mt-1">Consent @entry.Action.ToLower() via @entry.Source</p>
+                                </div>
+                            </div>
+                        }
+                    }
+                </div>
+            </div>
+
+            <div class="px-6 py-4 border-t border-border-primary bg-bg-primary/50">
+                <p class="text-xs text-text-tertiary">
+                    Consent history is retained for compliance purposes. You can manage your consent preferences at any time.
+                </p>
+            </div>
+        </div>
+    }
+
+    <!-- Additional Info -->
+    <div class="mt-6 p-4 bg-info-bg border border-info-border rounded-md">
+        <div class="flex items-start gap-3">
+            <svg class="w-5 h-5 text-info flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd" />
+            </svg>
+            <div class="text-sm text-info">
+                <p class="font-semibold mb-1">Managing Consent via Discord</p>
+                <p class="text-info/90">
+                    You can also manage your consent preferences directly in Discord using the <code class="px-1.5 py-0.5 bg-info/20 rounded font-mono text-xs">/consent</code> slash command. Changes made via Discord will be reflected here.
+                </p>
+            </div>
+        </div>
+    </div>
+}
+
+<style>
+    /* Toggle Switch Component */
+    .form-toggle {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+    }
+
+    .form-toggle-input {
+        position: absolute;
+        opacity: 0;
+        width: 0;
+        height: 0;
+    }
+
+    .form-toggle-track {
+        position: relative;
+        display: inline-block;
+        width: 2.75rem;
+        height: 1.5rem;
+        background-color: #3f4447;
+        border-radius: 9999px;
+        flex-shrink: 0;
+        transition: background-color 0.2s ease-in-out;
+    }
+
+    .form-toggle-thumb {
+        position: absolute;
+        top: 0.125rem;
+        left: 0.125rem;
+        width: 1.25rem;
+        height: 1.25rem;
+        background-color: #d7d3d0;
+        border-radius: 50%;
+        transition: transform 0.2s ease-in-out, background-color 0.2s ease-in-out;
+    }
+
+    .form-toggle:hover .form-toggle-track {
+        background-color: #4a4f52;
+    }
+
+    .form-toggle:hover .form-toggle-input:checked + .form-toggle-track {
+        background-color: #e5591f;
+    }
+
+    .form-toggle-input:focus-visible + .form-toggle-track {
+        outline: 2px solid #098ecf;
+        outline-offset: 2px;
+    }
+
+    .form-toggle-input:checked + .form-toggle-track {
+        background-color: #cb4e1b;
+    }
+
+    .form-toggle-input:checked + .form-toggle-track .form-toggle-thumb {
+        transform: translateX(1.25rem);
+        background-color: white;
+    }
+
+    .form-toggle-input:disabled + .form-toggle-track {
+        opacity: 0.6;
+        cursor: not-allowed;
+    }
+
+    /* Timeline styles */
+    .timeline-item::before {
+        content: '';
+        position: absolute;
+        left: 1rem;
+        top: 2.25rem;
+        bottom: -0.5rem;
+        width: 2px;
+        background-color: #3f4447;
+    }
+
+    .timeline-item:last-child::before {
+        display: none;
+    }
+</style>

--- a/src/DiscordBot.Bot/Pages/Account/Privacy.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Account/Privacy.cshtml.cs
@@ -1,0 +1,210 @@
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Entities;
+using DiscordBot.Core.Enums;
+using DiscordBot.Core.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace DiscordBot.Bot.Pages.Account;
+
+/// <summary>
+/// Page model for managing user privacy and consent preferences.
+/// Allows authenticated users to view and manage their consent settings for the Discord bot.
+/// </summary>
+[Authorize]
+public class PrivacyModel : PageModel
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly IConsentService _consentService;
+    private readonly ILogger<PrivacyModel> _logger;
+
+    public PrivacyModel(
+        UserManager<ApplicationUser> userManager,
+        IConsentService consentService,
+        ILogger<PrivacyModel> logger)
+    {
+        _userManager = userManager;
+        _consentService = consentService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Indicates whether the current user has a Discord account linked.
+    /// </summary>
+    public bool IsDiscordLinked { get; set; }
+
+    /// <summary>
+    /// The Discord user ID (snowflake) of the linked account.
+    /// </summary>
+    public ulong? DiscordUserId { get; set; }
+
+    /// <summary>
+    /// The Discord username of the linked account.
+    /// </summary>
+    public string? DiscordUsername { get; set; }
+
+    /// <summary>
+    /// List of consent statuses for all consent types.
+    /// </summary>
+    public IEnumerable<ConsentStatusDto> ConsentStatuses { get; set; } = Array.Empty<ConsentStatusDto>();
+
+    /// <summary>
+    /// List of consent history entries, ordered by most recent first.
+    /// </summary>
+    public IEnumerable<ConsentHistoryEntryDto> ConsentHistory { get; set; } = Array.Empty<ConsentHistoryEntryDto>();
+
+    /// <summary>
+    /// Status message to display to the user (success or error).
+    /// </summary>
+    [TempData]
+    public string? StatusMessage { get; set; }
+
+    /// <summary>
+    /// Indicates whether the status message is a success message.
+    /// </summary>
+    [TempData]
+    public bool IsSuccess { get; set; }
+
+    /// <summary>
+    /// Handles GET requests to display the privacy and consent settings page.
+    /// </summary>
+    public async Task<IActionResult> OnGetAsync()
+    {
+        _logger.LogTrace("Entering {MethodName}", nameof(OnGetAsync));
+
+        var user = await _userManager.GetUserAsync(User);
+        if (user == null)
+        {
+            _logger.LogWarning("User not found during Privacy page load");
+            return NotFound("User not found.");
+        }
+
+        _logger.LogDebug("Loading privacy settings for user {UserId}", user.Id);
+
+        // Check if Discord is linked
+        IsDiscordLinked = user.DiscordUserId.HasValue;
+        DiscordUserId = user.DiscordUserId;
+        DiscordUsername = user.DiscordUsername;
+
+        if (IsDiscordLinked && DiscordUserId.HasValue)
+        {
+            _logger.LogDebug("User {UserId} has Discord linked (Discord ID: {DiscordUserId}), fetching consent data",
+                user.Id, DiscordUserId.Value);
+
+            try
+            {
+                // Fetch consent statuses
+                ConsentStatuses = await _consentService.GetConsentStatusAsync(DiscordUserId.Value);
+                _logger.LogDebug("Retrieved {Count} consent statuses for user {UserId}",
+                    ConsentStatuses.Count(), user.Id);
+
+                // Fetch consent history
+                ConsentHistory = await _consentService.GetConsentHistoryAsync(DiscordUserId.Value);
+                _logger.LogInformation("Retrieved {Count} consent history entries for user {UserId}",
+                    ConsentHistory.Count(), user.Id);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error fetching consent data for user {UserId}", user.Id);
+                StatusMessage = "An error occurred while loading consent data.";
+                IsSuccess = false;
+            }
+        }
+        else
+        {
+            _logger.LogDebug("User {UserId} does not have Discord linked", user.Id);
+        }
+
+        return Page();
+    }
+
+    /// <summary>
+    /// Handles POST requests to toggle consent for a specific consent type.
+    /// </summary>
+    /// <param name="type">The consent type ID to toggle.</param>
+    /// <param name="grant">True to grant consent, false to revoke.</param>
+    public async Task<IActionResult> OnPostToggleConsentAsync(int type, bool grant)
+    {
+        _logger.LogTrace("Entering {MethodName} with type={Type}, grant={Grant}",
+            nameof(OnPostToggleConsentAsync), type, grant);
+
+        var user = await _userManager.GetUserAsync(User);
+        if (user == null)
+        {
+            _logger.LogWarning("User not found during consent toggle");
+            return NotFound("User not found.");
+        }
+
+        if (!user.DiscordUserId.HasValue)
+        {
+            _logger.LogWarning("User {UserId} attempted to toggle consent without Discord account linked", user.Id);
+            StatusMessage = "You must link your Discord account before managing consent preferences.";
+            IsSuccess = false;
+            return RedirectToPage();
+        }
+
+        // Validate consent type
+        if (!Enum.IsDefined(typeof(ConsentType), type))
+        {
+            _logger.LogWarning("User {UserId} attempted to toggle invalid consent type {Type}", user.Id, type);
+            StatusMessage = "Invalid consent type.";
+            IsSuccess = false;
+            return RedirectToPage();
+        }
+
+        var consentType = (ConsentType)type;
+        var discordUserId = user.DiscordUserId.Value;
+
+        _logger.LogInformation("User {UserId} (Discord ID: {DiscordUserId}) {Action} consent for {ConsentType}",
+            user.Id, discordUserId, grant ? "granting" : "revoking", consentType);
+
+        try
+        {
+            ConsentUpdateResult result;
+
+            if (grant)
+            {
+                result = await _consentService.GrantConsentAsync(discordUserId, consentType);
+            }
+            else
+            {
+                result = await _consentService.RevokeConsentAsync(discordUserId, consentType);
+            }
+
+            if (result.Succeeded)
+            {
+                _logger.LogInformation("Successfully {Action} consent for {ConsentType} for user {UserId}",
+                    grant ? "granted" : "revoked", consentType, user.Id);
+                StatusMessage = "Your consent preferences have been updated successfully.";
+                IsSuccess = true;
+            }
+            else
+            {
+                _logger.LogWarning("Failed to {Action} consent for {ConsentType} for user {UserId}: {ErrorCode} - {ErrorMessage}",
+                    grant ? "grant" : "revoke", consentType, user.Id, result.ErrorCode, result.ErrorMessage);
+
+                // Handle specific error codes with user-friendly messages
+                StatusMessage = result.ErrorCode switch
+                {
+                    ConsentUpdateResult.AlreadyGranted => "This consent is already granted.",
+                    ConsentUpdateResult.NotGranted => "This consent is not currently granted.",
+                    ConsentUpdateResult.UserNotFound => "Discord user not found.",
+                    ConsentUpdateResult.InvalidConsentType => "Invalid consent type.",
+                    ConsentUpdateResult.DatabaseError => "A database error occurred. Please try again.",
+                    _ => result.ErrorMessage ?? "Failed to update consent preferences. Please try again."
+                };
+                IsSuccess = false;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error toggling consent for user {UserId}", user.Id);
+            StatusMessage = "An error occurred while updating consent preferences.";
+            IsSuccess = false;
+        }
+
+        return RedirectToPage();
+    }
+}

--- a/src/DiscordBot.Bot/Pages/Shared/_Navbar.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/_Navbar.cshtml
@@ -94,6 +94,12 @@
             <p class="text-xs text-text-secondary">@user?.Email</p>
           </div>
           <div class="pt-1">
+            <a asp-page="/Account/Privacy" role="menuitem" class="flex items-center gap-2 px-4 py-2 text-sm text-text-primary hover:bg-bg-hover transition-colors">
+              <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+              </svg>
+              Privacy & Consent
+            </a>
             <form asp-page="/Account/Logout" asp-page-handler="Post" method="post" class="block">
               <button type="submit" role="menuitem" class="w-full text-left flex items-center gap-2 px-4 py-2 text-sm text-error hover:bg-bg-hover transition-colors">
                 <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">

--- a/src/DiscordBot.Bot/Program.cs
+++ b/src/DiscordBot.Bot/Program.cs
@@ -170,6 +170,9 @@ try
     builder.Services.AddScoped<IVerificationService, VerificationService>();
     builder.Services.AddHostedService<VerificationCleanupService>();
 
+    // Add Consent services
+    builder.Services.AddScoped<IConsentService, ConsentService>();
+
     // Add Metrics update background services
     builder.Services.AddHostedService<MetricsUpdateService>();
     builder.Services.AddHostedService<BusinessMetricsUpdateService>();

--- a/src/DiscordBot.Bot/Services/ConsentService.cs
+++ b/src/DiscordBot.Bot/Services/ConsentService.cs
@@ -1,0 +1,250 @@
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Entities;
+using DiscordBot.Core.Enums;
+using DiscordBot.Core.Interfaces;
+
+namespace DiscordBot.Bot.Services;
+
+/// <summary>
+/// Service for managing user consent operations for privacy compliance.
+/// </summary>
+public class ConsentService : IConsentService
+{
+    private readonly IUserConsentRepository _consentRepository;
+    private readonly ILogger<ConsentService> _logger;
+
+    private const string WebUISource = "WebUI";
+
+    public ConsentService(
+        IUserConsentRepository consentRepository,
+        ILogger<ConsentService> logger)
+    {
+        _consentRepository = consentRepository;
+        _logger = logger;
+    }
+
+    public async Task<IEnumerable<ConsentStatusDto>> GetConsentStatusAsync(
+        ulong discordUserId,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Retrieving consent status for Discord user {DiscordUserId}", discordUserId);
+
+        // Get all user consents
+        var userConsents = await _consentRepository.GetUserConsentsAsync(discordUserId, cancellationToken);
+
+        // Build status DTOs for all consent types
+        var consentStatuses = new List<ConsentStatusDto>();
+
+        foreach (ConsentType consentType in Enum.GetValues(typeof(ConsentType)))
+        {
+            var activeConsent = userConsents
+                .Where(c => c.ConsentType == consentType && c.IsActive)
+                .OrderByDescending(c => c.GrantedAt)
+                .FirstOrDefault();
+
+            consentStatuses.Add(new ConsentStatusDto
+            {
+                Type = (int)consentType,
+                TypeDisplayName = GetConsentTypeDisplayName(consentType),
+                Description = GetConsentTypeDescription(consentType),
+                IsGranted = activeConsent != null,
+                GrantedAt = activeConsent?.GrantedAt,
+                GrantedVia = activeConsent?.GrantedVia
+            });
+        }
+
+        _logger.LogDebug("Retrieved {Count} consent statuses for Discord user {DiscordUserId}",
+            consentStatuses.Count, discordUserId);
+
+        return consentStatuses;
+    }
+
+    public async Task<IEnumerable<ConsentHistoryEntryDto>> GetConsentHistoryAsync(
+        ulong discordUserId,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Retrieving consent history for Discord user {DiscordUserId}", discordUserId);
+
+        // Get all user consents (including revoked)
+        var userConsents = await _consentRepository.GetUserConsentsAsync(discordUserId, cancellationToken);
+
+        var historyEntries = new List<ConsentHistoryEntryDto>();
+
+        foreach (var consent in userConsents.OrderByDescending(c => c.GrantedAt))
+        {
+            // Add "Granted" entry
+            historyEntries.Add(new ConsentHistoryEntryDto
+            {
+                Type = (int)consent.ConsentType,
+                TypeDisplayName = GetConsentTypeDisplayName(consent.ConsentType),
+                Action = "Granted",
+                Timestamp = consent.GrantedAt,
+                Source = consent.GrantedVia ?? "Unknown"
+            });
+
+            // Add "Revoked" entry if consent was revoked
+            if (consent.RevokedAt.HasValue)
+            {
+                historyEntries.Add(new ConsentHistoryEntryDto
+                {
+                    Type = (int)consent.ConsentType,
+                    TypeDisplayName = GetConsentTypeDisplayName(consent.ConsentType),
+                    Action = "Revoked",
+                    Timestamp = consent.RevokedAt.Value,
+                    Source = consent.RevokedVia ?? "Unknown"
+                });
+            }
+        }
+
+        // Sort by timestamp descending (most recent first)
+        var sortedHistory = historyEntries.OrderByDescending(h => h.Timestamp).ToList();
+
+        _logger.LogDebug("Retrieved {Count} consent history entries for Discord user {DiscordUserId}",
+            sortedHistory.Count, discordUserId);
+
+        return sortedHistory;
+    }
+
+    public async Task<ConsentUpdateResult> GrantConsentAsync(
+        ulong discordUserId,
+        ConsentType type,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Granting consent {ConsentType} for Discord user {DiscordUserId} via {Source}",
+            type, discordUserId, WebUISource);
+
+        // Validate consent type
+        if (!Enum.IsDefined(typeof(ConsentType), type))
+        {
+            _logger.LogWarning("Invalid consent type {ConsentType} for Discord user {DiscordUserId}",
+                type, discordUserId);
+            return ConsentUpdateResult.Failure(
+                ConsentUpdateResult.InvalidConsentType,
+                "Invalid consent type.");
+        }
+
+        try
+        {
+            // Check if user already has active consent
+            var activeConsent = await _consentRepository.GetActiveConsentAsync(
+                discordUserId, type, cancellationToken);
+
+            if (activeConsent != null)
+            {
+                _logger.LogDebug("Discord user {DiscordUserId} already has active consent {ConsentType}",
+                    discordUserId, type);
+                return ConsentUpdateResult.Failure(
+                    ConsentUpdateResult.AlreadyGranted,
+                    "Consent is already granted for this type.");
+            }
+
+            // Create new consent record
+            var newConsent = new UserConsent
+            {
+                DiscordUserId = discordUserId,
+                ConsentType = type,
+                GrantedAt = DateTime.UtcNow,
+                GrantedVia = WebUISource,
+                RevokedAt = null,
+                RevokedVia = null
+            };
+
+            await _consentRepository.AddAsync(newConsent, cancellationToken);
+
+            _logger.LogInformation(
+                "Consent {ConsentType} granted for Discord user {DiscordUserId} via {Source}",
+                type, discordUserId, WebUISource);
+
+            return ConsentUpdateResult.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to grant consent {ConsentType} for Discord user {DiscordUserId}",
+                type, discordUserId);
+            return ConsentUpdateResult.Failure(
+                ConsentUpdateResult.DatabaseError,
+                "An error occurred while granting consent.");
+        }
+    }
+
+    public async Task<ConsentUpdateResult> RevokeConsentAsync(
+        ulong discordUserId,
+        ConsentType type,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Revoking consent {ConsentType} for Discord user {DiscordUserId} via {Source}",
+            type, discordUserId, WebUISource);
+
+        // Validate consent type
+        if (!Enum.IsDefined(typeof(ConsentType), type))
+        {
+            _logger.LogWarning("Invalid consent type {ConsentType} for Discord user {DiscordUserId}",
+                type, discordUserId);
+            return ConsentUpdateResult.Failure(
+                ConsentUpdateResult.InvalidConsentType,
+                "Invalid consent type.");
+        }
+
+        try
+        {
+            // Find active consent
+            var activeConsent = await _consentRepository.GetActiveConsentAsync(
+                discordUserId, type, cancellationToken);
+
+            if (activeConsent == null)
+            {
+                _logger.LogDebug("No active consent {ConsentType} found for Discord user {DiscordUserId}",
+                    type, discordUserId);
+                return ConsentUpdateResult.Failure(
+                    ConsentUpdateResult.NotGranted,
+                    "No active consent found for this type.");
+            }
+
+            // Revoke the consent
+            activeConsent.RevokedAt = DateTime.UtcNow;
+            activeConsent.RevokedVia = WebUISource;
+
+            await _consentRepository.UpdateAsync(activeConsent, cancellationToken);
+
+            _logger.LogInformation(
+                "Consent {ConsentType} revoked for Discord user {DiscordUserId} via {Source}",
+                type, discordUserId, WebUISource);
+
+            return ConsentUpdateResult.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to revoke consent {ConsentType} for Discord user {DiscordUserId}",
+                type, discordUserId);
+            return ConsentUpdateResult.Failure(
+                ConsentUpdateResult.DatabaseError,
+                "An error occurred while revoking consent.");
+        }
+    }
+
+    /// <summary>
+    /// Gets user-friendly display name for a consent type.
+    /// </summary>
+    private static string GetConsentTypeDisplayName(ConsentType type)
+    {
+        return type switch
+        {
+            ConsentType.MessageLogging => "Message Logging",
+            _ => type.ToString()
+        };
+    }
+
+    /// <summary>
+    /// Gets user-friendly description for a consent type.
+    /// </summary>
+    private static string GetConsentTypeDescription(ConsentType type)
+    {
+        return type switch
+        {
+            ConsentType.MessageLogging => "Allow the bot to log your messages and interactions for moderation, analytics, and troubleshooting purposes. This includes message content, timestamps, and metadata.",
+            _ => "No description available."
+        };
+    }
+}

--- a/src/DiscordBot.Core/DTOs/ConsentDtos.cs
+++ b/src/DiscordBot.Core/DTOs/ConsentDtos.cs
@@ -1,0 +1,97 @@
+namespace DiscordBot.Core.DTOs;
+
+/// <summary>
+/// Represents the current status of a user consent for a specific consent type.
+/// </summary>
+public class ConsentStatusDto
+{
+    /// <summary>
+    /// Type of consent (e.g., MessageLogging).
+    /// </summary>
+    public int Type { get; set; }
+
+    /// <summary>
+    /// User-friendly display name for the consent type.
+    /// </summary>
+    public string TypeDisplayName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Description explaining what this consent allows.
+    /// </summary>
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Indicates whether the user has currently granted this consent.
+    /// </summary>
+    public bool IsGranted { get; set; }
+
+    /// <summary>
+    /// Timestamp when consent was granted (null if never granted or currently revoked).
+    /// </summary>
+    public DateTime? GrantedAt { get; set; }
+
+    /// <summary>
+    /// Source through which consent was granted (e.g., "SlashCommand", "WebUI").
+    /// </summary>
+    public string? GrantedVia { get; set; }
+}
+
+/// <summary>
+/// Represents a historical consent change entry.
+/// </summary>
+public class ConsentHistoryEntryDto
+{
+    /// <summary>
+    /// Type of consent (e.g., MessageLogging).
+    /// </summary>
+    public int Type { get; set; }
+
+    /// <summary>
+    /// User-friendly display name for the consent type.
+    /// </summary>
+    public string TypeDisplayName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Action performed ("Granted" or "Revoked").
+    /// </summary>
+    public string Action { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Timestamp when the action occurred.
+    /// </summary>
+    public DateTime Timestamp { get; set; }
+
+    /// <summary>
+    /// Source through which the action was performed (e.g., "SlashCommand", "WebUI").
+    /// </summary>
+    public string Source { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Result of granting or revoking consent.
+/// </summary>
+public class ConsentUpdateResult
+{
+    public bool Succeeded { get; private set; }
+    public string? ErrorCode { get; private set; }
+    public string? ErrorMessage { get; private set; }
+
+    public static ConsentUpdateResult Success() => new()
+    {
+        Succeeded = true
+    };
+
+    public static ConsentUpdateResult Failure(string errorCode, string errorMessage) => new()
+    {
+        Succeeded = false,
+        ErrorCode = errorCode,
+        ErrorMessage = errorMessage
+    };
+
+    // Error codes
+    public const string UserNotFound = "USER_NOT_FOUND";
+    public const string InvalidConsentType = "INVALID_CONSENT_TYPE";
+    public const string AlreadyGranted = "ALREADY_GRANTED";
+    public const string NotGranted = "NOT_GRANTED";
+    public const string DatabaseError = "DATABASE_ERROR";
+}

--- a/src/DiscordBot.Core/Interfaces/IConsentService.cs
+++ b/src/DiscordBot.Core/Interfaces/IConsentService.cs
@@ -1,0 +1,54 @@
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Enums;
+
+namespace DiscordBot.Core.Interfaces;
+
+/// <summary>
+/// Service interface for managing user consent operations.
+/// </summary>
+public interface IConsentService
+{
+    /// <summary>
+    /// Gets the current consent status for all consent types for a user.
+    /// </summary>
+    /// <param name="discordUserId">Discord user ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of consent status for all consent types.</returns>
+    Task<IEnumerable<ConsentStatusDto>> GetConsentStatusAsync(
+        ulong discordUserId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the consent history for a user, ordered by most recent first.
+    /// </summary>
+    /// <param name="discordUserId">Discord user ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Ordered list of consent history entries.</returns>
+    Task<IEnumerable<ConsentHistoryEntryDto>> GetConsentHistoryAsync(
+        ulong discordUserId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Grants consent for a specific consent type via Web UI.
+    /// </summary>
+    /// <param name="discordUserId">Discord user ID.</param>
+    /// <param name="type">Type of consent to grant.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result indicating success or failure.</returns>
+    Task<ConsentUpdateResult> GrantConsentAsync(
+        ulong discordUserId,
+        ConsentType type,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Revokes consent for a specific consent type via Web UI.
+    /// </summary>
+    /// <param name="discordUserId">Discord user ID.</param>
+    /// <param name="type">Type of consent to revoke.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result indicating success or failure.</returns>
+    Task<ConsentUpdateResult> RevokeConsentAsync(
+        ulong discordUserId,
+        ConsentType type,
+        CancellationToken cancellationToken = default);
+}

--- a/tests/DiscordBot.Tests/Services/ConsentServiceTests.cs
+++ b/tests/DiscordBot.Tests/Services/ConsentServiceTests.cs
@@ -1,0 +1,857 @@
+using DiscordBot.Bot.Services;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Entities;
+using DiscordBot.Core.Enums;
+using DiscordBot.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace DiscordBot.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="ConsentService"/>.
+/// Tests cover consent status retrieval, history tracking, granting, and revoking consent.
+/// </summary>
+public class ConsentServiceTests
+{
+    private readonly Mock<IUserConsentRepository> _mockRepository;
+    private readonly Mock<ILogger<ConsentService>> _mockLogger;
+    private readonly ConsentService _service;
+
+    public ConsentServiceTests()
+    {
+        _mockRepository = new Mock<IUserConsentRepository>();
+        _mockLogger = new Mock<ILogger<ConsentService>>();
+        _service = new ConsentService(_mockRepository.Object, _mockLogger.Object);
+    }
+
+    #region GetConsentStatusAsync Tests
+
+    [Fact]
+    public async Task GetConsentStatusAsync_ReturnsAllConsentTypes_IncludingNotGranted()
+    {
+        // Arrange
+        var discordUserId = 123456789UL;
+        var userConsents = new List<UserConsent>
+        {
+            new UserConsent
+            {
+                Id = 1,
+                DiscordUserId = discordUserId,
+                ConsentType = ConsentType.MessageLogging,
+                GrantedAt = DateTime.UtcNow.AddDays(-5),
+                GrantedVia = "SlashCommand",
+                RevokedAt = null,
+                RevokedVia = null
+            }
+        };
+
+        _mockRepository
+            .Setup(r => r.GetUserConsentsAsync(discordUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(userConsents);
+
+        // Act
+        var result = await _service.GetConsentStatusAsync(discordUserId);
+
+        // Assert
+        var statuses = result.ToList();
+        statuses.Should().NotBeNull();
+        statuses.Should().HaveCountGreaterThanOrEqualTo(1, "should include at least MessageLogging consent type");
+
+        // Verify MessageLogging is present and granted
+        var messageLoggingStatus = statuses.FirstOrDefault(s => s.Type == (int)ConsentType.MessageLogging);
+        messageLoggingStatus.Should().NotBeNull();
+        messageLoggingStatus!.IsGranted.Should().BeTrue();
+        messageLoggingStatus.TypeDisplayName.Should().Be("Message Logging");
+        messageLoggingStatus.GrantedAt.Should().NotBeNull();
+        messageLoggingStatus.GrantedVia.Should().Be("SlashCommand");
+
+        _mockRepository.Verify(
+            r => r.GetUserConsentsAsync(discordUserId, It.IsAny<CancellationToken>()),
+            Times.Once,
+            "repository should be called once to fetch user consents");
+    }
+
+    [Fact]
+    public async Task GetConsentStatusAsync_ReturnsCorrectStatus_ForActiveConsent()
+    {
+        // Arrange
+        var discordUserId = 987654321UL;
+        var grantedAt = DateTime.UtcNow.AddDays(-10);
+        var userConsents = new List<UserConsent>
+        {
+            new UserConsent
+            {
+                Id = 1,
+                DiscordUserId = discordUserId,
+                ConsentType = ConsentType.MessageLogging,
+                GrantedAt = grantedAt,
+                GrantedVia = "WebUI",
+                RevokedAt = null,
+                RevokedVia = null
+            }
+        };
+
+        _mockRepository
+            .Setup(r => r.GetUserConsentsAsync(discordUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(userConsents);
+
+        // Act
+        var result = await _service.GetConsentStatusAsync(discordUserId);
+
+        // Assert
+        var statuses = result.ToList();
+        var messageLoggingStatus = statuses.First(s => s.Type == (int)ConsentType.MessageLogging);
+
+        messageLoggingStatus.IsGranted.Should().BeTrue("consent is active and not revoked");
+        messageLoggingStatus.GrantedAt.Should().Be(grantedAt);
+        messageLoggingStatus.GrantedVia.Should().Be("WebUI");
+        messageLoggingStatus.TypeDisplayName.Should().Be("Message Logging");
+        messageLoggingStatus.Description.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task GetConsentStatusAsync_ReturnsNotGranted_ForRevokedConsent()
+    {
+        // Arrange
+        var discordUserId = 111222333UL;
+        var userConsents = new List<UserConsent>
+        {
+            new UserConsent
+            {
+                Id = 1,
+                DiscordUserId = discordUserId,
+                ConsentType = ConsentType.MessageLogging,
+                GrantedAt = DateTime.UtcNow.AddDays(-10),
+                GrantedVia = "WebUI",
+                RevokedAt = DateTime.UtcNow.AddDays(-2),
+                RevokedVia = "WebUI"
+            }
+        };
+
+        _mockRepository
+            .Setup(r => r.GetUserConsentsAsync(discordUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(userConsents);
+
+        // Act
+        var result = await _service.GetConsentStatusAsync(discordUserId);
+
+        // Assert
+        var statuses = result.ToList();
+        var messageLoggingStatus = statuses.First(s => s.Type == (int)ConsentType.MessageLogging);
+
+        messageLoggingStatus.IsGranted.Should().BeFalse("consent was revoked");
+        messageLoggingStatus.GrantedAt.Should().BeNull("revoked consent should not show granted timestamp");
+        messageLoggingStatus.GrantedVia.Should().BeNull("revoked consent should not show granted source");
+    }
+
+    [Fact]
+    public async Task GetConsentStatusAsync_ReturnsNotGranted_WhenNoConsentExists()
+    {
+        // Arrange
+        var discordUserId = 444555666UL;
+        var userConsents = new List<UserConsent>();
+
+        _mockRepository
+            .Setup(r => r.GetUserConsentsAsync(discordUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(userConsents);
+
+        // Act
+        var result = await _service.GetConsentStatusAsync(discordUserId);
+
+        // Assert
+        var statuses = result.ToList();
+        statuses.Should().NotBeEmpty("should return status for all consent types");
+
+        var messageLoggingStatus = statuses.First(s => s.Type == (int)ConsentType.MessageLogging);
+        messageLoggingStatus.IsGranted.Should().BeFalse("no consent exists for this type");
+        messageLoggingStatus.GrantedAt.Should().BeNull();
+        messageLoggingStatus.GrantedVia.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetConsentStatusAsync_SelectsMostRecentActiveConsent_WhenMultipleExist()
+    {
+        // Arrange
+        var discordUserId = 777888999UL;
+        var olderGrantedAt = DateTime.UtcNow.AddDays(-20);
+        var newerGrantedAt = DateTime.UtcNow.AddDays(-5);
+        var userConsents = new List<UserConsent>
+        {
+            new UserConsent
+            {
+                Id = 1,
+                DiscordUserId = discordUserId,
+                ConsentType = ConsentType.MessageLogging,
+                GrantedAt = olderGrantedAt,
+                GrantedVia = "SlashCommand",
+                RevokedAt = DateTime.UtcNow.AddDays(-10),
+                RevokedVia = "SlashCommand"
+            },
+            new UserConsent
+            {
+                Id = 2,
+                DiscordUserId = discordUserId,
+                ConsentType = ConsentType.MessageLogging,
+                GrantedAt = newerGrantedAt,
+                GrantedVia = "WebUI",
+                RevokedAt = null,
+                RevokedVia = null
+            }
+        };
+
+        _mockRepository
+            .Setup(r => r.GetUserConsentsAsync(discordUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(userConsents);
+
+        // Act
+        var result = await _service.GetConsentStatusAsync(discordUserId);
+
+        // Assert
+        var statuses = result.ToList();
+        var messageLoggingStatus = statuses.First(s => s.Type == (int)ConsentType.MessageLogging);
+
+        messageLoggingStatus.IsGranted.Should().BeTrue();
+        messageLoggingStatus.GrantedAt.Should().Be(newerGrantedAt, "should use most recent active consent");
+        messageLoggingStatus.GrantedVia.Should().Be("WebUI");
+    }
+
+    #endregion
+
+    #region GetConsentHistoryAsync Tests
+
+    [Fact]
+    public async Task GetConsentHistoryAsync_ReturnsOrderedHistory_NewestFirst()
+    {
+        // Arrange
+        var discordUserId = 123456789UL;
+        var oldestGrantedAt = DateTime.UtcNow.AddDays(-30);
+        var middleGrantedAt = DateTime.UtcNow.AddDays(-20);
+        var newestGrantedAt = DateTime.UtcNow.AddDays(-10);
+
+        var userConsents = new List<UserConsent>
+        {
+            new UserConsent
+            {
+                Id = 1,
+                DiscordUserId = discordUserId,
+                ConsentType = ConsentType.MessageLogging,
+                GrantedAt = oldestGrantedAt,
+                GrantedVia = "SlashCommand",
+                RevokedAt = DateTime.UtcNow.AddDays(-25),
+                RevokedVia = "SlashCommand"
+            },
+            new UserConsent
+            {
+                Id = 2,
+                DiscordUserId = discordUserId,
+                ConsentType = ConsentType.MessageLogging,
+                GrantedAt = middleGrantedAt,
+                GrantedVia = "WebUI",
+                RevokedAt = DateTime.UtcNow.AddDays(-15),
+                RevokedVia = "WebUI"
+            },
+            new UserConsent
+            {
+                Id = 3,
+                DiscordUserId = discordUserId,
+                ConsentType = ConsentType.MessageLogging,
+                GrantedAt = newestGrantedAt,
+                GrantedVia = "WebUI",
+                RevokedAt = null,
+                RevokedVia = null
+            }
+        };
+
+        _mockRepository
+            .Setup(r => r.GetUserConsentsAsync(discordUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(userConsents);
+
+        // Act
+        var result = await _service.GetConsentHistoryAsync(discordUserId);
+
+        // Assert
+        var history = result.ToList();
+        history.Should().NotBeEmpty();
+
+        // First entry should be the most recent action (newest grant)
+        history[0].Timestamp.Should().Be(newestGrantedAt);
+        history[0].Action.Should().Be("Granted");
+
+        // History should be in descending order by timestamp
+        for (int i = 0; i < history.Count - 1; i++)
+        {
+            history[i].Timestamp.Should().BeOnOrAfter(history[i + 1].Timestamp,
+                "history should be ordered newest first");
+        }
+
+        _mockRepository.Verify(
+            r => r.GetUserConsentsAsync(discordUserId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetConsentHistoryAsync_IncludesBothGrantedAndRevokedEntries()
+    {
+        // Arrange
+        var discordUserId = 987654321UL;
+        var grantedAt = DateTime.UtcNow.AddDays(-10);
+        var revokedAt = DateTime.UtcNow.AddDays(-5);
+
+        var userConsents = new List<UserConsent>
+        {
+            new UserConsent
+            {
+                Id = 1,
+                DiscordUserId = discordUserId,
+                ConsentType = ConsentType.MessageLogging,
+                GrantedAt = grantedAt,
+                GrantedVia = "WebUI",
+                RevokedAt = revokedAt,
+                RevokedVia = "WebUI"
+            }
+        };
+
+        _mockRepository
+            .Setup(r => r.GetUserConsentsAsync(discordUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(userConsents);
+
+        // Act
+        var result = await _service.GetConsentHistoryAsync(discordUserId);
+
+        // Assert
+        var history = result.ToList();
+        history.Should().HaveCount(2, "should include both granted and revoked entries");
+
+        // First entry should be the revoke (most recent)
+        history[0].Action.Should().Be("Revoked");
+        history[0].Timestamp.Should().Be(revokedAt);
+        history[0].Source.Should().Be("WebUI");
+        history[0].TypeDisplayName.Should().Be("Message Logging");
+
+        // Second entry should be the grant
+        history[1].Action.Should().Be("Granted");
+        history[1].Timestamp.Should().Be(grantedAt);
+        history[1].Source.Should().Be("WebUI");
+    }
+
+    [Fact]
+    public async Task GetConsentHistoryAsync_ReturnsEmptyList_WhenNoHistory()
+    {
+        // Arrange
+        var discordUserId = 111222333UL;
+        var userConsents = new List<UserConsent>();
+
+        _mockRepository
+            .Setup(r => r.GetUserConsentsAsync(discordUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(userConsents);
+
+        // Act
+        var result = await _service.GetConsentHistoryAsync(discordUserId);
+
+        // Assert
+        var history = result.ToList();
+        history.Should().BeEmpty("no consent history exists for this user");
+
+        _mockRepository.Verify(
+            r => r.GetUserConsentsAsync(discordUserId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetConsentHistoryAsync_HandlesUnknownSource_WhenSourceIsNull()
+    {
+        // Arrange
+        var discordUserId = 444555666UL;
+        var userConsents = new List<UserConsent>
+        {
+            new UserConsent
+            {
+                Id = 1,
+                DiscordUserId = discordUserId,
+                ConsentType = ConsentType.MessageLogging,
+                GrantedAt = DateTime.UtcNow.AddDays(-10),
+                GrantedVia = null,
+                RevokedAt = null,
+                RevokedVia = null
+            }
+        };
+
+        _mockRepository
+            .Setup(r => r.GetUserConsentsAsync(discordUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(userConsents);
+
+        // Act
+        var result = await _service.GetConsentHistoryAsync(discordUserId);
+
+        // Assert
+        var history = result.ToList();
+        history.Should().HaveCount(1);
+        history[0].Source.Should().Be("Unknown", "null source should be replaced with 'Unknown'");
+    }
+
+    #endregion
+
+    #region GrantConsentAsync Tests
+
+    [Fact]
+    public async Task GrantConsentAsync_CreatesNewConsent_WhenNoneExists()
+    {
+        // Arrange
+        var discordUserId = 123456789UL;
+        var consentType = ConsentType.MessageLogging;
+
+        _mockRepository
+            .Setup(r => r.GetActiveConsentAsync(discordUserId, consentType, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(It.IsAny<UserConsent>());
+
+        UserConsent? capturedConsent = null;
+        _mockRepository
+            .Setup(r => r.AddAsync(It.IsAny<UserConsent>(), It.IsAny<CancellationToken>()))
+            .Callback<UserConsent, CancellationToken>((consent, _) => capturedConsent = consent)
+            .ReturnsAsync(It.IsAny<UserConsent>());
+
+        // Act
+        var result = await _service.GrantConsentAsync(discordUserId, consentType);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Succeeded.Should().BeTrue();
+        result.ErrorCode.Should().BeNull();
+        result.ErrorMessage.Should().BeNull();
+
+        capturedConsent.Should().NotBeNull();
+        capturedConsent!.DiscordUserId.Should().Be(discordUserId);
+        capturedConsent.ConsentType.Should().Be(consentType);
+        capturedConsent.GrantedVia.Should().Be("WebUI", "consent granted via service should use WebUI source");
+        capturedConsent.RevokedAt.Should().BeNull();
+        capturedConsent.RevokedVia.Should().BeNull();
+        capturedConsent.GrantedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+
+        _mockRepository.Verify(
+            r => r.GetActiveConsentAsync(discordUserId, consentType, It.IsAny<CancellationToken>()),
+            Times.Once,
+            "should check for existing active consent");
+
+        _mockRepository.Verify(
+            r => r.AddAsync(It.IsAny<UserConsent>(), It.IsAny<CancellationToken>()),
+            Times.Once,
+            "should add new consent record");
+    }
+
+    [Fact]
+    public async Task GrantConsentAsync_ReturnsAlreadyGranted_WhenActiveConsentExists()
+    {
+        // Arrange
+        var discordUserId = 987654321UL;
+        var consentType = ConsentType.MessageLogging;
+
+        var existingConsent = new UserConsent
+        {
+            Id = 1,
+            DiscordUserId = discordUserId,
+            ConsentType = consentType,
+            GrantedAt = DateTime.UtcNow.AddDays(-5),
+            GrantedVia = "SlashCommand",
+            RevokedAt = null,
+            RevokedVia = null
+        };
+
+        _mockRepository
+            .Setup(r => r.GetActiveConsentAsync(discordUserId, consentType, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingConsent);
+
+        // Act
+        var result = await _service.GrantConsentAsync(discordUserId, consentType);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Succeeded.Should().BeFalse();
+        result.ErrorCode.Should().Be(ConsentUpdateResult.AlreadyGranted);
+        result.ErrorMessage.Should().Be("Consent is already granted for this type.");
+
+        _mockRepository.Verify(
+            r => r.AddAsync(It.IsAny<UserConsent>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "should not add new consent when active consent already exists");
+    }
+
+    [Fact]
+    public async Task GrantConsentAsync_ReturnsInvalidConsentType_ForInvalidType()
+    {
+        // Arrange
+        var discordUserId = 111222333UL;
+        var invalidConsentType = (ConsentType)999;
+
+        // Act
+        var result = await _service.GrantConsentAsync(discordUserId, invalidConsentType);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Succeeded.Should().BeFalse();
+        result.ErrorCode.Should().Be(ConsentUpdateResult.InvalidConsentType);
+        result.ErrorMessage.Should().Be("Invalid consent type.");
+
+        _mockRepository.Verify(
+            r => r.GetActiveConsentAsync(It.IsAny<ulong>(), It.IsAny<ConsentType>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "should not check for active consent when type is invalid");
+
+        _mockRepository.Verify(
+            r => r.AddAsync(It.IsAny<UserConsent>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "should not add consent when type is invalid");
+    }
+
+    [Fact]
+    public async Task GrantConsentAsync_ReturnsDatabaseError_WhenRepositoryThrows()
+    {
+        // Arrange
+        var discordUserId = 444555666UL;
+        var consentType = ConsentType.MessageLogging;
+
+        _mockRepository
+            .Setup(r => r.GetActiveConsentAsync(discordUserId, consentType, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("Database connection failed"));
+
+        // Act
+        var result = await _service.GrantConsentAsync(discordUserId, consentType);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Succeeded.Should().BeFalse();
+        result.ErrorCode.Should().Be(ConsentUpdateResult.DatabaseError);
+        result.ErrorMessage.Should().Be("An error occurred while granting consent.");
+
+        _mockRepository.Verify(
+            r => r.AddAsync(It.IsAny<UserConsent>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "should not attempt to add consent when exception occurs");
+    }
+
+    [Fact]
+    public async Task GrantConsentAsync_SetsCorrectSource_AsWebUI()
+    {
+        // Arrange
+        var discordUserId = 777888999UL;
+        var consentType = ConsentType.MessageLogging;
+
+        _mockRepository
+            .Setup(r => r.GetActiveConsentAsync(discordUserId, consentType, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(It.IsAny<UserConsent>());
+
+        UserConsent? capturedConsent = null;
+        _mockRepository
+            .Setup(r => r.AddAsync(It.IsAny<UserConsent>(), It.IsAny<CancellationToken>()))
+            .Callback<UserConsent, CancellationToken>((consent, _) => capturedConsent = consent)
+            .ReturnsAsync(It.IsAny<UserConsent>());
+
+        // Act
+        await _service.GrantConsentAsync(discordUserId, consentType);
+
+        // Assert
+        capturedConsent.Should().NotBeNull();
+        capturedConsent!.GrantedVia.Should().Be("WebUI", "service should always use WebUI as source");
+    }
+
+    #endregion
+
+    #region RevokeConsentAsync Tests
+
+    [Fact]
+    public async Task RevokeConsentAsync_RevokesExistingActiveConsent()
+    {
+        // Arrange
+        var discordUserId = 123456789UL;
+        var consentType = ConsentType.MessageLogging;
+
+        var activeConsent = new UserConsent
+        {
+            Id = 1,
+            DiscordUserId = discordUserId,
+            ConsentType = consentType,
+            GrantedAt = DateTime.UtcNow.AddDays(-10),
+            GrantedVia = "WebUI",
+            RevokedAt = null,
+            RevokedVia = null
+        };
+
+        _mockRepository
+            .Setup(r => r.GetActiveConsentAsync(discordUserId, consentType, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(activeConsent);
+
+        UserConsent? updatedConsent = null;
+        _mockRepository
+            .Setup(r => r.UpdateAsync(It.IsAny<UserConsent>(), It.IsAny<CancellationToken>()))
+            .Callback<UserConsent, CancellationToken>((consent, _) => updatedConsent = consent)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _service.RevokeConsentAsync(discordUserId, consentType);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Succeeded.Should().BeTrue();
+        result.ErrorCode.Should().BeNull();
+        result.ErrorMessage.Should().BeNull();
+
+        updatedConsent.Should().NotBeNull();
+        updatedConsent!.RevokedAt.Should().NotBeNull();
+        updatedConsent.RevokedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+        updatedConsent.RevokedVia.Should().Be("WebUI", "consent revoked via service should use WebUI source");
+
+        _mockRepository.Verify(
+            r => r.GetActiveConsentAsync(discordUserId, consentType, It.IsAny<CancellationToken>()),
+            Times.Once,
+            "should check for active consent");
+
+        _mockRepository.Verify(
+            r => r.UpdateAsync(It.IsAny<UserConsent>(), It.IsAny<CancellationToken>()),
+            Times.Once,
+            "should update consent to revoke it");
+    }
+
+    [Fact]
+    public async Task RevokeConsentAsync_ReturnsNotGranted_WhenNoActiveConsent()
+    {
+        // Arrange
+        var discordUserId = 987654321UL;
+        var consentType = ConsentType.MessageLogging;
+
+        _mockRepository
+            .Setup(r => r.GetActiveConsentAsync(discordUserId, consentType, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(It.IsAny<UserConsent>());
+
+        // Act
+        var result = await _service.RevokeConsentAsync(discordUserId, consentType);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Succeeded.Should().BeFalse();
+        result.ErrorCode.Should().Be(ConsentUpdateResult.NotGranted);
+        result.ErrorMessage.Should().Be("No active consent found for this type.");
+
+        _mockRepository.Verify(
+            r => r.UpdateAsync(It.IsAny<UserConsent>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "should not update when no active consent exists");
+    }
+
+    [Fact]
+    public async Task RevokeConsentAsync_ReturnsInvalidConsentType_ForInvalidType()
+    {
+        // Arrange
+        var discordUserId = 111222333UL;
+        var invalidConsentType = (ConsentType)999;
+
+        // Act
+        var result = await _service.RevokeConsentAsync(discordUserId, invalidConsentType);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Succeeded.Should().BeFalse();
+        result.ErrorCode.Should().Be(ConsentUpdateResult.InvalidConsentType);
+        result.ErrorMessage.Should().Be("Invalid consent type.");
+
+        _mockRepository.Verify(
+            r => r.GetActiveConsentAsync(It.IsAny<ulong>(), It.IsAny<ConsentType>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "should not check for active consent when type is invalid");
+
+        _mockRepository.Verify(
+            r => r.UpdateAsync(It.IsAny<UserConsent>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "should not update when type is invalid");
+    }
+
+    [Fact]
+    public async Task RevokeConsentAsync_ReturnsDatabaseError_WhenRepositoryThrows()
+    {
+        // Arrange
+        var discordUserId = 444555666UL;
+        var consentType = ConsentType.MessageLogging;
+
+        _mockRepository
+            .Setup(r => r.GetActiveConsentAsync(discordUserId, consentType, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("Database connection failed"));
+
+        // Act
+        var result = await _service.RevokeConsentAsync(discordUserId, consentType);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Succeeded.Should().BeFalse();
+        result.ErrorCode.Should().Be(ConsentUpdateResult.DatabaseError);
+        result.ErrorMessage.Should().Be("An error occurred while revoking consent.");
+
+        _mockRepository.Verify(
+            r => r.UpdateAsync(It.IsAny<UserConsent>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "should not attempt to update when exception occurs");
+    }
+
+    [Fact]
+    public async Task RevokeConsentAsync_SetsCorrectSource_AsWebUI()
+    {
+        // Arrange
+        var discordUserId = 777888999UL;
+        var consentType = ConsentType.MessageLogging;
+
+        var activeConsent = new UserConsent
+        {
+            Id = 1,
+            DiscordUserId = discordUserId,
+            ConsentType = consentType,
+            GrantedAt = DateTime.UtcNow.AddDays(-10),
+            GrantedVia = "SlashCommand",
+            RevokedAt = null,
+            RevokedVia = null
+        };
+
+        _mockRepository
+            .Setup(r => r.GetActiveConsentAsync(discordUserId, consentType, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(activeConsent);
+
+        UserConsent? updatedConsent = null;
+        _mockRepository
+            .Setup(r => r.UpdateAsync(It.IsAny<UserConsent>(), It.IsAny<CancellationToken>()))
+            .Callback<UserConsent, CancellationToken>((consent, _) => updatedConsent = consent)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _service.RevokeConsentAsync(discordUserId, consentType);
+
+        // Assert
+        updatedConsent.Should().NotBeNull();
+        updatedConsent!.RevokedVia.Should().Be("WebUI", "service should always use WebUI as revoke source");
+    }
+
+    #endregion
+
+    #region Logging Tests
+
+    [Fact]
+    public async Task GetConsentStatusAsync_LogsDebugMessages()
+    {
+        // Arrange
+        var discordUserId = 123456789UL;
+        _mockRepository
+            .Setup(r => r.GetUserConsentsAsync(discordUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<UserConsent>());
+
+        // Act
+        await _service.GetConsentStatusAsync(discordUserId);
+
+        // Assert
+        _mockLogger.Verify(
+            l => l.Log(
+                LogLevel.Debug,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Retrieving consent status")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once,
+            "should log debug message when retrieving consent status");
+    }
+
+    [Fact]
+    public async Task GrantConsentAsync_LogsInformation_OnSuccess()
+    {
+        // Arrange
+        var discordUserId = 123456789UL;
+        var consentType = ConsentType.MessageLogging;
+
+        _mockRepository
+            .Setup(r => r.GetActiveConsentAsync(discordUserId, consentType, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(It.IsAny<UserConsent>());
+
+        _mockRepository
+            .Setup(r => r.AddAsync(It.IsAny<UserConsent>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(It.IsAny<UserConsent>());
+
+        // Act
+        await _service.GrantConsentAsync(discordUserId, consentType);
+
+        // Assert
+        _mockLogger.Verify(
+            l => l.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Consent") && v.ToString()!.Contains("granted")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once,
+            "should log information message when consent is successfully granted");
+    }
+
+    [Fact]
+    public async Task RevokeConsentAsync_LogsInformation_OnSuccess()
+    {
+        // Arrange
+        var discordUserId = 123456789UL;
+        var consentType = ConsentType.MessageLogging;
+
+        var activeConsent = new UserConsent
+        {
+            Id = 1,
+            DiscordUserId = discordUserId,
+            ConsentType = consentType,
+            GrantedAt = DateTime.UtcNow.AddDays(-10),
+            GrantedVia = "WebUI",
+            RevokedAt = null,
+            RevokedVia = null
+        };
+
+        _mockRepository
+            .Setup(r => r.GetActiveConsentAsync(discordUserId, consentType, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(activeConsent);
+
+        _mockRepository
+            .Setup(r => r.UpdateAsync(It.IsAny<UserConsent>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _service.RevokeConsentAsync(discordUserId, consentType);
+
+        // Assert
+        _mockLogger.Verify(
+            l => l.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Consent") && v.ToString()!.Contains("revoked")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once,
+            "should log information message when consent is successfully revoked");
+    }
+
+    [Fact]
+    public async Task GrantConsentAsync_LogsError_OnException()
+    {
+        // Arrange
+        var discordUserId = 123456789UL;
+        var consentType = ConsentType.MessageLogging;
+        var expectedException = new Exception("Database error");
+
+        _mockRepository
+            .Setup(r => r.GetActiveConsentAsync(discordUserId, consentType, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(expectedException);
+
+        // Act
+        await _service.GrantConsentAsync(discordUserId, consentType);
+
+        // Assert
+        _mockLogger.Verify(
+            l => l.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Failed to grant consent")),
+                expectedException,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once,
+            "should log error when exception occurs during grant");
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

Add Privacy & Consent settings page at `/Account/Privacy` where authenticated Discord users can view and manage their consent preferences through the web UI.

- Add `IConsentService` interface and `ConsentService` implementation for web-based consent operations
- Create Privacy Razor Page with consent toggles and history timeline
- Add 23 unit tests for ConsentService with comprehensive coverage
- Add navigation link in user dropdown menu

## Changes

### Backend
- **ConsentDtos.cs**: DTOs for consent status, history entries, and update results
- **IConsentService.cs**: Service interface for consent operations
- **ConsentService.cs**: Implementation with grant/revoke via "WebUI" source
- **Program.cs**: Register ConsentService in DI

### Frontend
- **Privacy.cshtml.cs**: PageModel with OnGet and OnPostToggleConsent handlers
- **Privacy.cshtml**: Razor view with three states (not linked, no consents, has consents)
- **_Navbar.cshtml**: Added Privacy link to user dropdown

### Testing
- **ConsentServiceTests.cs**: 23 unit tests covering all service methods

## Test plan

- [x] Build passes with no new errors
- [x] All tests pass (1064 total, 1052 passed, 12 skipped)
- [x] New ConsentService tests pass (23 tests)
- [ ] Manual testing: Navigate to /Account/Privacy
- [ ] Manual testing: Toggle consent preferences
- [ ] Manual testing: Verify consent history displays correctly
- [ ] Manual testing: Test with Discord account not linked

## Related

- Closes #134
- Part of Epic: User Consent & Privacy System (#130)
- Depends on: #132 (Consent Domain Model & Repository) - merged
- Depends on: #133 (Consent Slash Commands) - merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)