### PR TITLE
fix: Hide modules with no commands from Commands page

### DIFF
--- a/src/DiscordBot.Bot/Services/CommandMetadataService.cs
+++ b/src/DiscordBot.Bot/Services/CommandMetadataService.cs
@@ -47,13 +47,23 @@ public class CommandMetadataService : ICommandMetadataService
         foreach (var module in modules)
         {
             var moduleDto = MapModuleToDto(module);
-            moduleDtos.Add(moduleDto);
 
             _logger.LogDebug(
                 "Mapped module {ModuleName} with {CommandCount} commands (IsSlashGroup: {IsSlashGroup})",
                 moduleDto.Name,
                 moduleDto.CommandCount,
                 moduleDto.IsSlashGroup);
+
+            // Filter out modules with no slash commands (e.g., component handler modules)
+            if (moduleDto.CommandCount == 0)
+            {
+                _logger.LogDebug(
+                    "Excluding module {ModuleName} from results (no slash commands)",
+                    moduleDto.Name);
+                continue;
+            }
+
+            moduleDtos.Add(moduleDto);
         }
 
         _logger.LogInformation("Extracted metadata for {ModuleCount} modules with {CommandCount} total commands",


### PR DESCRIPTION
## Summary

- Filter modules in `CommandMetadataService.GetAllModulesAsync()` to exclude modules where `CommandCount == 0`
- This removes component handler modules (like `AdminComponent` and `ScheduleComponent`) from being displayed with "0 commands" on the Commands page
- Add debug logging when modules are excluded from results

## Test Plan

- [x] Verify `GetAllModulesAsync_WithComponentHandlerModule_ExcludesModulesWithNoCommands` test passes
- [x] Verify `GetAllModulesAsync_WithOnlyComponentHandlerModules_ReturnsEmptyList` test passes
- [x] All 19 CommandMetadataService tests pass
- [ ] Manually verify Commands page no longer shows AdminComponent/ScheduleComponent

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)