### PR TITLE
feat: Add consent check service with caching

### DIFF
--- a/src/DiscordBot.Core/Interfaces/IConsentService.cs
+++ b/src/DiscordBot.Core/Interfaces/IConsentService.cs
@@ -51,4 +51,38 @@ public interface IConsentService
         ulong discordUserId,
         ConsentType type,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Check if user has active consent for a specific type.
+    /// </summary>
+    /// <param name="discordUserId">Discord user ID.</param>
+    /// <param name="consentType">Type of consent to check.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if user has active consent, false otherwise.</returns>
+    Task<bool> HasConsentAsync(
+        ulong discordUserId,
+        ConsentType consentType,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Get all active consent types for a user.
+    /// </summary>
+    /// <param name="discordUserId">Discord user ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Collection of active consent types.</returns>
+    Task<IEnumerable<ConsentType>> GetActiveConsentsAsync(
+        ulong discordUserId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Batch check consent for multiple users (for efficiency).
+    /// </summary>
+    /// <param name="discordUserIds">Collection of Discord user IDs to check.</param>
+    /// <param name="consentType">Type of consent to check.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Dictionary mapping user IDs to their consent status.</returns>
+    Task<IDictionary<ulong, bool>> HasConsentBatchAsync(
+        IEnumerable<ulong> discordUserIds,
+        ConsentType consentType,
+        CancellationToken cancellationToken = default);
 }

--- a/src/DiscordBot.Core/Interfaces/IUserConsentRepository.cs
+++ b/src/DiscordBot.Core/Interfaces/IUserConsentRepository.cs
@@ -41,4 +41,16 @@ public interface IUserConsentRepository : IRepository<UserConsent>
         ulong discordUserId,
         ConsentType type,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Batch checks which users from a set have active consent for a specific type.
+    /// </summary>
+    /// <param name="discordUserIds">Collection of Discord user IDs to check.</param>
+    /// <param name="type">Type of consent to check.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Collection of user IDs that have active consent.</returns>
+    Task<IEnumerable<ulong>> GetUsersWithActiveConsentAsync(
+        IEnumerable<ulong> discordUserIds,
+        ConsentType type,
+        CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
## Summary

Implements the Consent Check Service as specified in issue #135. This adds a centralized service that other features can use to check whether a user has granted consent before collecting their data.

### New Service Methods
- **HasConsentAsync**: Check if a single user has active consent for a specific type, with 5-minute caching
- **GetActiveConsentsAsync**: Get all active consent types for a user
- **HasConsentBatchAsync**: Efficient batch checking for multiple users (checks cache first, queries DB only for misses)

### New Repository Method
- **GetUsersWithActiveConsentAsync**: Batch query to find which users have active consent for a given type

### Enhanced Existing Methods
- **GrantConsentAsync**: Now accepts optional `grantedVia` parameter (defaults to "WebUI")
- **RevokeConsentAsync**: Now accepts optional `revokedVia` parameter (defaults to "WebUI")
- Both methods now invalidate the cache when consent changes

### Usage Example
```csharp
public class MessageLoggingHandler
{
    private readonly IConsentService _consentService;
    
    public async Task HandleMessageAsync(SocketMessage message)
    {
        // Only log if user has consented
        if (!await _consentService.HasConsentAsync(message.Author.Id, ConsentType.MessageLogging))
            return;
            
        // Proceed with logging...
    }
}
```

## Implementation Details
- Uses `IMemoryCache` with 5-minute TTL for consent checks
- Cache key pattern: `consent:{userId}:{consentType}`
- Debug-level logging for all consent checks (for troubleshooting)
- Comprehensive unit tests for all new functionality

## Test Plan
- [x] All 33 ConsentService unit tests pass
- [x] All 28 UserConsentRepository unit tests pass
- [x] Build succeeds with no errors
- [x] Existing functionality unchanged (backward compatible)

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)