### PR TITLE
Add native systemd integration for Linux hosting (closes #329)

### DIFF
--- a/deployment/discordbot.env.template
+++ b/deployment/discordbot.env.template
@@ -1,0 +1,52 @@
+# Discord Bot Management System - Environment File Template
+#
+# Installation:
+#   1. Copy this file to /etc/discordbot/discordbot.env
+#   2. Replace placeholder values with your actual secrets
+#   3. Set restrictive permissions:
+#      sudo mkdir -p /etc/discordbot
+#      sudo chmod 700 /etc/discordbot
+#      sudo chmod 600 /etc/discordbot/discordbot.env
+#      sudo chown root:discordbot /etc/discordbot/discordbot.env
+#
+# IMPORTANT: Never commit this file with real secrets to version control!
+# This template file is safe to commit as it contains only placeholders.
+
+# =============================================================================
+# REQUIRED SETTINGS
+# =============================================================================
+
+# Discord Bot Token
+# Get this from: https://discord.com/developers/applications > Your App > Bot > Token
+Discord__Token=YOUR_BOT_TOKEN_HERE
+
+# Discord OAuth Credentials (required for admin UI login via Discord)
+# Get these from: https://discord.com/developers/applications > Your App > OAuth2
+Discord__OAuth__ClientId=YOUR_CLIENT_ID_HERE
+Discord__OAuth__ClientSecret=YOUR_CLIENT_SECRET_HERE
+
+# =============================================================================
+# OPTIONAL SETTINGS
+# =============================================================================
+
+# Discord Test Guild ID
+# Set this for instant command registration (otherwise global commands take up to 1 hour)
+# Discord__TestGuildId=123456789012345678
+
+# Default Admin User (created on first run if not exists)
+# IMPORTANT: Change the password immediately after first login!
+Identity__DefaultAdmin__Email=admin@example.com
+Identity__DefaultAdmin__Password=ChangeThisPassword123!
+
+# Seq API Key (if using Seq for centralized logging)
+# See: docs/articles/log-aggregation.md
+# Serilog__WriteTo__2__Args__apiKey=YOUR_SEQ_API_KEY
+
+# OpenTelemetry OTLP Endpoint (if using Jaeger/Grafana for distributed tracing)
+# OpenTelemetry__Tracing__OtlpEndpoint=http://localhost:4317
+
+# Database Connection String (override default SQLite path)
+# For SQLite (default):
+# ConnectionStrings__DefaultConnection=Data Source=/var/lib/discordbot/discordbot.db
+# For PostgreSQL:
+# ConnectionStrings__DefaultConnection=Host=localhost;Database=discordbot;Username=discordbot;Password=your-db-password

--- a/deployment/discordbot.service
+++ b/deployment/discordbot.service
@@ -1,0 +1,73 @@
+# Discord Bot Management System - systemd Service Unit File
+#
+# Installation:
+#   1. Copy this file to /etc/systemd/system/discordbot.service
+#   2. Create environment file at /etc/discordbot/discordbot.env (see discordbot.env.template)
+#   3. Set permissions: sudo chmod 600 /etc/discordbot/discordbot.env
+#   4. Reload systemd: sudo systemctl daemon-reload
+#   5. Enable service: sudo systemctl enable discordbot
+#   6. Start service: sudo systemctl start discordbot
+#
+# This service uses Type=notify which requires the Microsoft.Extensions.Hosting.Systemd
+# NuGet package. The application includes this package and calls UseSystemd() on startup.
+#
+# For more information, see: docs/articles/linux-deployment.md
+
+[Unit]
+Description=Discord Bot Management System
+Documentation=https://github.com/cpike5/discordbot
+After=network.target
+Wants=network-online.target
+
+[Service]
+# Type=notify enables proper startup notification with .NET systemd integration
+# The application will notify systemd when it's ready to accept connections
+Type=notify
+
+User=discordbot
+Group=discordbot
+WorkingDirectory=/opt/discordbot
+ExecStart=/usr/bin/dotnet /opt/discordbot/DiscordBot.Bot.dll
+
+# Restart policy
+Restart=always
+RestartSec=10
+
+# Timeouts
+# NotifyAccess is required for Type=notify services
+NotifyAccess=main
+# Give the application time to initialize (database migrations, etc.)
+TimeoutStartSec=120
+# Graceful shutdown timeout - allows Discord.NET to disconnect cleanly
+TimeoutStopSec=30
+
+# Process management
+KillMode=mixed
+
+# Security hardening
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/var/lib/discordbot /var/log/discordbot
+
+# Resource limits (optional - uncomment and adjust as needed)
+# MemoryMax=512M
+# CPUQuota=80%
+
+# Logging - forward to journald
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=discordbot
+
+# Environment
+Environment=ASPNETCORE_ENVIRONMENT=Production
+Environment=ASPNETCORE_URLS=http://localhost:5000
+Environment=DOTNET_PRINT_TELEMETRY_MESSAGE=false
+
+# Load secrets from environment file (RECOMMENDED)
+# Create this file with your secrets - see discordbot.env.template
+EnvironmentFile=/etc/discordbot/discordbot.env
+
+[Install]
+WantedBy=multi-user.target

--- a/src/DiscordBot.Bot/DiscordBot.Bot.csproj
+++ b/src/DiscordBot.Bot/DiscordBot.Bot.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.15" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.14.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="8.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="8.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />

--- a/src/DiscordBot.Bot/Program.cs
+++ b/src/DiscordBot.Bot/Program.cs
@@ -38,6 +38,9 @@ try
         .ReadFrom.Services(services)
         .Enrich.FromLogContext());
 
+    // Enable systemd integration (only activates when running under systemd)
+    builder.Host.UseSystemd();
+
     // Add Discord bot services
     builder.Services.AddDiscordBot(builder.Configuration);
 


### PR DESCRIPTION
## Summary

- Add `Microsoft.Extensions.Hosting.Systemd` NuGet package for native systemd integration
- Call `UseSystemd()` in Program.cs for proper startup notification and graceful shutdown
- Create `deployment/discordbot.service` sample unit file using `Type=notify`
- Create `deployment/discordbot.env.template` for secure secrets management
- Update `docs/articles/linux-deployment.md` with improved systemd configuration guidance

## Changes

### Code Changes
- **DiscordBot.Bot.csproj**: Added `Microsoft.Extensions.Hosting.Systemd` package reference (v8.0.0)
- **Program.cs**: Added `UseSystemd()` call after Serilog configuration

### Deployment Files
- **deployment/discordbot.service**: Sample systemd unit file with:
  - `Type=notify` for proper startup notification
  - Security hardening options (NoNewPrivileges, PrivateTmp, ProtectSystem, ProtectHome)
  - `EnvironmentFile` for secrets management
  - Detailed comments explaining each option
- **deployment/discordbot.env.template**: Template for secrets with installation instructions

### Documentation Updates
- Updated overview to describe systemd integration benefits
- Changed `Type=exec` to `Type=notify` in service file example
- Made `EnvironmentFile` the primary/recommended secrets approach
- Added note about the systemd NuGet package
- Added new troubleshooting section for systemd integration issues
- Fixed file path references (`secrets.env` → `discordbot.env`)

## Systemd Integration Benefits

The `UseSystemd()` integration provides:
- **Startup notification**: systemd knows when the application is ready to serve requests
- **Graceful shutdown**: Proper handling of SIGTERM for clean Discord disconnection
- **Watchdog support**: Health monitoring integration with systemd
- **journald integration**: Logs automatically forwarded to the system journal

The integration is safe to call on all platforms - it only activates when actually running under systemd.

## Test Plan

- [x] Solution builds successfully
- [ ] Verify application starts under systemd with `Type=notify`
- [ ] Verify graceful shutdown works with `systemctl stop`
- [ ] Verify logs appear in journald
- [ ] Verify existing Windows development workflow is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)