### PR TITLE
fix: Standardize typography across pages to use design system classes

### DIFF
--- a/src/DiscordBot.Bot/Pages/Admin/AuditLogs/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/AuditLogs/Index.cshtml
@@ -65,7 +65,7 @@
     <!-- Header -->
     <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
         <div>
-            <h1 class="text-2xl font-bold text-text-primary">Audit Logs</h1>
+            <h1 class="text-h1 text-text-primary">Audit Logs</h1>
             <p class="mt-1 text-sm text-text-secondary">Track administrative actions and changes across your bot</p>
         </div>
         <a asp-page-handler="Export"

--- a/src/DiscordBot.Bot/Pages/Admin/MessageLogs/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/MessageLogs/Index.cshtml
@@ -8,7 +8,7 @@
     <!-- Header -->
     <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
         <div>
-            <h1 class="text-2xl font-bold text-text-primary">Message Logs</h1>
+            <h1 class="text-h1 text-text-primary">Message Logs</h1>
             <p class="mt-1 text-sm text-text-secondary">View and search logged Discord messages</p>
         </div>
         <a asp-page="/Api/MessageLogs/Export" class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-text-primary bg-bg-secondary border border-border-primary rounded-md hover:bg-bg-hover transition-colors">

--- a/src/DiscordBot.Bot/Pages/Admin/Users/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Users/Index.cshtml
@@ -8,7 +8,7 @@
     <!-- Header -->
     <div class="flex justify-between items-center mb-6">
         <div>
-            <h1 class="text-2xl font-bold text-text-primary">Users</h1>
+            <h1 class="text-h1 text-text-primary">Users</h1>
             <p class="mt-1 text-sm text-text-secondary">Manage application users and their roles</p>
         </div>
         @if (Model.ViewModel.CanCreateUsers)

--- a/src/DiscordBot.Bot/Pages/CommandLogs/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/CommandLogs/Index.cshtml
@@ -12,7 +12,7 @@
     <!-- Page Header -->
     <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
         <div class="flex items-center gap-3">
-            <h1 class="text-2xl lg:text-3xl font-bold text-text-primary">Command Logs</h1>
+            <h1 class="text-h1 text-text-primary">Command Logs</h1>
             <partial name="Shared/Components/_Badge" model="new BadgeViewModel { Text = Model.ViewModel.TotalCount.ToString(), Variant = BadgeVariant.Blue, Size = BadgeSize.Medium }" />
         </div>
         <div class="flex items-center gap-3">

--- a/src/DiscordBot.Bot/Pages/Commands/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Commands/Index.cshtml
@@ -10,7 +10,7 @@
     <!-- Page Header -->
     <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
         <div class="flex items-center gap-3">
-            <h1 class="text-2xl lg:text-3xl font-bold text-text-primary">Commands</h1>
+            <h1 class="text-h1 text-text-primary">Commands</h1>
             <partial name="Shared/Components/_Badge" model="new BadgeViewModel { Text = Model.ViewModel.TotalCommandCount.ToString(), Variant = BadgeVariant.Blue, Size = BadgeSize.Medium }" />
         </div>
         <div class="flex items-center gap-3">

--- a/src/DiscordBot.Bot/Pages/Guilds/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Index.cshtml
@@ -12,7 +12,7 @@
     <!-- Page Header -->
     <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
         <div class="flex items-center gap-3">
-            <h1 class="text-2xl lg:text-3xl font-bold text-text-primary">Servers</h1>
+            <h1 class="text-h1 text-text-primary">Servers</h1>
             <partial name="Shared/Components/_Badge" model="new BadgeViewModel { Text = Model.ViewModel.TotalCount.ToString(), Variant = BadgeVariant.Blue, Size = BadgeSize.Medium }" />
         </div>
         <div class="flex items-center gap-3">

--- a/src/DiscordBot.Bot/Pages/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Index.cshtml
@@ -8,7 +8,7 @@
 <!-- Page Header -->
 <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
     <div>
-        <h1 class="text-2xl lg:text-3xl font-bold text-text-primary">Dashboard</h1>
+        <h1 class="text-h1 text-text-primary">Dashboard</h1>
         <p class="mt-1 text-text-secondary">Welcome back! Here's an overview of your bot's performance.</p>
     </div>
 </div>

--- a/src/DiscordBot.Bot/Pages/Shared/Components/_Card.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/Components/_Card.cshtml
@@ -35,7 +35,7 @@
                     }
                     else if (!string.IsNullOrEmpty(Model.Title))
                     {
-                        <h3 class="text-lg font-semibold text-text-primary">@Model.Title</h3>
+                        <h3 class="text-h5 text-text-primary">@Model.Title</h3>
                         @if (!string.IsNullOrEmpty(Model.Subtitle))
                         {
                             <p class="text-sm text-text-secondary mt-1">@Model.Subtitle</p>
@@ -57,7 +57,7 @@
                     }
                     else if (!string.IsNullOrEmpty(Model.Title))
                     {
-                        <h3 class="text-lg font-semibold text-text-primary">@Model.Title</h3>
+                        <h3 class="text-h5 text-text-primary">@Model.Title</h3>
                         @if (!string.IsNullOrEmpty(Model.Subtitle))
                         {
                             <p class="text-sm text-text-secondary mt-1">@Model.Subtitle</p>


### PR DESCRIPTION
## Summary

- Update all page headings to use `text-h1` class instead of arbitrary `text-2xl`/`text-3xl font-bold` combinations
- Update card component titles to use `text-h5` class instead of `text-lg font-semibold`

## Design System Reference

| Token    | Size  | Weight | Tracking | Usage          |
|----------|-------|--------|----------|----------------|
| text-h1  | 36px  | 700    | -0.01em  | Page titles    |
| text-h5  | 18px  | 500    | normal   | Widget titles  |

## Affected Files

- `Pages/Index.cshtml` (Dashboard)
- `Pages/Commands/Index.cshtml`
- `Pages/Guilds/Index.cshtml`
- `Pages/CommandLogs/Index.cshtml`
- `Pages/Admin/Users/Index.cshtml`
- `Pages/Admin/AuditLogs/Index.cshtml`
- `Pages/Admin/MessageLogs/Index.cshtml`
- `Pages/Shared/Components/_Card.cshtml` (2 occurrences)

## Test Plan

- [ ] Verify page headings render at correct size (36px) across all updated pages
- [ ] Verify card titles render at correct size (18px) in card components
- [ ] Check typography hierarchy remains consistent
- [ ] Confirm no visual regressions on mobile/desktop views

Closes #365, closes #373, closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)