### PR TITLE
UI: Move Server ID under server name on Guilds page

### DIFF
--- a/src/DiscordBot.Bot/Pages/Guilds/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Index.cshtml
@@ -115,9 +115,6 @@
                         <th class="px-6 py-4 text-left text-xs font-semibold text-text-primary uppercase tracking-wider">
                             Server Name
                         </th>
-                        <th class="px-6 py-4 text-left text-xs font-semibold text-text-primary uppercase tracking-wider hidden lg:table-cell">
-                            Server ID
-                        </th>
                         <th class="px-6 py-4 text-left text-xs font-semibold text-text-primary uppercase tracking-wider">
                             Members
                         </th>
@@ -153,13 +150,9 @@
                                         }
                                         <div class="min-w-0">
                                             <p class="font-medium text-text-primary truncate">@guild.Name</p>
-                                            <p class="text-xs text-text-tertiary lg:hidden font-mono">ID: @guild.Id</p>
+                                            <p class="text-xs text-text-tertiary font-mono">ID: @guild.Id</p>
                                         </div>
                                     </div>
-                                </td>
-                                <!-- Server ID (desktop only) -->
-                                <td class="px-6 py-4 text-text-secondary font-mono text-sm hidden lg:table-cell">
-                                    @guild.Id
                                 </td>
                                 <!-- Member Count -->
                                 <td class="px-6 py-4 text-text-secondary">
@@ -218,7 +211,7 @@
                     else
                     {
                         <tr>
-                            <td colspan="6" class="px-6 py-12 text-center">
+                            <td colspan="5" class="px-6 py-12 text-center">
                                 @{
                                     var hasFilters = !string.IsNullOrEmpty(Model.SearchTerm) || Model.StatusFilter.HasValue;
                                     var emptyTitle = hasFilters ? "No servers found" : "No servers yet";


### PR DESCRIPTION
## Summary

- Remove dedicated Server ID column from table header
- Remove Server ID table cell from row body
- Always display Server ID as small text under server name (removed `lg:hidden` class)
- Update empty state colspan from 6 to 5

## Test plan

- [ ] Navigate to `/Guilds` page
- [ ] Verify Server ID column no longer appears in the table header
- [ ] Verify Server ID appears as small text under each server name on desktop
- [ ] Verify Server ID appears under server name on mobile card view
- [ ] Verify empty state displays correctly (if no guilds exist)
- [ ] Resize browser to verify consistent ID display across breakpoints

Fixes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)