### PR TITLE
fix: Center bot status icon in collapsed sidebar (fixes #354)

### DIFF
--- a/src/DiscordBot.Bot/Pages/Shared/_Sidebar.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/_Sidebar.cshtml
@@ -134,9 +134,9 @@
     </div>
 
     <!-- Bot Status Footer -->
-    <div class="mt-4 pt-4 border-t border-border-secondary" role="status" aria-label="Bot status">
-      <div class="p-3 bg-bg-primary/50 rounded-lg">
-        <div class="flex items-center gap-3">
+    <div class="bot-status-footer mt-4 pt-4 border-t border-border-secondary" role="status" aria-label="Bot status">
+      <div class="bot-status-container p-3 bg-bg-primary/50 rounded-lg">
+        <div class="bot-status-content flex items-center gap-3">
           <div class="w-10 h-10 rounded-lg bg-success/15 flex items-center justify-center flex-shrink-0">
             <svg class="w-5 h-5 text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />

--- a/src/DiscordBot.Bot/wwwroot/css/site.css
+++ b/src/DiscordBot.Bot/wwwroot/css/site.css
@@ -1082,6 +1082,21 @@
     display: none;
   }
 
+  .sidebar-redesign.collapsed .bot-status-footer {
+    padding-top: 0.75rem;
+    margin-top: 0.75rem;
+  }
+
+  .sidebar-redesign.collapsed .bot-status-container {
+    padding: 0.75rem;
+    background: transparent;
+  }
+
+  .sidebar-redesign.collapsed .bot-status-content {
+    justify-content: center;
+    gap: 0;
+  }
+
   /* Dashboard Redesign - Early Collapsed State (via html class for FOUC prevention) */
   /* These rules apply when the sidebar should be collapsed BEFORE JavaScript runs */
   @media (min-width: 1024px) {
@@ -1104,6 +1119,21 @@
     html.sidebar-collapsed .sidebar-link-redesign {
       justify-content: center;
       padding: 0.75rem;
+    }
+
+    html.sidebar-collapsed .bot-status-footer {
+      padding-top: 0.75rem;
+      margin-top: 0.75rem;
+    }
+
+    html.sidebar-collapsed .bot-status-container {
+      padding: 0.75rem;
+      background: transparent;
+    }
+
+    html.sidebar-collapsed .bot-status-content {
+      justify-content: center;
+      gap: 0;
     }
   }
 


### PR DESCRIPTION
## Summary

- Adds CSS classes to the sidebar bot status section (`bot-status-footer`, `bot-status-container`, `bot-status-content`) for easier targeting
- Centers the status icon and adjusts spacing when sidebar is collapsed to 72px width
- Applies the same styles to both the JavaScript-toggled collapsed state and the early-load `html.sidebar-collapsed` state (for FOUC prevention)

## Changes

| File | Description |
|------|-------------|
| `_Sidebar.cshtml` | Added 3 CSS classes to status footer section elements |
| `site.css` | Added collapsed state rules for icon centering and spacing |

## Test Plan

- [ ] View the admin UI with sidebar expanded - status section should look unchanged
- [ ] Click the collapse button - icon should center with balanced padding (0.75rem)
- [ ] Refresh with sidebar collapsed - icon should remain centered (no FOUC)
- [ ] Verify on mobile breakpoint - sidebar behavior should be unaffected

Fixes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)