### PR TITLE
feat: Add dashboard stats API endpoint and complete dashboard tests (closes #249, closes #250)

### DIFF
--- a/src/DiscordBot.Bot/Controllers/BotController.cs
+++ b/src/DiscordBot.Bot/Controllers/BotController.cs
@@ -1,7 +1,11 @@
 using DiscordBot.Bot.Extensions;
+using DiscordBot.Core.Configuration;
 using DiscordBot.Core.DTOs;
 using DiscordBot.Core.Interfaces;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
 
 namespace DiscordBot.Bot.Controllers;
 
@@ -13,16 +17,36 @@ namespace DiscordBot.Bot.Controllers;
 public class BotController : ControllerBase
 {
     private readonly IBotService _botService;
+    private readonly IGuildService _guildService;
+    private readonly ICommandLogService _commandLogService;
+    private readonly IMemoryCache _cache;
+    private readonly CachingOptions _cachingOptions;
     private readonly ILogger<BotController> _logger;
+
+    private const string DashboardStatsCacheKey = "dashboard:aggregated-stats";
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BotController"/> class.
     /// </summary>
     /// <param name="botService">The bot service.</param>
+    /// <param name="guildService">The guild service.</param>
+    /// <param name="commandLogService">The command log service.</param>
+    /// <param name="cache">The memory cache.</param>
+    /// <param name="cachingOptions">The caching configuration options.</param>
     /// <param name="logger">The logger.</param>
-    public BotController(IBotService botService, ILogger<BotController> logger)
+    public BotController(
+        IBotService botService,
+        IGuildService guildService,
+        ICommandLogService commandLogService,
+        IMemoryCache cache,
+        IOptions<CachingOptions> cachingOptions,
+        ILogger<BotController> logger)
     {
         _botService = botService;
+        _guildService = guildService;
+        _commandLogService = commandLogService;
+        _cache = cache;
+        _cachingOptions = cachingOptions.Value;
         _logger = logger;
     }
 
@@ -59,6 +83,105 @@ public class BotController : ControllerBase
         _logger.LogTrace("Retrieved {Count} connected guilds", guilds.Count);
 
         return Ok(guilds);
+    }
+
+    /// <summary>
+    /// Gets aggregated dashboard statistics for initial load or SignalR fallback.
+    /// Returns bot status, guild stats, command stats, and recent activity.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Aggregated dashboard statistics.</returns>
+    [HttpGet("dashboard-stats")]
+    [Authorize(Policy = "RequireViewer")]
+    [ProducesResponseType(typeof(DashboardAggregatedDto), StatusCodes.Status200OK)]
+    public async Task<ActionResult<DashboardAggregatedDto>> GetDashboardStats(CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("Dashboard stats requested");
+
+        // Try to get from cache first
+        if (_cache.TryGetValue(DashboardStatsCacheKey, out DashboardAggregatedDto? cachedStats) && cachedStats != null)
+        {
+            _logger.LogTrace("Dashboard stats retrieved from cache");
+            return Ok(cachedStats);
+        }
+
+        // Build fresh stats
+        var stats = await BuildDashboardStatsAsync(cancellationToken);
+
+        // Cache the result
+        var cacheOptions = new MemoryCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(_cachingOptions.DashboardStatsCacheDurationSeconds)
+        };
+        _cache.Set(DashboardStatsCacheKey, stats, cacheOptions);
+
+        _logger.LogTrace("Dashboard stats retrieved and cached: {GuildCount} guilds, {TotalCommands} commands",
+            stats.GuildStats.TotalGuilds, stats.CommandStats.TotalCommands);
+
+        return Ok(stats);
+    }
+
+    /// <summary>
+    /// Builds aggregated dashboard statistics from all sources.
+    /// </summary>
+    private async Task<DashboardAggregatedDto> BuildDashboardStatsAsync(CancellationToken cancellationToken)
+    {
+        var now = DateTime.UtcNow;
+        var since24Hours = now.AddHours(-24);
+
+        // Get bot status
+        var botStatus = _botService.GetStatus();
+
+        // Get all guilds for member count
+        var guilds = await _guildService.GetAllGuildsAsync(cancellationToken);
+
+        // Get command stats for last 24 hours
+        var commandUsage = await _commandLogService.GetCommandStatsAsync(since24Hours, cancellationToken);
+
+        // Get recent command logs
+        var recentLogsResponse = await _commandLogService.GetLogsAsync(
+            new CommandLogQueryDto { Page = 1, PageSize = 10 },
+            cancellationToken);
+
+        // Build response matching SignalR update format
+        return new DashboardAggregatedDto
+        {
+            BotStatus = new BotStatusUpdateDto
+            {
+                ConnectionState = botStatus.ConnectionState,
+                Latency = botStatus.LatencyMs,
+                GuildCount = botStatus.GuildCount,
+                Uptime = botStatus.Uptime,
+                Timestamp = now
+            },
+            GuildStats = new GuildStatsDto
+            {
+                TotalGuilds = guilds.Count,
+                TotalMembers = guilds.Sum(g => g.MemberCount ?? 0)
+            },
+            CommandStats = new CommandStatsDto
+            {
+                TotalCommands = commandUsage.Values.Sum(),
+                SuccessfulCommands = recentLogsResponse.Items.Count(c => c.Success),
+                FailedCommands = recentLogsResponse.Items.Count(c => !c.Success),
+                CommandUsage = commandUsage
+            },
+            RecentActivity = recentLogsResponse.Items
+                .Select(log => new RecentActivityItemDto
+                {
+                    Id = log.Id,
+                    Type = "CommandExecuted",
+                    Description = $"/{log.CommandName}",
+                    Timestamp = log.ExecutedAt,
+                    GuildId = log.GuildId,
+                    GuildName = log.GuildName,
+                    UserId = log.UserId,
+                    Username = log.Username,
+                    Success = log.Success
+                })
+                .ToList(),
+            Timestamp = now
+        };
     }
 
     /// <summary>

--- a/src/DiscordBot.Core/Configuration/CachingOptions.cs
+++ b/src/DiscordBot.Core/Configuration/CachingOptions.cs
@@ -37,4 +37,11 @@ public class CachingOptions
     /// Default is 5 minutes.
     /// </summary>
     public int ConsentCacheDurationMinutes { get; set; } = 5;
+
+    /// <summary>
+    /// Gets or sets the cache duration (in seconds) for dashboard statistics.
+    /// Used to reduce load when fetching aggregated dashboard data.
+    /// Default is 5 seconds.
+    /// </summary>
+    public int DashboardStatsCacheDurationSeconds { get; set; } = 5;
 }

--- a/src/DiscordBot.Core/DTOs/DashboardAggregatedDto.cs
+++ b/src/DiscordBot.Core/DTOs/DashboardAggregatedDto.cs
@@ -1,0 +1,126 @@
+namespace DiscordBot.Core.DTOs;
+
+/// <summary>
+/// Data transfer object for aggregated dashboard statistics.
+/// Returned by the dashboard-stats API endpoint as a fallback when SignalR is unavailable.
+/// </summary>
+public class DashboardAggregatedDto
+{
+    /// <summary>
+    /// Gets or sets the bot status information.
+    /// </summary>
+    public BotStatusUpdateDto BotStatus { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the guild statistics.
+    /// </summary>
+    public GuildStatsDto GuildStats { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the command statistics for the last 24 hours.
+    /// </summary>
+    public CommandStatsDto CommandStats { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the recent activity items.
+    /// </summary>
+    public IReadOnlyList<RecentActivityItemDto> RecentActivity { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the timestamp when this data was retrieved.
+    /// </summary>
+    public DateTime Timestamp { get; set; }
+}
+
+/// <summary>
+/// Data transfer object for guild statistics.
+/// </summary>
+public class GuildStatsDto
+{
+    /// <summary>
+    /// Gets or sets the total number of guilds.
+    /// </summary>
+    public int TotalGuilds { get; set; }
+
+    /// <summary>
+    /// Gets or sets the total number of members across all guilds.
+    /// </summary>
+    public int TotalMembers { get; set; }
+}
+
+/// <summary>
+/// Data transfer object for command statistics.
+/// </summary>
+public class CommandStatsDto
+{
+    /// <summary>
+    /// Gets or sets the total number of commands executed in the time period.
+    /// </summary>
+    public int TotalCommands { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of successful commands.
+    /// </summary>
+    public int SuccessfulCommands { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of failed commands.
+    /// </summary>
+    public int FailedCommands { get; set; }
+
+    /// <summary>
+    /// Gets or sets the command usage by command name.
+    /// </summary>
+    public IDictionary<string, int> CommandUsage { get; set; } = new Dictionary<string, int>();
+}
+
+/// <summary>
+/// Data transfer object for a recent activity item.
+/// </summary>
+public class RecentActivityItemDto
+{
+    /// <summary>
+    /// Gets or sets the unique identifier for the activity.
+    /// </summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the type of activity (e.g., "CommandExecuted").
+    /// </summary>
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the description of the activity.
+    /// </summary>
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the timestamp when the activity occurred.
+    /// </summary>
+    public DateTime Timestamp { get; set; }
+
+    /// <summary>
+    /// Gets or sets the guild ID where the activity occurred.
+    /// </summary>
+    public ulong? GuildId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the guild name where the activity occurred.
+    /// </summary>
+    public string? GuildName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the user ID who performed the activity.
+    /// </summary>
+    public ulong UserId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the username who performed the activity.
+    /// </summary>
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the activity was successful.
+    /// </summary>
+    public bool Success { get; set; }
+}

--- a/tests/DiscordBot.Tests/Controllers/BotControllerTests.cs
+++ b/tests/DiscordBot.Tests/Controllers/BotControllerTests.cs
@@ -1,0 +1,419 @@
+using DiscordBot.Bot.Controllers;
+using DiscordBot.Core.Configuration;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace DiscordBot.Tests.Controllers;
+
+/// <summary>
+/// Unit tests for <see cref="BotController"/>.
+/// </summary>
+public class BotControllerTests
+{
+    private readonly Mock<IBotService> _mockBotService;
+    private readonly Mock<IGuildService> _mockGuildService;
+    private readonly Mock<ICommandLogService> _mockCommandLogService;
+    private readonly IMemoryCache _cache;
+    private readonly Mock<ILogger<BotController>> _mockLogger;
+    private readonly BotController _controller;
+
+    public BotControllerTests()
+    {
+        _mockBotService = new Mock<IBotService>();
+        _mockGuildService = new Mock<IGuildService>();
+        _mockCommandLogService = new Mock<ICommandLogService>();
+        _cache = new MemoryCache(new MemoryCacheOptions());
+        _mockLogger = new Mock<ILogger<BotController>>();
+
+        var cachingOptions = Options.Create(new CachingOptions
+        {
+            DashboardStatsCacheDurationSeconds = 5
+        });
+
+        _controller = new BotController(
+            _mockBotService.Object,
+            _mockGuildService.Object,
+            _mockCommandLogService.Object,
+            _cache,
+            cachingOptions,
+            _mockLogger.Object);
+
+        // Setup HttpContext for TraceIdentifier
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+    }
+
+    #region GetStatus Tests
+
+    [Fact]
+    public void GetStatus_ShouldReturnOkWithBotStatus()
+    {
+        // Arrange
+        var expectedStatus = new BotStatusDto
+        {
+            Uptime = TimeSpan.FromHours(5),
+            GuildCount = 10,
+            LatencyMs = 42,
+            ConnectionState = "Connected",
+            BotUsername = "TestBot",
+            StartTime = DateTime.UtcNow.AddHours(-5)
+        };
+
+        _mockBotService.Setup(s => s.GetStatus()).Returns(expectedStatus);
+
+        // Act
+        var result = _controller.GetStatus();
+
+        // Assert
+        result.Result.Should().BeOfType<OkObjectResult>();
+        var okResult = result.Result as OkObjectResult;
+        okResult!.Value.Should().BeSameAs(expectedStatus);
+    }
+
+    #endregion
+
+    #region GetConnectedGuilds Tests
+
+    [Fact]
+    public void GetConnectedGuilds_ShouldReturnOkWithGuildList()
+    {
+        // Arrange
+        var expectedGuilds = new List<GuildInfoDto>
+        {
+            new() { Id = 123456789, Name = "Test Guild 1", MemberCount = 100 },
+            new() { Id = 987654321, Name = "Test Guild 2", MemberCount = 50 }
+        };
+
+        _mockBotService.Setup(s => s.GetConnectedGuilds()).Returns(expectedGuilds);
+
+        // Act
+        var result = _controller.GetConnectedGuilds();
+
+        // Assert
+        result.Result.Should().BeOfType<OkObjectResult>();
+        var okResult = result.Result as OkObjectResult;
+        okResult!.Value.Should().BeSameAs(expectedGuilds);
+    }
+
+    #endregion
+
+    #region GetDashboardStats Tests
+
+    [Fact]
+    public async Task GetDashboardStats_ShouldReturnAggregatedStats()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        var result = await _controller.GetDashboardStats(CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<OkObjectResult>();
+        var okResult = result.Result as OkObjectResult;
+        var stats = okResult!.Value as DashboardAggregatedDto;
+
+        stats.Should().NotBeNull();
+        stats!.BotStatus.ConnectionState.Should().Be("Connected");
+        stats.BotStatus.GuildCount.Should().Be(5);
+        stats.GuildStats.TotalGuilds.Should().Be(2);
+        stats.GuildStats.TotalMembers.Should().Be(150);
+        stats.CommandStats.TotalCommands.Should().Be(25);
+        stats.RecentActivity.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task GetDashboardStats_ShouldCacheResult()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act - First call
+        await _controller.GetDashboardStats(CancellationToken.None);
+
+        // Act - Second call (should use cache)
+        await _controller.GetDashboardStats(CancellationToken.None);
+
+        // Assert - Services should only be called once
+        _mockBotService.Verify(s => s.GetStatus(), Times.Once);
+        _mockGuildService.Verify(s => s.GetAllGuildsAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _mockCommandLogService.Verify(s => s.GetCommandStatsAsync(It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()), Times.Once);
+        _mockCommandLogService.Verify(s => s.GetLogsAsync(It.IsAny<CommandLogQueryDto>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetDashboardStats_ShouldReturnCachedResult()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act - First call
+        var firstResult = await _controller.GetDashboardStats(CancellationToken.None);
+
+        // Modify mock to return different data
+        _mockBotService.Setup(s => s.GetStatus()).Returns(new BotStatusDto
+        {
+            ConnectionState = "Disconnected",
+            GuildCount = 0
+        });
+
+        // Act - Second call (should return cached result, not new data)
+        var secondResult = await _controller.GetDashboardStats(CancellationToken.None);
+
+        // Assert - Both results should be the same (from cache)
+        var firstStats = (firstResult.Result as OkObjectResult)?.Value as DashboardAggregatedDto;
+        var secondStats = (secondResult.Result as OkObjectResult)?.Value as DashboardAggregatedDto;
+
+        secondStats!.BotStatus.ConnectionState.Should().Be("Connected");
+        secondStats.BotStatus.GuildCount.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task GetDashboardStats_ShouldIncludeBotStatus()
+    {
+        // Arrange
+        var botStatus = new BotStatusDto
+        {
+            Uptime = TimeSpan.FromHours(10),
+            GuildCount = 15,
+            LatencyMs = 35,
+            ConnectionState = "Connected",
+            BotUsername = "TestBot",
+            StartTime = DateTime.UtcNow.AddHours(-10)
+        };
+
+        _mockBotService.Setup(s => s.GetStatus()).Returns(botStatus);
+        _mockGuildService.Setup(s => s.GetAllGuildsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<GuildDto>().AsReadOnly());
+        _mockCommandLogService.Setup(s => s.GetCommandStatsAsync(It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, int>());
+        _mockCommandLogService.Setup(s => s.GetLogsAsync(It.IsAny<CommandLogQueryDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaginatedResponseDto<CommandLogDto> { Items = new List<CommandLogDto>() });
+
+        // Act
+        var result = await _controller.GetDashboardStats(CancellationToken.None);
+
+        // Assert
+        var stats = (result.Result as OkObjectResult)?.Value as DashboardAggregatedDto;
+        stats!.BotStatus.ConnectionState.Should().Be("Connected");
+        stats.BotStatus.Latency.Should().Be(35);
+        stats.BotStatus.GuildCount.Should().Be(15);
+        stats.BotStatus.Uptime.Should().Be(TimeSpan.FromHours(10));
+    }
+
+    [Fact]
+    public async Task GetDashboardStats_ShouldCalculateTotalMembers()
+    {
+        // Arrange
+        _mockBotService.Setup(s => s.GetStatus()).Returns(new BotStatusDto { ConnectionState = "Connected" });
+        _mockGuildService.Setup(s => s.GetAllGuildsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<GuildDto>
+            {
+                new() { Id = 1, Name = "Guild 1", MemberCount = 100 },
+                new() { Id = 2, Name = "Guild 2", MemberCount = 200 },
+                new() { Id = 3, Name = "Guild 3", MemberCount = 300 }
+            }.AsReadOnly());
+        _mockCommandLogService.Setup(s => s.GetCommandStatsAsync(It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, int>());
+        _mockCommandLogService.Setup(s => s.GetLogsAsync(It.IsAny<CommandLogQueryDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaginatedResponseDto<CommandLogDto> { Items = new List<CommandLogDto>() });
+
+        // Act
+        var result = await _controller.GetDashboardStats(CancellationToken.None);
+
+        // Assert
+        var stats = (result.Result as OkObjectResult)?.Value as DashboardAggregatedDto;
+        stats!.GuildStats.TotalGuilds.Should().Be(3);
+        stats.GuildStats.TotalMembers.Should().Be(600);
+    }
+
+    [Fact]
+    public async Task GetDashboardStats_ShouldIncludeCommandStats()
+    {
+        // Arrange
+        _mockBotService.Setup(s => s.GetStatus()).Returns(new BotStatusDto { ConnectionState = "Connected" });
+        _mockGuildService.Setup(s => s.GetAllGuildsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<GuildDto>().AsReadOnly());
+        _mockCommandLogService.Setup(s => s.GetCommandStatsAsync(It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, int>
+            {
+                { "ping", 50 },
+                { "help", 30 },
+                { "info", 20 }
+            });
+        _mockCommandLogService.Setup(s => s.GetLogsAsync(It.IsAny<CommandLogQueryDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaginatedResponseDto<CommandLogDto>
+            {
+                Items = new List<CommandLogDto>
+                {
+                    new() { Id = Guid.NewGuid(), CommandName = "ping", Success = true },
+                    new() { Id = Guid.NewGuid(), CommandName = "help", Success = true },
+                    new() { Id = Guid.NewGuid(), CommandName = "fail", Success = false }
+                }
+            });
+
+        // Act
+        var result = await _controller.GetDashboardStats(CancellationToken.None);
+
+        // Assert
+        var stats = (result.Result as OkObjectResult)?.Value as DashboardAggregatedDto;
+        stats!.CommandStats.TotalCommands.Should().Be(100);
+        stats.CommandStats.SuccessfulCommands.Should().Be(2);
+        stats.CommandStats.FailedCommands.Should().Be(1);
+        stats.CommandStats.CommandUsage.Should().ContainKey("ping");
+        stats.CommandStats.CommandUsage["ping"].Should().Be(50);
+    }
+
+    [Fact]
+    public async Task GetDashboardStats_ShouldIncludeRecentActivity()
+    {
+        // Arrange
+        var commandLog = new CommandLogDto
+        {
+            Id = Guid.NewGuid(),
+            CommandName = "ping",
+            ExecutedAt = DateTime.UtcNow.AddMinutes(-5),
+            GuildId = 123456789,
+            GuildName = "Test Guild",
+            UserId = 987654321,
+            Username = "TestUser",
+            Success = true
+        };
+
+        _mockBotService.Setup(s => s.GetStatus()).Returns(new BotStatusDto { ConnectionState = "Connected" });
+        _mockGuildService.Setup(s => s.GetAllGuildsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<GuildDto>().AsReadOnly());
+        _mockCommandLogService.Setup(s => s.GetCommandStatsAsync(It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, int>());
+        _mockCommandLogService.Setup(s => s.GetLogsAsync(It.IsAny<CommandLogQueryDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaginatedResponseDto<CommandLogDto> { Items = new List<CommandLogDto> { commandLog } });
+
+        // Act
+        var result = await _controller.GetDashboardStats(CancellationToken.None);
+
+        // Assert
+        var stats = (result.Result as OkObjectResult)?.Value as DashboardAggregatedDto;
+        stats!.RecentActivity.Should().HaveCount(1);
+
+        var activity = stats.RecentActivity[0];
+        activity.Id.Should().Be(commandLog.Id);
+        activity.Type.Should().Be("CommandExecuted");
+        activity.Description.Should().Be("/ping");
+        activity.GuildId.Should().Be(123456789UL);
+        activity.GuildName.Should().Be("Test Guild");
+        activity.UserId.Should().Be(987654321UL);
+        activity.Username.Should().Be("TestUser");
+        activity.Success.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetDashboardStats_ShouldRequestLast10RecentActivities()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await _controller.GetDashboardStats(CancellationToken.None);
+
+        // Assert
+        _mockCommandLogService.Verify(
+            s => s.GetLogsAsync(
+                It.Is<CommandLogQueryDto>(q => q.PageSize == 10 && q.Page == 1),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetDashboardStats_ShouldIncludeTimestamp()
+    {
+        // Arrange
+        SetupDefaultMocks();
+        var beforeCall = DateTime.UtcNow;
+
+        // Act
+        var result = await _controller.GetDashboardStats(CancellationToken.None);
+        var afterCall = DateTime.UtcNow;
+
+        // Assert
+        var stats = (result.Result as OkObjectResult)?.Value as DashboardAggregatedDto;
+        stats!.Timestamp.Should().BeOnOrAfter(beforeCall);
+        stats.Timestamp.Should().BeOnOrBefore(afterCall);
+        stats.BotStatus.Timestamp.Should().BeOnOrAfter(beforeCall);
+        stats.BotStatus.Timestamp.Should().BeOnOrBefore(afterCall);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private void SetupDefaultMocks()
+    {
+        _mockBotService.Setup(s => s.GetStatus()).Returns(new BotStatusDto
+        {
+            Uptime = TimeSpan.FromHours(5),
+            GuildCount = 5,
+            LatencyMs = 42,
+            ConnectionState = "Connected",
+            BotUsername = "TestBot",
+            StartTime = DateTime.UtcNow.AddHours(-5)
+        });
+
+        _mockGuildService.Setup(s => s.GetAllGuildsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<GuildDto>
+            {
+                new() { Id = 1, Name = "Guild 1", MemberCount = 100 },
+                new() { Id = 2, Name = "Guild 2", MemberCount = 50 }
+            }.AsReadOnly());
+
+        _mockCommandLogService.Setup(s => s.GetCommandStatsAsync(It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, int>
+            {
+                { "ping", 15 },
+                { "help", 10 }
+            });
+
+        _mockCommandLogService.Setup(s => s.GetLogsAsync(It.IsAny<CommandLogQueryDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaginatedResponseDto<CommandLogDto>
+            {
+                Items = new List<CommandLogDto>
+                {
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        CommandName = "ping",
+                        ExecutedAt = DateTime.UtcNow.AddMinutes(-1),
+                        GuildId = 123456789,
+                        GuildName = "Test Guild",
+                        UserId = 987654321,
+                        Username = "TestUser",
+                        Success = true
+                    },
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        CommandName = "help",
+                        ExecutedAt = DateTime.UtcNow.AddMinutes(-5),
+                        GuildId = 123456789,
+                        GuildName = "Test Guild",
+                        UserId = 111111111,
+                        Username = "AnotherUser",
+                        Success = true
+                    }
+                },
+                TotalCount = 2,
+                Page = 1,
+                PageSize = 10
+            });
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

- Adds GET `/api/bot/dashboard-stats` endpoint that returns aggregated dashboard data for initial page load and SignalR fallback scenarios
- Response is cached for 5 seconds (configurable) to reduce database load
- Existing tests for `DashboardHub` and `DashboardUpdateService` already satisfy #250 requirements; added `BotControllerTests` for the new endpoint

## Changes Made

### New Files
- `src/DiscordBot.Core/DTOs/DashboardAggregatedDto.cs` - Response DTOs for aggregated dashboard data
- `tests/DiscordBot.Tests/Controllers/BotControllerTests.cs` - Comprehensive tests for BotController

### Modified Files
- `src/DiscordBot.Bot/Controllers/BotController.cs` - Added dashboard-stats endpoint with caching
- `src/DiscordBot.Core/Configuration/CachingOptions.cs` - Added DashboardStatsCacheDurationSeconds option

## API Details

**Endpoint:** `GET /api/bot/dashboard-stats`  
**Authorization:** RequireViewer policy

**Response includes:**
- Bot status (connection state, latency, uptime, guild count)
- Guild stats (total guilds, total members)
- Command stats (24h counts, usage breakdown)
- Recent activity (last 10 command executions)

## Test plan

- [x] All 1343 tests pass (12 skipped as expected)
- [x] New BotController tests cover endpoint functionality
- [x] Existing DashboardHub and DashboardUpdateService tests verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)