### PR TITLE
feat: Configure SignalR Infrastructure (#243)

### DIFF
--- a/docs/articles/signalr-realtime.md
+++ b/docs/articles/signalr-realtime.md
@@ -1,0 +1,699 @@
+# SignalR Real-Time Dashboard
+
+This document describes the SignalR infrastructure used for real-time updates in the Discord Bot Admin Dashboard.
+
+## Overview
+
+The dashboard uses SignalR to push real-time updates from the Discord bot backend to connected admin clients, enabling live bot status updates, guild event notifications, and command execution monitoring without requiring page refresh. This bidirectional communication channel allows the admin interface to display current state and react instantly to backend events.
+
+SignalR automatically negotiates the best transport protocol (WebSockets, Server-Sent Events, or Long Polling) based on client and server capabilities, falling back gracefully when necessary.
+
+## Architecture
+
+### Server Components
+
+| Component | Location | Purpose |
+|-----------|----------|---------|
+| `DashboardHub` | `src/DiscordBot.Bot/Hubs/DashboardHub.cs` | SignalR hub for managing client connections and providing hub methods |
+| `DashboardNotifier` | `src/DiscordBot.Bot/Services/DashboardNotifier.cs` | Service for broadcasting events from backend services to connected clients |
+| `IDashboardNotifier` | `src/DiscordBot.Core/Interfaces/IDashboardNotifier.cs` | Abstraction for the notifier service (Core layer) |
+
+### Client Components
+
+| Component | Location | Purpose |
+|-----------|----------|---------|
+| `dashboard-hub.js` | `src/DiscordBot.Bot/wwwroot/js/dashboard-hub.js` | JavaScript connection manager with automatic reconnection and event handling |
+| SignalR Client Library | CDN (cdnjs.cloudflare.com) | Microsoft SignalR JavaScript client (v8.0.0) |
+
+### Communication Flow
+
+```
+┌─────────────────┐         SignalR          ┌─────────────────┐
+│  Browser Client │◄─────────────────────────►│  DashboardHub   │
+│ (dashboard.js)  │     /hubs/dashboard       │   (ASP.NET)     │
+└─────────────────┘                           └────────┬────────┘
+                                                       │
+                                                       │ IHubContext<T>
+                                                       │
+                                              ┌────────▼────────┐
+                                              │ DashboardNotifier│
+                                              │   (Singleton)    │
+                                              └────────▲────────┘
+                                                       │
+                                         ┌─────────────┴──────────────┐
+                                         │                            │
+                                  ┌──────▼──────┐            ┌───────▼────────┐
+                                  │ BotService  │            │  Other Services │
+                                  │  (Inject    │            │  (Future: Guild,│
+                                  │ INotifier)  │            │   Commands, etc)│
+                                  └─────────────┘            └────────────────┘
+```
+
+## Hub Endpoint
+
+- **URL:** `/hubs/dashboard`
+- **Authentication:** Required (uses cookie authentication)
+- **Authorization:** `RequireViewer` policy (SuperAdmin, Admin, Moderator, or Viewer role)
+- **Transport:** WebSockets (with fallback to Server-Sent Events or Long Polling)
+
+The hub endpoint is mapped after the authentication and authorization middleware in `Program.cs`, ensuring all connections are authenticated before access is granted.
+
+## Hub Methods
+
+Hub methods are invoked by clients to interact with the server. These methods run on the server and can return values or perform actions.
+
+### JoinGuildGroup(guildId)
+
+Subscribes the client connection to a guild-specific group to receive real-time updates for that guild.
+
+**Parameters:**
+- `guildId` (ulong): The Discord guild ID as a numeric string
+
+**Returns:** Task (no value)
+
+**JavaScript Example:**
+
+```javascript
+// Join guild group to receive updates for guild 123456789012345678
+await DashboardHub.joinGuildGroup('123456789012345678');
+```
+
+**Use Case:** When a user navigates to a guild details page, join the guild group to receive real-time updates about that guild (member count changes, settings updates, etc.).
+
+**Group Naming Convention:** `guild-{guildId}` (e.g., `guild-123456789012345678`)
+
+**Future Enhancement:** Validate that the user has permission to access the requested guild before allowing group membership.
+
+---
+
+### LeaveGuildGroup(guildId)
+
+Unsubscribes the client from guild-specific updates when no longer interested in that guild's events.
+
+**Parameters:**
+- `guildId` (ulong): The Discord guild ID as a numeric string
+
+**Returns:** Task (no value)
+
+**JavaScript Example:**
+
+```javascript
+// Leave guild group when navigating away from guild details
+await DashboardHub.leaveGuildGroup('123456789012345678');
+```
+
+**Use Case:** When a user navigates away from a guild details page, leave the group to stop receiving unnecessary updates and reduce server broadcast overhead.
+
+---
+
+### GetCurrentStatus()
+
+Retrieves the current bot status synchronously from the server. This method returns data immediately rather than waiting for a broadcast event.
+
+**Parameters:** None
+
+**Returns:** `BotStatusDto` object
+
+**JavaScript Example:**
+
+```javascript
+// Get current bot status on page load
+const status = await DashboardHub.getCurrentStatus();
+console.log('Bot state:', status.connectionState);
+console.log('Guild count:', status.guildCount);
+console.log('Uptime:', status.uptime);
+console.log('Latency:', status.latency);
+```
+
+**BotStatusDto Properties:**
+- `connectionState` (string): Current Discord connection state (Connected, Connecting, Disconnected, etc.)
+- `guildCount` (int): Number of guilds the bot is currently in
+- `uptime` (TimeSpan): How long the bot has been running
+- `latency` (int?): Gateway latency in milliseconds (null if disconnected)
+- `isReady` (bool): Whether the bot is fully connected and ready
+
+**Use Case:** Fetch initial bot status when the dashboard page loads, before real-time updates begin arriving.
+
+---
+
+## Server-to-Client Events
+
+Server-to-client events are pushed from the server to listening clients. Clients register handlers for these events to react to backend changes.
+
+### BotStatusUpdated
+
+Broadcast to all connected clients when the bot's status changes (connection state, latency, guild count, etc.).
+
+**Event Data:** `BotStatusDto` object
+
+**JavaScript Example:**
+
+```javascript
+// Register handler for bot status updates
+DashboardHub.on('BotStatusUpdated', (status) => {
+    console.log('Bot status updated:', status);
+    updateBotStatusCard(status);
+    updateConnectionIndicator(status.connectionState);
+});
+```
+
+**Triggering Conditions:**
+- Bot connects to Discord
+- Bot disconnects from Discord
+- Guild count changes (bot joins/leaves guild)
+- Periodic status broadcasts (future implementation)
+
+**Broadcast Scope:** All authenticated dashboard clients
+
+---
+
+### GuildUpdated
+
+Sent to clients subscribed to a specific guild's group when that guild's data changes.
+
+**Event Data:** Varies based on update type (typically includes `guildId` and updated properties)
+
+**JavaScript Example:**
+
+```javascript
+// Register handler for guild-specific updates
+DashboardHub.on('GuildUpdated', (guildData) => {
+    console.log('Guild update received:', guildData);
+    refreshGuildCard(guildData.guildId, guildData);
+    showToast(`Guild ${guildData.name} updated`);
+});
+```
+
+**Triggering Conditions (Future Implementation):**
+- Guild settings changed via admin UI
+- Guild member count changes
+- Guild configuration updated
+- Welcome message settings modified
+
+**Broadcast Scope:** Only clients in the `guild-{guildId}` group
+
+---
+
+### CommandExecuted
+
+Fired when a slash command is executed in any guild (future implementation for real-time activity feed).
+
+**Event Data:** Command execution log object
+
+**JavaScript Example:**
+
+```javascript
+// Register handler for command execution events
+DashboardHub.on('CommandExecuted', (commandLog) => {
+    console.log('Command executed:', commandLog);
+    addToActivityFeed({
+        timestamp: commandLog.timestamp,
+        command: commandLog.commandName,
+        user: commandLog.userName,
+        guild: commandLog.guildName,
+        success: commandLog.success
+    });
+});
+```
+
+**Future Event Data Properties:**
+- `commandName` (string): The slash command that was executed
+- `userName` (string): Discord user who invoked the command
+- `guildId` (ulong): Guild where command was executed
+- `guildName` (string): Guild name
+- `timestamp` (DateTime): When the command was executed
+- `success` (bool): Whether the command executed successfully
+- `errorMessage` (string?): Error details if command failed
+
+**Broadcast Scope:** All authenticated dashboard clients (or guild-specific if filtering is implemented)
+
+---
+
+## Client Usage
+
+The `dashboard-hub.js` module provides a clean API for managing the SignalR connection and handling events.
+
+### Basic Connection on Page Load
+
+```javascript
+// Connect to dashboard hub when the page loads
+document.addEventListener('DOMContentLoaded', async () => {
+    const connected = await DashboardHub.connect();
+
+    if (connected) {
+        console.log('Connected to dashboard hub');
+
+        // Register event handlers
+        DashboardHub.on('BotStatusUpdated', handleBotStatusUpdate);
+        DashboardHub.on('GuildUpdated', handleGuildUpdate);
+
+        // Get initial status
+        const status = await DashboardHub.getCurrentStatus();
+        updateDashboardUI(status);
+    } else {
+        console.error('Failed to connect to dashboard hub');
+        showConnectionError();
+    }
+});
+
+// Clean disconnect when page is unloaded
+window.addEventListener('beforeunload', () => {
+    DashboardHub.disconnect();
+});
+```
+
+### Handling Connection State Events
+
+The connection manager emits local events for connection state changes that don't come from the server.
+
+```javascript
+// Connected successfully
+DashboardHub.on('connected', ({ connectionId }) => {
+    console.log('Connected with ID:', connectionId);
+    showConnectionIndicator('connected');
+    hideReconnectingMessage();
+});
+
+// Disconnected (connection closed)
+DashboardHub.on('disconnected', ({ error }) => {
+    console.warn('Disconnected from hub:', error);
+    showConnectionIndicator('disconnected');
+    showReconnectingMessage();
+});
+
+// Reconnecting after connection loss
+DashboardHub.on('reconnecting', ({ error }) => {
+    console.log('Connection lost, attempting to reconnect...');
+    showConnectionIndicator('reconnecting');
+    showReconnectingMessage();
+});
+
+// Reconnected successfully after connection loss
+DashboardHub.on('reconnected', ({ connectionId }) => {
+    console.log('Reconnected with ID:', connectionId);
+    showConnectionIndicator('connected');
+    hideReconnectingMessage();
+
+    // Re-fetch data that may have changed while disconnected
+    refreshDashboardData();
+});
+
+// Connection failed (initial connection attempt)
+DashboardHub.on('connectionFailed', ({ error }) => {
+    console.error('Connection failed:', error);
+    showConnectionIndicator('error');
+    showConnectionError(error.message);
+});
+```
+
+### Guild-Specific Subscriptions
+
+```javascript
+// When navigating to guild details page
+async function loadGuildDetails(guildId) {
+    // Join the guild group
+    await DashboardHub.joinGuildGroup(guildId);
+
+    // Register guild-specific event handler
+    DashboardHub.on('GuildUpdated', handleGuildUpdate);
+
+    // Load initial data
+    const guildData = await fetchGuildData(guildId);
+    renderGuildDetails(guildData);
+}
+
+// When navigating away from guild details page
+async function unloadGuildDetails(guildId) {
+    // Leave the guild group
+    await DashboardHub.leaveGuildGroup(guildId);
+
+    // Optionally remove handler if not needed on other pages
+    DashboardHub.off('GuildUpdated', handleGuildUpdate);
+}
+```
+
+### Checking Connection Status
+
+```javascript
+// Check if currently connected
+if (DashboardHub.isConnected()) {
+    console.log('Hub is connected');
+    const connectionId = DashboardHub.connectionId();
+    console.log('Connection ID:', connectionId);
+}
+```
+
+---
+
+## Broadcasting from Services
+
+Backend services can send real-time updates to dashboard clients by injecting `IDashboardNotifier`.
+
+### Injecting the Notifier
+
+```csharp
+public class BotService : IBotService
+{
+    private readonly IDashboardNotifier _notifier;
+    private readonly ILogger<BotService> _logger;
+
+    public BotService(
+        IDashboardNotifier notifier,
+        ILogger<BotService> logger)
+    {
+        _notifier = notifier;
+        _logger = logger;
+    }
+
+    public async Task OnBotStatusChangedAsync(BotStatusDto newStatus)
+    {
+        // Broadcast to all connected clients
+        await _notifier.BroadcastBotStatusAsync(newStatus);
+
+        _logger.LogInformation(
+            "Broadcasted bot status update: State={State}, Guilds={GuildCount}",
+            newStatus.ConnectionState,
+            newStatus.GuildCount);
+    }
+}
+```
+
+### Broadcasting to All Clients
+
+```csharp
+// Broadcast bot status to all dashboard clients
+var status = _botService.GetStatus();
+await _notifier.BroadcastBotStatusAsync(status);
+```
+
+### Sending Guild-Specific Updates
+
+```csharp
+// Send update only to clients subscribed to this guild
+await _notifier.SendGuildUpdateAsync(
+    guildId: 123456789012345678,
+    eventName: "GuildUpdated",
+    data: new
+    {
+        GuildId = 123456789012345678,
+        Name = "Updated Guild Name",
+        MemberCount = 150,
+        UpdatedAt = DateTime.UtcNow
+    });
+```
+
+### Broadcasting Custom Events
+
+```csharp
+// Broadcast any custom event to all clients
+await _notifier.BroadcastToAllAsync(
+    eventName: "MaintenanceScheduled",
+    data: new
+    {
+        Message = "Bot will restart in 5 minutes",
+        ScheduledAt = DateTime.UtcNow.AddMinutes(5)
+    });
+```
+
+---
+
+## Security Considerations
+
+### Authentication
+
+All SignalR connections require valid authentication. The hub uses the same cookie-based authentication as the rest of the application:
+
+- Users must be logged in with a valid session
+- Unauthenticated connection attempts receive HTTP 401 Unauthorized
+- Authentication state is validated on connection and reconnection
+
+### Authorization
+
+The `DashboardHub` is decorated with `[Authorize(Policy = "RequireViewer")]`, which enforces:
+
+- User must have SuperAdmin, Admin, Moderator, or Viewer role
+- Policy is defined in `Program.cs` authorization configuration
+- Same authorization level as viewing the dashboard pages
+
+### Future: Guild Access Validation
+
+Currently, any authenticated user can join any guild group. Future enhancement should validate that the user has permission to access the requested guild before allowing `JoinGuildGroup`:
+
+```csharp
+public async Task JoinGuildGroup(ulong guildId)
+{
+    // TODO: Validate user has access to this guild
+    // var hasAccess = await _guildService.ValidateGuildAccessAsync(
+    //     Context.User, guildId);
+    // if (!hasAccess)
+    //     throw new HubException("Access denied to this guild");
+
+    var groupName = GetGuildGroupName(guildId);
+    await Groups.AddToGroupAsync(Context.ConnectionId, groupName);
+}
+```
+
+### Connection Limits
+
+SignalR has built-in connection limits and timeout protection:
+
+- `KeepAliveInterval`: 15 seconds (server pings clients)
+- `ClientTimeoutInterval`: 30 seconds (server disconnects unresponsive clients)
+- `HandshakeTimeout`: 15 seconds (initial connection handshake limit)
+
+### Message Size and Rate Limiting
+
+- Default SignalR message size limits are sufficient for dashboard data
+- No custom rate limiting implemented currently
+- Consider adding rate limiting for hub method invocations in future if abuse is detected
+
+---
+
+## Configuration
+
+SignalR is configured in `src/DiscordBot.Bot/Program.cs` with the following options:
+
+```csharp
+builder.Services.AddSignalR(options =>
+{
+    // Enable detailed error messages only in development
+    options.EnableDetailedErrors = builder.Environment.IsDevelopment();
+
+    // Send keep-alive pings every 15 seconds
+    options.KeepAliveInterval = TimeSpan.FromSeconds(15);
+
+    // Disconnect clients that don't respond within 30 seconds
+    options.ClientTimeoutInterval = TimeSpan.FromSeconds(30);
+
+    // Initial handshake must complete within 15 seconds
+    options.HandshakeTimeout = TimeSpan.FromSeconds(15);
+});
+```
+
+### Configuration Options Explained
+
+| Option | Value | Purpose |
+|--------|-------|---------|
+| `EnableDetailedErrors` | `true` (dev only) | Exposes detailed exception messages to clients for debugging |
+| `KeepAliveInterval` | 15 seconds | How often server sends ping frames to keep connection alive |
+| `ClientTimeoutInterval` | 30 seconds | How long to wait for client response before disconnecting |
+| `HandshakeTimeout` | 15 seconds | Maximum time allowed for initial connection handshake |
+
+### Service Registration
+
+The `DashboardNotifier` is registered as a singleton in the DI container:
+
+```csharp
+builder.Services.AddSingleton<IDashboardNotifier, DashboardNotifier>();
+```
+
+This allows any service to inject `IDashboardNotifier` and broadcast to connected clients.
+
+### Endpoint Mapping
+
+The hub endpoint is mapped after authentication and authorization middleware:
+
+```csharp
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapControllers();
+app.MapRazorPages();
+
+// Map SignalR hub for real-time dashboard
+app.MapHub<DashboardHub>("/hubs/dashboard");
+```
+
+---
+
+## Troubleshooting
+
+### Connection Fails with 401 Unauthorized
+
+**Symptoms:**
+- Browser console shows SignalR connection failed with 401 status
+- `DashboardHub.connect()` returns `false`
+- Network tab shows WebSocket upgrade request rejected
+
+**Solutions:**
+1. Verify user is logged in (check for authentication cookie)
+2. Ensure user has at least Viewer role assigned
+3. Check that authentication middleware is enabled in `Program.cs`
+4. Verify user session hasn't expired (re-login if needed)
+5. Check browser cookies are enabled and not being blocked
+
+---
+
+### Connection Fails with CORS Error
+
+**Symptoms:**
+- Browser console shows CORS policy error
+- Connection fails when running dashboard on different port than API
+
+**Solutions:**
+1. Verify CORS is configured in `Program.cs` to allow the dashboard origin
+2. Ensure credentials are included in SignalR connection options:
+   ```javascript
+   connection = new signalR.HubConnectionBuilder()
+       .withUrl('/hubs/dashboard', {
+           withCredentials: true
+       })
+       .build();
+   ```
+3. If using reverse proxy, ensure WebSocket upgrade headers are forwarded
+
+---
+
+### Messages Not Received by Client
+
+**Symptoms:**
+- Connection successful but event handlers never fire
+- `BotStatusUpdated` events not appearing in console
+
+**Solutions:**
+1. Verify event handler is registered **before** calling `connect()`:
+   ```javascript
+   DashboardHub.on('BotStatusUpdated', handler);
+   await DashboardHub.connect();
+   ```
+2. Check event name matches exactly (case-sensitive): `BotStatusUpdated` not `botStatusUpdated`
+3. Ensure client is connected: `DashboardHub.isConnected()`
+4. Check server logs to confirm broadcasts are being sent
+5. Verify handler function is defined correctly:
+   ```javascript
+   function handler(data) {
+       console.log('Received:', data);
+   }
+   ```
+
+---
+
+### Guild Updates Not Received
+
+**Symptoms:**
+- Connected to hub but not receiving guild-specific events
+- `GuildUpdated` events not firing for a specific guild
+
+**Solutions:**
+1. Verify you joined the guild group: `await DashboardHub.joinGuildGroup(guildId)`
+2. Check the `guildId` matches exactly (as string, not number)
+3. Confirm the server is broadcasting to the correct group name (`guild-{guildId}`)
+4. Check browser console for any errors during `JoinGuildGroup` call
+5. Verify server logs show successful group join
+
+---
+
+### Reconnection Loops / Constant Disconnecting
+
+**Symptoms:**
+- Connection repeatedly connects and disconnects
+- "reconnecting" events firing continuously
+- Network tab shows many connection attempts
+
+**Solutions:**
+1. Check network connectivity and firewall settings
+2. Verify server is running and accessible at `/hubs/dashboard`
+3. Check for authentication cookie expiration (re-login may be needed)
+4. Review server logs for connection rejection reasons
+5. Ensure WebSockets are not being blocked by proxy or firewall
+6. Check for conflicting browser extensions blocking WebSockets
+7. If using nginx/IIS reverse proxy, verify WebSocket upgrade is configured
+
+---
+
+### WebSocket Connection Not Upgrading
+
+**Symptoms:**
+- Connection falls back to Long Polling instead of WebSockets
+- "Negotiate" request succeeds but no WebSocket connection established
+
+**Solutions:**
+1. Verify server supports WebSockets (IIS requires WebSocket feature enabled)
+2. Check reverse proxy configuration allows WebSocket upgrade headers
+3. Ensure firewall/antivirus isn't blocking WebSocket protocol
+4. Review browser console for WebSocket errors
+5. Test with browser developer tools Network tab to see negotiation details
+
+**nginx reverse proxy configuration example:**
+```nginx
+location /hubs/dashboard {
+    proxy_pass http://localhost:5000;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_cache_bypass $http_upgrade;
+}
+```
+
+---
+
+### High Memory Usage / Connection Leaks
+
+**Symptoms:**
+- Server memory grows over time
+- Many stale connections in logs
+- Application performance degrades
+
+**Solutions:**
+1. Ensure clients call `DashboardHub.disconnect()` on page unload
+2. Check that `beforeunload` event handler is registered:
+   ```javascript
+   window.addEventListener('beforeunload', () => {
+       DashboardHub.disconnect();
+   });
+   ```
+3. Verify server timeout settings are working (30-second client timeout)
+4. Monitor connection count in server logs
+5. Consider implementing server-side connection limits per user
+6. Review for JavaScript errors preventing proper disconnection
+
+---
+
+## Related Documentation
+
+- [API Endpoints](api-endpoints.md) - REST API documentation
+- [Authorization Policies](authorization-policies.md) - Role hierarchy and policies
+- [Identity Configuration](identity-configuration.md) - Authentication setup
+- [Design System](design-system.md) - UI component guidelines
+
+---
+
+## Future Enhancements
+
+This infrastructure provides the foundation for additional real-time features:
+
+1. **Bot Event Integration (Issue #244):** Broadcast bot connection state changes from `BotHostedService`
+2. **Guild Event Integration (Issue #245):** Notify clients when bot joins/leaves guilds
+3. **Command Activity Feed (Issue #246):** Real-time command execution notifications
+4. **Connection Indicator Component (Issue #247):** Visual UI component showing hub connection status
+5. **Guild Access Validation (Issue #248):** Validate user permissions before allowing guild group join
+6. **Presence Updates:** Show which admins are currently viewing the dashboard
+7. **Collaborative Editing Indicators:** Show when multiple admins are editing same settings
+8. **Real-time Metrics Streaming:** Push bot performance metrics to monitoring dashboards
+
+---
+
+**Version:** 0.3.0
+**Last Updated:** 2025-12-26
+**Issue Reference:** #243

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -24,6 +24,8 @@
       href: api-endpoints.md
     - name: Interactive Components
       href: interactive-components.md
+    - name: SignalR Real-Time Dashboard
+      href: signalr-realtime.md
 - name: Security & Authentication
   items:
     - name: Identity Configuration

--- a/docs/plans/issue-243-signalr-infrastructure.md
+++ b/docs/plans/issue-243-signalr-infrastructure.md
@@ -1,0 +1,1203 @@
+# Implementation Plan: Issue #243 - Configure SignalR Infrastructure
+
+**Document Version:** 1.0
+**Date:** 2025-12-26
+**Issue Reference:** GitHub Issue #243
+**Parent Feature:** #218 (Real-time Dashboard)
+
+---
+
+## 1. Requirement Summary
+
+Configure SignalR infrastructure to enable real-time communication between the Discord bot backend and the admin dashboard UI. This foundational issue establishes:
+
+1. SignalR services registration in Dependency Injection
+2. `DashboardHub` with authorization (accessible to all authenticated users with Viewer role or higher)
+3. Endpoint mapping at `/hubs/dashboard`
+4. SignalR JavaScript client library integrated into the layout
+5. Hub methods for guild-specific group subscriptions and status retrieval
+
+### Key Constraints
+
+- **Authorization:** Hub requires "RequireViewer" policy (consistent with dashboard access)
+- **No Additional NuGet Packages:** SignalR is included in ASP.NET Core 8
+- **Client Library:** Add via npm for build-time bundling or CDN for simplicity
+- **Group Pattern:** Use `guild-{guildId}` naming for guild-specific subscriptions
+- **Endpoint Position:** Map hub after `UseAuthorization()` middleware
+
+---
+
+## 2. Architectural Considerations
+
+### 2.1 Existing Infrastructure
+
+| Component | Location | Relevance |
+|-----------|----------|-----------|
+| `Program.cs` | `src/DiscordBot.Bot/Program.cs` | Services registration (lines 39-240), endpoint mapping (lines 281-282) |
+| `_Layout.cshtml` | `src/DiscordBot.Bot/Pages/Shared/_Layout.cshtml` | Scripts section for SignalR client |
+| `Index.cshtml` (Dashboard) | `src/DiscordBot.Bot/Pages/Index.cshtml` | Primary consumer of real-time updates |
+| `IBotService` | `src/DiscordBot.Core/Interfaces/IBotService.cs` | Bot status retrieval pattern |
+| `BotService` | `src/DiscordBot.Bot/Services/BotService.cs` | Implementation pattern for status |
+| Authorization Policies | `src/DiscordBot.Bot/Program.cs` (lines 134-165) | RequireViewer policy for dashboard access |
+| `package.json` | `src/DiscordBot.Bot/package.json` | npm for Tailwind; can add SignalR client |
+
+### 2.2 SignalR Architecture
+
+```
+                                    +------------------+
+                                    |   DashboardHub   |
+                                    |   /hubs/dashboard|
+                                    +--------+---------+
+                                             |
+            +--------------------------------+--------------------------------+
+            |                                |                                |
+    +-------v--------+              +--------v-------+              +--------v--------+
+    | JoinGuildGroup |              | LeaveGuildGroup|              | GetCurrentStatus|
+    | (guildId)      |              | (guildId)      |              | ()              |
+    +----------------+              +----------------+              +-----------------+
+            |                                |                                |
+            v                                v                                v
+    Groups.AddToGroupAsync          Groups.RemoveFromGroupAsync       Return BotStatusDto
+    ("guild-{guildId}")             ("guild-{guildId}")
+```
+
+**Group Naming Convention:**
+- Guild-specific: `guild-{guildId}` (e.g., `guild-123456789012345678`)
+- Future: Could add `all-guilds` for broadcast to all connected admins
+
+### 2.3 Authorization Model
+
+The hub uses the same authorization as the dashboard page:
+
+```csharp
+// Policy: RequireViewer (already defined in Program.cs)
+// Allows: SuperAdmin, Admin, Moderator, Viewer
+options.AddPolicy("RequireViewer", policy =>
+    policy.RequireRole(
+        IdentitySeeder.Roles.SuperAdmin,
+        IdentitySeeder.Roles.Admin,
+        IdentitySeeder.Roles.Moderator,
+        IdentitySeeder.Roles.Viewer));
+```
+
+### 2.4 Client Library Options
+
+| Option | Pros | Cons | Recommendation |
+|--------|------|------|----------------|
+| **npm + bundling** | Version controlled, offline capable | Adds build complexity | Preferred for production |
+| **CDN (unpkg/jsdelivr)** | Simple setup, no build changes | External dependency, requires internet | Good for initial setup |
+| **libman** | Visual Studio integrated | Less common in CLI workflows | Not recommended |
+
+**Recommendation:** Use CDN initially for faster implementation, with a follow-up task to bundle via npm if needed.
+
+### 2.5 Security Considerations
+
+1. **Authentication Required:** Hub decorated with `[Authorize]` attribute
+2. **Cookie Authentication:** SignalR uses existing cookie auth for WebSocket connections
+3. **Guild Access Validation:** Future enhancement - validate user has access to requested guild before joining group
+4. **Connection Limits:** Consider implementing per-user connection limits in future
+5. **Message Size:** Default SignalR limits are sufficient for dashboard data
+
+### 2.6 Integration Points
+
+| Integration | Approach |
+|-------------|----------|
+| Authentication | Uses existing cookie authentication |
+| Authorization | Applies RequireViewer policy |
+| Bot Status | Inject IBotService for GetCurrentStatus |
+| Future: Bot Events | BotHostedService will call hub to broadcast updates |
+| Future: Guild Events | GuildService will notify hub of guild changes |
+
+---
+
+## 3. Subagent Task Plan
+
+### 3.1 dotnet-specialist Tasks
+
+#### Task 243.1: Create DashboardHub Class
+
+**Description:** Create the SignalR hub for dashboard real-time communication.
+
+**Directory to Create:** `src/DiscordBot.Bot/Hubs/`
+
+**File to Create:** `src/DiscordBot.Bot/Hubs/DashboardHub.cs`
+
+```csharp
+using Discord.WebSocket;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+
+namespace DiscordBot.Bot.Hubs;
+
+/// <summary>
+/// SignalR hub for real-time dashboard updates.
+/// Provides methods for guild-specific subscriptions and status retrieval.
+/// </summary>
+[Authorize(Policy = "RequireViewer")]
+public class DashboardHub : Hub
+{
+    private readonly IBotService _botService;
+    private readonly ILogger<DashboardHub> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DashboardHub"/> class.
+    /// </summary>
+    /// <param name="botService">The bot service for status retrieval.</param>
+    /// <param name="logger">The logger.</param>
+    public DashboardHub(
+        IBotService botService,
+        ILogger<DashboardHub> logger)
+    {
+        _botService = botService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Called when a client connects to the hub.
+    /// </summary>
+    public override async Task OnConnectedAsync()
+    {
+        var userId = Context.UserIdentifier ?? "unknown";
+        var userName = Context.User?.Identity?.Name ?? "unknown";
+
+        _logger.LogInformation(
+            "Dashboard client connected: ConnectionId={ConnectionId}, User={UserName}",
+            Context.ConnectionId,
+            userName);
+
+        await base.OnConnectedAsync();
+    }
+
+    /// <summary>
+    /// Called when a client disconnects from the hub.
+    /// </summary>
+    /// <param name="exception">The exception that caused the disconnect, if any.</param>
+    public override async Task OnDisconnectedAsync(Exception? exception)
+    {
+        var userName = Context.User?.Identity?.Name ?? "unknown";
+
+        if (exception != null)
+        {
+            _logger.LogWarning(
+                exception,
+                "Dashboard client disconnected with error: ConnectionId={ConnectionId}, User={UserName}",
+                Context.ConnectionId,
+                userName);
+        }
+        else
+        {
+            _logger.LogInformation(
+                "Dashboard client disconnected: ConnectionId={ConnectionId}, User={UserName}",
+                Context.ConnectionId,
+                userName);
+        }
+
+        await base.OnDisconnectedAsync(exception);
+    }
+
+    /// <summary>
+    /// Joins a guild-specific group to receive updates for that guild.
+    /// </summary>
+    /// <param name="guildId">The Discord guild ID to subscribe to.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public async Task JoinGuildGroup(ulong guildId)
+    {
+        var groupName = GetGuildGroupName(guildId);
+        var userName = Context.User?.Identity?.Name ?? "unknown";
+
+        await Groups.AddToGroupAsync(Context.ConnectionId, groupName);
+
+        _logger.LogDebug(
+            "Client joined guild group: ConnectionId={ConnectionId}, User={UserName}, GuildId={GuildId}",
+            Context.ConnectionId,
+            userName,
+            guildId);
+    }
+
+    /// <summary>
+    /// Leaves a guild-specific group to stop receiving updates for that guild.
+    /// </summary>
+    /// <param name="guildId">The Discord guild ID to unsubscribe from.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public async Task LeaveGuildGroup(ulong guildId)
+    {
+        var groupName = GetGuildGroupName(guildId);
+        var userName = Context.User?.Identity?.Name ?? "unknown";
+
+        await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupName);
+
+        _logger.LogDebug(
+            "Client left guild group: ConnectionId={ConnectionId}, User={UserName}, GuildId={GuildId}",
+            Context.ConnectionId,
+            userName,
+            guildId);
+    }
+
+    /// <summary>
+    /// Gets the current bot status.
+    /// </summary>
+    /// <returns>The current bot status.</returns>
+    public BotStatusDto GetCurrentStatus()
+    {
+        _logger.LogDebug(
+            "Status requested by client: ConnectionId={ConnectionId}",
+            Context.ConnectionId);
+
+        return _botService.GetStatus();
+    }
+
+    /// <summary>
+    /// Gets the group name for a guild.
+    /// </summary>
+    /// <param name="guildId">The guild ID.</param>
+    /// <returns>The group name.</returns>
+    private static string GetGuildGroupName(ulong guildId) => $"guild-{guildId}";
+}
+```
+
+**Acceptance Criteria:**
+- [ ] Hub created in `Hubs/` directory
+- [ ] `[Authorize(Policy = "RequireViewer")]` attribute applied
+- [ ] `JoinGuildGroup(ulong guildId)` method implemented
+- [ ] `LeaveGuildGroup(ulong guildId)` method implemented
+- [ ] `GetCurrentStatus()` method returns `BotStatusDto`
+- [ ] Connection/disconnection logging implemented
+- [ ] XML documentation on all public members
+- [ ] Solution builds without errors
+
+---
+
+#### Task 243.2: Update Program.cs - Add SignalR Services
+
+**Description:** Register SignalR services in the DI container.
+
+**File to Modify:** `src/DiscordBot.Bot/Program.cs`
+
+Add after line 220 (`builder.Services.AddRazorPages();`):
+
+```csharp
+// Add SignalR for real-time dashboard updates
+builder.Services.AddSignalR(options =>
+{
+    // Configure SignalR options
+    options.EnableDetailedErrors = builder.Environment.IsDevelopment();
+    options.KeepAliveInterval = TimeSpan.FromSeconds(15);
+    options.ClientTimeoutInterval = TimeSpan.FromSeconds(30);
+    options.HandshakeTimeout = TimeSpan.FromSeconds(15);
+});
+```
+
+**Rationale for Configuration:**
+- `EnableDetailedErrors`: Only in development for debugging
+- `KeepAliveInterval`: 15 seconds (default) keeps connections alive
+- `ClientTimeoutInterval`: 30 seconds before considering client disconnected
+- `HandshakeTimeout`: 15 seconds for initial connection handshake
+
+**Acceptance Criteria:**
+- [ ] `AddSignalR()` called in service registration
+- [ ] Options configured appropriately for development/production
+- [ ] Solution builds without errors
+
+---
+
+#### Task 243.3: Update Program.cs - Map Hub Endpoint
+
+**Description:** Map the DashboardHub endpoint.
+
+**File to Modify:** `src/DiscordBot.Bot/Program.cs`
+
+Add required using statement at top of file:
+
+```csharp
+using DiscordBot.Bot.Hubs;
+```
+
+Add after line 282 (`app.MapRazorPages();`):
+
+```csharp
+// Map SignalR hub for real-time dashboard
+app.MapHub<DashboardHub>("/hubs/dashboard");
+```
+
+**Endpoint Position:** After `UseAuthorization()` but with other endpoint mappings ensures:
+1. Authentication middleware has run
+2. Authorization can be evaluated
+3. Consistent with other endpoints
+
+**Acceptance Criteria:**
+- [ ] Using statement added for `DiscordBot.Bot.Hubs`
+- [ ] Hub mapped to `/hubs/dashboard`
+- [ ] Endpoint mapped after authorization middleware
+- [ ] Solution builds without errors
+
+---
+
+#### Task 243.4: Create IDashboardNotifier Interface
+
+**Description:** Create an interface for services to send notifications through the hub.
+
+**File to Create:** `src/DiscordBot.Core/Interfaces/IDashboardNotifier.cs`
+
+```csharp
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Core.Interfaces;
+
+/// <summary>
+/// Interface for sending real-time notifications to dashboard clients.
+/// Used by services to broadcast updates through SignalR.
+/// </summary>
+public interface IDashboardNotifier
+{
+    /// <summary>
+    /// Broadcasts a bot status update to all connected clients.
+    /// </summary>
+    /// <param name="status">The updated bot status.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task BroadcastBotStatusAsync(BotStatusDto status, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sends a guild-specific update to clients subscribed to that guild.
+    /// </summary>
+    /// <param name="guildId">The guild ID.</param>
+    /// <param name="eventName">The event name for client-side handling.</param>
+    /// <param name="data">The event data.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task SendGuildUpdateAsync(ulong guildId, string eventName, object data, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Broadcasts a message to all connected dashboard clients.
+    /// </summary>
+    /// <param name="eventName">The event name for client-side handling.</param>
+    /// <param name="data">The event data.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task BroadcastToAllAsync(string eventName, object data, CancellationToken cancellationToken = default);
+}
+```
+
+**Acceptance Criteria:**
+- [ ] Interface defined in Core project
+- [ ] Methods for broadcast and guild-specific notifications
+- [ ] XML documentation on all members
+- [ ] Solution builds without errors
+
+---
+
+#### Task 243.5: Create DashboardNotifier Service
+
+**Description:** Implement the dashboard notifier using SignalR hub context.
+
+**File to Create:** `src/DiscordBot.Bot/Services/DashboardNotifier.cs`
+
+```csharp
+using DiscordBot.Bot.Hubs;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Interfaces;
+using Microsoft.AspNetCore.SignalR;
+
+namespace DiscordBot.Bot.Services;
+
+/// <summary>
+/// Service for sending real-time notifications to dashboard clients via SignalR.
+/// </summary>
+public class DashboardNotifier : IDashboardNotifier
+{
+    private readonly IHubContext<DashboardHub> _hubContext;
+    private readonly ILogger<DashboardNotifier> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DashboardNotifier"/> class.
+    /// </summary>
+    /// <param name="hubContext">The SignalR hub context.</param>
+    /// <param name="logger">The logger.</param>
+    public DashboardNotifier(
+        IHubContext<DashboardHub> hubContext,
+        ILogger<DashboardNotifier> logger)
+    {
+        _hubContext = hubContext;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task BroadcastBotStatusAsync(BotStatusDto status, CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Broadcasting bot status update to all clients");
+
+        await _hubContext.Clients.All.SendAsync(
+            "BotStatusUpdated",
+            status,
+            cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task SendGuildUpdateAsync(
+        ulong guildId,
+        string eventName,
+        object data,
+        CancellationToken cancellationToken = default)
+    {
+        var groupName = $"guild-{guildId}";
+
+        _logger.LogDebug(
+            "Sending guild update: GuildId={GuildId}, Event={EventName}",
+            guildId,
+            eventName);
+
+        await _hubContext.Clients.Group(groupName).SendAsync(
+            eventName,
+            data,
+            cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task BroadcastToAllAsync(
+        string eventName,
+        object data,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Broadcasting to all clients: Event={EventName}", eventName);
+
+        await _hubContext.Clients.All.SendAsync(
+            eventName,
+            data,
+            cancellationToken);
+    }
+}
+```
+
+**File to Modify:** `src/DiscordBot.Bot/Program.cs`
+
+Add service registration after other singleton services (around line 177):
+
+```csharp
+// Add SignalR dashboard notifier
+builder.Services.AddSingleton<IDashboardNotifier, DashboardNotifier>();
+```
+
+**Acceptance Criteria:**
+- [ ] DashboardNotifier implements IDashboardNotifier
+- [ ] Uses IHubContext<DashboardHub> for sending messages
+- [ ] Proper logging for debugging
+- [ ] Registered as singleton in DI
+- [ ] Solution builds without errors
+
+---
+
+### 3.2 html-prototyper Tasks
+
+#### Task 243.6: Add SignalR Client Script to Layout
+
+**Description:** Add the SignalR JavaScript client library to the shared layout.
+
+**File to Modify:** `src/DiscordBot.Bot/Pages/Shared/_Layout.cshtml`
+
+Add before the navigation.js script (around line 42):
+
+```html
+    <!-- SignalR Client Library -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/microsoft-signalr/8.0.0/signalr.min.js"
+            integrity="sha512-7rhBJh1vn+Fs27RkAMXvjgL+WJiMUjYqMOl5E2V+8rLfUypXbprEWQGZGxKgaEHR4TKZJaBoVpchN8SWdKv+jg=="
+            crossorigin="anonymous"
+            referrerpolicy="no-referrer"></script>
+```
+
+**CDN Choice:** Using cdnjs.cloudflare.com with SRI hash for security.
+
+**Alternative (npm bundling - future):** If bundling via npm is preferred later:
+
+**File to Modify:** `src/DiscordBot.Bot/package.json`
+
+Add to devDependencies:
+```json
+"@microsoft/signalr": "^8.0.0"
+```
+
+Then create `wwwroot/js/signalr-bundle.js` that imports and exposes the SignalR connection.
+
+**Acceptance Criteria:**
+- [ ] SignalR client script added to layout
+- [ ] Integrity hash included for security
+- [ ] Script loads before page-specific scripts
+- [ ] No console errors on page load
+
+---
+
+#### Task 243.7: Create Dashboard SignalR Connection Manager
+
+**Description:** Create a JavaScript module for managing the dashboard SignalR connection.
+
+**File to Create:** `src/DiscordBot.Bot/wwwroot/js/dashboard-hub.js`
+
+```javascript
+/**
+ * Dashboard Hub Connection Manager
+ * Manages the SignalR connection to the DashboardHub for real-time updates.
+ */
+const DashboardHub = (function() {
+    'use strict';
+
+    let connection = null;
+    let isConnected = false;
+    let reconnectAttempts = 0;
+    const maxReconnectAttempts = 5;
+    const reconnectDelayMs = 2000;
+
+    // Event handlers storage
+    const eventHandlers = {};
+
+    /**
+     * Initializes the SignalR connection to the dashboard hub.
+     * @returns {Promise<boolean>} True if connection successful, false otherwise.
+     */
+    async function connect() {
+        if (connection && isConnected) {
+            console.log('[DashboardHub] Already connected');
+            return true;
+        }
+
+        try {
+            connection = new signalR.HubConnectionBuilder()
+                .withUrl('/hubs/dashboard')
+                .withAutomaticReconnect({
+                    nextRetryDelayInMilliseconds: (retryContext) => {
+                        // Exponential backoff: 0s, 2s, 4s, 8s, 16s, then stop
+                        if (retryContext.previousRetryCount >= maxReconnectAttempts) {
+                            return null; // Stop reconnecting
+                        }
+                        return Math.min(1000 * Math.pow(2, retryContext.previousRetryCount), 16000);
+                    }
+                })
+                .configureLogging(signalR.LogLevel.Information)
+                .build();
+
+            // Set up connection state handlers
+            connection.onreconnecting((error) => {
+                console.warn('[DashboardHub] Connection lost, attempting to reconnect...', error);
+                isConnected = false;
+                triggerEvent('reconnecting', { error });
+            });
+
+            connection.onreconnected((connectionId) => {
+                console.log('[DashboardHub] Reconnected with ID:', connectionId);
+                isConnected = true;
+                reconnectAttempts = 0;
+                triggerEvent('reconnected', { connectionId });
+            });
+
+            connection.onclose((error) => {
+                console.warn('[DashboardHub] Connection closed', error);
+                isConnected = false;
+                triggerEvent('disconnected', { error });
+            });
+
+            // Start the connection
+            await connection.start();
+            isConnected = true;
+            reconnectAttempts = 0;
+            console.log('[DashboardHub] Connected successfully');
+            triggerEvent('connected', { connectionId: connection.connectionId });
+
+            return true;
+        } catch (error) {
+            console.error('[DashboardHub] Failed to connect:', error);
+            isConnected = false;
+            triggerEvent('connectionFailed', { error });
+            return false;
+        }
+    }
+
+    /**
+     * Disconnects from the dashboard hub.
+     * @returns {Promise<void>}
+     */
+    async function disconnect() {
+        if (connection) {
+            try {
+                await connection.stop();
+                console.log('[DashboardHub] Disconnected');
+            } catch (error) {
+                console.error('[DashboardHub] Error during disconnect:', error);
+            }
+            isConnected = false;
+        }
+    }
+
+    /**
+     * Joins a guild-specific group to receive updates for that guild.
+     * @param {string} guildId - The Discord guild ID.
+     * @returns {Promise<void>}
+     */
+    async function joinGuildGroup(guildId) {
+        if (!connection || !isConnected) {
+            console.warn('[DashboardHub] Not connected, cannot join guild group');
+            return;
+        }
+
+        try {
+            await connection.invoke('JoinGuildGroup', guildId);
+            console.log('[DashboardHub] Joined guild group:', guildId);
+        } catch (error) {
+            console.error('[DashboardHub] Failed to join guild group:', error);
+        }
+    }
+
+    /**
+     * Leaves a guild-specific group.
+     * @param {string} guildId - The Discord guild ID.
+     * @returns {Promise<void>}
+     */
+    async function leaveGuildGroup(guildId) {
+        if (!connection || !isConnected) {
+            console.warn('[DashboardHub] Not connected, cannot leave guild group');
+            return;
+        }
+
+        try {
+            await connection.invoke('LeaveGuildGroup', guildId);
+            console.log('[DashboardHub] Left guild group:', guildId);
+        } catch (error) {
+            console.error('[DashboardHub] Failed to leave guild group:', error);
+        }
+    }
+
+    /**
+     * Gets the current bot status from the server.
+     * @returns {Promise<object|null>} The bot status object or null on error.
+     */
+    async function getCurrentStatus() {
+        if (!connection || !isConnected) {
+            console.warn('[DashboardHub] Not connected, cannot get status');
+            return null;
+        }
+
+        try {
+            const status = await connection.invoke('GetCurrentStatus');
+            return status;
+        } catch (error) {
+            console.error('[DashboardHub] Failed to get status:', error);
+            return null;
+        }
+    }
+
+    /**
+     * Registers a handler for a specific server event.
+     * @param {string} eventName - The event name from the server.
+     * @param {function} handler - The callback function.
+     */
+    function on(eventName, handler) {
+        if (!eventHandlers[eventName]) {
+            eventHandlers[eventName] = [];
+        }
+        eventHandlers[eventName].push(handler);
+
+        // Register with SignalR if connected
+        if (connection) {
+            connection.on(eventName, handler);
+        }
+    }
+
+    /**
+     * Removes a handler for a specific server event.
+     * @param {string} eventName - The event name.
+     * @param {function} handler - The handler to remove.
+     */
+    function off(eventName, handler) {
+        if (eventHandlers[eventName]) {
+            const index = eventHandlers[eventName].indexOf(handler);
+            if (index > -1) {
+                eventHandlers[eventName].splice(index, 1);
+            }
+        }
+
+        if (connection) {
+            connection.off(eventName, handler);
+        }
+    }
+
+    /**
+     * Triggers local event handlers (for connection state events).
+     * @param {string} eventName - The event name.
+     * @param {object} data - The event data.
+     */
+    function triggerEvent(eventName, data) {
+        if (eventHandlers[eventName]) {
+            eventHandlers[eventName].forEach(handler => {
+                try {
+                    handler(data);
+                } catch (error) {
+                    console.error('[DashboardHub] Error in event handler:', error);
+                }
+            });
+        }
+    }
+
+    /**
+     * Checks if currently connected.
+     * @returns {boolean} True if connected.
+     */
+    function getIsConnected() {
+        return isConnected;
+    }
+
+    /**
+     * Gets the current connection ID.
+     * @returns {string|null} The connection ID or null if not connected.
+     */
+    function getConnectionId() {
+        return connection ? connection.connectionId : null;
+    }
+
+    // Public API
+    return {
+        connect,
+        disconnect,
+        joinGuildGroup,
+        leaveGuildGroup,
+        getCurrentStatus,
+        on,
+        off,
+        isConnected: getIsConnected,
+        connectionId: getConnectionId
+    };
+})();
+
+// Auto-export for module systems if available
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = DashboardHub;
+}
+```
+
+**Acceptance Criteria:**
+- [ ] Module created with IIFE pattern for encapsulation
+- [ ] Connection management with automatic reconnect
+- [ ] Guild group subscription methods
+- [ ] Event handler registration
+- [ ] Connection state events (connected, disconnected, reconnecting)
+- [ ] Error handling and logging
+- [ ] No global pollution (single `DashboardHub` object)
+
+---
+
+### 3.3 docs-writer Tasks
+
+#### Task 243.8: Document SignalR Infrastructure
+
+**Description:** Create technical documentation for the SignalR infrastructure.
+
+**File to Create:** `docs/articles/signalr-realtime.md`
+
+```markdown
+# SignalR Real-Time Dashboard
+
+This document describes the SignalR infrastructure used for real-time updates in the Discord Bot Admin Dashboard.
+
+## Overview
+
+The dashboard uses SignalR to push real-time updates to connected clients, enabling live bot status, guild events, and command execution notifications without page refresh.
+
+## Architecture
+
+### Server Components
+
+| Component | Location | Purpose |
+|-----------|----------|---------|
+| `DashboardHub` | `src/DiscordBot.Bot/Hubs/DashboardHub.cs` | SignalR hub for client connections |
+| `DashboardNotifier` | `src/DiscordBot.Bot/Services/DashboardNotifier.cs` | Service for broadcasting from other services |
+| `IDashboardNotifier` | `src/DiscordBot.Core/Interfaces/IDashboardNotifier.cs` | Abstraction for notifier |
+
+### Client Components
+
+| Component | Location | Purpose |
+|-----------|----------|---------|
+| `dashboard-hub.js` | `wwwroot/js/dashboard-hub.js` | JavaScript connection manager |
+| SignalR Client | CDN | Microsoft SignalR JavaScript client |
+
+## Hub Endpoint
+
+- **URL:** `/hubs/dashboard`
+- **Authentication:** Required (uses cookie authentication)
+- **Authorization:** `RequireViewer` policy (all authenticated users with roles)
+
+## Hub Methods
+
+### JoinGuildGroup(guildId)
+
+Subscribes the client to updates for a specific guild.
+
+```javascript
+await DashboardHub.joinGuildGroup('123456789012345678');
+```
+
+### LeaveGuildGroup(guildId)
+
+Unsubscribes from guild-specific updates.
+
+```javascript
+await DashboardHub.leaveGuildGroup('123456789012345678');
+```
+
+### GetCurrentStatus()
+
+Retrieves the current bot status synchronously.
+
+```javascript
+const status = await DashboardHub.getCurrentStatus();
+console.log(status.connectionState, status.guildCount);
+```
+
+## Server-to-Client Events
+
+### BotStatusUpdated
+
+Fired when bot status changes (connection state, latency, guild count).
+
+```javascript
+DashboardHub.on('BotStatusUpdated', (status) => {
+    console.log('Bot status:', status);
+    updateBotStatusUI(status);
+});
+```
+
+### GuildUpdated
+
+Fired when a guild's data changes (sent only to clients subscribed to that guild).
+
+```javascript
+DashboardHub.on('GuildUpdated', (guildData) => {
+    console.log('Guild update:', guildData);
+    refreshGuildCard(guildData);
+});
+```
+
+### CommandExecuted
+
+Fired when a command is executed (future implementation).
+
+```javascript
+DashboardHub.on('CommandExecuted', (commandLog) => {
+    console.log('Command executed:', commandLog);
+    addToActivityFeed(commandLog);
+});
+```
+
+## Client Usage
+
+### Basic Connection
+
+```javascript
+// Connect on page load
+document.addEventListener('DOMContentLoaded', async () => {
+    const connected = await DashboardHub.connect();
+    if (connected) {
+        console.log('Connected to dashboard hub');
+
+        // Register event handlers
+        DashboardHub.on('BotStatusUpdated', handleStatusUpdate);
+
+        // Get initial status
+        const status = await DashboardHub.getCurrentStatus();
+        updateUI(status);
+    }
+});
+
+// Disconnect on page unload
+window.addEventListener('beforeunload', () => {
+    DashboardHub.disconnect();
+});
+```
+
+### Connection State Events
+
+```javascript
+DashboardHub.on('connected', ({ connectionId }) => {
+    console.log('Connected with ID:', connectionId);
+    showConnectionIndicator('connected');
+});
+
+DashboardHub.on('disconnected', ({ error }) => {
+    console.warn('Disconnected:', error);
+    showConnectionIndicator('disconnected');
+});
+
+DashboardHub.on('reconnecting', ({ error }) => {
+    console.log('Reconnecting...');
+    showConnectionIndicator('reconnecting');
+});
+
+DashboardHub.on('reconnected', ({ connectionId }) => {
+    console.log('Reconnected with ID:', connectionId);
+    showConnectionIndicator('connected');
+    // Re-fetch any missed data
+    refreshDashboardData();
+});
+```
+
+## Broadcasting from Services
+
+Services can send real-time updates by injecting `IDashboardNotifier`:
+
+```csharp
+public class SomeService
+{
+    private readonly IDashboardNotifier _notifier;
+
+    public SomeService(IDashboardNotifier notifier)
+    {
+        _notifier = notifier;
+    }
+
+    public async Task DoSomethingAsync()
+    {
+        // ... perform operation ...
+
+        // Notify all clients
+        await _notifier.BroadcastBotStatusAsync(newStatus);
+
+        // Or notify specific guild subscribers
+        await _notifier.SendGuildUpdateAsync(
+            guildId,
+            "GuildSettingsChanged",
+            new { Setting = "value" });
+    }
+}
+```
+
+## Security Considerations
+
+1. **Authentication:** All connections require valid authentication cookies
+2. **Authorization:** Hub requires at least Viewer role
+3. **Guild Access:** Future: Validate user has access to guild before allowing group join
+4. **Rate Limiting:** SignalR has built-in connection limits
+
+## Configuration
+
+SignalR is configured in `Program.cs`:
+
+```csharp
+builder.Services.AddSignalR(options =>
+{
+    options.EnableDetailedErrors = builder.Environment.IsDevelopment();
+    options.KeepAliveInterval = TimeSpan.FromSeconds(15);
+    options.ClientTimeoutInterval = TimeSpan.FromSeconds(30);
+});
+```
+
+## Troubleshooting
+
+### Connection Fails
+
+1. Check authentication - user must be logged in
+2. Verify browser allows WebSocket connections
+3. Check for CORS issues if running on different ports
+4. Review browser console for detailed errors
+
+### Messages Not Received
+
+1. Verify event handler is registered before connection
+2. Check the event name matches exactly (case-sensitive)
+3. Ensure client is subscribed to the correct guild group
+4. Check server logs for broadcast activity
+
+### Reconnection Loops
+
+1. Check network connectivity
+2. Verify server is running
+3. Check for authentication expiry
+4. Review server logs for connection rejection reasons
+```
+
+**Acceptance Criteria:**
+- [ ] Architecture documented with component locations
+- [ ] All hub methods documented with examples
+- [ ] Client usage patterns explained
+- [ ] Broadcasting from services demonstrated
+- [ ] Security considerations listed
+- [ ] Troubleshooting section included
+
+---
+
+### 3.4 Testing Considerations
+
+#### Task 243.9: Manual Testing Checklist
+
+**Description:** Define manual testing steps to verify SignalR infrastructure.
+
+**Testing Steps:**
+
+1. **Basic Connection Test**
+   - [ ] Navigate to dashboard page
+   - [ ] Open browser developer tools (Network tab)
+   - [ ] Verify WebSocket connection established to `/hubs/dashboard`
+   - [ ] Check console for "Connected successfully" log
+
+2. **Authentication Test**
+   - [ ] Log out of application
+   - [ ] Open browser console
+   - [ ] Attempt to connect: `DashboardHub.connect()`
+   - [ ] Verify connection fails with 401 Unauthorized
+
+3. **Status Retrieval Test**
+   - [ ] Connect to hub
+   - [ ] Call `await DashboardHub.getCurrentStatus()`
+   - [ ] Verify returned object has expected properties (uptime, guildCount, etc.)
+
+4. **Guild Group Test**
+   - [ ] Connect to hub
+   - [ ] Call `await DashboardHub.joinGuildGroup('123456789')`
+   - [ ] Verify no errors in console
+   - [ ] Call `await DashboardHub.leaveGuildGroup('123456789')`
+   - [ ] Verify no errors
+
+5. **Reconnection Test**
+   - [ ] Connect to hub
+   - [ ] Stop the server (Ctrl+C)
+   - [ ] Verify "reconnecting" event fires
+   - [ ] Restart the server
+   - [ ] Verify "reconnected" event fires
+
+6. **Page Navigation Test**
+   - [ ] Connect on dashboard
+   - [ ] Navigate to another page
+   - [ ] Return to dashboard
+   - [ ] Verify new connection established
+
+**Acceptance Criteria:**
+- [ ] All manual tests pass
+- [ ] No JavaScript errors in console
+- [ ] Connection indicators work correctly
+
+---
+
+## 4. Timeline / Dependency Map
+
+```
+Phase 1: Core Infrastructure (Day 1)
+├── Task 243.1: Create DashboardHub Class
+├── Task 243.2: Add SignalR Services to Program.cs
+├── Task 243.3: Map Hub Endpoint
+└── Task 243.4: Create IDashboardNotifier Interface
+
+Phase 2: Service Layer (Day 1)
+└── Task 243.5: Create DashboardNotifier Service (depends on 243.1, 243.4)
+
+Phase 3: Client Integration (Day 1-2)
+├── Task 243.6: Add SignalR Client to Layout
+└── Task 243.7: Create Dashboard Hub JavaScript Module (depends on 243.6)
+
+Phase 4: Documentation & Testing (Day 2)
+├── Task 243.8: Document SignalR Infrastructure
+└── Task 243.9: Manual Testing (depends on all above)
+```
+
+**Parallel Opportunities:**
+- Tasks 243.1, 243.2, 243.3 can be done together (all Program.cs/Hub setup)
+- Task 243.4 can be done in parallel with hub creation
+- Tasks 243.6, 243.7 can start once backend is complete
+- Task 243.8 can start once design is finalized
+
+**Estimated Timeline:** 1-2 days
+
+---
+
+## 5. Acceptance Criteria Summary
+
+### Functional Requirements
+
+- [ ] SignalR hub accessible at `/hubs/dashboard`
+- [ ] Hub requires authentication (returns 401 if not logged in)
+- [ ] Hub methods work: JoinGuildGroup, LeaveGuildGroup, GetCurrentStatus
+- [ ] JavaScript client can connect and invoke methods
+- [ ] Automatic reconnection works when connection is lost
+- [ ] Event handlers receive server-pushed messages
+
+### Technical Requirements
+
+- [ ] `DashboardHub` class in `Hubs/` directory with `[Authorize]` attribute
+- [ ] SignalR services registered in DI container
+- [ ] Hub endpoint mapped after authorization middleware
+- [ ] `IDashboardNotifier` interface in Core project
+- [ ] `DashboardNotifier` service registered as singleton
+- [ ] SignalR client library loaded in layout
+- [ ] `dashboard-hub.js` module created with connection management
+
+### Security Requirements
+
+- [ ] Hub requires authentication
+- [ ] Hub requires "RequireViewer" authorization policy
+- [ ] Client library loaded with SRI integrity hash
+- [ ] No sensitive data exposed in hub methods
+
+### Documentation Requirements
+
+- [ ] Technical documentation created
+- [ ] Client usage examples provided
+- [ ] Troubleshooting guide included
+
+---
+
+## 6. Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| WebSocket blocked by proxy/firewall | Low | Medium | SignalR auto-falls back to long polling |
+| Memory leak from connection accumulation | Low | High | Proper disconnect on page unload, server-side timeout |
+| Stale data after reconnection | Medium | Low | Re-fetch data on reconnect event |
+| CDN unavailability | Low | Medium | Consider bundling via npm as fallback |
+| Authentication cookie expiry during connection | Low | Medium | Handle 401 and redirect to login |
+
+### Performance Considerations
+
+1. **Connection Overhead:** Each dashboard client maintains one WebSocket
+2. **Message Size:** Keep payloads small; avoid sending large data sets
+3. **Broadcast Frequency:** Future work should throttle rapid status updates
+4. **Group Size:** Monitor guild group sizes; consider fan-out strategies for large groups
+
+---
+
+## 7. File Summary
+
+### Files to Create
+
+| File | Project | Description |
+|------|---------|-------------|
+| `Hubs/DashboardHub.cs` | Bot | SignalR hub for dashboard |
+| `Interfaces/IDashboardNotifier.cs` | Core | Notifier interface |
+| `Services/DashboardNotifier.cs` | Bot | Notifier implementation |
+| `wwwroot/js/dashboard-hub.js` | Bot | JavaScript connection manager |
+| `articles/signalr-realtime.md` | docs | Technical documentation |
+
+### Files to Modify
+
+| File | Changes |
+|------|---------|
+| `Program.cs` | Add SignalR services, map hub endpoint |
+| `_Layout.cshtml` | Add SignalR client script reference |
+
+### Dependencies
+
+| Package | Version | Source |
+|---------|---------|--------|
+| SignalR Server | Included | ASP.NET Core 8 |
+| @microsoft/signalr | 8.0.0 | CDN (cdnjs.cloudflare.com) |
+
+---
+
+## 8. Future Enhancements
+
+This issue establishes the foundation. Future issues will build upon it:
+
+1. **Issue #244:** Integrate bot status events (BotHostedService broadcasts status changes)
+2. **Issue #245:** Integrate guild events (join/leave guild notifications)
+3. **Issue #246:** Real-time command activity feed
+4. **Issue #247:** Connection status indicator UI component
+5. **Issue #248:** Guild access validation in JoinGuildGroup
+
+---
+
+*Document prepared by: Systems Architect*
+*Ready for implementation by: dotnet-specialist, html-prototyper, docs-writer*

--- a/src/DiscordBot.Bot/Hubs/DashboardHub.cs
+++ b/src/DiscordBot.Bot/Hubs/DashboardHub.cs
@@ -1,0 +1,130 @@
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+
+namespace DiscordBot.Bot.Hubs;
+
+/// <summary>
+/// SignalR hub for real-time dashboard updates.
+/// Provides methods for guild-specific subscriptions and status retrieval.
+/// </summary>
+[Authorize(Policy = "RequireViewer")]
+public class DashboardHub : Hub
+{
+    private readonly IBotService _botService;
+    private readonly ILogger<DashboardHub> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DashboardHub"/> class.
+    /// </summary>
+    /// <param name="botService">The bot service for status retrieval.</param>
+    /// <param name="logger">The logger.</param>
+    public DashboardHub(
+        IBotService botService,
+        ILogger<DashboardHub> logger)
+    {
+        _botService = botService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Called when a client connects to the hub.
+    /// </summary>
+    public override async Task OnConnectedAsync()
+    {
+        var userName = Context.User?.Identity?.Name ?? "unknown";
+
+        _logger.LogInformation(
+            "Dashboard client connected: ConnectionId={ConnectionId}, User={UserName}",
+            Context.ConnectionId,
+            userName);
+
+        await base.OnConnectedAsync();
+    }
+
+    /// <summary>
+    /// Called when a client disconnects from the hub.
+    /// </summary>
+    /// <param name="exception">The exception that caused the disconnect, if any.</param>
+    public override async Task OnDisconnectedAsync(Exception? exception)
+    {
+        var userName = Context.User?.Identity?.Name ?? "unknown";
+
+        if (exception != null)
+        {
+            _logger.LogWarning(
+                exception,
+                "Dashboard client disconnected with error: ConnectionId={ConnectionId}, User={UserName}",
+                Context.ConnectionId,
+                userName);
+        }
+        else
+        {
+            _logger.LogInformation(
+                "Dashboard client disconnected: ConnectionId={ConnectionId}, User={UserName}",
+                Context.ConnectionId,
+                userName);
+        }
+
+        await base.OnDisconnectedAsync(exception);
+    }
+
+    /// <summary>
+    /// Joins a guild-specific group to receive updates for that guild.
+    /// </summary>
+    /// <param name="guildId">The Discord guild ID to subscribe to.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public async Task JoinGuildGroup(ulong guildId)
+    {
+        var groupName = GetGuildGroupName(guildId);
+        var userName = Context.User?.Identity?.Name ?? "unknown";
+
+        await Groups.AddToGroupAsync(Context.ConnectionId, groupName);
+
+        _logger.LogDebug(
+            "Client joined guild group: ConnectionId={ConnectionId}, User={UserName}, GuildId={GuildId}",
+            Context.ConnectionId,
+            userName,
+            guildId);
+    }
+
+    /// <summary>
+    /// Leaves a guild-specific group to stop receiving updates for that guild.
+    /// </summary>
+    /// <param name="guildId">The Discord guild ID to unsubscribe from.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public async Task LeaveGuildGroup(ulong guildId)
+    {
+        var groupName = GetGuildGroupName(guildId);
+        var userName = Context.User?.Identity?.Name ?? "unknown";
+
+        await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupName);
+
+        _logger.LogDebug(
+            "Client left guild group: ConnectionId={ConnectionId}, User={UserName}, GuildId={GuildId}",
+            Context.ConnectionId,
+            userName,
+            guildId);
+    }
+
+    /// <summary>
+    /// Gets the current bot status.
+    /// </summary>
+    /// <returns>The current bot status.</returns>
+    public BotStatusDto GetCurrentStatus()
+    {
+        _logger.LogDebug(
+            "Status requested by client: ConnectionId={ConnectionId}",
+            Context.ConnectionId);
+
+        return _botService.GetStatus();
+    }
+
+    /// <summary>
+    /// Gets the group name for a guild.
+    /// </summary>
+    /// <param name="guildId">The guild ID.</param>
+    /// <returns>The group name.</returns>
+    private static string GetGuildGroupName(ulong guildId) => $"guild-{guildId}";
+}

--- a/src/DiscordBot.Bot/Pages/Shared/_Layout.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/_Layout.cshtml
@@ -38,6 +38,13 @@
     <!-- Toast Notifications Container -->
     @await Html.PartialAsync("_ToastContainer")
 
+    <!-- SignalR Client Library -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/microsoft-signalr/8.0.0/signalr.min.js"
+            integrity="sha512-7rhBJh1vn+Fs27RkAMXvjgL+WJiMUjYqMOl5E2V+8rLfUypXbprEWQGZGxKgaEHR4TKZJaBoVpchN8SWdKv+jg=="
+            crossorigin="anonymous"
+            referrerpolicy="no-referrer"></script>
+    <!-- Dashboard Hub Connection Manager -->
+    <script src="~/js/dashboard-hub.js" asp-append-version="true"></script>
     <!-- JavaScript for Navigation -->
     <script src="~/js/navigation.js" asp-append-version="true"></script>
     <!-- JavaScript for Toast Notifications -->

--- a/src/DiscordBot.Bot/Services/DashboardNotifier.cs
+++ b/src/DiscordBot.Bot/Services/DashboardNotifier.cs
@@ -1,0 +1,73 @@
+using DiscordBot.Bot.Hubs;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Interfaces;
+using Microsoft.AspNetCore.SignalR;
+
+namespace DiscordBot.Bot.Services;
+
+/// <summary>
+/// Service for sending real-time notifications to dashboard clients via SignalR.
+/// </summary>
+public class DashboardNotifier : IDashboardNotifier
+{
+    private readonly IHubContext<DashboardHub> _hubContext;
+    private readonly ILogger<DashboardNotifier> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DashboardNotifier"/> class.
+    /// </summary>
+    /// <param name="hubContext">The SignalR hub context.</param>
+    /// <param name="logger">The logger.</param>
+    public DashboardNotifier(
+        IHubContext<DashboardHub> hubContext,
+        ILogger<DashboardNotifier> logger)
+    {
+        _hubContext = hubContext;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task BroadcastBotStatusAsync(BotStatusDto status, CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Broadcasting bot status update to all clients");
+
+        await _hubContext.Clients.All.SendAsync(
+            "BotStatusUpdated",
+            status,
+            cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task SendGuildUpdateAsync(
+        ulong guildId,
+        string eventName,
+        object data,
+        CancellationToken cancellationToken = default)
+    {
+        var groupName = $"guild-{guildId}";
+
+        _logger.LogDebug(
+            "Sending guild update: GuildId={GuildId}, Event={EventName}",
+            guildId,
+            eventName);
+
+        await _hubContext.Clients.Group(groupName).SendAsync(
+            eventName,
+            data,
+            cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task BroadcastToAllAsync(
+        string eventName,
+        object data,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Broadcasting to all clients: Event={EventName}", eventName);
+
+        await _hubContext.Clients.All.SendAsync(
+            eventName,
+            data,
+            cancellationToken);
+    }
+}

--- a/src/DiscordBot.Bot/wwwroot/js/dashboard-hub.js
+++ b/src/DiscordBot.Bot/wwwroot/js/dashboard-hub.js
@@ -1,0 +1,236 @@
+/**
+ * Dashboard Hub Connection Manager
+ * Manages the SignalR connection to the DashboardHub for real-time updates.
+ */
+const DashboardHub = (function() {
+    'use strict';
+
+    let connection = null;
+    let isConnected = false;
+    let reconnectAttempts = 0;
+    const maxReconnectAttempts = 5;
+    const reconnectDelayMs = 2000;
+
+    // Event handlers storage
+    const eventHandlers = {};
+
+    /**
+     * Initializes the SignalR connection to the dashboard hub.
+     * @returns {Promise<boolean>} True if connection successful, false otherwise.
+     */
+    async function connect() {
+        if (connection && isConnected) {
+            console.log('[DashboardHub] Already connected');
+            return true;
+        }
+
+        try {
+            connection = new signalR.HubConnectionBuilder()
+                .withUrl('/hubs/dashboard')
+                .withAutomaticReconnect({
+                    nextRetryDelayInMilliseconds: (retryContext) => {
+                        // Exponential backoff: 0s, 2s, 4s, 8s, 16s, then stop
+                        if (retryContext.previousRetryCount >= maxReconnectAttempts) {
+                            return null; // Stop reconnecting
+                        }
+                        return Math.min(1000 * Math.pow(2, retryContext.previousRetryCount), 16000);
+                    }
+                })
+                .configureLogging(signalR.LogLevel.Information)
+                .build();
+
+            // Set up connection state handlers
+            connection.onreconnecting((error) => {
+                console.warn('[DashboardHub] Connection lost, attempting to reconnect...', error);
+                isConnected = false;
+                triggerEvent('reconnecting', { error });
+            });
+
+            connection.onreconnected((connectionId) => {
+                console.log('[DashboardHub] Reconnected with ID:', connectionId);
+                isConnected = true;
+                reconnectAttempts = 0;
+                triggerEvent('reconnected', { connectionId });
+            });
+
+            connection.onclose((error) => {
+                console.warn('[DashboardHub] Connection closed', error);
+                isConnected = false;
+                triggerEvent('disconnected', { error });
+            });
+
+            // Start the connection
+            await connection.start();
+            isConnected = true;
+            reconnectAttempts = 0;
+            console.log('[DashboardHub] Connected successfully');
+            triggerEvent('connected', { connectionId: connection.connectionId });
+
+            return true;
+        } catch (error) {
+            console.error('[DashboardHub] Failed to connect:', error);
+            isConnected = false;
+            triggerEvent('connectionFailed', { error });
+            return false;
+        }
+    }
+
+    /**
+     * Disconnects from the dashboard hub.
+     * @returns {Promise<void>}
+     */
+    async function disconnect() {
+        if (connection) {
+            try {
+                await connection.stop();
+                console.log('[DashboardHub] Disconnected');
+            } catch (error) {
+                console.error('[DashboardHub] Error during disconnect:', error);
+            }
+            isConnected = false;
+        }
+    }
+
+    /**
+     * Joins a guild-specific group to receive updates for that guild.
+     * @param {string} guildId - The Discord guild ID.
+     * @returns {Promise<void>}
+     */
+    async function joinGuildGroup(guildId) {
+        if (!connection || !isConnected) {
+            console.warn('[DashboardHub] Not connected, cannot join guild group');
+            return;
+        }
+
+        try {
+            await connection.invoke('JoinGuildGroup', guildId);
+            console.log('[DashboardHub] Joined guild group:', guildId);
+        } catch (error) {
+            console.error('[DashboardHub] Failed to join guild group:', error);
+        }
+    }
+
+    /**
+     * Leaves a guild-specific group.
+     * @param {string} guildId - The Discord guild ID.
+     * @returns {Promise<void>}
+     */
+    async function leaveGuildGroup(guildId) {
+        if (!connection || !isConnected) {
+            console.warn('[DashboardHub] Not connected, cannot leave guild group');
+            return;
+        }
+
+        try {
+            await connection.invoke('LeaveGuildGroup', guildId);
+            console.log('[DashboardHub] Left guild group:', guildId);
+        } catch (error) {
+            console.error('[DashboardHub] Failed to leave guild group:', error);
+        }
+    }
+
+    /**
+     * Gets the current bot status from the server.
+     * @returns {Promise<object|null>} The bot status object or null on error.
+     */
+    async function getCurrentStatus() {
+        if (!connection || !isConnected) {
+            console.warn('[DashboardHub] Not connected, cannot get status');
+            return null;
+        }
+
+        try {
+            const status = await connection.invoke('GetCurrentStatus');
+            return status;
+        } catch (error) {
+            console.error('[DashboardHub] Failed to get status:', error);
+            return null;
+        }
+    }
+
+    /**
+     * Registers a handler for a specific server event.
+     * @param {string} eventName - The event name from the server.
+     * @param {function} handler - The callback function.
+     */
+    function on(eventName, handler) {
+        if (!eventHandlers[eventName]) {
+            eventHandlers[eventName] = [];
+        }
+        eventHandlers[eventName].push(handler);
+
+        // Register with SignalR if connected
+        if (connection) {
+            connection.on(eventName, handler);
+        }
+    }
+
+    /**
+     * Removes a handler for a specific server event.
+     * @param {string} eventName - The event name.
+     * @param {function} handler - The handler to remove.
+     */
+    function off(eventName, handler) {
+        if (eventHandlers[eventName]) {
+            const index = eventHandlers[eventName].indexOf(handler);
+            if (index > -1) {
+                eventHandlers[eventName].splice(index, 1);
+            }
+        }
+
+        if (connection) {
+            connection.off(eventName, handler);
+        }
+    }
+
+    /**
+     * Triggers local event handlers (for connection state events).
+     * @param {string} eventName - The event name.
+     * @param {object} data - The event data.
+     */
+    function triggerEvent(eventName, data) {
+        if (eventHandlers[eventName]) {
+            eventHandlers[eventName].forEach(handler => {
+                try {
+                    handler(data);
+                } catch (error) {
+                    console.error('[DashboardHub] Error in event handler:', error);
+                }
+            });
+        }
+    }
+
+    /**
+     * Checks if currently connected.
+     * @returns {boolean} True if connected.
+     */
+    function getIsConnected() {
+        return isConnected;
+    }
+
+    /**
+     * Gets the current connection ID.
+     * @returns {string|null} The connection ID or null if not connected.
+     */
+    function getConnectionId() {
+        return connection ? connection.connectionId : null;
+    }
+
+    // Public API
+    return {
+        connect,
+        disconnect,
+        joinGuildGroup,
+        leaveGuildGroup,
+        getCurrentStatus,
+        on,
+        off,
+        isConnected: getIsConnected,
+        connectionId: getConnectionId
+    };
+})();
+
+// Auto-export for module systems if available
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = DashboardHub;
+}

--- a/src/DiscordBot.Core/Interfaces/IDashboardNotifier.cs
+++ b/src/DiscordBot.Core/Interfaces/IDashboardNotifier.cs
@@ -1,0 +1,37 @@
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Core.Interfaces;
+
+/// <summary>
+/// Interface for sending real-time notifications to dashboard clients.
+/// Used by services to broadcast updates through SignalR.
+/// </summary>
+public interface IDashboardNotifier
+{
+    /// <summary>
+    /// Broadcasts a bot status update to all connected clients.
+    /// </summary>
+    /// <param name="status">The updated bot status.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task BroadcastBotStatusAsync(BotStatusDto status, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sends a guild-specific update to clients subscribed to that guild.
+    /// </summary>
+    /// <param name="guildId">The guild ID.</param>
+    /// <param name="eventName">The event name for client-side handling.</param>
+    /// <param name="data">The event data.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task SendGuildUpdateAsync(ulong guildId, string eventName, object data, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Broadcasts a message to all connected dashboard clients.
+    /// </summary>
+    /// <param name="eventName">The event name for client-side handling.</param>
+    /// <param name="data">The event data.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task BroadcastToAllAsync(string eventName, object data, CancellationToken cancellationToken = default);
+}

--- a/tests/DiscordBot.Tests/Hubs/DashboardHubTests.cs
+++ b/tests/DiscordBot.Tests/Hubs/DashboardHubTests.cs
@@ -1,0 +1,348 @@
+using DiscordBot.Bot.Hubs;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Security.Claims;
+
+namespace DiscordBot.Tests.Hubs;
+
+/// <summary>
+/// Unit tests for <see cref="DashboardHub"/>.
+/// Tests SignalR hub operations including group management, status retrieval, and connection lifecycle.
+/// </summary>
+public class DashboardHubTests
+{
+    private readonly Mock<IBotService> _mockBotService;
+    private readonly Mock<ILogger<DashboardHub>> _mockLogger;
+    private readonly Mock<IGroupManager> _mockGroupManager;
+    private readonly Mock<HubCallerContext> _mockContext;
+    private readonly DashboardHub _hub;
+
+    public DashboardHubTests()
+    {
+        _mockBotService = new Mock<IBotService>();
+        _mockLogger = new Mock<ILogger<DashboardHub>>();
+        _mockGroupManager = new Mock<IGroupManager>();
+        _mockContext = new Mock<HubCallerContext>();
+
+        _hub = new DashboardHub(_mockBotService.Object, _mockLogger.Object);
+
+        // Setup hub context with mocked group manager
+        _mockContext.Setup(c => c.ConnectionId).Returns("test-connection-id-123");
+        _mockContext.Setup(c => c.User).Returns(new ClaimsPrincipal(new ClaimsIdentity(new[]
+        {
+            new Claim(ClaimTypes.Name, "testuser")
+        }, "TestAuth")));
+
+        _hub.Context = _mockContext.Object;
+        _hub.Groups = _mockGroupManager.Object;
+    }
+
+    [Fact]
+    public async Task JoinGuildGroup_ShouldAddToGroup()
+    {
+        // Arrange
+        const ulong guildId = 123456789;
+        var expectedGroupName = $"guild-{guildId}";
+
+        // Act
+        await _hub.JoinGuildGroup(guildId);
+
+        // Assert
+        _mockGroupManager.Verify(
+            g => g.AddToGroupAsync(
+                "test-connection-id-123",
+                expectedGroupName,
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "Should add connection to guild-specific group");
+    }
+
+    [Fact]
+    public async Task JoinGuildGroup_ShouldLogDebugMessage()
+    {
+        // Arrange
+        const ulong guildId = 987654321;
+
+        // Act
+        await _hub.JoinGuildGroup(guildId);
+
+        // Assert
+        _mockLogger.Verify(
+            l => l.Log(
+                LogLevel.Debug,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Client joined guild group")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once,
+            "Should log debug message when client joins guild group");
+    }
+
+    [Fact]
+    public async Task JoinGuildGroup_WithMultipleGuilds_ShouldAddToEachGroup()
+    {
+        // Arrange
+        const ulong guildId1 = 111111111;
+        const ulong guildId2 = 222222222;
+
+        // Act
+        await _hub.JoinGuildGroup(guildId1);
+        await _hub.JoinGuildGroup(guildId2);
+
+        // Assert
+        _mockGroupManager.Verify(
+            g => g.AddToGroupAsync(
+                "test-connection-id-123",
+                $"guild-{guildId1}",
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "Should add to first guild group");
+
+        _mockGroupManager.Verify(
+            g => g.AddToGroupAsync(
+                "test-connection-id-123",
+                $"guild-{guildId2}",
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "Should add to second guild group");
+    }
+
+    [Fact]
+    public async Task LeaveGuildGroup_ShouldRemoveFromGroup()
+    {
+        // Arrange
+        const ulong guildId = 123456789;
+        var expectedGroupName = $"guild-{guildId}";
+
+        // Act
+        await _hub.LeaveGuildGroup(guildId);
+
+        // Assert
+        _mockGroupManager.Verify(
+            g => g.RemoveFromGroupAsync(
+                "test-connection-id-123",
+                expectedGroupName,
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "Should remove connection from guild-specific group");
+    }
+
+    [Fact]
+    public async Task LeaveGuildGroup_ShouldLogDebugMessage()
+    {
+        // Arrange
+        const ulong guildId = 987654321;
+
+        // Act
+        await _hub.LeaveGuildGroup(guildId);
+
+        // Assert
+        _mockLogger.Verify(
+            l => l.Log(
+                LogLevel.Debug,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Client left guild group")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once,
+            "Should log debug message when client leaves guild group");
+    }
+
+    [Fact]
+    public void GetCurrentStatus_ShouldReturnBotStatus()
+    {
+        // Arrange
+        var expectedStatus = new BotStatusDto
+        {
+            Uptime = TimeSpan.FromHours(2),
+            GuildCount = 5,
+            LatencyMs = 42,
+            ConnectionState = "Connected",
+            BotUsername = "TestBot",
+            StartTime = DateTime.UtcNow.AddHours(-2)
+        };
+
+        _mockBotService
+            .Setup(b => b.GetStatus())
+            .Returns(expectedStatus);
+
+        // Act
+        var result = _hub.GetCurrentStatus();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeSameAs(expectedStatus, "Should return the exact status from bot service");
+
+        _mockBotService.Verify(
+            b => b.GetStatus(),
+            Times.Once,
+            "Should call bot service to get status");
+    }
+
+    [Fact]
+    public void GetCurrentStatus_ShouldLogDebugMessage()
+    {
+        // Arrange
+        var status = new BotStatusDto
+        {
+            GuildCount = 3,
+            ConnectionState = "Connected"
+        };
+
+        _mockBotService.Setup(b => b.GetStatus()).Returns(status);
+
+        // Act
+        _hub.GetCurrentStatus();
+
+        // Assert
+        _mockLogger.Verify(
+            l => l.Log(
+                LogLevel.Debug,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Status requested by client")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once,
+            "Should log debug message when status is requested");
+    }
+
+    [Fact]
+    public async Task OnConnectedAsync_ShouldLogConnection()
+    {
+        // Act
+        await _hub.OnConnectedAsync();
+
+        // Assert
+        _mockLogger.Verify(
+            l => l.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) =>
+                    v.ToString()!.Contains("Dashboard client connected") &&
+                    v.ToString()!.Contains("test-connection-id-123") &&
+                    v.ToString()!.Contains("testuser")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once,
+            "Should log information when client connects");
+    }
+
+    [Fact]
+    public async Task OnConnectedAsync_WithAnonymousUser_ShouldLogUnknownUser()
+    {
+        // Arrange
+        var anonymousContext = new Mock<HubCallerContext>();
+        anonymousContext.Setup(c => c.ConnectionId).Returns("anonymous-connection");
+        anonymousContext.Setup(c => c.User).Returns(new ClaimsPrincipal(new ClaimsIdentity())); // Not authenticated
+
+        _hub.Context = anonymousContext.Object;
+
+        // Act
+        await _hub.OnConnectedAsync();
+
+        // Assert
+        _mockLogger.Verify(
+            l => l.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("unknown")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once,
+            "Should log 'unknown' for anonymous users");
+    }
+
+    [Fact]
+    public async Task OnDisconnectedAsync_WithoutException_ShouldLogInformation()
+    {
+        // Act
+        await _hub.OnDisconnectedAsync(null);
+
+        // Assert
+        _mockLogger.Verify(
+            l => l.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) =>
+                    v.ToString()!.Contains("Dashboard client disconnected") &&
+                    v.ToString()!.Contains("test-connection-id-123") &&
+                    v.ToString()!.Contains("testuser")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once,
+            "Should log information when client disconnects normally");
+
+        _mockLogger.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never,
+            "Should not log warning when disconnection is clean");
+    }
+
+    [Fact]
+    public async Task OnDisconnectedAsync_WithException_ShouldLogWarning()
+    {
+        // Arrange
+        var exception = new Exception("Connection lost");
+
+        // Act
+        await _hub.OnDisconnectedAsync(exception);
+
+        // Assert
+        _mockLogger.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) =>
+                    v.ToString()!.Contains("Dashboard client disconnected with error") &&
+                    v.ToString()!.Contains("test-connection-id-123") &&
+                    v.ToString()!.Contains("testuser")),
+                exception,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once,
+            "Should log warning with exception when client disconnects abnormally");
+
+        _mockLogger.Verify(
+            l => l.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Dashboard client disconnected") && !v.ToString()!.Contains("with error")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never,
+            "Should not log normal disconnection when exception occurred");
+    }
+
+    [Fact]
+    public async Task OnDisconnectedAsync_WithAnonymousUser_ShouldLogUnknownUser()
+    {
+        // Arrange
+        var anonymousContext = new Mock<HubCallerContext>();
+        anonymousContext.Setup(c => c.ConnectionId).Returns("anonymous-connection");
+        anonymousContext.Setup(c => c.User).Returns(new ClaimsPrincipal(new ClaimsIdentity())); // Not authenticated
+
+        _hub.Context = anonymousContext.Object;
+
+        // Act
+        await _hub.OnDisconnectedAsync(null);
+
+        // Assert
+        _mockLogger.Verify(
+            l => l.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("unknown")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once,
+            "Should log 'unknown' for anonymous users on disconnect");
+    }
+}

--- a/tests/DiscordBot.Tests/Services/DashboardNotifierTests.cs
+++ b/tests/DiscordBot.Tests/Services/DashboardNotifierTests.cs
@@ -1,0 +1,380 @@
+using DiscordBot.Bot.Hubs;
+using DiscordBot.Bot.Services;
+using DiscordBot.Core.DTOs;
+using FluentAssertions;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace DiscordBot.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="DashboardNotifier"/>.
+/// Tests SignalR broadcasting and guild-specific notification capabilities.
+/// </summary>
+public class DashboardNotifierTests
+{
+    private readonly Mock<IHubContext<DashboardHub>> _mockHubContext;
+    private readonly Mock<ILogger<DashboardNotifier>> _mockLogger;
+    private readonly Mock<IHubClients> _mockClients;
+    private readonly Mock<IClientProxy> _mockAllClientsProxy;
+    private readonly Mock<IClientProxy> _mockGroupClientsProxy;
+    private readonly DashboardNotifier _notifier;
+
+    public DashboardNotifierTests()
+    {
+        _mockHubContext = new Mock<IHubContext<DashboardHub>>();
+        _mockLogger = new Mock<ILogger<DashboardNotifier>>();
+        _mockClients = new Mock<IHubClients>();
+        _mockAllClientsProxy = new Mock<IClientProxy>();
+        _mockGroupClientsProxy = new Mock<IClientProxy>();
+
+        // Setup hub context with mocked clients
+        _mockHubContext.Setup(h => h.Clients).Returns(_mockClients.Object);
+        _mockClients.Setup(c => c.All).Returns(_mockAllClientsProxy.Object);
+        _mockClients.Setup(c => c.Group(It.IsAny<string>())).Returns(_mockGroupClientsProxy.Object);
+
+        _notifier = new DashboardNotifier(_mockHubContext.Object, _mockLogger.Object);
+    }
+
+    [Fact]
+    public async Task BroadcastBotStatusAsync_ShouldSendToAllClients()
+    {
+        // Arrange
+        var status = new BotStatusDto
+        {
+            Uptime = TimeSpan.FromHours(3),
+            GuildCount = 10,
+            LatencyMs = 25,
+            ConnectionState = "Connected",
+            BotUsername = "TestBot",
+            StartTime = DateTime.UtcNow.AddHours(-3)
+        };
+
+        // Act
+        await _notifier.BroadcastBotStatusAsync(status);
+
+        // Assert
+        _mockAllClientsProxy.Verify(
+            c => c.SendCoreAsync(
+                "BotStatusUpdated",
+                It.Is<object[]>(args => args.Length == 1 && args[0] == status),
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "Should send bot status update to all clients");
+    }
+
+    [Fact]
+    public async Task BroadcastBotStatusAsync_ShouldLogDebugMessage()
+    {
+        // Arrange
+        var status = new BotStatusDto
+        {
+            GuildCount = 5,
+            ConnectionState = "Connected"
+        };
+
+        // Act
+        await _notifier.BroadcastBotStatusAsync(status);
+
+        // Assert
+        _mockLogger.Verify(
+            l => l.Log(
+                LogLevel.Debug,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Broadcasting bot status update to all clients")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once,
+            "Should log debug message when broadcasting bot status");
+    }
+
+    [Fact]
+    public async Task BroadcastBotStatusAsync_WithCancellationToken_ShouldPassToken()
+    {
+        // Arrange
+        var status = new BotStatusDto { GuildCount = 3 };
+        var cancellationTokenSource = new CancellationTokenSource();
+        var token = cancellationTokenSource.Token;
+
+        // Act
+        await _notifier.BroadcastBotStatusAsync(status, token);
+
+        // Assert
+        _mockAllClientsProxy.Verify(
+            c => c.SendCoreAsync(
+                "BotStatusUpdated",
+                It.IsAny<object[]>(),
+                token),
+            Times.Once,
+            "Should pass cancellation token to SignalR send method");
+    }
+
+    [Fact]
+    public async Task SendGuildUpdateAsync_ShouldSendToGuildGroup()
+    {
+        // Arrange
+        const ulong guildId = 123456789;
+        const string eventName = "GuildMemberJoined";
+        var eventData = new { UserId = 987654321, Username = "NewUser" };
+        var expectedGroupName = $"guild-{guildId}";
+
+        // Act
+        await _notifier.SendGuildUpdateAsync(guildId, eventName, eventData);
+
+        // Assert
+        _mockClients.Verify(
+            c => c.Group(expectedGroupName),
+            Times.Once,
+            "Should target the correct guild group");
+
+        _mockGroupClientsProxy.Verify(
+            c => c.SendCoreAsync(
+                eventName,
+                It.Is<object[]>(args => args.Length == 1 && args[0] == eventData),
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "Should send event to guild group with correct event name and data");
+    }
+
+    [Fact]
+    public async Task SendGuildUpdateAsync_ShouldLogDebugMessage()
+    {
+        // Arrange
+        const ulong guildId = 555555555;
+        const string eventName = "GuildSettingsChanged";
+        var eventData = new { SettingName = "WelcomeChannel", NewValue = 123456 };
+
+        // Act
+        await _notifier.SendGuildUpdateAsync(guildId, eventName, eventData);
+
+        // Assert
+        _mockLogger.Verify(
+            l => l.Log(
+                LogLevel.Debug,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) =>
+                    v.ToString()!.Contains("Sending guild update") &&
+                    v.ToString()!.Contains(guildId.ToString()) &&
+                    v.ToString()!.Contains(eventName)),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once,
+            "Should log debug message with guild ID and event name");
+    }
+
+    [Fact]
+    public async Task SendGuildUpdateAsync_WithDifferentGuilds_ShouldTargetCorrectGroups()
+    {
+        // Arrange
+        const ulong guildId1 = 111111111;
+        const ulong guildId2 = 222222222;
+        const string eventName = "Update";
+        var data = new { Value = 123 };
+
+        // Act
+        await _notifier.SendGuildUpdateAsync(guildId1, eventName, data);
+        await _notifier.SendGuildUpdateAsync(guildId2, eventName, data);
+
+        // Assert
+        _mockClients.Verify(
+            c => c.Group($"guild-{guildId1}"),
+            Times.Once,
+            "Should target first guild group");
+
+        _mockClients.Verify(
+            c => c.Group($"guild-{guildId2}"),
+            Times.Once,
+            "Should target second guild group");
+
+        _mockGroupClientsProxy.Verify(
+            c => c.SendCoreAsync(
+                eventName,
+                It.IsAny<object[]>(),
+                It.IsAny<CancellationToken>()),
+            Times.Exactly(2),
+            "Should send to both guild groups");
+    }
+
+    [Fact]
+    public async Task SendGuildUpdateAsync_WithCancellationToken_ShouldPassToken()
+    {
+        // Arrange
+        const ulong guildId = 999999999;
+        const string eventName = "TestEvent";
+        var data = new { Test = true };
+        var cancellationTokenSource = new CancellationTokenSource();
+        var token = cancellationTokenSource.Token;
+
+        // Act
+        await _notifier.SendGuildUpdateAsync(guildId, eventName, data, token);
+
+        // Assert
+        _mockGroupClientsProxy.Verify(
+            c => c.SendCoreAsync(
+                eventName,
+                It.IsAny<object[]>(),
+                token),
+            Times.Once,
+            "Should pass cancellation token to SignalR send method");
+    }
+
+    [Fact]
+    public async Task BroadcastToAllAsync_ShouldSendEventToAllClients()
+    {
+        // Arrange
+        const string eventName = "ServerMaintenance";
+        var eventData = new
+        {
+            Message = "Server will restart in 5 minutes",
+            ScheduledTime = DateTime.UtcNow.AddMinutes(5)
+        };
+
+        // Act
+        await _notifier.BroadcastToAllAsync(eventName, eventData);
+
+        // Assert
+        _mockAllClientsProxy.Verify(
+            c => c.SendCoreAsync(
+                eventName,
+                It.Is<object[]>(args => args.Length == 1 && args[0] == eventData),
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "Should send custom event to all clients");
+    }
+
+    [Fact]
+    public async Task BroadcastToAllAsync_ShouldLogDebugMessage()
+    {
+        // Arrange
+        const string eventName = "CustomNotification";
+        var data = new { Type = "Info", Content = "Test" };
+
+        // Act
+        await _notifier.BroadcastToAllAsync(eventName, data);
+
+        // Assert
+        _mockLogger.Verify(
+            l => l.Log(
+                LogLevel.Debug,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) =>
+                    v.ToString()!.Contains("Broadcasting to all clients") &&
+                    v.ToString()!.Contains(eventName)),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once,
+            "Should log debug message with event name");
+    }
+
+    [Fact]
+    public async Task BroadcastToAllAsync_WithDifferentEvents_ShouldSendEachEvent()
+    {
+        // Arrange
+        const string event1 = "Event1";
+        const string event2 = "Event2";
+        var data1 = new { Value = 1 };
+        var data2 = new { Value = 2 };
+
+        // Act
+        await _notifier.BroadcastToAllAsync(event1, data1);
+        await _notifier.BroadcastToAllAsync(event2, data2);
+
+        // Assert
+        _mockAllClientsProxy.Verify(
+            c => c.SendCoreAsync(
+                event1,
+                It.Is<object[]>(args => args[0] == data1),
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "Should send first event with correct data");
+
+        _mockAllClientsProxy.Verify(
+            c => c.SendCoreAsync(
+                event2,
+                It.Is<object[]>(args => args[0] == data2),
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "Should send second event with correct data");
+    }
+
+    [Fact]
+    public async Task BroadcastToAllAsync_WithCancellationToken_ShouldPassToken()
+    {
+        // Arrange
+        const string eventName = "TestEvent";
+        var data = new { Test = true };
+        var cancellationTokenSource = new CancellationTokenSource();
+        var token = cancellationTokenSource.Token;
+
+        // Act
+        await _notifier.BroadcastToAllAsync(eventName, data, token);
+
+        // Assert
+        _mockAllClientsProxy.Verify(
+            c => c.SendCoreAsync(
+                eventName,
+                It.IsAny<object[]>(),
+                token),
+            Times.Once,
+            "Should pass cancellation token to SignalR send method");
+    }
+
+    [Fact]
+    public async Task BroadcastToAllAsync_WithComplexObject_ShouldSerializeCorrectly()
+    {
+        // Arrange
+        const string eventName = "ComplexEvent";
+        var complexData = new
+        {
+            Id = 12345,
+            Name = "Test",
+            Tags = new[] { "tag1", "tag2", "tag3" },
+            Metadata = new { CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow },
+            IsActive = true
+        };
+
+        // Act
+        await _notifier.BroadcastToAllAsync(eventName, complexData);
+
+        // Assert
+        _mockAllClientsProxy.Verify(
+            c => c.SendCoreAsync(
+                eventName,
+                It.Is<object[]>(args =>
+                    args.Length == 1 &&
+                    args[0] == complexData),
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "Should send complex object without modification");
+    }
+
+    [Fact]
+    public async Task SendGuildUpdateAsync_WithComplexEventData_ShouldSendCorrectly()
+    {
+        // Arrange
+        const ulong guildId = 777777777;
+        const string eventName = "ComplexGuildEvent";
+        var complexData = new
+        {
+            GuildId = guildId,
+            Members = new[] { 1UL, 2UL, 3UL },
+            Settings = new { WelcomeEnabled = true, LogChannel = 123456UL },
+            Timestamp = DateTime.UtcNow
+        };
+
+        // Act
+        await _notifier.SendGuildUpdateAsync(guildId, eventName, complexData);
+
+        // Assert
+        _mockGroupClientsProxy.Verify(
+            c => c.SendCoreAsync(
+                eventName,
+                It.Is<object[]>(args =>
+                    args.Length == 1 &&
+                    args[0] == complexData),
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "Should send complex guild event data without modification");
+    }
+}


### PR DESCRIPTION
## Summary

Add SignalR infrastructure for real-time dashboard communication, establishing the foundation for live updates in the admin UI.

- Create DashboardHub with RequireViewer authorization
- Implement IDashboardNotifier service for broadcasting updates
- Add SignalR JavaScript client with automatic reconnection
- Map hub endpoint at /hubs/dashboard

## Changes

### Server Components
| File | Purpose |
|------|---------|
| `src/DiscordBot.Bot/Hubs/DashboardHub.cs` | SignalR hub with group management |
| `src/DiscordBot.Core/Interfaces/IDashboardNotifier.cs` | Abstraction for broadcasting |
| `src/DiscordBot.Bot/Services/DashboardNotifier.cs` | Implementation using IHubContext |
| `src/DiscordBot.Bot/Program.cs` | SignalR service registration and endpoint mapping |

### Client Components
| File | Purpose |
|------|---------|
| `src/DiscordBot.Bot/wwwroot/js/dashboard-hub.js` | Connection manager with reconnection |
| `src/DiscordBot.Bot/Pages/Shared/_Layout.cshtml` | SignalR client library reference |

### Tests
| File | Tests |
|------|-------|
| `tests/DiscordBot.Tests/Hubs/DashboardHubTests.cs` | 12 tests for hub methods |
| `tests/DiscordBot.Tests/Services/DashboardNotifierTests.cs` | 13 tests for notifier |

### Documentation
| File | Purpose |
|------|---------|
| `docs/articles/signalr-realtime.md` | Technical documentation |
| `docs/plans/issue-243-signalr-infrastructure.md` | Implementation plan |

## Test Plan

- [x] All 1,283 tests pass
- [x] 25 new SignalR-specific tests added
- [ ] Manual testing: Connect to hub in browser console with `DashboardHub.connect()`
- [ ] Verify authentication required (401 when logged out)
- [ ] Verify group subscription with `DashboardHub.joinGuildGroup('123')`

## Related Issues

- Closes #243
- Part of #218 (Real-time Dashboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)