### PR TITLE
feat: Implement Commands page UI (#206, #207, #208)

### DIFF
--- a/src/DiscordBot.Bot/Pages/Commands/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Commands/Index.cshtml
@@ -1,0 +1,162 @@
+@page
+@model DiscordBot.Bot.Pages.Commands.IndexModel
+@using DiscordBot.Bot.ViewModels.Components
+@using DiscordBot.Bot.ViewModels.Pages
+@{
+    ViewData["Title"] = "Commands";
+}
+
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <!-- Page Header -->
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+        <div class="flex items-center gap-3">
+            <h1 class="text-2xl lg:text-3xl font-bold text-text-primary">Commands</h1>
+            <partial name="Shared/Components/_Badge" model="new BadgeViewModel { Text = Model.ViewModel.TotalCommandCount.ToString(), Variant = BadgeVariant.Blue, Size = BadgeSize.Medium }" />
+        </div>
+        <div class="flex items-center gap-3">
+            <span class="text-sm text-text-secondary">
+                @Model.ViewModel.ModuleCount module@(Model.ViewModel.ModuleCount != 1 ? "s" : "") registered
+            </span>
+        </div>
+    </div>
+
+    @if (Model.ViewModel.HasModules)
+    {
+        <!-- Command Modules -->
+        <div class="space-y-4">
+            @foreach (var module in Model.ViewModel.Modules)
+            {
+                <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden" id="module-@module.ModuleId">
+                    <!-- Module Header (clickable to expand/collapse) -->
+                    <button type="button"
+                            class="w-full flex items-center justify-between px-6 py-4 hover:bg-bg-hover/50 transition-colors focus:outline-none focus:ring-2 focus:ring-border-focus focus:ring-inset"
+                            onclick="toggleModule('@module.ModuleId')"
+                            aria-expanded="true"
+                            aria-controls="commands-@module.ModuleId">
+                        <div class="flex items-center gap-3">
+                            <!-- Module Icon -->
+                            <div class="w-10 h-10 rounded-lg bg-gradient-to-br from-accent-blue to-accent-orange flex items-center justify-center text-white flex-shrink-0">
+                                <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                                </svg>
+                            </div>
+                            <div class="text-left">
+                                <h2 class="text-lg font-semibold text-text-primary">
+                                    @module.DisplayName
+                                    @if (module.IsSlashGroup && !string.IsNullOrEmpty(module.GroupName))
+                                    {
+                                        <span class="text-text-tertiary font-normal text-sm ml-2">/@module.GroupName</span>
+                                    }
+                                </h2>
+                                @if (!string.IsNullOrEmpty(module.Description))
+                                {
+                                    <p class="text-sm text-text-secondary">@module.Description</p>
+                                }
+                            </div>
+                        </div>
+                        <div class="flex items-center gap-3">
+                            <span class="text-sm text-text-tertiary">@module.CommandCount command@(module.CommandCount != 1 ? "s" : "")</span>
+                            <svg class="w-5 h-5 text-text-tertiary transition-transform duration-200 module-chevron" fill="none" viewBox="0 0 24 24" stroke="currentColor" data-module="@module.ModuleId">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                            </svg>
+                        </div>
+                    </button>
+
+                    <!-- Command List (collapsible) -->
+                    <div id="commands-@module.ModuleId" class="border-t border-border-primary">
+                        <div class="divide-y divide-border-secondary">
+                            @foreach (var command in module.Commands)
+                            {
+                                <div class="px-6 py-4 hover:bg-bg-hover/30 transition-colors">
+                                    <div class="flex flex-col lg:flex-row lg:items-start gap-3">
+                                        <!-- Command Name and Parameters -->
+                                        <div class="flex-1 min-w-0">
+                                            <div class="flex flex-wrap items-center gap-2 mb-1">
+                                                <code class="text-accent-orange font-mono font-semibold text-sm">@command.FullDisplayName</code>
+                                                @if (!string.IsNullOrEmpty(command.ParametersDisplay))
+                                                {
+                                                    <code class="text-text-tertiary font-mono text-sm">@command.ParametersDisplay</code>
+                                                }
+                                            </div>
+                                            <p class="text-sm text-text-secondary">@command.Description</p>
+
+                                            <!-- Parameters Details (if any) -->
+                                            @if (command.HasParameters)
+                                            {
+                                                <div class="mt-3 space-y-2">
+                                                    @foreach (var param in command.Parameters)
+                                                    {
+                                                        <div class="flex items-start gap-2 text-sm">
+                                                            <span class="font-mono text-text-primary">@param.Name</span>
+                                                            <span class="text-text-tertiary">(@param.Type@(param.IsRequired ? ", required" : ", optional"))</span>
+                                                            @if (!string.IsNullOrEmpty(param.Description))
+                                                            {
+                                                                <span class="text-text-secondary">- @param.Description</span>
+                                                            }
+                                                        </div>
+                                                        @if (param.HasChoices)
+                                                        {
+                                                            <div class="ml-4 text-xs text-text-tertiary">
+                                                                Choices: @string.Join(", ", param.Choices!)
+                                                            </div>
+                                                        }
+                                                    }
+                                                </div>
+                                            }
+                                        </div>
+
+                                        <!-- Precondition Badges -->
+                                        @if (command.HasPreconditions)
+                                        {
+                                            <div class="flex flex-wrap gap-2 lg:flex-shrink-0">
+                                                @foreach (var badge in command.PreconditionBadges)
+                                                {
+                                                    <partial name="Shared/Components/_Badge" model="badge" />
+                                                }
+                                            </div>
+                                        }
+                                    </div>
+                                </div>
+                            }
+                        </div>
+                    </div>
+                </div>
+            }
+        </div>
+    }
+    else
+    {
+        <!-- Empty State -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-12">
+            @{
+                var emptyState = new EmptyStateViewModel
+                {
+                    Type = EmptyStateType.NoData,
+                    Title = "No commands loaded",
+                    Description = "The bot hasn't loaded any command modules yet. Commands will appear once the bot has connected to Discord."
+                };
+            }
+            <partial name="Shared/Components/_EmptyState" model="emptyState" />
+        </div>
+    }
+</div>
+
+@section Scripts {
+    <script>
+        function toggleModule(moduleId) {
+            const commandsContainer = document.getElementById('commands-' + moduleId);
+            const chevron = document.querySelector('.module-chevron[data-module="' + moduleId + '"]');
+            const button = commandsContainer.parentElement.querySelector('button');
+
+            if (commandsContainer.classList.contains('hidden')) {
+                commandsContainer.classList.remove('hidden');
+                chevron.classList.remove('rotate-180');
+                button.setAttribute('aria-expanded', 'true');
+            } else {
+                commandsContainer.classList.add('hidden');
+                chevron.classList.add('rotate-180');
+                button.setAttribute('aria-expanded', 'false');
+            }
+        }
+    </script>
+}

--- a/src/DiscordBot.Bot/Pages/Commands/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Commands/Index.cshtml.cs
@@ -1,0 +1,52 @@
+using DiscordBot.Bot.ViewModels.Pages;
+using DiscordBot.Core.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace DiscordBot.Bot.Pages.Commands;
+
+/// <summary>
+/// Page model for displaying all registered command modules and their commands.
+/// </summary>
+[Authorize]
+public class IndexModel : PageModel
+{
+    private readonly ICommandMetadataService _commandMetadataService;
+    private readonly ILogger<IndexModel> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IndexModel"/> class.
+    /// </summary>
+    /// <param name="commandMetadataService">The command metadata service.</param>
+    /// <param name="logger">The logger.</param>
+    public IndexModel(
+        ICommandMetadataService commandMetadataService,
+        ILogger<IndexModel> logger)
+    {
+        _commandMetadataService = commandMetadataService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Gets the view model containing command list data.
+    /// </summary>
+    public CommandsListViewModel ViewModel { get; private set; } = new();
+
+    /// <summary>
+    /// Handles the GET request for the Commands page.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task OnGetAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("User accessing commands page");
+
+        var modules = await _commandMetadataService.GetAllModulesAsync(cancellationToken);
+
+        ViewModel = CommandsListViewModel.FromDtos(modules);
+
+        _logger.LogDebug(
+            "Loaded {ModuleCount} modules with {CommandCount} total commands",
+            ViewModel.ModuleCount,
+            ViewModel.TotalCommandCount);
+    }
+}

--- a/src/DiscordBot.Bot/Pages/Shared/_Sidebar.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/_Sidebar.cshtml
@@ -27,14 +27,13 @@
         </a>
       </authorize>
 
-      <!-- Commands - visible to Viewers+ (Coming Soon) -->
-      <span class="sidebar-link sidebar-link-disabled" aria-disabled="true" title="Coming Soon">
+      <!-- Commands - visible to all authenticated users -->
+      <a asp-page="/Commands/Index" class="sidebar-link @(ViewContext.RouteData.Values["page"]?.ToString()?.StartsWith("/Commands") == true ? "active" : "")">
         <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
         </svg>
         Commands
-        <span class="sidebar-badge">Soon</span>
-      </span>
+      </a>
 
       <!-- Logs - visible to Viewers+ -->
       <a asp-page="/CommandLogs/Index" class="sidebar-link @(ViewContext.RouteData.Values["page"]?.ToString() == "/CommandLogs/Index" ? "active" : "")">

--- a/src/DiscordBot.Bot/ViewModels/Pages/CommandItemViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Pages/CommandItemViewModel.cs
@@ -1,0 +1,182 @@
+using DiscordBot.Bot.ViewModels.Components;
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Bot.ViewModels.Pages;
+
+/// <summary>
+/// View model for an individual command, including parameters and preconditions.
+/// </summary>
+public record CommandItemViewModel
+{
+    /// <summary>
+    /// Gets the command name formatted for display (e.g., "/ping").
+    /// </summary>
+    public string DisplayName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the full command name including group prefix (e.g., "/consent grant").
+    /// </summary>
+    public string FullDisplayName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the command description.
+    /// </summary>
+    public string Description { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the formatted parameters string for display.
+    /// </summary>
+    public string ParametersDisplay { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the collection of parameter view models.
+    /// </summary>
+    public IReadOnlyList<CommandParameterViewModel> Parameters { get; init; } = Array.Empty<CommandParameterViewModel>();
+
+    /// <summary>
+    /// Gets whether the command has any parameters.
+    /// </summary>
+    public bool HasParameters => Parameters.Count > 0;
+
+    /// <summary>
+    /// Gets the collection of precondition badges to display.
+    /// </summary>
+    public IReadOnlyList<BadgeViewModel> PreconditionBadges { get; init; } = Array.Empty<BadgeViewModel>();
+
+    /// <summary>
+    /// Gets whether the command has any preconditions.
+    /// </summary>
+    public bool HasPreconditions => PreconditionBadges.Count > 0;
+
+    /// <summary>
+    /// Creates a <see cref="CommandItemViewModel"/> from a <see cref="CommandInfoDto"/>.
+    /// </summary>
+    /// <param name="dto">The command DTO to map from.</param>
+    /// <returns>A new <see cref="CommandItemViewModel"/> instance.</returns>
+    public static CommandItemViewModel FromDto(CommandInfoDto dto)
+    {
+        var parameters = dto.Parameters.Select(CommandParameterViewModel.FromDto).ToList();
+        var parametersDisplay = FormatParametersDisplay(parameters);
+        var preconditionBadges = dto.Preconditions.Select(MapPreconditionToBadge).ToList();
+
+        return new CommandItemViewModel
+        {
+            DisplayName = $"/{dto.Name}",
+            FullDisplayName = $"/{dto.FullName}",
+            Description = dto.Description,
+            Parameters = parameters,
+            ParametersDisplay = parametersDisplay,
+            PreconditionBadges = preconditionBadges
+        };
+    }
+
+    /// <summary>
+    /// Formats the parameters for inline display.
+    /// </summary>
+    /// <param name="parameters">The parameters to format.</param>
+    /// <returns>A formatted string showing parameter names and types.</returns>
+    private static string FormatParametersDisplay(IReadOnlyList<CommandParameterViewModel> parameters)
+    {
+        if (parameters.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var parts = parameters.Select(p =>
+        {
+            var name = p.Name;
+            if (p.IsRequired)
+            {
+                return $"<{name}>";
+            }
+            return $"[{name}]";
+        });
+
+        return string.Join(" ", parts);
+    }
+
+    /// <summary>
+    /// Maps a precondition DTO to a badge view model with appropriate styling.
+    /// </summary>
+    /// <param name="precondition">The precondition to map.</param>
+    /// <returns>A <see cref="BadgeViewModel"/> with appropriate styling.</returns>
+    private static BadgeViewModel MapPreconditionToBadge(PreconditionDto precondition)
+    {
+        var (variant, displayName) = precondition.Type switch
+        {
+            PreconditionType.Admin => (BadgeVariant.Orange, "Admin"),
+            PreconditionType.Owner => (BadgeVariant.Error, "Owner"),
+            PreconditionType.RateLimit => (BadgeVariant.Warning, precondition.Configuration ?? "Rate Limited"),
+            PreconditionType.BotPermission => (BadgeVariant.Blue, $"Bot: {precondition.Configuration ?? "Permission"}"),
+            PreconditionType.UserPermission => (BadgeVariant.Blue, $"User: {precondition.Configuration ?? "Permission"}"),
+            PreconditionType.Context => (BadgeVariant.Default, precondition.Configuration ?? "Context"),
+            _ => (BadgeVariant.Default, precondition.Name)
+        };
+
+        return new BadgeViewModel
+        {
+            Text = displayName,
+            Variant = variant,
+            Size = BadgeSize.Small
+        };
+    }
+}
+
+/// <summary>
+/// View model for a command parameter.
+/// </summary>
+public record CommandParameterViewModel
+{
+    /// <summary>
+    /// Gets the parameter name.
+    /// </summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the parameter description.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Gets the friendly type name.
+    /// </summary>
+    public string Type { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets whether the parameter is required.
+    /// </summary>
+    public bool IsRequired { get; init; }
+
+    /// <summary>
+    /// Gets the default value for the parameter, if any.
+    /// </summary>
+    public string? DefaultValue { get; init; }
+
+    /// <summary>
+    /// Gets the available choices for the parameter.
+    /// </summary>
+    public IReadOnlyList<string>? Choices { get; init; }
+
+    /// <summary>
+    /// Gets whether the parameter has choices.
+    /// </summary>
+    public bool HasChoices => Choices != null && Choices.Count > 0;
+
+    /// <summary>
+    /// Creates a <see cref="CommandParameterViewModel"/> from a <see cref="CommandParameterDto"/>.
+    /// </summary>
+    /// <param name="dto">The parameter DTO to map from.</param>
+    /// <returns>A new <see cref="CommandParameterViewModel"/> instance.</returns>
+    public static CommandParameterViewModel FromDto(CommandParameterDto dto)
+    {
+        return new CommandParameterViewModel
+        {
+            Name = dto.Name,
+            Description = dto.Description,
+            Type = dto.Type,
+            IsRequired = dto.IsRequired,
+            DefaultValue = dto.DefaultValue,
+            Choices = dto.Choices?.ToList()
+        };
+    }
+}

--- a/src/DiscordBot.Bot/ViewModels/Pages/CommandModuleViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Pages/CommandModuleViewModel.cs
@@ -1,0 +1,67 @@
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Bot.ViewModels.Pages;
+
+/// <summary>
+/// View model for a command module, containing commands and module metadata.
+/// </summary>
+public record CommandModuleViewModel
+{
+    /// <summary>
+    /// Gets the module class name.
+    /// </summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the formatted display name for the module.
+    /// </summary>
+    public string DisplayName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the module description.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Gets whether the module uses a slash command group.
+    /// </summary>
+    public bool IsSlashGroup { get; init; }
+
+    /// <summary>
+    /// Gets the group prefix for grouped commands.
+    /// </summary>
+    public string? GroupName { get; init; }
+
+    /// <summary>
+    /// Gets the collection of command view models in this module.
+    /// </summary>
+    public IReadOnlyList<CommandItemViewModel> Commands { get; init; } = Array.Empty<CommandItemViewModel>();
+
+    /// <summary>
+    /// Gets the total number of commands in this module.
+    /// </summary>
+    public int CommandCount => Commands.Count;
+
+    /// <summary>
+    /// Gets a unique identifier for this module (used for collapse/expand).
+    /// </summary>
+    public string ModuleId => Name.ToLowerInvariant().Replace(" ", "-");
+
+    /// <summary>
+    /// Creates a <see cref="CommandModuleViewModel"/> from a <see cref="CommandModuleDto"/>.
+    /// </summary>
+    /// <param name="dto">The command module DTO to map from.</param>
+    /// <returns>A new <see cref="CommandModuleViewModel"/> instance.</returns>
+    public static CommandModuleViewModel FromDto(CommandModuleDto dto)
+    {
+        return new CommandModuleViewModel
+        {
+            Name = dto.Name,
+            DisplayName = dto.DisplayName,
+            Description = dto.Description,
+            IsSlashGroup = dto.IsSlashGroup,
+            GroupName = dto.GroupName,
+            Commands = dto.Commands.Select(CommandItemViewModel.FromDto).ToList()
+        };
+    }
+}

--- a/src/DiscordBot.Bot/ViewModels/Pages/CommandsListViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Pages/CommandsListViewModel.cs
@@ -1,0 +1,42 @@
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Bot.ViewModels.Pages;
+
+/// <summary>
+/// View model for the Commands page, displaying all registered command modules.
+/// </summary>
+public record CommandsListViewModel
+{
+    /// <summary>
+    /// Gets the collection of command module view models.
+    /// </summary>
+    public IReadOnlyList<CommandModuleViewModel> Modules { get; init; } = Array.Empty<CommandModuleViewModel>();
+
+    /// <summary>
+    /// Gets the total number of modules.
+    /// </summary>
+    public int ModuleCount => Modules.Count;
+
+    /// <summary>
+    /// Gets the total number of commands across all modules.
+    /// </summary>
+    public int TotalCommandCount => Modules.Sum(m => m.CommandCount);
+
+    /// <summary>
+    /// Gets whether there are any modules to display.
+    /// </summary>
+    public bool HasModules => Modules.Count > 0;
+
+    /// <summary>
+    /// Creates a <see cref="CommandsListViewModel"/> from a collection of <see cref="CommandModuleDto"/>.
+    /// </summary>
+    /// <param name="dtos">The command module DTOs to map from.</param>
+    /// <returns>A new <see cref="CommandsListViewModel"/> instance.</returns>
+    public static CommandsListViewModel FromDtos(IEnumerable<CommandModuleDto> dtos)
+    {
+        return new CommandsListViewModel
+        {
+            Modules = dtos.Select(CommandModuleViewModel.FromDto).ToList()
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Implements ViewModels for Commands page (CommandsListViewModel, CommandModuleViewModel, CommandItemViewModel) as specified in #206
- Creates Commands Razor Page displaying all registered command modules with collapsible sections as specified in #207
- Updates sidebar navigation to enable Commands link with proper active state styling as specified in #208

## Changes Made
### ViewModels (#206)
- `CommandsListViewModel` - Main page ViewModel with module list, counts, and factory method
- `CommandModuleViewModel` - Module ViewModel with display name, commands list, and collapsible ID
- `CommandItemViewModel` - Command ViewModel with formatted display names, parameters, and precondition badges
- `CommandParameterViewModel` - Parameter ViewModel with type, required flag, and choices

### Razor Page (#207)
- `Pages/Commands/Index.cshtml.cs` - PageModel that loads command metadata via ICommandMetadataService
- `Pages/Commands/Index.cshtml` - Responsive view with:
  - Page header showing command count
  - Collapsible module cards with expand/collapse functionality
  - Command list with formatted names, descriptions, and parameters
  - Precondition badges with color-coded styling
  - Empty state when no commands are loaded

### Navigation (#208)
- Updated `_Sidebar.cshtml` to enable Commands link
- Added active state highlighting for Commands page
- Removed "Coming Soon" badge and disabled styling

## Test plan
- [ ] Page loads at `/Commands` URL
- [ ] All registered command modules display with correct names
- [ ] Commands show description, parameters (with required/optional indicator), and preconditions
- [ ] Module sections expand/collapse when clicking headers
- [ ] Precondition badges show correct colors (Admin=orange, Owner=red, RateLimit=warning)
- [ ] Sidebar Commands link shows active state when on Commands page
- [ ] Empty state displays when bot has no modules loaded
- [ ] Build succeeds without errors
- [ ] All existing tests pass

Closes #206, closes #207, closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)