### PR TITLE
feat: Add ScheduledMessage service layer, background executor, and API controller

### DIFF
--- a/src/DiscordBot.Bot/Controllers/ScheduledMessagesController.cs
+++ b/src/DiscordBot.Bot/Controllers/ScheduledMessagesController.cs
@@ -1,0 +1,451 @@
+using DiscordBot.Bot.Extensions;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DiscordBot.Bot.Controllers;
+
+/// <summary>
+/// Controller for scheduled message operations and management.
+/// Provides CRUD operations and execution control for scheduled messages within guilds.
+/// </summary>
+[ApiController]
+[Route("api/guilds/{guildId}/scheduled-messages")]
+[Authorize(Policy = "RequireAdmin")]
+public class ScheduledMessagesController : ControllerBase
+{
+    private readonly IScheduledMessageService _scheduledMessageService;
+    private readonly ILogger<ScheduledMessagesController> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ScheduledMessagesController"/> class.
+    /// </summary>
+    /// <param name="scheduledMessageService">The scheduled message service.</param>
+    /// <param name="logger">The logger.</param>
+    public ScheduledMessagesController(
+        IScheduledMessageService scheduledMessageService,
+        ILogger<ScheduledMessagesController> logger)
+    {
+        _scheduledMessageService = scheduledMessageService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Gets all scheduled messages for a guild with pagination.
+    /// </summary>
+    /// <param name="guildId">The guild's Discord snowflake ID.</param>
+    /// <param name="page">Page number (1-based). Default is 1.</param>
+    /// <param name="pageSize">Number of items per page. Default is 20.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A paginated list of scheduled messages for the guild.</returns>
+    [HttpGet]
+    [ProducesResponseType(typeof(PaginatedResponseDto<ScheduledMessageDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<PaginatedResponseDto<ScheduledMessageDto>>> GetScheduledMessages(
+        ulong guildId,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 20,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Scheduled messages list requested for guild {GuildId}, page {Page}, pageSize {PageSize}",
+            guildId, page, pageSize);
+
+        if (page < 1)
+        {
+            _logger.LogWarning("Invalid page number: {Page}", page);
+
+            return BadRequest(new ApiErrorDto
+            {
+                Message = "Invalid page number",
+                Detail = "Page number must be greater than or equal to 1.",
+                StatusCode = StatusCodes.Status400BadRequest,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+
+        if (pageSize < 1 || pageSize > 100)
+        {
+            _logger.LogWarning("Invalid page size: {PageSize}", pageSize);
+
+            return BadRequest(new ApiErrorDto
+            {
+                Message = "Invalid page size",
+                Detail = "Page size must be between 1 and 100.",
+                StatusCode = StatusCodes.Status400BadRequest,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+
+        var (items, totalCount) = await _scheduledMessageService.GetByGuildIdAsync(
+            guildId,
+            page,
+            pageSize,
+            cancellationToken);
+
+        var response = new PaginatedResponseDto<ScheduledMessageDto>
+        {
+            Items = items.ToList(),
+            Page = page,
+            PageSize = pageSize,
+            TotalCount = totalCount
+        };
+
+        _logger.LogTrace("Retrieved {Count} of {Total} scheduled messages for guild {GuildId}",
+            items.Count(), totalCount, guildId);
+
+        return Ok(response);
+    }
+
+    /// <summary>
+    /// Gets a specific scheduled message by ID.
+    /// </summary>
+    /// <param name="guildId">The guild's Discord snowflake ID.</param>
+    /// <param name="id">The scheduled message's unique identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The scheduled message data if found.</returns>
+    [HttpGet("{id}")]
+    [ProducesResponseType(typeof(ScheduledMessageDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<ScheduledMessageDto>> GetScheduledMessageById(
+        ulong guildId,
+        Guid id,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("Scheduled message {MessageId} requested for guild {GuildId}", id, guildId);
+
+        var message = await _scheduledMessageService.GetByIdAsync(id, cancellationToken);
+
+        if (message == null || message.GuildId != guildId)
+        {
+            _logger.LogWarning("Scheduled message {MessageId} not found for guild {GuildId}", id, guildId);
+
+            return NotFound(new ApiErrorDto
+            {
+                Message = "Scheduled message not found",
+                Detail = $"No scheduled message with ID {id} exists for guild {guildId}.",
+                StatusCode = StatusCodes.Status404NotFound,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+
+        _logger.LogTrace("Scheduled message {MessageId} retrieved: {Title}", id, message.Title);
+
+        return Ok(message);
+    }
+
+    /// <summary>
+    /// Creates a new scheduled message.
+    /// </summary>
+    /// <param name="guildId">The guild's Discord snowflake ID.</param>
+    /// <param name="request">The creation request containing the scheduled message data.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The created scheduled message data.</returns>
+    [HttpPost]
+    [ProducesResponseType(typeof(ScheduledMessageDto), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<ScheduledMessageDto>> CreateScheduledMessage(
+        ulong guildId,
+        [FromBody] ScheduledMessageCreateDto request,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Scheduled message creation requested for guild {GuildId}", guildId);
+
+        if (request == null)
+        {
+            _logger.LogWarning("Invalid scheduled message creation request: request body is null");
+
+            return BadRequest(new ApiErrorDto
+            {
+                Message = "Invalid request",
+                Detail = "Request body cannot be null.",
+                StatusCode = StatusCodes.Status400BadRequest,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+
+        // Ensure the GuildId from the route matches the request (override if needed)
+        request.GuildId = guildId;
+
+        try
+        {
+            var message = await _scheduledMessageService.CreateAsync(request, cancellationToken);
+
+            _logger.LogInformation("Scheduled message {MessageId} created successfully for guild {GuildId}",
+                message.Id, guildId);
+
+            return CreatedAtAction(
+                nameof(GetScheduledMessageById),
+                new { guildId, id = message.Id },
+                message);
+        }
+        catch (ArgumentException ex)
+        {
+            _logger.LogWarning(ex, "Invalid scheduled message creation request for guild {GuildId}", guildId);
+
+            return BadRequest(new ApiErrorDto
+            {
+                Message = "Invalid request",
+                Detail = ex.Message,
+                StatusCode = StatusCodes.Status400BadRequest,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+    }
+
+    /// <summary>
+    /// Updates an existing scheduled message.
+    /// </summary>
+    /// <param name="guildId">The guild's Discord snowflake ID.</param>
+    /// <param name="id">The scheduled message's unique identifier.</param>
+    /// <param name="request">The update request containing the fields to update.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The updated scheduled message data.</returns>
+    [HttpPut("{id}")]
+    [ProducesResponseType(typeof(ScheduledMessageDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<ScheduledMessageDto>> UpdateScheduledMessage(
+        ulong guildId,
+        Guid id,
+        [FromBody] ScheduledMessageUpdateDto request,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Scheduled message {MessageId} update requested for guild {GuildId}", id, guildId);
+
+        if (request == null)
+        {
+            _logger.LogWarning("Invalid scheduled message update request: request body is null");
+
+            return BadRequest(new ApiErrorDto
+            {
+                Message = "Invalid request",
+                Detail = "Request body cannot be null.",
+                StatusCode = StatusCodes.Status400BadRequest,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+
+        // Verify the message belongs to the guild
+        var existing = await _scheduledMessageService.GetByIdAsync(id, cancellationToken);
+        if (existing == null || existing.GuildId != guildId)
+        {
+            _logger.LogWarning("Scheduled message {MessageId} not found for update in guild {GuildId}",
+                id, guildId);
+
+            return NotFound(new ApiErrorDto
+            {
+                Message = "Scheduled message not found",
+                Detail = $"No scheduled message with ID {id} exists for guild {guildId}.",
+                StatusCode = StatusCodes.Status404NotFound,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+
+        try
+        {
+            var message = await _scheduledMessageService.UpdateAsync(id, request, cancellationToken);
+
+            if (message == null)
+            {
+                _logger.LogWarning("Scheduled message {MessageId} not found for update", id);
+
+                return NotFound(new ApiErrorDto
+                {
+                    Message = "Scheduled message not found",
+                    Detail = $"No scheduled message with ID {id} exists.",
+                    StatusCode = StatusCodes.Status404NotFound,
+                    TraceId = HttpContext.GetCorrelationId()
+                });
+            }
+
+            _logger.LogInformation("Scheduled message {MessageId} updated successfully", id);
+
+            return Ok(message);
+        }
+        catch (ArgumentException ex)
+        {
+            _logger.LogWarning(ex, "Invalid scheduled message update request for message {MessageId}", id);
+
+            return BadRequest(new ApiErrorDto
+            {
+                Message = "Invalid request",
+                Detail = ex.Message,
+                StatusCode = StatusCodes.Status400BadRequest,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+    }
+
+    /// <summary>
+    /// Deletes a scheduled message.
+    /// </summary>
+    /// <param name="guildId">The guild's Discord snowflake ID.</param>
+    /// <param name="id">The scheduled message's unique identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>No content on success.</returns>
+    [HttpDelete("{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeleteScheduledMessage(
+        ulong guildId,
+        Guid id,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Scheduled message {MessageId} deletion requested for guild {GuildId}", id, guildId);
+
+        // Verify the message belongs to the guild
+        var existing = await _scheduledMessageService.GetByIdAsync(id, cancellationToken);
+        if (existing == null || existing.GuildId != guildId)
+        {
+            _logger.LogWarning("Scheduled message {MessageId} not found for deletion in guild {GuildId}",
+                id, guildId);
+
+            return NotFound(new ApiErrorDto
+            {
+                Message = "Scheduled message not found",
+                Detail = $"No scheduled message with ID {id} exists for guild {guildId}.",
+                StatusCode = StatusCodes.Status404NotFound,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+
+        var success = await _scheduledMessageService.DeleteAsync(id, cancellationToken);
+
+        if (!success)
+        {
+            _logger.LogWarning("Scheduled message {MessageId} not found for deletion", id);
+
+            return NotFound(new ApiErrorDto
+            {
+                Message = "Scheduled message not found",
+                Detail = $"No scheduled message with ID {id} exists.",
+                StatusCode = StatusCodes.Status404NotFound,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+
+        _logger.LogInformation("Scheduled message {MessageId} deleted successfully", id);
+
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Executes a scheduled message immediately, regardless of its scheduled time.
+    /// </summary>
+    /// <param name="guildId">The guild's Discord snowflake ID.</param>
+    /// <param name="id">The scheduled message's unique identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Success message.</returns>
+    [HttpPost("{id}/execute")]
+    [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> ExecuteScheduledMessage(
+        ulong guildId,
+        Guid id,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Scheduled message {MessageId} immediate execution requested for guild {GuildId}",
+            id, guildId);
+
+        // Verify the message belongs to the guild
+        var existing = await _scheduledMessageService.GetByIdAsync(id, cancellationToken);
+        if (existing == null || existing.GuildId != guildId)
+        {
+            _logger.LogWarning("Scheduled message {MessageId} not found for execution in guild {GuildId}",
+                id, guildId);
+
+            return NotFound(new ApiErrorDto
+            {
+                Message = "Scheduled message not found",
+                Detail = $"No scheduled message with ID {id} exists for guild {guildId}.",
+                StatusCode = StatusCodes.Status404NotFound,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+
+        var success = await _scheduledMessageService.ExecuteScheduledMessageAsync(id, cancellationToken);
+
+        if (!success)
+        {
+            _logger.LogError("Failed to execute scheduled message {MessageId}", id);
+
+            return StatusCode(StatusCodes.Status500InternalServerError, new ApiErrorDto
+            {
+                Message = "Execution failed",
+                Detail = $"Failed to execute scheduled message {id}. Check logs for details.",
+                StatusCode = StatusCodes.Status500InternalServerError,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+
+        _logger.LogInformation("Scheduled message {MessageId} executed successfully", id);
+
+        return Ok(new { Message = "Scheduled message executed successfully", MessageId = id });
+    }
+
+    /// <summary>
+    /// Validates a cron expression for correctness.
+    /// </summary>
+    /// <param name="guildId">The guild's Discord snowflake ID (required for route but not used).</param>
+    /// <param name="request">The validation request containing the cron expression.</param>
+    /// <returns>Validation result.</returns>
+    [HttpPost("validate-cron")]
+    [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> ValidateCronExpression(
+        ulong guildId,
+        [FromBody] CronValidationRequestDto request)
+    {
+        _logger.LogDebug("Cron expression validation requested for guild {GuildId}", guildId);
+
+        if (request == null || string.IsNullOrWhiteSpace(request.CronExpression))
+        {
+            _logger.LogWarning("Invalid cron validation request: cron expression is null or empty");
+
+            return BadRequest(new ApiErrorDto
+            {
+                Message = "Invalid request",
+                Detail = "Cron expression is required.",
+                StatusCode = StatusCodes.Status400BadRequest,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+
+        var (isValid, errorMessage) = await _scheduledMessageService.ValidateCronExpressionAsync(request.CronExpression);
+
+        if (isValid)
+        {
+            _logger.LogDebug("Cron expression validated successfully: {CronExpression}", request.CronExpression);
+
+            return Ok(new
+            {
+                IsValid = true,
+                Message = "Cron expression is valid",
+                CronExpression = request.CronExpression
+            });
+        }
+
+        _logger.LogWarning("Cron expression validation failed: {Error}", errorMessage);
+
+        return BadRequest(new ApiErrorDto
+        {
+            Message = "Invalid cron expression",
+            Detail = errorMessage,
+            StatusCode = StatusCodes.Status400BadRequest,
+            TraceId = HttpContext.GetCorrelationId()
+        });
+    }
+}
+
+/// <summary>
+/// Request DTO for cron expression validation.
+/// </summary>
+public class CronValidationRequestDto
+{
+    /// <summary>
+    /// Gets or sets the cron expression to validate.
+    /// </summary>
+    public string CronExpression { get; set; } = string.Empty;
+}

--- a/src/DiscordBot.Bot/DiscordBot.Bot.csproj
+++ b/src/DiscordBot.Bot/DiscordBot.Bot.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="AspNet.Security.OAuth.Discord" Version="8.0.0" />
+    <PackageReference Include="Cronos" Version="0.11.1" />
     <PackageReference Include="Discord.Net" Version="3.18.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.*">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/DiscordBot.Bot/Program.cs
+++ b/src/DiscordBot.Bot/Program.cs
@@ -211,6 +211,12 @@ try
     builder.Services.AddHostedService<MetricsUpdateService>();
     builder.Services.AddHostedService<BusinessMetricsUpdateService>();
 
+    // Add Scheduled Messages services
+    builder.Services.Configure<ScheduledMessagesOptions>(
+        builder.Configuration.GetSection(ScheduledMessagesOptions.SectionName));
+    builder.Services.AddScoped<IScheduledMessageService, ScheduledMessageService>();
+    builder.Services.AddHostedService<ScheduledMessageExecutionService>();
+
     // Add HttpClient for Discord API calls
     builder.Services.AddHttpClient("Discord", client =>
     {

--- a/src/DiscordBot.Bot/Services/ScheduledMessageExecutionService.cs
+++ b/src/DiscordBot.Bot/Services/ScheduledMessageExecutionService.cs
@@ -1,0 +1,150 @@
+using DiscordBot.Core.Configuration;
+using DiscordBot.Core.Interfaces;
+using Microsoft.Extensions.Options;
+
+namespace DiscordBot.Bot.Services;
+
+/// <summary>
+/// Background service that periodically checks for and executes scheduled messages that are due.
+/// Runs at configured intervals and processes messages concurrently with timeout protection.
+/// </summary>
+public class ScheduledMessageExecutionService : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IOptions<ScheduledMessagesOptions> _options;
+    private readonly ILogger<ScheduledMessageExecutionService> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ScheduledMessageExecutionService"/> class.
+    /// </summary>
+    /// <param name="scopeFactory">The service scope factory for creating scoped services.</param>
+    /// <param name="options">The scheduled messages configuration options.</param>
+    /// <param name="logger">The logger.</param>
+    public ScheduledMessageExecutionService(
+        IServiceScopeFactory scopeFactory,
+        IOptions<ScheduledMessagesOptions> options,
+        ILogger<ScheduledMessageExecutionService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _options = options;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Scheduled message execution service starting");
+
+        _logger.LogInformation(
+            "Scheduled message execution service enabled. Check interval: {IntervalSeconds}s, Max concurrent: {MaxConcurrent}, Timeout: {TimeoutSeconds}s",
+            _options.Value.CheckIntervalSeconds,
+            _options.Value.MaxConcurrentExecutions,
+            _options.Value.ExecutionTimeoutSeconds);
+
+        // Initial delay to let the app start up and Discord client connect
+        await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await ProcessDueMessagesAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                // Normal shutdown
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error during scheduled message processing");
+            }
+
+            // Wait for next check interval
+            var interval = TimeSpan.FromSeconds(_options.Value.CheckIntervalSeconds);
+            await Task.Delay(interval, stoppingToken);
+        }
+
+        _logger.LogInformation("Scheduled message execution service stopping");
+    }
+
+    /// <summary>
+    /// Processes all due scheduled messages by executing them concurrently with timeout protection.
+    /// </summary>
+    /// <param name="stoppingToken">Cancellation token to respect during processing.</param>
+    private async Task ProcessDueMessagesAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogDebug("Checking for due scheduled messages");
+
+        using var scope = _scopeFactory.CreateScope();
+        var repository = scope.ServiceProvider.GetRequiredService<IScheduledMessageRepository>();
+        var service = scope.ServiceProvider.GetRequiredService<IScheduledMessageService>();
+
+        // Get all due messages
+        var dueMessages = await repository.GetDueMessagesAsync(stoppingToken);
+        var messageList = dueMessages.ToList();
+
+        if (messageList.Count == 0)
+        {
+            _logger.LogTrace("No scheduled messages due for execution");
+            return;
+        }
+
+        _logger.LogInformation("Found {Count} scheduled messages due for execution", messageList.Count);
+
+        // Create a semaphore to limit concurrent executions
+        using var semaphore = new SemaphoreSlim(_options.Value.MaxConcurrentExecutions);
+        var executionTimeout = TimeSpan.FromSeconds(_options.Value.ExecutionTimeoutSeconds);
+
+        // Execute messages concurrently with semaphore and timeout protection
+        var executionTasks = messageList.Select(async message =>
+        {
+            await semaphore.WaitAsync(stoppingToken);
+            try
+            {
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+                cts.CancelAfter(executionTimeout);
+
+                _logger.LogDebug("Executing scheduled message {MessageId}: {Title}",
+                    message.Id, message.Title);
+
+                var success = await service.ExecuteScheduledMessageAsync(message.Id, cts.Token);
+
+                if (success)
+                {
+                    _logger.LogInformation("Successfully executed scheduled message {MessageId}: {Title}",
+                        message.Id, message.Title);
+                }
+                else
+                {
+                    _logger.LogWarning("Failed to execute scheduled message {MessageId}: {Title}",
+                        message.Id, message.Title);
+                }
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                _logger.LogInformation("Scheduled message execution cancelled due to shutdown: {MessageId}",
+                    message.Id);
+            }
+            catch (OperationCanceledException)
+            {
+                _logger.LogWarning("Scheduled message execution timed out after {Timeout}s: {MessageId}",
+                    executionTimeout.TotalSeconds, message.Id);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error executing scheduled message {MessageId}: {Title}",
+                    message.Id, message.Title);
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        });
+
+        // Wait for all executions to complete
+        await Task.WhenAll(executionTasks);
+
+        _logger.LogInformation("Completed processing {Count} scheduled messages", messageList.Count);
+    }
+}

--- a/src/DiscordBot.Bot/Services/ScheduledMessageService.cs
+++ b/src/DiscordBot.Bot/Services/ScheduledMessageService.cs
@@ -1,0 +1,429 @@
+using Cronos;
+using Discord;
+using Discord.WebSocket;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Entities;
+using DiscordBot.Core.Enums;
+using DiscordBot.Core.Interfaces;
+
+namespace DiscordBot.Bot.Services;
+
+/// <summary>
+/// Service for scheduled message operations and execution management.
+/// </summary>
+public class ScheduledMessageService : IScheduledMessageService
+{
+    private readonly IScheduledMessageRepository _repository;
+    private readonly DiscordSocketClient _client;
+    private readonly ILogger<ScheduledMessageService> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ScheduledMessageService"/> class.
+    /// </summary>
+    /// <param name="repository">The scheduled message repository.</param>
+    /// <param name="client">The Discord socket client.</param>
+    /// <param name="logger">The logger.</param>
+    public ScheduledMessageService(
+        IScheduledMessageRepository repository,
+        DiscordSocketClient client,
+        ILogger<ScheduledMessageService> logger)
+    {
+        _repository = repository;
+        _client = client;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task<ScheduledMessageDto?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Retrieving scheduled message {MessageId}", id);
+
+        var message = await _repository.GetByIdWithGuildAsync(id, cancellationToken);
+        if (message == null)
+        {
+            _logger.LogWarning("Scheduled message {MessageId} not found", id);
+            return null;
+        }
+
+        var dto = MapToDto(message);
+        _logger.LogDebug("Retrieved scheduled message {MessageId}: {Title}", id, dto.Title);
+
+        return dto;
+    }
+
+    /// <inheritdoc/>
+    public async Task<(IEnumerable<ScheduledMessageDto> Items, int TotalCount)> GetByGuildIdAsync(
+        ulong guildId,
+        int page,
+        int pageSize,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Retrieving scheduled messages for guild {GuildId}, page {Page}, pageSize {PageSize}",
+            guildId, page, pageSize);
+
+        var (messages, totalCount) = await _repository.GetByGuildIdAsync(guildId, page, pageSize, cancellationToken);
+        var dtos = messages.Select(MapToDto);
+
+        _logger.LogInformation("Retrieved {Count} of {Total} scheduled messages for guild {GuildId}",
+            messages.Count(), totalCount, guildId);
+
+        return (dtos, totalCount);
+    }
+
+    /// <inheritdoc/>
+    public async Task<ScheduledMessageDto> CreateAsync(ScheduledMessageCreateDto dto, CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Creating scheduled message for guild {GuildId}, channel {ChannelId}: {Title}",
+            dto.GuildId, dto.ChannelId, dto.Title);
+
+        // Validate cron expression if frequency is Custom
+        if (dto.Frequency == ScheduleFrequency.Custom)
+        {
+            if (string.IsNullOrWhiteSpace(dto.CronExpression))
+            {
+                var error = "Cron expression is required when frequency is Custom";
+                _logger.LogWarning(error);
+                throw new ArgumentException(error, nameof(dto));
+            }
+
+            var (isValid, errorMessage) = await ValidateCronExpressionAsync(dto.CronExpression);
+            if (!isValid)
+            {
+                _logger.LogWarning("Invalid cron expression: {Error}", errorMessage);
+                throw new ArgumentException(errorMessage, nameof(dto));
+            }
+        }
+
+        var now = DateTime.UtcNow;
+        var message = new ScheduledMessage
+        {
+            Id = Guid.NewGuid(),
+            GuildId = dto.GuildId,
+            ChannelId = dto.ChannelId,
+            Title = dto.Title,
+            Content = dto.Content,
+            CronExpression = dto.CronExpression,
+            Frequency = dto.Frequency,
+            IsEnabled = dto.IsEnabled,
+            NextExecutionAt = dto.NextExecutionAt,
+            CreatedAt = now,
+            UpdatedAt = now,
+            CreatedBy = dto.CreatedBy
+        };
+
+        await _repository.AddAsync(message, cancellationToken);
+
+        _logger.LogInformation("Scheduled message {MessageId} created successfully for guild {GuildId}",
+            message.Id, dto.GuildId);
+
+        return MapToDto(message);
+    }
+
+    /// <inheritdoc/>
+    public async Task<ScheduledMessageDto?> UpdateAsync(Guid id, ScheduledMessageUpdateDto dto, CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Updating scheduled message {MessageId}", id);
+
+        var message = await _repository.GetByIdAsync(id, cancellationToken);
+        if (message == null)
+        {
+            _logger.LogWarning("Scheduled message {MessageId} not found for update", id);
+            return null;
+        }
+
+        // Apply updates only for non-null fields
+        if (dto.ChannelId.HasValue)
+        {
+            message.ChannelId = dto.ChannelId.Value;
+        }
+
+        if (dto.Title != null)
+        {
+            message.Title = dto.Title;
+        }
+
+        if (dto.Content != null)
+        {
+            message.Content = dto.Content;
+        }
+
+        if (dto.Frequency.HasValue)
+        {
+            message.Frequency = dto.Frequency.Value;
+
+            // Validate cron expression if frequency is changed to Custom
+            if (dto.Frequency.Value == ScheduleFrequency.Custom)
+            {
+                var cronExpr = dto.CronExpression ?? message.CronExpression;
+                if (string.IsNullOrWhiteSpace(cronExpr))
+                {
+                    var error = "Cron expression is required when frequency is Custom";
+                    _logger.LogWarning(error);
+                    throw new ArgumentException(error, nameof(dto));
+                }
+
+                var (isValid, errorMessage) = await ValidateCronExpressionAsync(cronExpr);
+                if (!isValid)
+                {
+                    _logger.LogWarning("Invalid cron expression: {Error}", errorMessage);
+                    throw new ArgumentException(errorMessage, nameof(dto));
+                }
+            }
+        }
+
+        if (dto.CronExpression != null)
+        {
+            // Validate if frequency is Custom
+            if (message.Frequency == ScheduleFrequency.Custom)
+            {
+                var (isValid, errorMessage) = await ValidateCronExpressionAsync(dto.CronExpression);
+                if (!isValid)
+                {
+                    _logger.LogWarning("Invalid cron expression: {Error}", errorMessage);
+                    throw new ArgumentException(errorMessage, nameof(dto));
+                }
+            }
+
+            message.CronExpression = dto.CronExpression;
+        }
+
+        if (dto.IsEnabled.HasValue)
+        {
+            message.IsEnabled = dto.IsEnabled.Value;
+        }
+
+        if (dto.NextExecutionAt.HasValue)
+        {
+            message.NextExecutionAt = dto.NextExecutionAt.Value;
+        }
+
+        message.UpdatedAt = DateTime.UtcNow;
+
+        await _repository.UpdateAsync(message, cancellationToken);
+
+        _logger.LogInformation("Scheduled message {MessageId} updated successfully", id);
+
+        return MapToDto(message);
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> DeleteAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Deleting scheduled message {MessageId}", id);
+
+        var message = await _repository.GetByIdAsync(id, cancellationToken);
+        if (message == null)
+        {
+            _logger.LogWarning("Scheduled message {MessageId} not found for deletion", id);
+            return false;
+        }
+
+        await _repository.DeleteAsync(message, cancellationToken);
+
+        _logger.LogInformation("Scheduled message {MessageId} deleted successfully", id);
+
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public Task<DateTime?> CalculateNextExecutionAsync(
+        ScheduleFrequency frequency,
+        string? cronExpression,
+        DateTime? baseTime = null)
+    {
+        var now = baseTime ?? DateTime.UtcNow;
+
+        try
+        {
+            var nextExecution = frequency switch
+            {
+                ScheduleFrequency.Once => null,
+                ScheduleFrequency.Hourly => now.AddHours(1),
+                ScheduleFrequency.Daily => now.AddDays(1),
+                ScheduleFrequency.Weekly => now.AddDays(7),
+                ScheduleFrequency.Monthly => now.AddMonths(1),
+                ScheduleFrequency.Custom => CalculateNextFromCron(cronExpression, now),
+                _ => throw new ArgumentOutOfRangeException(nameof(frequency), frequency, "Invalid schedule frequency")
+            };
+
+            _logger.LogDebug("Calculated next execution for {Frequency}: {NextExecution}",
+                frequency, nextExecution);
+
+            return Task.FromResult(nextExecution);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to calculate next execution for frequency {Frequency}", frequency);
+            return Task.FromResult<DateTime?>(null);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> ExecuteScheduledMessageAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Executing scheduled message {MessageId}", id);
+
+        var message = await _repository.GetByIdAsync(id, cancellationToken);
+        if (message == null)
+        {
+            _logger.LogWarning("Scheduled message {MessageId} not found for execution", id);
+            return false;
+        }
+
+        try
+        {
+            // Get the Discord channel
+            var channel = _client.GetChannel(message.ChannelId) as IMessageChannel;
+            if (channel == null)
+            {
+                _logger.LogError("Channel {ChannelId} not found for scheduled message {MessageId}",
+                    message.ChannelId, id);
+                return false;
+            }
+
+            // Send the message to Discord
+            await channel.SendMessageAsync(message.Content);
+
+            _logger.LogInformation("Scheduled message {MessageId} sent successfully to channel {ChannelId}",
+                id, message.ChannelId);
+
+            // Update execution state
+            message.LastExecutedAt = DateTime.UtcNow;
+
+            // Calculate next execution time or disable if OneTime
+            if (message.Frequency == ScheduleFrequency.Once)
+            {
+                message.IsEnabled = false;
+                message.NextExecutionAt = null;
+                _logger.LogInformation("Scheduled message {MessageId} disabled after one-time execution", id);
+            }
+            else
+            {
+                var nextExecution = await CalculateNextExecutionAsync(
+                    message.Frequency,
+                    message.CronExpression,
+                    message.LastExecutedAt);
+
+                if (nextExecution.HasValue)
+                {
+                    message.NextExecutionAt = nextExecution.Value;
+                    _logger.LogDebug("Next execution for message {MessageId} scheduled at {NextExecution}",
+                        id, nextExecution.Value);
+                }
+                else
+                {
+                    _logger.LogWarning("Failed to calculate next execution for message {MessageId}, disabling", id);
+                    message.IsEnabled = false;
+                    message.NextExecutionAt = null;
+                }
+            }
+
+            message.UpdatedAt = DateTime.UtcNow;
+            await _repository.UpdateAsync(message, cancellationToken);
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to execute scheduled message {MessageId}", id);
+            return false;
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task<(bool IsValid, string? ErrorMessage)> ValidateCronExpressionAsync(string cronExpression)
+    {
+        if (string.IsNullOrWhiteSpace(cronExpression))
+        {
+            return Task.FromResult<(bool, string?)>((false, "Cron expression cannot be empty"));
+        }
+
+        try
+        {
+            // Try to parse the cron expression
+            var expression = CronExpression.Parse(cronExpression, CronFormat.IncludeSeconds);
+
+            // Try to get next occurrence to verify it's valid
+            var next = expression.GetNextOccurrence(DateTime.UtcNow, TimeZoneInfo.Utc);
+            if (!next.HasValue)
+            {
+                return Task.FromResult<(bool, string?)>((false, "Cron expression has no future occurrences"));
+            }
+
+            _logger.LogDebug("Cron expression validated: {CronExpression}, next occurrence: {Next}",
+                cronExpression, next.Value);
+
+            return Task.FromResult<(bool, string?)>((true, null));
+        }
+        catch (CronFormatException ex)
+        {
+            _logger.LogWarning(ex, "Invalid cron expression: {CronExpression}", cronExpression);
+            return Task.FromResult<(bool, string?)>((false, $"Invalid cron expression format: {ex.Message}"));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error validating cron expression: {CronExpression}", cronExpression);
+            return Task.FromResult<(bool, string?)>((false, $"Error validating cron expression: {ex.Message}"));
+        }
+    }
+
+    /// <summary>
+    /// Calculates the next execution time from a cron expression.
+    /// </summary>
+    /// <param name="cronExpression">The cron expression.</param>
+    /// <param name="baseTime">The base time to calculate from.</param>
+    /// <returns>The next execution time, or null if calculation fails.</returns>
+    private DateTime? CalculateNextFromCron(string? cronExpression, DateTime baseTime)
+    {
+        if (string.IsNullOrWhiteSpace(cronExpression))
+        {
+            _logger.LogWarning("Cron expression is null or empty");
+            return null;
+        }
+
+        try
+        {
+            var expression = CronExpression.Parse(cronExpression, CronFormat.IncludeSeconds);
+            var next = expression.GetNextOccurrence(baseTime, TimeZoneInfo.Utc);
+
+            if (!next.HasValue)
+            {
+                _logger.LogWarning("Cron expression {CronExpression} has no next occurrence", cronExpression);
+                return null;
+            }
+
+            return next.Value;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to parse cron expression: {CronExpression}", cronExpression);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Maps a ScheduledMessage entity to a ScheduledMessageDto.
+    /// </summary>
+    /// <param name="message">The scheduled message entity.</param>
+    /// <returns>The mapped ScheduledMessageDto.</returns>
+    private static ScheduledMessageDto MapToDto(ScheduledMessage message)
+    {
+        return new ScheduledMessageDto
+        {
+            Id = message.Id,
+            GuildId = message.GuildId,
+            GuildName = message.Guild?.Name,
+            ChannelId = message.ChannelId,
+            Title = message.Title,
+            Content = message.Content,
+            CronExpression = message.CronExpression,
+            Frequency = message.Frequency,
+            IsEnabled = message.IsEnabled,
+            LastExecutedAt = message.LastExecutedAt,
+            NextExecutionAt = message.NextExecutionAt,
+            CreatedAt = message.CreatedAt,
+            CreatedBy = message.CreatedBy,
+            UpdatedAt = message.UpdatedAt
+        };
+    }
+}

--- a/src/DiscordBot.Bot/appsettings.json
+++ b/src/DiscordBot.Bot/appsettings.json
@@ -72,6 +72,11 @@
     "CleanupBatchSize": 1000,
     "CleanupIntervalHours": 24
   },
+  "ScheduledMessages": {
+    "CheckIntervalSeconds": 60,
+    "MaxConcurrentExecutions": 5,
+    "ExecutionTimeoutSeconds": 30
+  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Information",

--- a/src/DiscordBot.Core/Configuration/ScheduledMessagesOptions.cs
+++ b/src/DiscordBot.Core/Configuration/ScheduledMessagesOptions.cs
@@ -1,0 +1,33 @@
+namespace DiscordBot.Core.Configuration;
+
+/// <summary>
+/// Configuration options for scheduled message execution and background processing.
+/// </summary>
+public class ScheduledMessagesOptions
+{
+    /// <summary>
+    /// The configuration section name for binding.
+    /// </summary>
+    public const string SectionName = "ScheduledMessages";
+
+    /// <summary>
+    /// Gets or sets the interval (in seconds) between scheduled message checks.
+    /// The background service will check for due messages at this interval.
+    /// Default is 60 seconds.
+    /// </summary>
+    public int CheckIntervalSeconds { get; set; } = 60;
+
+    /// <summary>
+    /// Gets or sets the maximum number of scheduled messages to execute concurrently.
+    /// Used to prevent resource exhaustion when many messages are due simultaneously.
+    /// Default is 5.
+    /// </summary>
+    public int MaxConcurrentExecutions { get; set; } = 5;
+
+    /// <summary>
+    /// Gets or sets the timeout (in seconds) for individual message execution.
+    /// If a message execution takes longer than this, it will be cancelled.
+    /// Default is 30 seconds.
+    /// </summary>
+    public int ExecutionTimeoutSeconds { get; set; } = 30;
+}

--- a/src/DiscordBot.Core/Interfaces/IScheduledMessageService.cs
+++ b/src/DiscordBot.Core/Interfaces/IScheduledMessageService.cs
@@ -1,0 +1,85 @@
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Enums;
+
+namespace DiscordBot.Core.Interfaces;
+
+/// <summary>
+/// Service interface for scheduled message operations and execution management.
+/// </summary>
+public interface IScheduledMessageService
+{
+    /// <summary>
+    /// Gets a scheduled message by ID.
+    /// </summary>
+    /// <param name="id">The unique identifier of the scheduled message.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The scheduled message data, or null if not found.</returns>
+    Task<ScheduledMessageDto?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets scheduled messages for a specific guild with pagination.
+    /// </summary>
+    /// <param name="guildId">The guild's Discord snowflake ID.</param>
+    /// <param name="page">Page number (1-based).</param>
+    /// <param name="pageSize">Number of items per page.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A tuple containing the paginated scheduled messages and the total count.</returns>
+    Task<(IEnumerable<ScheduledMessageDto> Items, int TotalCount)> GetByGuildIdAsync(
+        ulong guildId,
+        int page,
+        int pageSize,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates a new scheduled message.
+    /// </summary>
+    /// <param name="dto">The creation request containing the scheduled message data.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The created scheduled message data.</returns>
+    Task<ScheduledMessageDto> CreateAsync(ScheduledMessageCreateDto dto, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates an existing scheduled message.
+    /// </summary>
+    /// <param name="id">The unique identifier of the scheduled message to update.</param>
+    /// <param name="dto">The update request containing the fields to update.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The updated scheduled message data, or null if not found.</returns>
+    Task<ScheduledMessageDto?> UpdateAsync(Guid id, ScheduledMessageUpdateDto dto, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes a scheduled message.
+    /// </summary>
+    /// <param name="id">The unique identifier of the scheduled message to delete.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the message was deleted, false if not found.</returns>
+    Task<bool> DeleteAsync(Guid id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Calculates the next execution time based on frequency and optional base time.
+    /// </summary>
+    /// <param name="frequency">The schedule frequency.</param>
+    /// <param name="cronExpression">The cron expression (required when frequency is Custom).</param>
+    /// <param name="baseTime">The base time to calculate from. Defaults to current UTC time if not specified.</param>
+    /// <returns>The calculated next execution time, or null if calculation fails.</returns>
+    Task<DateTime?> CalculateNextExecutionAsync(
+        ScheduleFrequency frequency,
+        string? cronExpression,
+        DateTime? baseTime = null);
+
+    /// <summary>
+    /// Executes a scheduled message immediately by sending it to Discord and updating its state.
+    /// Updates LastExecutedAt and NextExecutionAt. Disables the message if frequency is Once.
+    /// </summary>
+    /// <param name="id">The unique identifier of the scheduled message to execute.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if execution was successful, false if the message was not found or execution failed.</returns>
+    Task<bool> ExecuteScheduledMessageAsync(Guid id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Validates a cron expression for correctness.
+    /// </summary>
+    /// <param name="cronExpression">The cron expression to validate.</param>
+    /// <returns>A tuple indicating whether the expression is valid and an error message if not.</returns>
+    Task<(bool IsValid, string? ErrorMessage)> ValidateCronExpressionAsync(string cronExpression);
+}

--- a/tests/DiscordBot.Tests/Controllers/ScheduledMessagesControllerTests.cs
+++ b/tests/DiscordBot.Tests/Controllers/ScheduledMessagesControllerTests.cs
@@ -1,0 +1,815 @@
+using DiscordBot.Bot.Controllers;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Enums;
+using DiscordBot.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace DiscordBot.Tests.Controllers;
+
+/// <summary>
+/// Unit tests for ScheduledMessagesController.
+/// Tests cover all CRUD endpoints, validation, error handling, and API responses.
+/// </summary>
+public class ScheduledMessagesControllerTests
+{
+    private readonly Mock<IScheduledMessageService> _mockService;
+    private readonly Mock<ILogger<ScheduledMessagesController>> _mockLogger;
+    private readonly ScheduledMessagesController _controller;
+    private const ulong TestGuildId = 123456789UL;
+
+    public ScheduledMessagesControllerTests()
+    {
+        _mockService = new Mock<IScheduledMessageService>();
+        _mockLogger = new Mock<ILogger<ScheduledMessagesController>>();
+        _controller = new ScheduledMessagesController(_mockService.Object, _mockLogger.Object);
+
+        // Setup HttpContext for TraceIdentifier and correlation ID
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+    }
+
+    #region Helper Methods
+
+    private static ScheduledMessageDto CreateTestDto(
+        Guid? id = null,
+        ulong guildId = TestGuildId,
+        string title = "Test Message")
+    {
+        return new ScheduledMessageDto
+        {
+            Id = id ?? Guid.NewGuid(),
+            GuildId = guildId,
+            GuildName = "Test Guild",
+            ChannelId = 987654321UL,
+            Title = title,
+            Content = "Test Content",
+            Frequency = ScheduleFrequency.Daily,
+            IsEnabled = true,
+            NextExecutionAt = DateTime.UtcNow.AddDays(1),
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = "test-user",
+            UpdatedAt = DateTime.UtcNow
+        };
+    }
+
+    #endregion
+
+    #region GetScheduledMessages Tests
+
+    [Fact]
+    public async Task GetScheduledMessages_WithValidParameters_ReturnsOkWithPaginatedResults()
+    {
+        // Arrange
+        var messages = new List<ScheduledMessageDto>
+        {
+            CreateTestDto(title: "Message 1"),
+            CreateTestDto(title: "Message 2")
+        };
+
+        _mockService
+            .Setup(s => s.GetByGuildIdAsync(TestGuildId, 1, 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((messages, 2));
+
+        // Act
+        var result = await _controller.GetScheduledMessages(TestGuildId, 1, 20);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Result.Should().BeOfType<OkObjectResult>();
+
+        var okResult = result.Result as OkObjectResult;
+        okResult.Should().NotBeNull();
+        okResult!.Value.Should().BeOfType<PaginatedResponseDto<ScheduledMessageDto>>();
+
+        var response = okResult.Value as PaginatedResponseDto<ScheduledMessageDto>;
+        response.Should().NotBeNull();
+        response!.Items.Should().HaveCount(2);
+        response.Page.Should().Be(1);
+        response.PageSize.Should().Be(20);
+        response.TotalCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetScheduledMessages_WithInvalidPage_ReturnsBadRequest()
+    {
+        // Act
+        var result = await _controller.GetScheduledMessages(TestGuildId, 0, 20);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+
+        var badRequestResult = result.Result as BadRequestObjectResult;
+        badRequestResult.Should().NotBeNull();
+        badRequestResult!.Value.Should().BeOfType<ApiErrorDto>();
+
+        var error = badRequestResult.Value as ApiErrorDto;
+        error.Should().NotBeNull();
+        error!.Message.Should().Be("Invalid page number");
+        error.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+
+        _mockService.Verify(
+            s => s.GetByGuildIdAsync(It.IsAny<ulong>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GetScheduledMessages_WithInvalidPageSize_ReturnsBadRequest()
+    {
+        // Act
+        var result = await _controller.GetScheduledMessages(TestGuildId, 1, 0);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+
+        var badRequestResult = result.Result as BadRequestObjectResult;
+        var error = badRequestResult!.Value as ApiErrorDto;
+        error.Should().NotBeNull();
+        error!.Message.Should().Be("Invalid page size");
+        error.Detail.Should().Contain("between 1 and 100");
+    }
+
+    [Theory]
+    [InlineData(101)]
+    [InlineData(200)]
+    public async Task GetScheduledMessages_WithPageSizeAboveLimit_ReturnsBadRequest(int pageSize)
+    {
+        // Act
+        var result = await _controller.GetScheduledMessages(TestGuildId, 1, pageSize);
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+        var badRequestResult = result.Result as BadRequestObjectResult;
+        var error = badRequestResult!.Value as ApiErrorDto;
+        error!.Message.Should().Be("Invalid page size");
+    }
+
+    [Fact]
+    public async Task GetScheduledMessages_WithEmptyResults_ReturnsOkWithEmptyList()
+    {
+        // Arrange
+        _mockService
+            .Setup(s => s.GetByGuildIdAsync(TestGuildId, 1, 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new List<ScheduledMessageDto>(), 0));
+
+        // Act
+        var result = await _controller.GetScheduledMessages(TestGuildId, 1, 20);
+
+        // Assert
+        result.Result.Should().BeOfType<OkObjectResult>();
+        var okResult = result.Result as OkObjectResult;
+        var response = okResult!.Value as PaginatedResponseDto<ScheduledMessageDto>;
+        response!.Items.Should().BeEmpty();
+        response.TotalCount.Should().Be(0);
+    }
+
+    #endregion
+
+    #region GetScheduledMessageById Tests
+
+    [Fact]
+    public async Task GetScheduledMessageById_WithExistingMessage_ReturnsOk()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var dto = CreateTestDto(id: messageId);
+
+        _mockService
+            .Setup(s => s.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(dto);
+
+        // Act
+        var result = await _controller.GetScheduledMessageById(TestGuildId, messageId, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Result.Should().BeOfType<OkObjectResult>();
+
+        var okResult = result.Result as OkObjectResult;
+        okResult.Should().NotBeNull();
+        okResult!.Value.Should().BeOfType<ScheduledMessageDto>();
+
+        var returnedDto = okResult.Value as ScheduledMessageDto;
+        returnedDto.Should().NotBeNull();
+        returnedDto!.Id.Should().Be(messageId);
+        returnedDto.Title.Should().Be("Test Message");
+    }
+
+    [Fact]
+    public async Task GetScheduledMessageById_WithNonExistentMessage_ReturnsNotFound()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+
+        _mockService
+            .Setup(s => s.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ScheduledMessageDto?)null);
+
+        // Act
+        var result = await _controller.GetScheduledMessageById(TestGuildId, messageId, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Result.Should().BeOfType<NotFoundObjectResult>();
+
+        var notFoundResult = result.Result as NotFoundObjectResult;
+        notFoundResult.Should().NotBeNull();
+        notFoundResult!.Value.Should().BeOfType<ApiErrorDto>();
+
+        var error = notFoundResult.Value as ApiErrorDto;
+        error.Should().NotBeNull();
+        error!.Message.Should().Be("Scheduled message not found");
+        error.Detail.Should().Contain(messageId.ToString());
+        error.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Fact]
+    public async Task GetScheduledMessageById_WithWrongGuild_ReturnsNotFound()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var dto = CreateTestDto(id: messageId, guildId: 999999999UL); // Different guild
+
+        _mockService
+            .Setup(s => s.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(dto);
+
+        // Act
+        var result = await _controller.GetScheduledMessageById(TestGuildId, messageId, CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    #endregion
+
+    #region CreateScheduledMessage Tests
+
+    [Fact]
+    public async Task CreateScheduledMessage_WithValidRequest_ReturnsCreated()
+    {
+        // Arrange
+        var createDto = new ScheduledMessageCreateDto
+        {
+            GuildId = TestGuildId,
+            ChannelId = 987654321UL,
+            Title = "New Message",
+            Content = "New Content",
+            Frequency = ScheduleFrequency.Daily,
+            IsEnabled = true,
+            NextExecutionAt = DateTime.UtcNow.AddDays(1),
+            CreatedBy = "user123"
+        };
+
+        var createdDto = CreateTestDto(title: "New Message");
+
+        _mockService
+            .Setup(s => s.CreateAsync(It.IsAny<ScheduledMessageCreateDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(createdDto);
+
+        // Act
+        var result = await _controller.CreateScheduledMessage(TestGuildId, createDto, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Result.Should().BeOfType<CreatedAtActionResult>();
+
+        var createdResult = result.Result as CreatedAtActionResult;
+        createdResult.Should().NotBeNull();
+        createdResult!.ActionName.Should().Be(nameof(ScheduledMessagesController.GetScheduledMessageById));
+        createdResult.Value.Should().BeOfType<ScheduledMessageDto>();
+
+        var returnedDto = createdResult.Value as ScheduledMessageDto;
+        returnedDto.Should().NotBeNull();
+        returnedDto!.Title.Should().Be("New Message");
+
+        _mockService.Verify(
+            s => s.CreateAsync(It.Is<ScheduledMessageCreateDto>(d => d.GuildId == TestGuildId), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateScheduledMessage_WithNullRequest_ReturnsBadRequest()
+    {
+        // Act
+        var result = await _controller.CreateScheduledMessage(TestGuildId, null!, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+
+        var badRequestResult = result.Result as BadRequestObjectResult;
+        badRequestResult.Should().NotBeNull();
+        badRequestResult!.Value.Should().BeOfType<ApiErrorDto>();
+
+        var error = badRequestResult.Value as ApiErrorDto;
+        error.Should().NotBeNull();
+        error!.Message.Should().Be("Invalid request");
+        error.Detail.Should().Contain("cannot be null");
+
+        _mockService.Verify(
+            s => s.CreateAsync(It.IsAny<ScheduledMessageCreateDto>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateScheduledMessage_WithServiceArgumentException_ReturnsBadRequest()
+    {
+        // Arrange
+        var createDto = new ScheduledMessageCreateDto
+        {
+            GuildId = TestGuildId,
+            ChannelId = 987654321UL,
+            Title = "Invalid",
+            Content = "Content",
+            Frequency = ScheduleFrequency.Custom,
+            CronExpression = "invalid",
+            IsEnabled = true,
+            CreatedBy = "user123"
+        };
+
+        _mockService
+            .Setup(s => s.CreateAsync(It.IsAny<ScheduledMessageCreateDto>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ArgumentException("Invalid cron expression format"));
+
+        // Act
+        var result = await _controller.CreateScheduledMessage(TestGuildId, createDto, CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+        var badRequestResult = result.Result as BadRequestObjectResult;
+        var error = badRequestResult!.Value as ApiErrorDto;
+        error!.Detail.Should().Contain("Invalid cron expression format");
+    }
+
+    [Fact]
+    public async Task CreateScheduledMessage_OverridesGuildIdFromRoute()
+    {
+        // Arrange
+        var createDto = new ScheduledMessageCreateDto
+        {
+            GuildId = 999999999UL, // Wrong guild ID in request
+            ChannelId = 987654321UL,
+            Title = "Message",
+            Content = "Content",
+            Frequency = ScheduleFrequency.Daily,
+            IsEnabled = true,
+            CreatedBy = "user123"
+        };
+
+        var createdDto = CreateTestDto();
+
+        _mockService
+            .Setup(s => s.CreateAsync(It.IsAny<ScheduledMessageCreateDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(createdDto);
+
+        // Act
+        await _controller.CreateScheduledMessage(TestGuildId, createDto, CancellationToken.None);
+
+        // Assert
+        _mockService.Verify(
+            s => s.CreateAsync(
+                It.Is<ScheduledMessageCreateDto>(d => d.GuildId == TestGuildId),
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "controller should override GuildId with route parameter");
+    }
+
+    #endregion
+
+    #region UpdateScheduledMessage Tests
+
+    [Fact]
+    public async Task UpdateScheduledMessage_WithValidRequest_ReturnsOk()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var existingDto = CreateTestDto(id: messageId);
+        var updateDto = new ScheduledMessageUpdateDto
+        {
+            Title = "Updated Title",
+            Content = "Updated Content"
+        };
+
+        _mockService
+            .Setup(s => s.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingDto);
+
+        var updatedDto = CreateTestDto(id: messageId);
+        updatedDto.Title = "Updated Title";
+        updatedDto.Content = "Updated Content";
+
+        _mockService
+            .Setup(s => s.UpdateAsync(messageId, updateDto, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(updatedDto);
+
+        // Act
+        var result = await _controller.UpdateScheduledMessage(TestGuildId, messageId, updateDto, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Result.Should().BeOfType<OkObjectResult>();
+
+        var okResult = result.Result as OkObjectResult;
+        okResult.Should().NotBeNull();
+        okResult!.Value.Should().BeOfType<ScheduledMessageDto>();
+
+        var returnedDto = okResult.Value as ScheduledMessageDto;
+        returnedDto.Should().NotBeNull();
+        returnedDto!.Title.Should().Be("Updated Title");
+    }
+
+    [Fact]
+    public async Task UpdateScheduledMessage_WithNullRequest_ReturnsBadRequest()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+
+        // Act
+        var result = await _controller.UpdateScheduledMessage(TestGuildId, messageId, null!, CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+        var badRequestResult = result.Result as BadRequestObjectResult;
+        var error = badRequestResult!.Value as ApiErrorDto;
+        error!.Message.Should().Be("Invalid request");
+
+        _mockService.Verify(
+            s => s.UpdateAsync(It.IsAny<Guid>(), It.IsAny<ScheduledMessageUpdateDto>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateScheduledMessage_WithNonExistentMessage_ReturnsNotFound()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var updateDto = new ScheduledMessageUpdateDto { Title = "Updated" };
+
+        _mockService
+            .Setup(s => s.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ScheduledMessageDto?)null);
+
+        // Act
+        var result = await _controller.UpdateScheduledMessage(TestGuildId, messageId, updateDto, CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<NotFoundObjectResult>();
+
+        _mockService.Verify(
+            s => s.UpdateAsync(It.IsAny<Guid>(), It.IsAny<ScheduledMessageUpdateDto>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "update should not be called if message doesn't exist");
+    }
+
+    [Fact]
+    public async Task UpdateScheduledMessage_WithWrongGuild_ReturnsNotFound()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var existingDto = CreateTestDto(id: messageId, guildId: 999999999UL); // Different guild
+        var updateDto = new ScheduledMessageUpdateDto { Title = "Updated" };
+
+        _mockService
+            .Setup(s => s.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingDto);
+
+        // Act
+        var result = await _controller.UpdateScheduledMessage(TestGuildId, messageId, updateDto, CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
+    public async Task UpdateScheduledMessage_WithServiceArgumentException_ReturnsBadRequest()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var existingDto = CreateTestDto(id: messageId);
+        var updateDto = new ScheduledMessageUpdateDto
+        {
+            Frequency = ScheduleFrequency.Custom,
+            CronExpression = "invalid"
+        };
+
+        _mockService
+            .Setup(s => s.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingDto);
+
+        _mockService
+            .Setup(s => s.UpdateAsync(messageId, updateDto, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ArgumentException("Invalid cron expression"));
+
+        // Act
+        var result = await _controller.UpdateScheduledMessage(TestGuildId, messageId, updateDto, CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    #endregion
+
+    #region DeleteScheduledMessage Tests
+
+    [Fact]
+    public async Task DeleteScheduledMessage_WithExistingMessage_ReturnsNoContent()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var existingDto = CreateTestDto(id: messageId);
+
+        _mockService
+            .Setup(s => s.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingDto);
+
+        _mockService
+            .Setup(s => s.DeleteAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        // Act
+        var result = await _controller.DeleteScheduledMessage(TestGuildId, messageId, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeOfType<NoContentResult>();
+
+        _mockService.Verify(
+            s => s.DeleteAsync(messageId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteScheduledMessage_WithNonExistentMessage_ReturnsNotFound()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+
+        _mockService
+            .Setup(s => s.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ScheduledMessageDto?)null);
+
+        // Act
+        var result = await _controller.DeleteScheduledMessage(TestGuildId, messageId, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<NotFoundObjectResult>();
+
+        _mockService.Verify(
+            s => s.DeleteAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "delete should not be called if message doesn't exist");
+    }
+
+    [Fact]
+    public async Task DeleteScheduledMessage_WithWrongGuild_ReturnsNotFound()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var existingDto = CreateTestDto(id: messageId, guildId: 999999999UL);
+
+        _mockService
+            .Setup(s => s.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingDto);
+
+        // Act
+        var result = await _controller.DeleteScheduledMessage(TestGuildId, messageId, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
+    public async Task DeleteScheduledMessage_WhenDeleteFails_ReturnsNotFound()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var existingDto = CreateTestDto(id: messageId);
+
+        _mockService
+            .Setup(s => s.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingDto);
+
+        _mockService
+            .Setup(s => s.DeleteAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        // Act
+        var result = await _controller.DeleteScheduledMessage(TestGuildId, messageId, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    #endregion
+
+    #region ExecuteScheduledMessage Tests
+
+    [Fact]
+    public async Task ExecuteScheduledMessage_WithValidMessage_ReturnsOk()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var existingDto = CreateTestDto(id: messageId);
+
+        _mockService
+            .Setup(s => s.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingDto);
+
+        _mockService
+            .Setup(s => s.ExecuteScheduledMessageAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        // Act
+        var result = await _controller.ExecuteScheduledMessage(TestGuildId, messageId, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeOfType<OkObjectResult>();
+
+        var okResult = result as OkObjectResult;
+        okResult.Should().NotBeNull();
+
+        _mockService.Verify(
+            s => s.ExecuteScheduledMessageAsync(messageId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteScheduledMessage_WithNonExistentMessage_ReturnsNotFound()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+
+        _mockService
+            .Setup(s => s.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ScheduledMessageDto?)null);
+
+        // Act
+        var result = await _controller.ExecuteScheduledMessage(TestGuildId, messageId, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<NotFoundObjectResult>();
+
+        _mockService.Verify(
+            s => s.ExecuteScheduledMessageAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteScheduledMessage_WithWrongGuild_ReturnsNotFound()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var existingDto = CreateTestDto(id: messageId, guildId: 999999999UL);
+
+        _mockService
+            .Setup(s => s.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingDto);
+
+        // Act
+        var result = await _controller.ExecuteScheduledMessage(TestGuildId, messageId, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
+    public async Task ExecuteScheduledMessage_WhenExecutionFails_ReturnsInternalServerError()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var existingDto = CreateTestDto(id: messageId);
+
+        _mockService
+            .Setup(s => s.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingDto);
+
+        _mockService
+            .Setup(s => s.ExecuteScheduledMessageAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        // Act
+        var result = await _controller.ExecuteScheduledMessage(TestGuildId, messageId, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<ObjectResult>();
+
+        var objectResult = result as ObjectResult;
+        objectResult.Should().NotBeNull();
+        objectResult!.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+        objectResult.Value.Should().BeOfType<ApiErrorDto>();
+
+        var error = objectResult.Value as ApiErrorDto;
+        error!.Message.Should().Be("Execution failed");
+    }
+
+    #endregion
+
+    #region ValidateCronExpression Tests
+
+    [Fact]
+    public async Task ValidateCronExpression_WithValidExpression_ReturnsOk()
+    {
+        // Arrange
+        var request = new CronValidationRequestDto
+        {
+            CronExpression = "0 0 9 * * *"
+        };
+
+        _mockService
+            .Setup(s => s.ValidateCronExpressionAsync(request.CronExpression))
+            .ReturnsAsync((true, null));
+
+        // Act
+        var result = await _controller.ValidateCronExpression(TestGuildId, request);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeOfType<OkObjectResult>();
+
+        var okResult = result as OkObjectResult;
+        okResult.Should().NotBeNull();
+
+        _mockService.Verify(
+            s => s.ValidateCronExpressionAsync(request.CronExpression),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ValidateCronExpression_WithInvalidExpression_ReturnsBadRequest()
+    {
+        // Arrange
+        var request = new CronValidationRequestDto
+        {
+            CronExpression = "invalid cron"
+        };
+
+        _mockService
+            .Setup(s => s.ValidateCronExpressionAsync(request.CronExpression))
+            .ReturnsAsync((false, "Invalid cron expression format"));
+
+        // Act
+        var result = await _controller.ValidateCronExpression(TestGuildId, request);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeOfType<BadRequestObjectResult>();
+
+        var badRequestResult = result as BadRequestObjectResult;
+        badRequestResult.Should().NotBeNull();
+        badRequestResult!.Value.Should().BeOfType<ApiErrorDto>();
+
+        var error = badRequestResult.Value as ApiErrorDto;
+        error.Should().NotBeNull();
+        error!.Message.Should().Be("Invalid cron expression");
+        error.Detail.Should().Contain("Invalid cron expression format");
+    }
+
+    [Fact]
+    public async Task ValidateCronExpression_WithNullRequest_ReturnsBadRequest()
+    {
+        // Act
+        var result = await _controller.ValidateCronExpression(TestGuildId, null!);
+
+        // Assert
+        result.Should().BeOfType<BadRequestObjectResult>();
+
+        var badRequestResult = result as BadRequestObjectResult;
+        var error = badRequestResult!.Value as ApiErrorDto;
+        error!.Message.Should().Be("Invalid request");
+        error.Detail.Should().Contain("Cron expression is required");
+
+        _mockService.Verify(
+            s => s.ValidateCronExpressionAsync(It.IsAny<string>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ValidateCronExpression_WithEmptyExpression_ReturnsBadRequest()
+    {
+        // Arrange
+        var request = new CronValidationRequestDto
+        {
+            CronExpression = ""
+        };
+
+        // Act
+        var result = await _controller.ValidateCronExpression(TestGuildId, request);
+
+        // Assert
+        result.Should().BeOfType<BadRequestObjectResult>();
+        var badRequestResult = result as BadRequestObjectResult;
+        var error = badRequestResult!.Value as ApiErrorDto;
+        error!.Detail.Should().Contain("Cron expression is required");
+    }
+
+    #endregion
+}

--- a/tests/DiscordBot.Tests/Services/ScheduledMessageExecutionServiceTests.cs
+++ b/tests/DiscordBot.Tests/Services/ScheduledMessageExecutionServiceTests.cs
@@ -1,0 +1,286 @@
+using DiscordBot.Bot.Services;
+using DiscordBot.Core.Configuration;
+using DiscordBot.Core.Entities;
+using DiscordBot.Core.Enums;
+using DiscordBot.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace DiscordBot.Tests.Services;
+
+/// <summary>
+/// Unit tests for ScheduledMessageExecutionService.
+/// Tests cover initialization, configuration, and dependency resolution.
+/// Note: Full end-to-end execution tests are covered by integration tests due to the 10-second startup delay.
+/// </summary>
+public class ScheduledMessageExecutionServiceTests
+{
+    private readonly Mock<IServiceScopeFactory> _mockScopeFactory;
+    private readonly Mock<IServiceScope> _mockScope;
+    private readonly Mock<IServiceProvider> _mockServiceProvider;
+    private readonly Mock<IScheduledMessageRepository> _mockRepository;
+    private readonly Mock<IScheduledMessageService> _mockService;
+    private readonly Mock<ILogger<ScheduledMessageExecutionService>> _mockLogger;
+    private readonly IOptions<ScheduledMessagesOptions> _options;
+
+    public ScheduledMessageExecutionServiceTests()
+    {
+        _mockRepository = new Mock<IScheduledMessageRepository>();
+        _mockService = new Mock<IScheduledMessageService>();
+        _mockServiceProvider = new Mock<IServiceProvider>();
+        _mockScope = new Mock<IServiceScope>();
+        _mockScopeFactory = new Mock<IServiceScopeFactory>();
+        _mockLogger = new Mock<ILogger<ScheduledMessageExecutionService>>();
+
+        // Configure options with reasonable values
+        var optionsValue = new ScheduledMessagesOptions
+        {
+            CheckIntervalSeconds = 60,
+            MaxConcurrentExecutions = 5,
+            ExecutionTimeoutSeconds = 30
+        };
+        _options = Options.Create(optionsValue);
+
+        // Setup scope factory to return mocked services
+        _mockServiceProvider
+            .Setup(sp => sp.GetService(typeof(IScheduledMessageRepository)))
+            .Returns(_mockRepository.Object);
+
+        _mockServiceProvider
+            .Setup(sp => sp.GetService(typeof(IScheduledMessageService)))
+            .Returns(_mockService.Object);
+
+        _mockScope
+            .Setup(s => s.ServiceProvider)
+            .Returns(_mockServiceProvider.Object);
+
+        _mockScopeFactory
+            .Setup(f => f.CreateScope())
+            .Returns(_mockScope.Object);
+    }
+
+    #region Service Initialization Tests
+
+    [Fact]
+    public void Constructor_WithValidDependencies_CreatesInstance()
+    {
+        // Act
+        var service = new ScheduledMessageExecutionService(
+            _mockScopeFactory.Object,
+            _options,
+            _mockLogger.Object);
+
+        // Assert
+        service.Should().NotBeNull();
+    }
+
+    // Note: Constructor null parameter tests are not included because the service uses
+    // nullable reference types and doesn't throw ArgumentNullException. Null parameters
+    // would result in NullReferenceException at runtime when the null values are accessed.
+
+    #endregion
+
+    #region Configuration Tests
+
+    [Fact]
+    public void Options_AreCorrectlyConfigured()
+    {
+        // Arrange & Act
+        var service = new ScheduledMessageExecutionService(
+            _mockScopeFactory.Object,
+            _options,
+            _mockLogger.Object);
+
+        // Assert
+        _options.Value.CheckIntervalSeconds.Should().Be(60);
+        _options.Value.MaxConcurrentExecutions.Should().Be(5);
+        _options.Value.ExecutionTimeoutSeconds.Should().Be(30);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(30)]
+    [InlineData(60)]
+    [InlineData(300)]
+    public void Options_CheckIntervalSeconds_AcceptsValidValues(int seconds)
+    {
+        // Arrange
+        var options = Options.Create(new ScheduledMessagesOptions
+        {
+            CheckIntervalSeconds = seconds,
+            MaxConcurrentExecutions = 5,
+            ExecutionTimeoutSeconds = 30
+        });
+
+        // Act
+        var service = new ScheduledMessageExecutionService(
+            _mockScopeFactory.Object,
+            options,
+            _mockLogger.Object);
+
+        // Assert
+        service.Should().NotBeNull();
+        options.Value.CheckIntervalSeconds.Should().Be(seconds);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(5)]
+    [InlineData(10)]
+    public void Options_MaxConcurrentExecutions_AcceptsValidValues(int maxConcurrent)
+    {
+        // Arrange
+        var options = Options.Create(new ScheduledMessagesOptions
+        {
+            CheckIntervalSeconds = 60,
+            MaxConcurrentExecutions = maxConcurrent,
+            ExecutionTimeoutSeconds = 30
+        });
+
+        // Act
+        var service = new ScheduledMessageExecutionService(
+            _mockScopeFactory.Object,
+            options,
+            _mockLogger.Object);
+
+        // Assert
+        service.Should().NotBeNull();
+        options.Value.MaxConcurrentExecutions.Should().Be(maxConcurrent);
+    }
+
+    [Theory]
+    [InlineData(10)]
+    [InlineData(30)]
+    [InlineData(60)]
+    public void Options_ExecutionTimeoutSeconds_AcceptsValidValues(int timeout)
+    {
+        // Arrange
+        var options = Options.Create(new ScheduledMessagesOptions
+        {
+            CheckIntervalSeconds = 60,
+            MaxConcurrentExecutions = 5,
+            ExecutionTimeoutSeconds = timeout
+        });
+
+        // Act
+        var service = new ScheduledMessageExecutionService(
+            _mockScopeFactory.Object,
+            options,
+            _mockLogger.Object);
+
+        // Assert
+        service.Should().NotBeNull();
+        options.Value.ExecutionTimeoutSeconds.Should().Be(timeout);
+    }
+
+    #endregion
+
+    #region Service Lifecycle Tests
+
+    [Fact]
+    public async Task StartAsync_WithValidConfiguration_Starts()
+    {
+        // Arrange
+        var service = new ScheduledMessageExecutionService(
+            _mockScopeFactory.Object,
+            _options,
+            _mockLogger.Object);
+
+        var cts = new CancellationTokenSource();
+
+        // Act
+        Func<Task> act = async () =>
+        {
+            await service.StartAsync(cts.Token);
+            await cts.CancelAsync();
+            await service.StopAsync(CancellationToken.None);
+        };
+
+        // Assert
+        await act.Should().NotThrowAsync("service should start and stop cleanly");
+    }
+
+    [Fact]
+    public async Task StopAsync_WithoutStart_DoesNotThrow()
+    {
+        // Arrange
+        var service = new ScheduledMessageExecutionService(
+            _mockScopeFactory.Object,
+            _options,
+            _mockLogger.Object);
+
+        // Act
+        Func<Task> act = async () => await service.StopAsync(CancellationToken.None);
+
+        // Assert
+        await act.Should().NotThrowAsync("stopping without starting should be safe");
+    }
+
+    [Fact]
+    public async Task StartAsync_RespectsCancellationToken()
+    {
+        // Arrange
+        var service = new ScheduledMessageExecutionService(
+            _mockScopeFactory.Object,
+            _options,
+            _mockLogger.Object);
+
+        var cts = new CancellationTokenSource();
+
+        // Start service
+        var startTask = service.StartAsync(cts.Token);
+
+        // Act - Cancel immediately
+        await cts.CancelAsync();
+
+        // Assert - Should complete gracefully
+        Func<Task> act = async () => await service.StopAsync(CancellationToken.None);
+        await act.Should().CompleteWithinAsync(
+            TimeSpan.FromSeconds(5),
+            "service should respect cancellation and shutdown quickly");
+    }
+
+    #endregion
+
+    #region Dependency Injection Tests
+
+    [Fact]
+    public async Task Service_UsesScopeFactory_ForDependencyResolution()
+    {
+        // Arrange
+        var options = Options.Create(new ScheduledMessagesOptions
+        {
+            CheckIntervalSeconds = 1, // Fast interval for this test
+            MaxConcurrentExecutions = 5,
+            ExecutionTimeoutSeconds = 30
+        });
+
+        var service = new ScheduledMessageExecutionService(
+            _mockScopeFactory.Object,
+            options,
+            _mockLogger.Object);
+
+        _mockRepository
+            .Setup(r => r.GetDueMessagesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ScheduledMessage>());
+
+        var cts = new CancellationTokenSource();
+
+        // Act
+        await service.StartAsync(cts.Token);
+        await Task.Delay(TimeSpan.FromSeconds(12)); // Wait for initial delay + one check
+        await cts.CancelAsync();
+        await service.StopAsync(CancellationToken.None);
+
+        // Assert
+        _mockScopeFactory.Verify(
+            f => f.CreateScope(),
+            Times.AtLeastOnce,
+            "service should create scopes for dependency injection");
+    }
+
+    #endregion
+}

--- a/tests/DiscordBot.Tests/Services/ScheduledMessageServiceTests.cs
+++ b/tests/DiscordBot.Tests/Services/ScheduledMessageServiceTests.cs
@@ -1,0 +1,709 @@
+using Discord;
+using Discord.WebSocket;
+using DiscordBot.Bot.Services;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Entities;
+using DiscordBot.Core.Enums;
+using DiscordBot.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace DiscordBot.Tests.Services;
+
+/// <summary>
+/// Unit tests for ScheduledMessageService.
+/// Tests cover CRUD operations, message execution, cron validation, and next execution calculations.
+/// </summary>
+public class ScheduledMessageServiceTests
+{
+    private readonly Mock<IScheduledMessageRepository> _mockRepository;
+    private readonly Mock<DiscordSocketClient> _mockDiscordClient;
+    private readonly Mock<ILogger<ScheduledMessageService>> _mockLogger;
+    private readonly ScheduledMessageService _service;
+
+    public ScheduledMessageServiceTests()
+    {
+        _mockRepository = new Mock<IScheduledMessageRepository>();
+        _mockDiscordClient = new Mock<DiscordSocketClient>();
+        _mockLogger = new Mock<ILogger<ScheduledMessageService>>();
+        _service = new ScheduledMessageService(
+            _mockRepository.Object,
+            _mockDiscordClient.Object,
+            _mockLogger.Object);
+    }
+
+    #region Helper Methods
+
+    private static ScheduledMessage CreateTestScheduledMessage(
+        Guid? id = null,
+        ulong guildId = 123456789UL,
+        ulong channelId = 987654321UL,
+        string title = "Test Message",
+        string content = "Test Content",
+        ScheduleFrequency frequency = ScheduleFrequency.Daily,
+        bool isEnabled = true,
+        DateTime? nextExecutionAt = null,
+        DateTime? lastExecutedAt = null,
+        string? cronExpression = null)
+    {
+        return new ScheduledMessage
+        {
+            Id = id ?? Guid.NewGuid(),
+            GuildId = guildId,
+            ChannelId = channelId,
+            Title = title,
+            Content = content,
+            Frequency = frequency,
+            IsEnabled = isEnabled,
+            NextExecutionAt = nextExecutionAt,
+            LastExecutedAt = lastExecutedAt,
+            CronExpression = cronExpression,
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = "test-user",
+            UpdatedAt = DateTime.UtcNow,
+            Guild = new Guild
+            {
+                Id = guildId,
+                Name = "Test Guild",
+                JoinedAt = DateTime.UtcNow,
+                IsActive = true
+            }
+        };
+    }
+
+    #endregion
+
+    #region GetByIdAsync Tests
+
+    [Fact]
+    public async Task GetByIdAsync_WithExistingMessage_ReturnsDto()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var message = CreateTestScheduledMessage(id: messageId);
+
+        _mockRepository
+            .Setup(r => r.GetByIdWithGuildAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(message);
+
+        // Act
+        var result = await _service.GetByIdAsync(messageId);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(messageId);
+        result.Title.Should().Be("Test Message");
+        result.Content.Should().Be("Test Content");
+        result.GuildName.Should().Be("Test Guild");
+
+        _mockRepository.Verify(
+            r => r.GetByIdWithGuildAsync(messageId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WithNonExistentMessage_ReturnsNull()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+
+        _mockRepository
+            .Setup(r => r.GetByIdWithGuildAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ScheduledMessage?)null);
+
+        // Act
+        var result = await _service.GetByIdAsync(messageId);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    #endregion
+
+    #region GetByGuildIdAsync Tests
+
+    [Fact]
+    public async Task GetByGuildIdAsync_ReturnsPaginatedResults()
+    {
+        // Arrange
+        const ulong guildId = 123456789UL;
+        var messages = new List<ScheduledMessage>
+        {
+            CreateTestScheduledMessage(title: "Message 1", guildId: guildId),
+            CreateTestScheduledMessage(title: "Message 2", guildId: guildId)
+        };
+
+        _mockRepository
+            .Setup(r => r.GetByGuildIdAsync(guildId, 1, 10, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((messages, 2));
+
+        // Act
+        var (items, totalCount) = await _service.GetByGuildIdAsync(guildId, 1, 10);
+
+        // Assert
+        items.Should().HaveCount(2);
+        totalCount.Should().Be(2);
+        items.Should().Contain(m => m.Title == "Message 1");
+        items.Should().Contain(m => m.Title == "Message 2");
+
+        _mockRepository.Verify(
+            r => r.GetByGuildIdAsync(guildId, 1, 10, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetByGuildIdAsync_WithNoResults_ReturnsEmpty()
+    {
+        // Arrange
+        const ulong guildId = 123456789UL;
+
+        _mockRepository
+            .Setup(r => r.GetByGuildIdAsync(guildId, 1, 10, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new List<ScheduledMessage>(), 0));
+
+        // Act
+        var (items, totalCount) = await _service.GetByGuildIdAsync(guildId, 1, 10);
+
+        // Assert
+        items.Should().BeEmpty();
+        totalCount.Should().Be(0);
+    }
+
+    #endregion
+
+    #region CreateAsync Tests
+
+    [Fact]
+    public async Task CreateAsync_WithValidDto_CreatesAndReturnsMessage()
+    {
+        // Arrange
+        var createDto = new ScheduledMessageCreateDto
+        {
+            GuildId = 123456789UL,
+            ChannelId = 987654321UL,
+            Title = "New Message",
+            Content = "New Content",
+            Frequency = ScheduleFrequency.Daily,
+            IsEnabled = true,
+            NextExecutionAt = DateTime.UtcNow.AddDays(1),
+            CreatedBy = "user123"
+        };
+
+        _mockRepository
+            .Setup(r => r.AddAsync(It.IsAny<ScheduledMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ScheduledMessage m, CancellationToken ct) => m);
+
+        // Act
+        var result = await _service.CreateAsync(createDto);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.GuildId.Should().Be(123456789UL);
+        result.ChannelId.Should().Be(987654321UL);
+        result.Title.Should().Be("New Message");
+        result.Content.Should().Be("New Content");
+        result.Frequency.Should().Be(ScheduleFrequency.Daily);
+        result.IsEnabled.Should().BeTrue();
+        result.CreatedBy.Should().Be("user123");
+
+        _mockRepository.Verify(
+            r => r.AddAsync(It.IsAny<ScheduledMessage>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithCustomFrequency_ValidatesCronExpression()
+    {
+        // Arrange
+        var createDto = new ScheduledMessageCreateDto
+        {
+            GuildId = 123456789UL,
+            ChannelId = 987654321UL,
+            Title = "Cron Message",
+            Content = "Content",
+            Frequency = ScheduleFrequency.Custom,
+            CronExpression = "0 0 9 * * *", // Valid cron: 9 AM daily
+            IsEnabled = true,
+            CreatedBy = "user123"
+        };
+
+        _mockRepository
+            .Setup(r => r.AddAsync(It.IsAny<ScheduledMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ScheduledMessage m, CancellationToken ct) => m);
+
+        // Act
+        var result = await _service.CreateAsync(createDto);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Frequency.Should().Be(ScheduleFrequency.Custom);
+        result.CronExpression.Should().Be("0 0 9 * * *");
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithCustomFrequency_AndNullCronExpression_ThrowsArgumentException()
+    {
+        // Arrange
+        var createDto = new ScheduledMessageCreateDto
+        {
+            GuildId = 123456789UL,
+            ChannelId = 987654321UL,
+            Title = "Invalid Message",
+            Content = "Content",
+            Frequency = ScheduleFrequency.Custom,
+            CronExpression = null,
+            IsEnabled = true,
+            CreatedBy = "user123"
+        };
+
+        // Act
+        Func<Task> act = async () => await _service.CreateAsync(createDto);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*Cron expression is required*");
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithCustomFrequency_AndInvalidCronExpression_ThrowsArgumentException()
+    {
+        // Arrange
+        var createDto = new ScheduledMessageCreateDto
+        {
+            GuildId = 123456789UL,
+            ChannelId = 987654321UL,
+            Title = "Invalid Cron",
+            Content = "Content",
+            Frequency = ScheduleFrequency.Custom,
+            CronExpression = "invalid cron",
+            IsEnabled = true,
+            CreatedBy = "user123"
+        };
+
+        // Act
+        Func<Task> act = async () => await _service.CreateAsync(createDto);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*Invalid cron expression*");
+    }
+
+    #endregion
+
+    #region UpdateAsync Tests
+
+    [Fact]
+    public async Task UpdateAsync_WithExistingMessage_UpdatesAndReturnsDto()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var existingMessage = CreateTestScheduledMessage(id: messageId, title: "Old Title");
+
+        var updateDto = new ScheduledMessageUpdateDto
+        {
+            Title = "Updated Title",
+            Content = "Updated Content",
+            IsEnabled = false
+        };
+
+        _mockRepository
+            .Setup(r => r.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingMessage);
+
+        _mockRepository
+            .Setup(r => r.UpdateAsync(It.IsAny<ScheduledMessage>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _service.UpdateAsync(messageId, updateDto);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(messageId);
+        result.Title.Should().Be("Updated Title");
+        result.Content.Should().Be("Updated Content");
+        result.IsEnabled.Should().BeFalse();
+
+        _mockRepository.Verify(
+            r => r.UpdateAsync(It.Is<ScheduledMessage>(m =>
+                m.Id == messageId &&
+                m.Title == "Updated Title" &&
+                m.Content == "Updated Content" &&
+                m.IsEnabled == false),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WithNonExistentMessage_ReturnsNull()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var updateDto = new ScheduledMessageUpdateDto { Title = "Updated" };
+
+        _mockRepository
+            .Setup(r => r.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ScheduledMessage?)null);
+
+        // Act
+        var result = await _service.UpdateAsync(messageId, updateDto);
+
+        // Assert
+        result.Should().BeNull();
+
+        _mockRepository.Verify(
+            r => r.UpdateAsync(It.IsAny<ScheduledMessage>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WithPartialUpdate_OnlyUpdatesProvidedFields()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var existingMessage = CreateTestScheduledMessage(
+            id: messageId,
+            title: "Original Title",
+            content: "Original Content",
+            isEnabled: true);
+
+        var updateDto = new ScheduledMessageUpdateDto
+        {
+            Title = "New Title"
+            // Only updating title, other fields should remain unchanged
+        };
+
+        _mockRepository
+            .Setup(r => r.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingMessage);
+
+        _mockRepository
+            .Setup(r => r.UpdateAsync(It.IsAny<ScheduledMessage>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _service.UpdateAsync(messageId, updateDto);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Title.Should().Be("New Title");
+        result.Content.Should().Be("Original Content"); // Unchanged
+        result.IsEnabled.Should().BeTrue(); // Unchanged
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WithCustomFrequency_ValidatesCronExpression()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var existingMessage = CreateTestScheduledMessage(id: messageId, frequency: ScheduleFrequency.Daily);
+
+        var updateDto = new ScheduledMessageUpdateDto
+        {
+            Frequency = ScheduleFrequency.Custom,
+            CronExpression = "invalid cron"
+        };
+
+        _mockRepository
+            .Setup(r => r.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingMessage);
+
+        // Act
+        Func<Task> act = async () => await _service.UpdateAsync(messageId, updateDto);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*Invalid cron expression*");
+    }
+
+    #endregion
+
+    #region DeleteAsync Tests
+
+    [Fact]
+    public async Task DeleteAsync_WithExistingMessage_DeletesAndReturnsTrue()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var message = CreateTestScheduledMessage(id: messageId);
+
+        _mockRepository
+            .Setup(r => r.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(message);
+
+        _mockRepository
+            .Setup(r => r.DeleteAsync(It.IsAny<ScheduledMessage>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _service.DeleteAsync(messageId);
+
+        // Assert
+        result.Should().BeTrue();
+
+        _mockRepository.Verify(
+            r => r.DeleteAsync(It.Is<ScheduledMessage>(m => m.Id == messageId), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WithNonExistentMessage_ReturnsFalse()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+
+        _mockRepository
+            .Setup(r => r.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ScheduledMessage?)null);
+
+        // Act
+        var result = await _service.DeleteAsync(messageId);
+
+        // Assert
+        result.Should().BeFalse();
+
+        _mockRepository.Verify(
+            r => r.DeleteAsync(It.IsAny<ScheduledMessage>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    #endregion
+
+    #region CalculateNextExecutionAsync Tests
+
+    [Fact]
+    public async Task CalculateNextExecutionAsync_WithOnceFrequency_ReturnsNull()
+    {
+        // Arrange
+        var baseTime = DateTime.UtcNow;
+
+        // Act
+        var result = await _service.CalculateNextExecutionAsync(ScheduleFrequency.Once, null, baseTime);
+
+        // Assert
+        result.Should().BeNull("Once frequency should not have a next execution");
+    }
+
+    [Fact]
+    public async Task CalculateNextExecutionAsync_WithHourlyFrequency_ReturnsOneHourLater()
+    {
+        // Arrange
+        var baseTime = new DateTime(2025, 1, 1, 10, 0, 0, DateTimeKind.Utc);
+
+        // Act
+        var result = await _service.CalculateNextExecutionAsync(ScheduleFrequency.Hourly, null, baseTime);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().Be(new DateTime(2025, 1, 1, 11, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public async Task CalculateNextExecutionAsync_WithDailyFrequency_ReturnsOneDayLater()
+    {
+        // Arrange
+        var baseTime = new DateTime(2025, 1, 1, 10, 0, 0, DateTimeKind.Utc);
+
+        // Act
+        var result = await _service.CalculateNextExecutionAsync(ScheduleFrequency.Daily, null, baseTime);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().Be(new DateTime(2025, 1, 2, 10, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public async Task CalculateNextExecutionAsync_WithWeeklyFrequency_ReturnsOneWeekLater()
+    {
+        // Arrange
+        var baseTime = new DateTime(2025, 1, 1, 10, 0, 0, DateTimeKind.Utc);
+
+        // Act
+        var result = await _service.CalculateNextExecutionAsync(ScheduleFrequency.Weekly, null, baseTime);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().Be(new DateTime(2025, 1, 8, 10, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public async Task CalculateNextExecutionAsync_WithMonthlyFrequency_ReturnsOneMonthLater()
+    {
+        // Arrange
+        var baseTime = new DateTime(2025, 1, 15, 10, 0, 0, DateTimeKind.Utc);
+
+        // Act
+        var result = await _service.CalculateNextExecutionAsync(ScheduleFrequency.Monthly, null, baseTime);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().Be(new DateTime(2025, 2, 15, 10, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public async Task CalculateNextExecutionAsync_WithCustomFrequency_AndValidCron_ReturnsNextOccurrence()
+    {
+        // Arrange
+        var baseTime = new DateTime(2025, 1, 1, 8, 0, 0, DateTimeKind.Utc);
+        const string cronExpression = "0 0 9 * * *"; // 9 AM daily
+
+        // Act
+        var result = await _service.CalculateNextExecutionAsync(ScheduleFrequency.Custom, cronExpression, baseTime);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Value.Hour.Should().Be(9);
+        result.Value.Minute.Should().Be(0);
+        result.Value.Should().BeAfter(baseTime);
+    }
+
+    [Fact]
+    public async Task CalculateNextExecutionAsync_WithCustomFrequency_AndNullCron_ReturnsNull()
+    {
+        // Arrange
+        var baseTime = DateTime.UtcNow;
+
+        // Act
+        var result = await _service.CalculateNextExecutionAsync(ScheduleFrequency.Custom, null, baseTime);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CalculateNextExecutionAsync_WithCustomFrequency_AndInvalidCron_ReturnsNull()
+    {
+        // Arrange
+        var baseTime = DateTime.UtcNow;
+        const string invalidCron = "invalid cron expression";
+
+        // Act
+        var result = await _service.CalculateNextExecutionAsync(ScheduleFrequency.Custom, invalidCron, baseTime);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    #endregion
+
+    #region ValidateCronExpressionAsync Tests
+
+    [Fact]
+    public async Task ValidateCronExpressionAsync_WithValidExpression_ReturnsTrue()
+    {
+        // Arrange
+        const string validCron = "0 0 9 * * *"; // 9 AM daily
+
+        // Act
+        var (isValid, errorMessage) = await _service.ValidateCronExpressionAsync(validCron);
+
+        // Assert
+        isValid.Should().BeTrue();
+        errorMessage.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ValidateCronExpressionAsync_WithInvalidExpression_ReturnsFalseWithError()
+    {
+        // Arrange
+        const string invalidCron = "invalid cron";
+
+        // Act
+        var (isValid, errorMessage) = await _service.ValidateCronExpressionAsync(invalidCron);
+
+        // Assert
+        isValid.Should().BeFalse();
+        errorMessage.Should().NotBeNullOrEmpty();
+        errorMessage.Should().Contain("Invalid cron expression");
+    }
+
+    [Fact]
+    public async Task ValidateCronExpressionAsync_WithNullExpression_ReturnsFalseWithError()
+    {
+        // Arrange
+        string? nullCron = null;
+
+        // Act
+        var (isValid, errorMessage) = await _service.ValidateCronExpressionAsync(nullCron!);
+
+        // Assert
+        isValid.Should().BeFalse();
+        errorMessage.Should().Be("Cron expression cannot be empty");
+    }
+
+    [Fact]
+    public async Task ValidateCronExpressionAsync_WithEmptyExpression_ReturnsFalseWithError()
+    {
+        // Arrange
+        const string emptyCron = "";
+
+        // Act
+        var (isValid, errorMessage) = await _service.ValidateCronExpressionAsync(emptyCron);
+
+        // Assert
+        isValid.Should().BeFalse();
+        errorMessage.Should().Be("Cron expression cannot be empty");
+    }
+
+    #endregion
+
+    #region ExecuteScheduledMessageAsync Tests
+
+    // Note: Tests that require mocking Discord.NET's SocketChannel (SendsMessageAndUpdatesState, DisablesMessageAfterExecution)
+    // are not included here because SocketChannel is a concrete class that cannot be mocked with Moq.
+    // These scenarios should be covered by integration tests instead.
+
+    [Fact]
+    public async Task ExecuteScheduledMessageAsync_WithNonExistentMessage_ReturnsFalse()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+
+        _mockRepository
+            .Setup(r => r.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ScheduledMessage?)null);
+
+        // Act
+        var result = await _service.ExecuteScheduledMessageAsync(messageId);
+
+        // Assert
+        result.Should().BeFalse();
+
+        _mockRepository.Verify(
+            r => r.UpdateAsync(It.IsAny<ScheduledMessage>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteScheduledMessageAsync_WithNonExistentChannel_ReturnsFalse()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var message = CreateTestScheduledMessage(id: messageId);
+
+        _mockDiscordClient
+            .Setup(c => c.GetChannel(message.ChannelId))
+            .Returns((SocketChannel?)null);
+
+        _mockRepository
+            .Setup(r => r.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(message);
+
+        // Act
+        var result = await _service.ExecuteScheduledMessageAsync(messageId);
+
+        // Assert
+        result.Should().BeFalse();
+
+        _mockRepository.Verify(
+            r => r.UpdateAsync(It.IsAny<ScheduledMessage>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // Note: ExecuteScheduledMessageAsync_WhenSendMessageFails test removed because
+    // SocketChannel is a concrete class that cannot be mocked with Moq.
+    // This scenario should be covered by integration tests instead.
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Implements ScheduledMessage service layer with CRUD operations, cron expression parsing using Cronos library, and message execution (#236)
- Adds ScheduledMessageExecutionService background service that polls for due messages and executes them with concurrency control and timeout protection (#237)
- Creates ScheduledMessagesController REST API with full CRUD, execute-now, and cron validation endpoints (#238)

## Changes
### New Files
- `src/DiscordBot.Core/Interfaces/IScheduledMessageService.cs` - Service interface
- `src/DiscordBot.Core/Configuration/ScheduledMessagesOptions.cs` - Configuration options
- `src/DiscordBot.Bot/Services/ScheduledMessageService.cs` - Service implementation
- `src/DiscordBot.Bot/Services/ScheduledMessageExecutionService.cs` - Background executor
- `src/DiscordBot.Bot/Controllers/ScheduledMessagesController.cs` - REST API controller
- `tests/DiscordBot.Tests/Services/ScheduledMessageServiceTests.cs` - Service tests (28 tests)
- `tests/DiscordBot.Tests/Services/ScheduledMessageExecutionServiceTests.cs` - Executor tests (10 tests)
- `tests/DiscordBot.Tests/Controllers/ScheduledMessagesControllerTests.cs` - Controller tests (27 tests)

### Modified Files
- `src/DiscordBot.Bot/Program.cs` - DI registration
- `src/DiscordBot.Bot/appsettings.json` - Configuration section
- `src/DiscordBot.Bot/DiscordBot.Bot.csproj` - Cronos package reference

## API Endpoints
| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/api/guilds/{guildId}/scheduled-messages` | List with pagination |
| GET | `/api/guilds/{guildId}/scheduled-messages/{id}` | Get by ID |
| POST | `/api/guilds/{guildId}/scheduled-messages` | Create new message |
| PUT | `/api/guilds/{guildId}/scheduled-messages/{id}` | Update message |
| DELETE | `/api/guilds/{guildId}/scheduled-messages/{id}` | Delete message |
| POST | `/api/guilds/{guildId}/scheduled-messages/{id}/execute` | Execute immediately |
| POST | `/api/guilds/{guildId}/scheduled-messages/validate-cron` | Validate cron expression |

## Test Plan
- [x] All 105 ScheduledMessage-related tests pass
- [x] Build succeeds with no errors
- [ ] Manual testing of API endpoints via Swagger
- [ ] Manual testing of background service execution

Closes #236, closes #237, closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)