### PR TITLE
fix: Fix Command Logs date filter issues (#201)

### DIFF
--- a/src/DiscordBot.Bot/Pages/CommandLogs/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/CommandLogs/Index.cshtml
@@ -82,14 +82,27 @@
                     <!-- Quick Date Presets -->
                     <div class="mb-4">
                         <label class="block text-sm font-medium text-text-primary mb-2">Quick Date Range</label>
+                        @{
+                            var today = DateTime.UtcNow.Date;
+                            var isToday = Model.StartDate.HasValue && Model.EndDate.HasValue &&
+                                         Model.StartDate.Value.Date == today && Model.EndDate.Value.Date == today;
+                            var is7Days = Model.StartDate.HasValue && Model.EndDate.HasValue &&
+                                         Model.StartDate.Value.Date == today.AddDays(-7) && Model.EndDate.Value.Date == today;
+                            var is30Days = Model.StartDate.HasValue && Model.EndDate.HasValue &&
+                                          Model.StartDate.Value.Date == today.AddDays(-30) && Model.EndDate.Value.Date == today;
+
+                            string GetPresetClass(bool isActive) => isActive
+                                ? "px-3 py-1.5 text-xs font-medium bg-accent-blue text-white border border-accent-blue rounded-md hover:bg-accent-blue/90 transition-colors"
+                                : "px-3 py-1.5 text-xs font-medium bg-bg-tertiary text-text-secondary border border-border-primary rounded-md hover:bg-bg-hover transition-colors";
+                        }
                         <div class="flex flex-wrap gap-2">
-                            <button type="button" onclick="setDatePreset('today')" class="px-3 py-1.5 text-xs font-medium bg-bg-tertiary text-text-secondary border border-border-primary rounded-md hover:bg-bg-hover transition-colors">
+                            <button type="button" onclick="setDatePreset('today')" class="@GetPresetClass(isToday)">
                                 Today
                             </button>
-                            <button type="button" onclick="setDatePreset('7days')" class="px-3 py-1.5 text-xs font-medium bg-bg-tertiary text-text-secondary border border-border-primary rounded-md hover:bg-bg-hover transition-colors">
+                            <button type="button" onclick="setDatePreset('7days')" class="@GetPresetClass(is7Days)">
                                 Last 7 Days
                             </button>
-                            <button type="button" onclick="setDatePreset('30days')" class="px-3 py-1.5 text-xs font-medium bg-bg-tertiary text-text-secondary border border-border-primary rounded-md hover:bg-bg-hover transition-colors">
+                            <button type="button" onclick="setDatePreset('30days')" class="@GetPresetClass(is30Days)">
                                 Last 30 Days
                             </button>
                         </div>
@@ -472,6 +485,9 @@
 
             startDateInput.value = startDate.toISOString().split('T')[0];
             endDateInput.value = today.toISOString().split('T')[0];
+
+            // Auto-submit the form after setting the date preset
+            document.getElementById('filterForm').submit();
         }
     </script>
 }

--- a/src/DiscordBot.Bot/Pages/CommandLogs/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/CommandLogs/Index.cshtml.cs
@@ -94,6 +94,16 @@ public class IndexModel : PageModel
         // Load guilds for dropdown
         AvailableGuilds = await _guildService.GetAllGuildsAsync(cancellationToken);
 
+        // Set default date filter to "Today" if no filters are provided
+        // This prevents showing all historical logs on first page load
+        if (!StartDate.HasValue && !EndDate.HasValue && string.IsNullOrWhiteSpace(SearchTerm) &&
+            !GuildId.HasValue && string.IsNullOrWhiteSpace(CommandName) && !StatusFilter.HasValue)
+        {
+            var today = DateTime.UtcNow.Date;
+            StartDate = today;
+            EndDate = today;
+        }
+
         var query = new CommandLogQueryDto
         {
             SearchTerm = SearchTerm,


### PR DESCRIPTION
## Summary

Fixes multiple UX issues with date filtering on the Command Logs page:

- **Fix "Today" filter excluding today's commands** - End date filter now includes the entire day by using `< end+1 day` instead of `<= end date`
- **Make quick date presets auto-submit** - Clicking "Today", "Last 7 Days", or "Last 30 Days" now immediately applies the filter
- **Add default date filter on page load** - Page now defaults to "Today" when no filters are provided to prevent showing all historical logs
- **Add visual feedback for active presets** - Selected date preset buttons are now highlighted (matches Analytics page styling)
- **Fix Details page showing 'Unknown' username** - Override GetByIdAsync to include User and Guild navigation properties

## Files Changed

| File | Change |
|------|--------|
| `CommandLogRepository.cs` | Fixed end date filter logic, added GetByIdAsync override to include User/Guild |
| `Index.cshtml` | Added auto-submit on preset click, added visual feedback for active presets |
| `Index.cshtml.cs` | Added default "Today" filter when no filters provided |

## Test Plan

- [x] Build succeeds with no new warnings
- [x] All 1187 tests pass
- [x] Verify "Today" filter shows commands executed today (not just up to midnight)
- [x] Verify clicking quick date presets immediately applies the filter
- [x] Verify page loads with "Today" filter by default
- [x] Verify active preset button is visually highlighted
- [x] Verify Details page shows username instead of 'Unknown'

Fixes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)