### PR TITLE
fix: Remove duplicate 'ms' suffix from latency display

### DIFF
--- a/src/DiscordBot.Bot/wwwroot/js/dashboard-realtime.js
+++ b/src/DiscordBot.Bot/wwwroot/js/dashboard-realtime.js
@@ -93,7 +93,7 @@ const DashboardRealtime = (function() {
 
         // Update DOM elements
         updateElement(card, '[data-connection-state]', data.connectionState);
-        updateElement(card, '[data-latency]', data.latency ? `${data.latency}ms` : 'N/A');
+        updateElement(card, '[data-latency]', data.latency ?? 'N/A');
         updateElement(card, '[data-uptime]', formatUptime(data.uptime));
         updateElement(card, '[data-guild-count]', data.guildCount);
         updateElement(card, '[data-last-updated]', 'Just now');


### PR DESCRIPTION
## Summary

- Remove duplicate 'ms' suffix from latency value in SignalR real-time updates
- The JavaScript was adding 'ms' to the value, but the HTML template already includes a styled 'ms' suffix
- Changed `data.latency ? `${data.latency}ms` : 'N/A'` to `data.latency ?? 'N/A'`

Fixes #351

## Test plan

- [ ] Navigate to the dashboard
- [ ] Wait for a SignalR real-time update to occur (or trigger a bot status change)
- [ ] Verify the latency displays as "XXms" (not "XXmsms")

🤖 Generated with [Claude Code](https://claude.com/claude-code)