### PR TITLE
feat: Add Core layer DTOs and interface for Commands page (#204)

### DIFF
--- a/src/DiscordBot.Core/DTOs/CommandInfoDto.cs
+++ b/src/DiscordBot.Core/DTOs/CommandInfoDto.cs
@@ -1,0 +1,39 @@
+namespace DiscordBot.Core.DTOs;
+
+/// <summary>
+/// Data transfer object for individual command information.
+/// </summary>
+public class CommandInfoDto
+{
+    /// <summary>
+    /// Gets or sets the command name.
+    /// </summary>
+    /// <example>ping, help</example>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the full command name including group prefix.
+    /// </summary>
+    /// <example>consent grant, user info</example>
+    public string FullName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the command description.
+    /// </summary>
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the list of command parameters.
+    /// </summary>
+    public List<CommandParameterDto> Parameters { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the list of preconditions applied to the command.
+    /// </summary>
+    public List<PreconditionDto> Preconditions { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the name of the module containing this command.
+    /// </summary>
+    public string ModuleName { get; set; } = string.Empty;
+}

--- a/src/DiscordBot.Core/DTOs/CommandModuleDto.cs
+++ b/src/DiscordBot.Core/DTOs/CommandModuleDto.cs
@@ -1,0 +1,45 @@
+namespace DiscordBot.Core.DTOs;
+
+/// <summary>
+/// Data transfer object for command module information.
+/// </summary>
+public class CommandModuleDto
+{
+    /// <summary>
+    /// Gets or sets the module class name.
+    /// </summary>
+    /// <example>GeneralModule, ConsentModule</example>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the formatted display name for the module.
+    /// </summary>
+    /// <example>General, Consent</example>
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the module description from the [Group] attribute.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the module uses a slash command group.
+    /// </summary>
+    public bool IsSlashGroup { get; set; }
+
+    /// <summary>
+    /// Gets or sets the group prefix for grouped commands.
+    /// </summary>
+    /// <example>consent, user</example>
+    public string? GroupName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the list of commands in this module.
+    /// </summary>
+    public List<CommandInfoDto> Commands { get; set; } = new();
+
+    /// <summary>
+    /// Gets the total number of commands in this module.
+    /// </summary>
+    public int CommandCount => Commands.Count;
+}

--- a/src/DiscordBot.Core/DTOs/CommandParameterDto.cs
+++ b/src/DiscordBot.Core/DTOs/CommandParameterDto.cs
@@ -1,0 +1,44 @@
+namespace DiscordBot.Core.DTOs;
+
+/// <summary>
+/// Data transfer object for command parameter information.
+/// </summary>
+public class CommandParameterDto
+{
+    /// <summary>
+    /// Gets or sets the name of the parameter.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the description of the parameter.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Gets or sets the friendly type name of the parameter.
+    /// </summary>
+    /// <example>String, Integer, User, Channel</example>
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets whether the parameter is required.
+    /// </summary>
+    public bool IsRequired { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default value for the parameter, if any.
+    /// </summary>
+    /// <remarks>
+    /// The default value is serialized as a string for display purposes.
+    /// </remarks>
+    public string? DefaultValue { get; set; }
+
+    /// <summary>
+    /// Gets or sets the available choices for the parameter.
+    /// </summary>
+    /// <remarks>
+    /// Populated for enum parameters or parameters with explicit choice attributes.
+    /// </remarks>
+    public List<string>? Choices { get; set; }
+}

--- a/src/DiscordBot.Core/DTOs/PreconditionDto.cs
+++ b/src/DiscordBot.Core/DTOs/PreconditionDto.cs
@@ -1,0 +1,27 @@
+namespace DiscordBot.Core.DTOs;
+
+/// <summary>
+/// Data transfer object for command precondition information.
+/// </summary>
+public class PreconditionDto
+{
+    /// <summary>
+    /// Gets or sets the name of the precondition.
+    /// </summary>
+    /// <example>RequireAdmin, RateLimit</example>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the type of the precondition.
+    /// </summary>
+    public PreconditionType Type { get; set; }
+
+    /// <summary>
+    /// Gets or sets the configuration details for the precondition.
+    /// </summary>
+    /// <remarks>
+    /// Contains human-readable configuration information, such as "3 per hour" for rate limits
+    /// or permission names for permission-based preconditions.
+    /// </remarks>
+    public string? Configuration { get; set; }
+}

--- a/src/DiscordBot.Core/DTOs/PreconditionType.cs
+++ b/src/DiscordBot.Core/DTOs/PreconditionType.cs
@@ -1,0 +1,42 @@
+namespace DiscordBot.Core.DTOs;
+
+/// <summary>
+/// Enumeration of precondition types for command validation.
+/// </summary>
+public enum PreconditionType
+{
+    /// <summary>
+    /// Requires admin role (RequireAdminAttribute).
+    /// </summary>
+    Admin,
+
+    /// <summary>
+    /// Requires owner role (RequireOwnerAttribute).
+    /// </summary>
+    Owner,
+
+    /// <summary>
+    /// Rate limiting precondition (RateLimitAttribute).
+    /// </summary>
+    RateLimit,
+
+    /// <summary>
+    /// Requires bot to have specific permissions (RequireBotPermission).
+    /// </summary>
+    BotPermission,
+
+    /// <summary>
+    /// Requires user to have specific permissions (RequireUserPermission).
+    /// </summary>
+    UserPermission,
+
+    /// <summary>
+    /// Requires specific context (RequireContext).
+    /// </summary>
+    Context,
+
+    /// <summary>
+    /// Custom precondition not covered by standard types.
+    /// </summary>
+    Custom
+}

--- a/src/DiscordBot.Core/Interfaces/ICommandMetadataService.cs
+++ b/src/DiscordBot.Core/Interfaces/ICommandMetadataService.cs
@@ -1,0 +1,16 @@
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Core.Interfaces;
+
+/// <summary>
+/// Service interface for retrieving command metadata from the Discord.NET InteractionService.
+/// </summary>
+public interface ICommandMetadataService
+{
+    /// <summary>
+    /// Gets all command modules with their commands and metadata.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A read-only list of command module DTOs.</returns>
+    Task<IReadOnlyList<CommandModuleDto>> GetAllModulesAsync(CancellationToken cancellationToken = default);
+}


### PR DESCRIPTION
## Summary

- Add Data Transfer Objects (DTOs) and service interface for command metadata
- Created as part of the Commands Page feature (#202)
- Enables the admin UI to display command information from Discord.NET's InteractionService

## Changes

### New DTOs (`src/DiscordBot.Core/DTOs/`)

| File | Purpose |
|------|---------|
| `PreconditionType.cs` | Enum for precondition types (Admin, Owner, RateLimit, BotPermission, UserPermission, Context, Custom) |
| `PreconditionDto.cs` | Command precondition with name, type, and configuration |
| `CommandParameterDto.cs` | Parameter details including type, description, required flag, default value, and choices |
| `CommandInfoDto.cs` | Individual command with name, description, parameters, and preconditions |
| `CommandModuleDto.cs` | Module grouping with display name, group info, and commands list |

### New Interface (`src/DiscordBot.Core/Interfaces/`)

| File | Purpose |
|------|---------|
| `ICommandMetadataService.cs` | Service contract for retrieving command metadata from InteractionService |

## Test Plan

- [x] Solution builds successfully
- [x] All DTOs have XML documentation
- [x] DTOs follow existing codebase patterns
- [x] Interface signature matches expected service contract

## Related Issues

- Closes #204
- Part of #202 (Commands Page Feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)