### PR TITLE
fix: Sync Guilds button icon disappears after clicking (fixes #271)

### DIFF
--- a/src/DiscordBot.Bot/wwwroot/js/loading-manager.js
+++ b/src/DiscordBot.Bot/wwwroot/js/loading-manager.js
@@ -145,10 +145,10 @@ const LoadingManager = {
     }
 
     if (isLoading) {
-      // Store original state
+      // Store original state including full HTML structure
       if (!this.activeButtons.has(button)) {
         this.activeButtons.set(button, {
-          text: button.textContent,
+          html: button.innerHTML,
           disabled: button.disabled,
           ariaDisabled: button.getAttribute('aria-disabled')
         });
@@ -167,15 +167,15 @@ const LoadingManager = {
         </svg>
       `;
 
-      // Update button content
-      const textToShow = loadingText || this.activeButtons.get(button).text;
+      // Update button content with spinner and loading text
+      const textToShow = loadingText || button.textContent.trim();
       button.innerHTML = `${spinnerHtml}<span>${textToShow}</span>`;
 
     } else {
-      // Restore original state
+      // Restore original state including full HTML structure
       const originalState = this.activeButtons.get(button);
       if (originalState) {
-        button.textContent = originalState.text;
+        button.innerHTML = originalState.html;
         button.disabled = originalState.disabled;
 
         if (originalState.ariaDisabled !== null) {


### PR DESCRIPTION
## Summary

- Changed `LoadingManager.setButtonLoading()` to store/restore `innerHTML` instead of `textContent`
- This preserves the full HTML structure of buttons (including icons) when transitioning between loading/normal states
- Fixes the "Sync All Guilds" button and any other buttons with child elements that use this loading pattern

## Root Cause

The previous implementation stored `button.textContent` which strips all HTML, then restored it which destroyed the button's structure. By using `innerHTML` instead, the complete DOM structure is preserved.

## Test Plan

- [ ] Navigate to Dashboard
- [ ] Click "Sync All Guilds" in Quick Actions
- [ ] Verify spinner appears during loading
- [ ] Verify icon is restored after action completes

Fixes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)