### PR TITLE
Make Connected Servers widget rows clickable to navigate to guild details

### DIFF
--- a/src/DiscordBot.Bot/Pages/Shared/Components/_ConnectedServersWidget.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/Components/_ConnectedServersWidget.cshtml
@@ -30,9 +30,14 @@
                 {
                     @foreach (var server in Model.Servers)
                     {
-                        <tr class="hover:bg-bg-hover transition-colors">
+                        <tr class="hover:bg-bg-hover transition-colors cursor-pointer group focus:outline-none focus:ring-2 focus:ring-border-focus focus:ring-inset"
+                            onclick="if (!event.target.closest('button')) window.location.href='@server.DetailUrl'"
+                            tabindex="0"
+                            role="link"
+                            aria-label="View details for @server.Name"
+                            onkeydown="if (event.key === 'Enter' && !event.target.closest('button')) window.location.href='@server.DetailUrl'">
                             <td class="px-6 py-4">
-                                <div class="flex items-center gap-3">
+                                <a href="@server.DetailUrl" class="flex items-center gap-3 focus:outline-none" tabindex="-1">
                                     @if (!string.IsNullOrEmpty(server.IconUrl))
                                     {
                                         <img src="@server.IconUrl" alt="@server.Name icon" class="w-10 h-10 rounded-full" />
@@ -44,10 +49,10 @@
                                         </div>
                                     }
                                     <div>
-                                        <p class="font-medium text-text-primary">@server.Name</p>
+                                        <p class="font-medium text-text-primary group-hover:text-accent-blue transition-colors">@server.Name</p>
                                         <p class="text-xs text-text-tertiary font-mono">ID: @server.Id</p>
                                     </div>
-                                </div>
+                                </a>
                             </td>
                             <td class="px-6 py-4 text-text-secondary">@server.MemberCount.ToString("N0")</td>
                             <td class="px-6 py-4">


### PR DESCRIPTION
## Summary
- Makes server rows in the Connected Servers dashboard widget clickable
- Clicking a row navigates to the guild details page (`/Guilds/Details/{guildId}`)
- Server name changes to accent-blue on row hover for visual feedback
- Full keyboard accessibility (tab, Enter key, focus ring)

Fixes #352

## Changes
- Modified `_ConnectedServersWidget.cshtml` to add:
  - `onclick` handler on `<tr>` that navigates to `server.DetailUrl`
  - `cursor-pointer` and `group` classes for hover interaction
  - `tabindex="0"`, `role="link"`, `aria-label` for accessibility
  - `onkeydown` handler for Enter key navigation
  - `focus:ring-2 focus:ring-border-focus focus:ring-inset` for visible focus state
  - Server name wrapped in `<a>` tag with `group-hover:text-accent-blue` styling
  - Action button clicks excluded from row navigation via `!event.target.closest('button')`

## Acceptance Criteria
- [x] Server name/icon in Connected Servers widget is clickable
- [x] Clicking navigates to the correct guild details page
- [x] Hover state shows visual feedback (color change, cursor pointer)
- [x] Active/click state provides visual feedback
- [x] Keyboard accessible (can tab to and activate with Enter)
- [x] Mobile touch targets are appropriately sized (existing row padding maintained)

## Test Plan
- [ ] Navigate to Dashboard and verify server rows show pointer cursor on hover
- [ ] Verify server name turns accent-blue on row hover
- [ ] Click a server row and verify navigation to `/Guilds/Details/{guildId}`
- [ ] Verify action button (kebab menu) can be clicked without triggering row navigation
- [ ] Tab to a server row and verify focus ring appears
- [ ] Press Enter on focused row and verify navigation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)