### PR TITLE
fix: Address critical accessibility and typography issues

### DIFF
--- a/src/DiscordBot.Bot/Pages/Shared/Components/_Badge.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/Components/_Badge.cshtml
@@ -2,7 +2,7 @@
 @{
     var sizeClasses = Model.Size switch
     {
-        DiscordBot.Bot.ViewModels.Components.BadgeSize.Small => "px-2 py-0.5 text-[10px]",
+        DiscordBot.Bot.ViewModels.Components.BadgeSize.Small => "px-2 py-0.5 text-xs",
         DiscordBot.Bot.ViewModels.Components.BadgeSize.Large => "px-4 py-1.5 text-sm",
         _ => "px-3 py-1 text-xs"
     };
@@ -35,7 +35,7 @@
             DiscordBot.Bot.ViewModels.Components.BadgeVariant.Orange => "bg-accent-orange text-white",
             DiscordBot.Bot.ViewModels.Components.BadgeVariant.Blue => "bg-accent-blue text-white",
             DiscordBot.Bot.ViewModels.Components.BadgeVariant.Success => "bg-success text-white",
-            DiscordBot.Bot.ViewModels.Components.BadgeVariant.Warning => "bg-warning text-white",
+            DiscordBot.Bot.ViewModels.Components.BadgeVariant.Warning => "bg-warning text-bg-primary",
             DiscordBot.Bot.ViewModels.Components.BadgeVariant.Error => "bg-error text-white",
             DiscordBot.Bot.ViewModels.Components.BadgeVariant.Info => "bg-info text-white",
             _ => "bg-bg-tertiary text-text-secondary"

--- a/src/DiscordBot.Bot/tailwind.config.js
+++ b/src/DiscordBot.Bot/tailwind.config.js
@@ -20,6 +20,7 @@ module.exports = {
           primary: '#d7d3d0',
           secondary: '#a8a5a3',
           tertiary: '#7a7876',
+          placeholder: '#8a8886',
           inverse: '#1d2022',
         },
         // Brand accent colors

--- a/src/DiscordBot.Bot/wwwroot/css/site.css
+++ b/src/DiscordBot.Bot/wwwroot/css/site.css
@@ -41,6 +41,7 @@
     --color-text-primary: #d7d3d0;
     --color-text-secondary: #a8a5a3;
     --color-text-tertiary: #7a7876;
+    --color-text-placeholder: #8a8886;
 
     /* Accent colors */
     --color-accent-blue: #098ecf;
@@ -251,7 +252,7 @@
     @apply transition-all duration-150 ease-in-out;
   }
   .form-input::placeholder {
-    @apply text-text-tertiary;
+    @apply text-text-placeholder;
   }
   .form-input:hover {
     @apply border-accent-blue;


### PR DESCRIPTION
## Summary

- Fix warning badge text color (WCAG AA contrast violation) - changed from white to dark text
- Fix small badge font size (below design system minimum) - changed from 10px to 12px (text-xs)
- Add text-placeholder color token for improved form placeholder contrast

## Changes

| Issue | Severity | Fix |
|-------|----------|-----|
| Warning badge contrast | Critical (P0) | `text-white` → `text-bg-primary` (#1d2022) |
| Small badge font size | High (P1) | `text-[10px]` → `text-xs` (12px) |
| Placeholder contrast | High (P1) | Added `text-placeholder` (#8a8886) token |

## Files Changed

- `src/DiscordBot.Bot/Pages/Shared/Components/_Badge.cshtml` - Badge component fixes
- `src/DiscordBot.Bot/tailwind.config.js` - Added placeholder color token
- `src/DiscordBot.Bot/wwwroot/css/site.css` - CSS variable and placeholder style

## Test Plan

- [x] Build succeeds with Tailwind CSS regeneration
- [x] All 1695 tests pass
- [ ] Manual contrast testing with browser dev tools
- [ ] Visual inspection of warning badges
- [ ] Form placeholder visibility on all input types

Fixes #364
Closes #370
Closes #371
Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)