### PR TITLE
fix: Use dynamic version from assembly in dashboard bot status banner

### DIFF
--- a/src/DiscordBot.Bot/Pages/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Index.cshtml.cs
@@ -18,6 +18,7 @@ public class IndexModel : PageModel
     private readonly IGuildService _guildService;
     private readonly ICommandLogService _commandLogService;
     private readonly IAuditLogService _auditLogService;
+    private readonly IVersionService _versionService;
 
     public BotStatusViewModel BotStatus { get; private set; } = default!;
     public GuildStatsViewModel GuildStats { get; private set; } = default!;
@@ -37,13 +38,15 @@ public class IndexModel : PageModel
         IBotService botService,
         IGuildService guildService,
         ICommandLogService commandLogService,
-        IAuditLogService auditLogService)
+        IAuditLogService auditLogService,
+        IVersionService versionService)
     {
         _logger = logger;
         _botService = botService;
         _guildService = guildService;
         _commandLogService = commandLogService;
         _auditLogService = auditLogService;
+        _versionService = versionService;
     }
 
     public async Task OnGetAsync()
@@ -162,7 +165,7 @@ public class IndexModel : PageModel
             ServerCount = guildList.Count,
             TotalMembers = totalMembers,
             UptimeDisplay = BotStatusViewModel.FormatUptime(statusDto.Uptime),
-            Version = "v0.3.3",
+            Version = _versionService.GetVersion(),
             LatencyMs = statusDto.LatencyMs
         };
     }

--- a/src/DiscordBot.Core/Configuration/ApplicationOptions.cs
+++ b/src/DiscordBot.Core/Configuration/ApplicationOptions.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+
 namespace DiscordBot.Core.Configuration;
 
 /// <summary>
@@ -30,7 +32,17 @@ public class ApplicationOptions
 
     /// <summary>
     /// Gets or sets the application version displayed in the UI.
-    /// Default is "0.1.0".
+    /// Defaults to the InformationalVersion from the entry assembly.
     /// </summary>
-    public string Version { get; set; } = "0.1.0";
+    public string Version { get; set; } = GetDefaultVersion();
+
+    /// <summary>
+    /// Gets the default version from the entry assembly's InformationalVersion attribute.
+    /// </summary>
+    private static string GetDefaultVersion()
+    {
+        return Assembly.GetEntryAssembly()?
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+            .InformationalVersion ?? "Unknown";
+    }
 }


### PR DESCRIPTION
## Summary
- Inject `IVersionService` into `IndexModel` and use it for bot status banner version display
- Update `ApplicationOptions.Version` default to read from assembly's `InformationalVersion` attribute
- Version now automatically reflects the value from `Directory.Build.props` (e.g., `v0.3.7-dev`)

## Changes
| File | Change |
|------|--------|
| `Index.cshtml.cs` | Inject `IVersionService`, use `_versionService.GetVersion()` instead of hardcoded `"v0.3.3"` |
| `ApplicationOptions.cs` | Change default `Version` to read from assembly `InformationalVersion` attribute |

## Test Plan
- [x] Build succeeds with no errors
- [x] All 1695 tests pass
- [ ] Verify dashboard shows correct version (e.g., `v0.3.7-dev`) in bot status banner
- [ ] Verify sidebar version matches bot status banner version (both use `IVersionService`)

Fixes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)