### PR TITLE
feat: Add HTML prototypes for Rat Watch Analytics pages

### DIFF
--- a/docs/prototypes/features/rat-watch-analytics/global-analytics.html
+++ b/docs/prototypes/features/rat-watch-analytics/global-analytics.html
@@ -1,0 +1,1546 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Global Rat Watch Analytics - Discord Bot Admin</title>
+
+  <!-- Shared Styles -->
+  <link rel="stylesheet" href="../../css/main.css">
+
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="../../css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
+
+  <!-- Chart.js for charts -->
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+
+  <style>
+    /* Layout Structure Variables */
+    :root {
+      --navbar-height: 64px;
+      --sidebar-width: 256px;
+      --sidebar-collapsed-width: 72px;
+    }
+
+    /* Enhanced Navbar */
+    .navbar-redesign {
+      height: var(--navbar-height);
+      background: linear-gradient(180deg, #262a2d 0%, #262a2d 100%);
+      border-bottom: 1px solid var(--color-border-primary);
+      backdrop-filter: blur(8px);
+    }
+
+    /* Enhanced Sidebar */
+    .sidebar-redesign {
+      width: var(--sidebar-width);
+      background-color: var(--color-bg-secondary);
+      border-right: 1px solid var(--color-border-primary);
+      transition: width 0.2s ease-out, transform 0.2s ease-out;
+    }
+
+    .sidebar-redesign.collapsed {
+      width: var(--sidebar-collapsed-width);
+    }
+
+    /* Sidebar Link Redesign */
+    .sidebar-link-redesign {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0.75rem 1rem;
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: var(--color-text-secondary);
+      text-decoration: none;
+      border-radius: 0.5rem;
+      transition: all 0.15s ease-in-out;
+      position: relative;
+    }
+
+    .sidebar-link-redesign:hover {
+      color: var(--color-text-primary);
+      background-color: var(--color-bg-hover);
+    }
+
+    .sidebar-link-redesign.active {
+      color: var(--color-text-primary);
+      background-color: rgba(203, 78, 27, 0.12);
+    }
+
+    .sidebar-link-redesign.active::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 3px;
+      height: 24px;
+      background-color: var(--color-accent-orange);
+      border-radius: 0 2px 2px 0;
+    }
+
+    /* Sidebar Section Header */
+    .sidebar-section-header {
+      padding: 0.5rem 1rem;
+      font-size: 0.6875rem;
+      font-weight: 600;
+      color: var(--color-text-tertiary);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    /* Sidebar Badge */
+    .sidebar-badge-redesign {
+      margin-left: auto;
+      padding: 0.125rem 0.5rem;
+      font-size: 0.6875rem;
+      font-weight: 600;
+      color: var(--color-text-primary);
+      background-color: var(--color-border-primary);
+      border-radius: 9999px;
+      min-width: 1.25rem;
+      text-align: center;
+    }
+
+    /* Content Area */
+    .main-content-redesign {
+      margin-left: var(--sidebar-width);
+      margin-top: var(--navbar-height);
+      min-height: calc(100vh - var(--navbar-height));
+      background-color: var(--color-bg-primary);
+      transition: margin-left 0.2s ease-out;
+    }
+
+    @media (max-width: 1023px) {
+      .main-content-redesign {
+        margin-left: 0;
+      }
+    }
+
+    /* Mobile Overlay */
+    .mobile-overlay {
+      position: fixed;
+      inset: 0;
+      background-color: rgba(0, 0, 0, 0.5);
+      backdrop-filter: blur(2px);
+      z-index: calc(var(--z-fixed) - 1);
+      opacity: 0;
+      visibility: hidden;
+      transition: all 0.2s ease-out;
+    }
+
+    .mobile-overlay.active {
+      opacity: 1;
+      visibility: visible;
+    }
+
+    /* Hero Metrics Cards */
+    .hero-metric-card {
+      background-color: var(--color-bg-secondary);
+      border: 1px solid var(--color-border-primary);
+      border-radius: 0.75rem;
+      padding: 1.5rem;
+      transition: all 0.2s ease-out;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .hero-metric-card:hover {
+      border-color: var(--color-border-focus);
+      transform: translateY(-2px);
+      box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15);
+    }
+
+    .hero-metric-card::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 3px;
+    }
+
+    .hero-metric-card.accent-blue::before {
+      background: linear-gradient(90deg, var(--color-accent-blue), var(--color-accent-blue-hover));
+    }
+
+    .hero-metric-card.accent-orange::before {
+      background: linear-gradient(90deg, var(--color-accent-orange), var(--color-accent-orange-hover));
+    }
+
+    .hero-metric-card.accent-success::before {
+      background: linear-gradient(90deg, var(--color-success), #34d399);
+    }
+
+    .hero-metric-card.accent-warning::before {
+      background: linear-gradient(90deg, var(--color-warning), #fbbf24);
+    }
+
+    .hero-metric-card.accent-info::before {
+      background: linear-gradient(90deg, var(--color-info), #22d3ee);
+    }
+
+    /* Chart Container */
+    .chart-container {
+      background-color: var(--color-bg-secondary);
+      border: 1px solid var(--color-border-primary);
+      border-radius: 0.75rem;
+      padding: 1.5rem;
+    }
+
+    .chart-container canvas {
+      max-height: 280px;
+    }
+
+    /* Table Row Hover */
+    .guild-row {
+      transition: background-color 0.15s ease-out;
+    }
+
+    .guild-row:hover {
+      background-color: var(--color-bg-hover);
+    }
+
+    /* User Menu Dropdown */
+    .user-menu-dropdown {
+      position: absolute;
+      right: 0;
+      top: calc(100% + 0.5rem);
+      width: 240px;
+      background-color: var(--color-bg-tertiary);
+      border: 1px solid var(--color-border-primary);
+      border-radius: 0.5rem;
+      box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(-8px);
+      transition: all 0.15s ease-out;
+      z-index: var(--z-popover);
+    }
+
+    .user-menu-dropdown.active {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0);
+    }
+
+    /* Bot Status Indicator */
+    .bot-status-indicator {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 0.75rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 600;
+    }
+
+    .bot-status-indicator.online {
+      background-color: rgba(16, 185, 129, 0.15);
+      color: var(--color-success);
+    }
+
+    .status-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background-color: currentColor;
+    }
+
+    .status-dot.pulse {
+      animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+    }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.5; }
+    }
+
+    /* Filter dropdown */
+    .filter-dropdown {
+      position: relative;
+    }
+
+    .filter-dropdown-menu {
+      position: absolute;
+      top: 100%;
+      left: 0;
+      margin-top: 0.5rem;
+      min-width: 200px;
+      background-color: var(--color-bg-tertiary);
+      border: 1px solid var(--color-border-primary);
+      border-radius: 0.5rem;
+      box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(-8px);
+      transition: all 0.15s ease-out;
+      z-index: var(--z-dropdown);
+    }
+
+    .filter-dropdown-menu.active {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0);
+    }
+
+    /* Collapsed Sidebar */
+    .sidebar-redesign.collapsed .sidebar-link-text,
+    .sidebar-redesign.collapsed .sidebar-badge-redesign,
+    .sidebar-redesign.collapsed .sidebar-section-header,
+    .sidebar-redesign.collapsed .bot-status-text {
+      display: none;
+    }
+
+    .sidebar-redesign.collapsed .sidebar-link-redesign {
+      justify-content: center;
+      padding: 0.75rem;
+    }
+
+    /* System Health Indicator */
+    .health-indicator {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.375rem;
+      padding: 0.25rem 0.625rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 600;
+    }
+
+    .health-indicator.healthy {
+      background-color: rgba(16, 185, 129, 0.15);
+      color: var(--color-success);
+    }
+
+    .health-indicator.warning {
+      background-color: rgba(245, 158, 11, 0.15);
+      color: var(--color-warning);
+    }
+
+    .health-indicator.critical {
+      background-color: rgba(239, 68, 68, 0.15);
+      color: var(--color-error);
+    }
+  </style>
+</head>
+<body class="bg-bg-primary text-text-primary font-sans antialiased">
+
+  <!-- Mobile Sidebar Overlay -->
+  <div id="mobileOverlay" class="mobile-overlay lg:hidden" onclick="toggleMobileSidebar()"></div>
+
+  <!-- Top Navigation Bar (64px) -->
+  <nav class="navbar-redesign fixed top-0 left-0 right-0 flex items-center justify-between px-4 lg:px-6" style="z-index: var(--z-fixed);">
+    <!-- Left Section: Menu Toggle & Logo -->
+    <div class="flex items-center gap-4">
+      <button
+        id="mobileMenuToggle"
+        onclick="toggleMobileSidebar()"
+        class="lg:hidden p-2 rounded-lg text-text-secondary hover:text-text-primary hover:bg-bg-hover transition-colors"
+        aria-label="Toggle sidebar menu"
+        aria-expanded="false"
+        aria-controls="sidebar"
+      >
+        <svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
+
+      <button
+        id="sidebarCollapseToggle"
+        onclick="toggleSidebarCollapse()"
+        class="hidden lg:flex p-2 rounded-lg text-text-secondary hover:text-text-primary hover:bg-bg-hover transition-colors"
+        aria-label="Toggle sidebar"
+      >
+        <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
+
+      <a href="../../features/dashboard-redesign/dashboard.html" class="flex items-center gap-3">
+        <div class="w-9 h-9 rounded-lg bg-accent-orange flex items-center justify-center shadow-lg shadow-accent-orange/20">
+          <svg class="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M20.317 4.492c-1.53-.69-3.17-1.2-4.885-1.49a.075.075 0 0 0-.079.036c-.21.369-.444.85-.608 1.23a18.566 18.566 0 0 0-5.487 0 12.36 12.36 0 0 0-.617-1.23A.077.077 0 0 0 8.562 3c-1.714.29-3.354.8-4.885 1.491a.07.07 0 0 0-.032.027C.533 9.093-.32 13.555.099 17.961a.08.08 0 0 0 .031.055 20.03 20.03 0 0 0 5.993 2.98.078.078 0 0 0 .084-.026c.36-.687.772-1.341 1.225-1.962a.077.077 0 0 0-.041-.104 13.201 13.201 0 0 1-1.872-.878.075.075 0 0 1-.008-.125c.126-.093.252-.19.372-.287a.075.075 0 0 1 .078-.01c3.927 1.764 8.18 1.764 12.061 0a.075.075 0 0 1 .079.009c.12.098.245.195.372.288a.075.075 0 0 1-.006.125c-.598.344-1.22.635-1.873.877a.075.075 0 0 0-.041.105c.36.687.772 1.341 1.225 1.962a.077.077 0 0 0 .084.028 19.963 19.963 0 0 0 6.002-2.981.076.076 0 0 0 .032-.054c.5-5.094-.838-9.52-3.549-13.442a.06.06 0 0 0-.031-.028zM8.02 15.278c-1.182 0-2.157-1.069-2.157-2.38 0-1.312.956-2.38 2.157-2.38 1.21 0 2.176 1.077 2.157 2.38 0 1.312-.956 2.38-2.157 2.38zm7.975 0c-1.183 0-2.157-1.069-2.157-2.38 0-1.312.955-2.38 2.157-2.38 1.21 0 2.176 1.077 2.157 2.38 0 1.312-.946 2.38-2.157 2.38z"/>
+          </svg>
+        </div>
+        <span class="text-lg font-bold text-text-primary hidden sm:block">Bot Admin</span>
+      </a>
+    </div>
+
+    <!-- Center Section: Search -->
+    <div class="hidden md:flex flex-1 max-w-lg mx-8">
+      <div class="relative w-full">
+        <svg class="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+        </svg>
+        <input
+          type="search"
+          placeholder="Search servers, commands, logs..."
+          class="w-full pl-10 pr-4 py-2.5 text-sm bg-bg-primary border border-border-primary rounded-lg text-text-primary placeholder-text-tertiary focus:border-border-focus focus:ring-2 focus:ring-border-focus/20 transition-all"
+        />
+        <kbd class="absolute right-3 top-1/2 -translate-y-1/2 hidden lg:inline-flex items-center px-2 py-0.5 text-xs font-medium text-text-tertiary bg-bg-tertiary border border-border-primary rounded">
+          <span class="text-xs">Ctrl</span>
+          <span class="mx-0.5">+</span>
+          <span>K</span>
+        </kbd>
+      </div>
+    </div>
+
+    <!-- Right Section -->
+    <div class="flex items-center gap-2">
+      <div class="hidden lg:flex bot-status-indicator online">
+        <span class="status-dot pulse"></span>
+        <span>Online</span>
+      </div>
+
+      <div class="relative">
+        <button
+          onclick="toggleUserMenu()"
+          class="flex items-center gap-2 p-1.5 rounded-lg hover:bg-bg-hover transition-colors"
+          aria-label="User menu"
+          aria-expanded="false"
+          aria-haspopup="true"
+        >
+          <div class="w-8 h-8 rounded-full bg-gradient-to-br from-accent-blue to-accent-blue-active flex items-center justify-center text-white font-semibold text-sm ring-2 ring-bg-secondary">
+            SA
+          </div>
+          <svg class="hidden sm:block w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+
+        <div id="userMenuDropdown" class="user-menu-dropdown">
+          <div class="px-4 py-3 border-b border-border-primary">
+            <p class="text-sm font-semibold text-text-primary">Super Admin</p>
+            <p class="text-xs text-text-secondary mt-0.5">admin@example.com</p>
+            <span class="inline-flex items-center mt-2 px-2 py-0.5 text-xs font-semibold text-accent-orange bg-accent-orange/10 rounded-full">
+              SuperAdmin
+            </span>
+          </div>
+          <div class="py-1">
+            <a href="#" class="flex items-center gap-3 px-4 py-2.5 text-sm text-text-secondary hover:bg-bg-hover hover:text-text-primary transition-colors">
+              <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+              </svg>
+              Profile
+            </a>
+            <a href="#" class="flex items-center gap-3 px-4 py-2.5 text-sm text-text-secondary hover:bg-bg-hover hover:text-text-primary transition-colors">
+              <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              </svg>
+              Settings
+            </a>
+          </div>
+          <div class="py-1 border-t border-border-primary">
+            <a href="#" class="flex items-center gap-3 px-4 py-2.5 text-sm text-error hover:bg-error-bg transition-colors">
+              <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+              </svg>
+              Sign out
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <!-- Sidebar Navigation (256px) -->
+  <aside
+    id="sidebar"
+    class="sidebar-redesign fixed top-16 left-0 h-[calc(100vh-64px)] transform -translate-x-full lg:translate-x-0 overflow-y-auto overflow-x-hidden"
+    style="z-index: var(--z-fixed);"
+  >
+    <nav class="flex flex-col h-full p-3">
+      <!-- Main Navigation -->
+      <div class="space-y-1">
+        <a href="../../features/dashboard-redesign/dashboard.html" class="sidebar-link-redesign">
+          <svg class="w-5 h-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+          </svg>
+          <span class="sidebar-link-text">Dashboard</span>
+        </a>
+
+        <a href="#" class="sidebar-link-redesign">
+          <svg class="w-5 h-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" />
+          </svg>
+          <span class="sidebar-link-text">Guilds</span>
+          <span class="sidebar-badge-redesign">12</span>
+        </a>
+
+        <a href="#" class="sidebar-link-redesign">
+          <svg class="w-5 h-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+          </svg>
+          <span class="sidebar-link-text">Commands</span>
+        </a>
+      </div>
+
+      <div class="my-4 border-t border-border-secondary"></div>
+
+      <div>
+        <p class="sidebar-section-header">Analytics</p>
+        <div class="mt-2 space-y-1">
+          <a href="#" class="sidebar-link-redesign">
+            <svg class="w-5 h-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+            </svg>
+            <span class="sidebar-link-text">Command Analytics</span>
+          </a>
+
+          <a href="#" class="sidebar-link-redesign active">
+            <svg class="w-5 h-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+            </svg>
+            <span class="sidebar-link-text">Rat Watch Analytics</span>
+          </a>
+        </div>
+      </div>
+
+      <div class="my-4 border-t border-border-secondary"></div>
+
+      <div>
+        <p class="sidebar-section-header">Administration</p>
+        <div class="mt-2 space-y-1">
+          <a href="#" class="sidebar-link-redesign">
+            <svg class="w-5 h-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+            </svg>
+            <span class="sidebar-link-text">Users</span>
+          </a>
+
+          <a href="#" class="sidebar-link-redesign">
+            <svg class="w-5 h-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" />
+            </svg>
+            <span class="sidebar-link-text">Audit Logs</span>
+          </a>
+
+          <a href="#" class="sidebar-link-redesign">
+            <svg class="w-5 h-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+            </svg>
+            <span class="sidebar-link-text">Settings</span>
+          </a>
+
+          <a href="#" class="sidebar-link-redesign">
+            <svg class="w-5 h-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+            </svg>
+            <span class="sidebar-link-text">Bot Control</span>
+          </a>
+        </div>
+      </div>
+
+      <div class="flex-1"></div>
+
+      <div class="mt-4 p-3 bg-bg-primary/50 rounded-lg">
+        <div class="flex items-center gap-3">
+          <div class="w-10 h-10 rounded-lg bg-success/15 flex items-center justify-center">
+            <svg class="w-5 h-5 text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+            </svg>
+          </div>
+          <div class="bot-status-text flex-1 min-w-0">
+            <p class="text-sm font-medium text-text-primary">Bot Online</p>
+            <p class="text-xs text-text-tertiary">v0.3.10-dev</p>
+          </div>
+        </div>
+      </div>
+    </nav>
+  </aside>
+
+  <!-- Main Content Area -->
+  <main class="main-content-redesign">
+    <div class="p-6 lg:p-8">
+
+      <!-- Breadcrumb -->
+      <nav aria-label="Breadcrumb" class="mb-6">
+        <ol class="flex items-center gap-2 text-sm">
+          <li>
+            <a href="../../features/dashboard-redesign/dashboard.html" class="text-text-secondary hover:text-accent-blue transition-colors">
+              <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+              </svg>
+            </a>
+          </li>
+          <li class="text-text-tertiary" aria-hidden="true">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+          </li>
+          <li>
+            <a href="#" class="text-text-secondary hover:text-accent-blue transition-colors">Admin</a>
+          </li>
+          <li class="text-text-tertiary" aria-hidden="true">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+          </li>
+          <li>
+            <span class="text-text-primary font-medium" aria-current="page">Rat Watch Analytics</span>
+          </li>
+        </ol>
+      </nav>
+
+      <!-- Page Header -->
+      <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
+        <div>
+          <div class="flex items-center gap-3">
+            <h1 class="text-2xl lg:text-3xl font-bold text-text-primary">Global Rat Watch Analytics</h1>
+            <span class="health-indicator healthy">
+              <span class="w-1.5 h-1.5 rounded-full bg-current"></span>
+              Healthy
+            </span>
+          </div>
+          <p class="mt-1 text-text-secondary">Cross-guild metrics and analytics for Rat Watch feature across all servers.</p>
+        </div>
+        <div class="flex items-center gap-3">
+          <span class="text-xs text-text-tertiary" id="lastUpdated">Last updated: just now</span>
+          <button class="inline-flex items-center gap-2 px-4 py-2.5 bg-bg-secondary hover:bg-bg-hover border border-border-primary text-text-primary font-medium text-sm rounded-lg transition-colors">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+            </svg>
+            Export Report
+          </button>
+        </div>
+      </div>
+
+      <!-- Global Stats Cards -->
+      <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4 lg:gap-6 mb-8">
+        <!-- Total Guilds Using -->
+        <div class="hero-metric-card accent-blue">
+          <div class="flex items-start justify-between">
+            <div>
+              <p class="text-sm font-medium text-text-secondary">Total Guilds Using</p>
+              <p class="mt-2 text-3xl font-bold text-text-primary">12</p>
+              <div class="mt-2 flex items-center gap-1.5">
+                <span class="flex items-center gap-1 text-xs font-medium text-success">
+                  <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18" />
+                  </svg>
+                  +2
+                </span>
+                <span class="text-xs text-text-tertiary">this month</span>
+              </div>
+            </div>
+            <div class="p-3 bg-accent-blue/10 rounded-xl">
+              <svg class="w-6 h-6 text-accent-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" />
+              </svg>
+            </div>
+          </div>
+        </div>
+
+        <!-- Total Watches -->
+        <div class="hero-metric-card accent-orange">
+          <div class="flex items-start justify-between">
+            <div>
+              <p class="text-sm font-medium text-text-secondary">Total Watches</p>
+              <p class="mt-2 text-3xl font-bold text-text-primary">1,847</p>
+              <div class="mt-2 flex items-center gap-1.5">
+                <span class="text-xs text-text-tertiary">All time across all guilds</span>
+              </div>
+            </div>
+            <div class="p-3 bg-accent-orange/10 rounded-xl">
+              <svg class="w-6 h-6 text-accent-orange" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+              </svg>
+            </div>
+          </div>
+        </div>
+
+        <!-- Active Now -->
+        <div class="hero-metric-card accent-success">
+          <div class="flex items-start justify-between">
+            <div>
+              <p class="text-sm font-medium text-text-secondary">Active Now</p>
+              <p class="mt-2 text-3xl font-bold text-text-primary">8</p>
+              <div class="mt-2 flex items-center gap-1.5">
+                <span class="inline-flex items-center gap-1 px-1.5 py-0.5 text-xs font-medium text-warning bg-warning/10 rounded">3 Pending</span>
+                <span class="inline-flex items-center gap-1 px-1.5 py-0.5 text-xs font-medium text-info bg-info/10 rounded">5 Voting</span>
+              </div>
+            </div>
+            <div class="p-3 bg-success/10 rounded-xl">
+              <svg class="w-6 h-6 text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
+              </svg>
+            </div>
+          </div>
+        </div>
+
+        <!-- Today's Activity -->
+        <div class="hero-metric-card accent-warning">
+          <div class="flex items-start justify-between">
+            <div>
+              <p class="text-sm font-medium text-text-secondary">Today's Activity</p>
+              <p class="mt-2 text-3xl font-bold text-text-primary">23</p>
+              <div class="mt-2 flex items-center gap-1.5">
+                <span class="flex items-center gap-1 text-xs font-medium text-success">
+                  <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18" />
+                  </svg>
+                  +15%
+                </span>
+                <span class="text-xs text-text-tertiary">vs yesterday</span>
+              </div>
+            </div>
+            <div class="p-3 bg-warning/10 rounded-xl">
+              <svg class="w-6 h-6 text-warning" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Guild Filter & Date Range -->
+      <div class="flex flex-col sm:flex-row gap-4 mb-6">
+        <!-- Guild Filter Dropdown -->
+        <div class="filter-dropdown">
+          <button
+            id="guildFilterBtn"
+            onclick="toggleGuildFilter()"
+            class="inline-flex items-center justify-between gap-2 w-full sm:w-64 px-4 py-2.5 bg-bg-secondary border border-border-primary rounded-lg text-sm text-text-primary hover:bg-bg-hover transition-colors"
+          >
+            <span class="flex items-center gap-2">
+              <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
+              </svg>
+              <span id="selectedGuild">All Guilds</span>
+            </span>
+            <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          <div id="guildFilterMenu" class="filter-dropdown-menu">
+            <div class="p-2">
+              <button onclick="selectGuild('All Guilds')" class="w-full flex items-center gap-2 px-3 py-2 text-sm text-text-primary hover:bg-bg-hover rounded-lg transition-colors">
+                <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                </svg>
+                All Guilds
+              </button>
+              <div class="my-1 border-t border-border-secondary"></div>
+              <button onclick="selectGuild('The Rat\'s Nest')" class="w-full flex items-center gap-2 px-3 py-2 text-sm text-text-primary hover:bg-bg-hover rounded-lg transition-colors">
+                <div class="w-5 h-5 rounded bg-gradient-to-br from-purple-500 to-pink-500 flex items-center justify-center text-white text-xs font-bold">R</div>
+                The Rat's Nest
+              </button>
+              <button onclick="selectGuild('Cheese Factory')" class="w-full flex items-center gap-2 px-3 py-2 text-sm text-text-primary hover:bg-bg-hover rounded-lg transition-colors">
+                <div class="w-5 h-5 rounded bg-gradient-to-br from-yellow-500 to-orange-500 flex items-center justify-center text-white text-xs font-bold">C</div>
+                Cheese Factory
+              </button>
+              <button onclick="selectGuild('Night Shift')" class="w-full flex items-center gap-2 px-3 py-2 text-sm text-text-primary hover:bg-bg-hover rounded-lg transition-colors">
+                <div class="w-5 h-5 rounded bg-gradient-to-br from-blue-500 to-indigo-500 flex items-center justify-center text-white text-xs font-bold">N</div>
+                Night Shift
+              </button>
+              <button onclick="selectGuild('Underground')" class="w-full flex items-center gap-2 px-3 py-2 text-sm text-text-primary hover:bg-bg-hover rounded-lg transition-colors">
+                <div class="w-5 h-5 rounded bg-gradient-to-br from-gray-600 to-gray-800 flex items-center justify-center text-white text-xs font-bold">U</div>
+                Underground
+              </button>
+              <button onclick="selectGuild('New Server')" class="w-full flex items-center gap-2 px-3 py-2 text-sm text-text-primary hover:bg-bg-hover rounded-lg transition-colors">
+                <div class="w-5 h-5 rounded bg-gradient-to-br from-green-500 to-emerald-500 flex items-center justify-center text-white text-xs font-bold">N</div>
+                New Server
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Date Range Filter -->
+        <div class="flex items-center gap-2">
+          <button onclick="setDateRange('7d')" class="date-range-btn px-3 py-2 text-sm font-medium bg-accent-blue/10 text-accent-blue border border-accent-blue/30 rounded-lg transition-colors" data-range="7d">
+            7 Days
+          </button>
+          <button onclick="setDateRange('30d')" class="date-range-btn px-3 py-2 text-sm font-medium bg-bg-secondary text-text-secondary border border-border-primary hover:bg-bg-hover rounded-lg transition-colors" data-range="30d">
+            30 Days
+          </button>
+          <button onclick="setDateRange('90d')" class="date-range-btn px-3 py-2 text-sm font-medium bg-bg-secondary text-text-secondary border border-border-primary hover:bg-bg-hover rounded-lg transition-colors" data-range="90d">
+            90 Days
+          </button>
+          <button onclick="setDateRange('all')" class="date-range-btn px-3 py-2 text-sm font-medium bg-bg-secondary text-text-secondary border border-border-primary hover:bg-bg-hover rounded-lg transition-colors" data-range="all">
+            All Time
+          </button>
+        </div>
+      </div>
+
+      <!-- Charts Grid -->
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+        <!-- Activity by Guild (Horizontal Bar Chart) -->
+        <div class="chart-container">
+          <div class="flex items-center justify-between mb-4">
+            <h3 class="text-lg font-semibold text-text-primary">Activity by Guild</h3>
+            <span class="text-xs text-text-tertiary">Total watches per guild</span>
+          </div>
+          <canvas id="activityByGuildChart"></canvas>
+        </div>
+
+        <!-- Global Trends (Line Chart) -->
+        <div class="chart-container">
+          <div class="flex items-center justify-between mb-4">
+            <h3 class="text-lg font-semibold text-text-primary">Global Trends</h3>
+            <span class="text-xs text-text-tertiary">Watches created over time</span>
+          </div>
+          <canvas id="globalTrendsChart"></canvas>
+        </div>
+
+        <!-- Outcome Distribution (Doughnut Chart) -->
+        <div class="chart-container">
+          <div class="flex items-center justify-between mb-4">
+            <h3 class="text-lg font-semibold text-text-primary">Outcome Distribution</h3>
+            <span class="text-xs text-text-tertiary">Global totals across all guilds</span>
+          </div>
+          <div class="flex items-center justify-center">
+            <div class="relative" style="max-width: 280px; width: 100%;">
+              <canvas id="outcomeDistributionChart"></canvas>
+              <div class="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
+                <span class="text-3xl font-bold text-text-primary">1,847</span>
+                <span class="text-sm text-text-secondary">Total</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Most Active Guilds This Week -->
+        <div class="chart-container">
+          <div class="flex items-center justify-between mb-4">
+            <h3 class="text-lg font-semibold text-text-primary">Most Active This Week</h3>
+            <span class="text-xs text-text-tertiary">Top 5 guilds by activity</span>
+          </div>
+          <canvas id="mostActiveGuildsChart"></canvas>
+        </div>
+      </div>
+
+      <!-- Per-Guild Summary Table -->
+      <div class="bg-bg-secondary border border-border-primary rounded-xl overflow-hidden">
+        <div class="flex items-center justify-between px-6 py-4 border-b border-border-primary">
+          <h2 class="text-lg font-semibold text-text-primary">Per-Guild Summary</h2>
+          <div class="flex items-center gap-2">
+            <span class="text-sm text-text-tertiary">Showing 5 of 12 guilds</span>
+            <button class="text-sm font-medium text-accent-blue hover:text-accent-blue-hover transition-colors">
+              View All
+            </button>
+          </div>
+        </div>
+
+        <div class="overflow-x-auto">
+          <table class="w-full">
+            <thead class="bg-bg-primary/50">
+              <tr>
+                <th class="px-6 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Guild</th>
+                <th class="px-6 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Total Watches</th>
+                <th class="px-6 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Active</th>
+                <th class="px-6 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Guilty Rate</th>
+                <th class="px-6 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Check-in Rate</th>
+                <th class="px-6 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Health</th>
+                <th class="px-6 py-3 text-right text-xs font-semibold text-text-secondary uppercase tracking-wider">Actions</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-border-primary">
+              <!-- The Rat's Nest -->
+              <tr class="guild-row">
+                <td class="px-6 py-4">
+                  <div class="flex items-center gap-3">
+                    <div class="w-10 h-10 rounded-lg bg-gradient-to-br from-purple-500 to-pink-500 flex items-center justify-center text-white font-bold text-sm">RN</div>
+                    <div>
+                      <p class="font-medium text-text-primary">The Rat's Nest</p>
+                      <p class="text-xs text-text-tertiary font-mono">ID: 1234567890</p>
+                    </div>
+                  </div>
+                </td>
+                <td class="px-6 py-4">
+                  <span class="text-text-primary font-medium">247</span>
+                </td>
+                <td class="px-6 py-4">
+                  <span class="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-semibold text-warning bg-warning/10 rounded-full">
+                    <span class="w-1.5 h-1.5 bg-warning rounded-full animate-pulse"></span>
+                    3 Active
+                  </span>
+                </td>
+                <td class="px-6 py-4">
+                  <div class="flex items-center gap-2">
+                    <div class="flex-1 h-2 bg-bg-primary rounded-full overflow-hidden max-w-[100px]">
+                      <div class="h-full bg-error rounded-full" style="width: 68%"></div>
+                    </div>
+                    <span class="text-sm text-text-primary font-medium">68%</span>
+                  </div>
+                </td>
+                <td class="px-6 py-4">
+                  <div class="flex items-center gap-2">
+                    <div class="flex-1 h-2 bg-bg-primary rounded-full overflow-hidden max-w-[100px]">
+                      <div class="h-full bg-success rounded-full" style="width: 45%"></div>
+                    </div>
+                    <span class="text-sm text-text-primary font-medium">45%</span>
+                  </div>
+                </td>
+                <td class="px-6 py-4">
+                  <span class="health-indicator healthy">
+                    <span class="w-1.5 h-1.5 rounded-full bg-current"></span>
+                    Healthy
+                  </span>
+                </td>
+                <td class="px-6 py-4 text-right">
+                  <a href="guild-analytics.html?guild=rats-nest" class="inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-accent-blue hover:text-accent-blue-hover transition-colors">
+                    View
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                    </svg>
+                  </a>
+                </td>
+              </tr>
+
+              <!-- Cheese Factory -->
+              <tr class="guild-row">
+                <td class="px-6 py-4">
+                  <div class="flex items-center gap-3">
+                    <div class="w-10 h-10 rounded-lg bg-gradient-to-br from-yellow-500 to-orange-500 flex items-center justify-center text-white font-bold text-sm">CF</div>
+                    <div>
+                      <p class="font-medium text-text-primary">Cheese Factory</p>
+                      <p class="text-xs text-text-tertiary font-mono">ID: 2345678901</p>
+                    </div>
+                  </div>
+                </td>
+                <td class="px-6 py-4">
+                  <span class="text-text-primary font-medium">189</span>
+                </td>
+                <td class="px-6 py-4">
+                  <span class="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-semibold text-info bg-info/10 rounded-full">
+                    <span class="w-1.5 h-1.5 bg-info rounded-full animate-pulse"></span>
+                    2 Active
+                  </span>
+                </td>
+                <td class="px-6 py-4">
+                  <div class="flex items-center gap-2">
+                    <div class="flex-1 h-2 bg-bg-primary rounded-full overflow-hidden max-w-[100px]">
+                      <div class="h-full bg-error rounded-full" style="width: 72%"></div>
+                    </div>
+                    <span class="text-sm text-text-primary font-medium">72%</span>
+                  </div>
+                </td>
+                <td class="px-6 py-4">
+                  <div class="flex items-center gap-2">
+                    <div class="flex-1 h-2 bg-bg-primary rounded-full overflow-hidden max-w-[100px]">
+                      <div class="h-full bg-success rounded-full" style="width: 38%"></div>
+                    </div>
+                    <span class="text-sm text-text-primary font-medium">38%</span>
+                  </div>
+                </td>
+                <td class="px-6 py-4">
+                  <span class="health-indicator healthy">
+                    <span class="w-1.5 h-1.5 rounded-full bg-current"></span>
+                    Healthy
+                  </span>
+                </td>
+                <td class="px-6 py-4 text-right">
+                  <a href="guild-analytics.html?guild=cheese-factory" class="inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-accent-blue hover:text-accent-blue-hover transition-colors">
+                    View
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                    </svg>
+                  </a>
+                </td>
+              </tr>
+
+              <!-- Night Shift -->
+              <tr class="guild-row">
+                <td class="px-6 py-4">
+                  <div class="flex items-center gap-3">
+                    <div class="w-10 h-10 rounded-lg bg-gradient-to-br from-blue-500 to-indigo-500 flex items-center justify-center text-white font-bold text-sm">NS</div>
+                    <div>
+                      <p class="font-medium text-text-primary">Night Shift</p>
+                      <p class="text-xs text-text-tertiary font-mono">ID: 3456789012</p>
+                    </div>
+                  </div>
+                </td>
+                <td class="px-6 py-4">
+                  <span class="text-text-primary font-medium">156</span>
+                </td>
+                <td class="px-6 py-4">
+                  <span class="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-semibold text-info bg-info/10 rounded-full">
+                    <span class="w-1.5 h-1.5 bg-info rounded-full animate-pulse"></span>
+                    1 Active
+                  </span>
+                </td>
+                <td class="px-6 py-4">
+                  <div class="flex items-center gap-2">
+                    <div class="flex-1 h-2 bg-bg-primary rounded-full overflow-hidden max-w-[100px]">
+                      <div class="h-full bg-warning rounded-full" style="width: 55%"></div>
+                    </div>
+                    <span class="text-sm text-text-primary font-medium">55%</span>
+                  </div>
+                </td>
+                <td class="px-6 py-4">
+                  <div class="flex items-center gap-2">
+                    <div class="flex-1 h-2 bg-bg-primary rounded-full overflow-hidden max-w-[100px]">
+                      <div class="h-full bg-success rounded-full" style="width: 62%"></div>
+                    </div>
+                    <span class="text-sm text-text-primary font-medium">62%</span>
+                  </div>
+                </td>
+                <td class="px-6 py-4">
+                  <span class="health-indicator healthy">
+                    <span class="w-1.5 h-1.5 rounded-full bg-current"></span>
+                    Healthy
+                  </span>
+                </td>
+                <td class="px-6 py-4 text-right">
+                  <a href="guild-analytics.html?guild=night-shift" class="inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-accent-blue hover:text-accent-blue-hover transition-colors">
+                    View
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                    </svg>
+                  </a>
+                </td>
+              </tr>
+
+              <!-- Underground -->
+              <tr class="guild-row">
+                <td class="px-6 py-4">
+                  <div class="flex items-center gap-3">
+                    <div class="w-10 h-10 rounded-lg bg-gradient-to-br from-gray-600 to-gray-800 flex items-center justify-center text-white font-bold text-sm">UG</div>
+                    <div>
+                      <p class="font-medium text-text-primary">Underground</p>
+                      <p class="text-xs text-text-tertiary font-mono">ID: 4567890123</p>
+                    </div>
+                  </div>
+                </td>
+                <td class="px-6 py-4">
+                  <span class="text-text-primary font-medium">134</span>
+                </td>
+                <td class="px-6 py-4">
+                  <span class="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-semibold text-text-tertiary bg-bg-primary rounded-full">
+                    <span class="w-1.5 h-1.5 bg-text-tertiary rounded-full"></span>
+                    0 Active
+                  </span>
+                </td>
+                <td class="px-6 py-4">
+                  <div class="flex items-center gap-2">
+                    <div class="flex-1 h-2 bg-bg-primary rounded-full overflow-hidden max-w-[100px]">
+                      <div class="h-full bg-error rounded-full" style="width: 81%"></div>
+                    </div>
+                    <span class="text-sm text-text-primary font-medium">81%</span>
+                  </div>
+                </td>
+                <td class="px-6 py-4">
+                  <div class="flex items-center gap-2">
+                    <div class="flex-1 h-2 bg-bg-primary rounded-full overflow-hidden max-w-[100px]">
+                      <div class="h-full bg-warning rounded-full" style="width: 28%"></div>
+                    </div>
+                    <span class="text-sm text-text-primary font-medium">28%</span>
+                  </div>
+                </td>
+                <td class="px-6 py-4">
+                  <span class="health-indicator warning">
+                    <span class="w-1.5 h-1.5 rounded-full bg-current"></span>
+                    Low Activity
+                  </span>
+                </td>
+                <td class="px-6 py-4 text-right">
+                  <a href="guild-analytics.html?guild=underground" class="inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-accent-blue hover:text-accent-blue-hover transition-colors">
+                    View
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                    </svg>
+                  </a>
+                </td>
+              </tr>
+
+              <!-- New Server -->
+              <tr class="guild-row">
+                <td class="px-6 py-4">
+                  <div class="flex items-center gap-3">
+                    <div class="w-10 h-10 rounded-lg bg-gradient-to-br from-green-500 to-emerald-500 flex items-center justify-center text-white font-bold text-sm">NS</div>
+                    <div>
+                      <p class="font-medium text-text-primary">New Server</p>
+                      <p class="text-xs text-text-tertiary font-mono">ID: 5678901234</p>
+                    </div>
+                  </div>
+                </td>
+                <td class="px-6 py-4">
+                  <span class="text-text-primary font-medium">23</span>
+                  <span class="ml-2 inline-flex items-center px-1.5 py-0.5 text-xs font-medium text-info bg-info/10 rounded">New</span>
+                </td>
+                <td class="px-6 py-4">
+                  <span class="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-semibold text-warning bg-warning/10 rounded-full">
+                    <span class="w-1.5 h-1.5 bg-warning rounded-full animate-pulse"></span>
+                    2 Active
+                  </span>
+                </td>
+                <td class="px-6 py-4">
+                  <div class="flex items-center gap-2">
+                    <div class="flex-1 h-2 bg-bg-primary rounded-full overflow-hidden max-w-[100px]">
+                      <div class="h-full bg-success rounded-full" style="width: 45%"></div>
+                    </div>
+                    <span class="text-sm text-text-primary font-medium">45%</span>
+                  </div>
+                </td>
+                <td class="px-6 py-4">
+                  <div class="flex items-center gap-2">
+                    <div class="flex-1 h-2 bg-bg-primary rounded-full overflow-hidden max-w-[100px]">
+                      <div class="h-full bg-success rounded-full" style="width: 78%"></div>
+                    </div>
+                    <span class="text-sm text-text-primary font-medium">78%</span>
+                  </div>
+                </td>
+                <td class="px-6 py-4">
+                  <span class="health-indicator healthy">
+                    <span class="w-1.5 h-1.5 rounded-full bg-current"></span>
+                    Healthy
+                  </span>
+                </td>
+                <td class="px-6 py-4 text-right">
+                  <a href="guild-analytics.html?guild=new-server" class="inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-accent-blue hover:text-accent-blue-hover transition-colors">
+                    View
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                    </svg>
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Pagination -->
+        <div class="flex items-center justify-between px-6 py-4 border-t border-border-primary bg-bg-primary/30">
+          <p class="text-sm text-text-secondary">
+            Showing <span class="font-medium text-text-primary">1</span> to <span class="font-medium text-text-primary">5</span> of <span class="font-medium text-text-primary">12</span> guilds
+          </p>
+          <div class="flex items-center gap-2">
+            <button disabled class="px-3 py-1.5 text-sm font-medium text-text-tertiary bg-bg-secondary border border-border-primary rounded-lg cursor-not-allowed">
+              Previous
+            </button>
+            <button class="px-3 py-1.5 text-sm font-medium text-text-primary bg-bg-secondary border border-border-primary hover:bg-bg-hover rounded-lg transition-colors">
+              Next
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Footer Note -->
+      <div class="mt-8 text-center">
+        <p class="text-sm text-text-tertiary">
+          Global Rat Watch Analytics Prototype -
+          <a href="guild-analytics.html" class="text-accent-blue hover:text-accent-blue-hover transition-colors">Guild Analytics</a> |
+          <a href="../../features/dashboard-redesign/dashboard.html" class="text-accent-blue hover:text-accent-blue-hover transition-colors">Dashboard</a>
+        </p>
+      </div>
+
+    </div>
+  </main>
+
+  <!-- JavaScript -->
+  <script>
+    // State
+    let sidebarCollapsed = false;
+    let mobileSidebarOpen = false;
+    let selectedDateRange = '7d';
+
+    // DOM Elements
+    const sidebar = document.getElementById('sidebar');
+    const mobileOverlay = document.getElementById('mobileOverlay');
+    const mobileMenuToggle = document.getElementById('mobileMenuToggle');
+    const userMenuDropdown = document.getElementById('userMenuDropdown');
+    const mainContent = document.querySelector('.main-content-redesign');
+    const guildFilterMenu = document.getElementById('guildFilterMenu');
+
+    // Toggle mobile sidebar
+    function toggleMobileSidebar() {
+      mobileSidebarOpen = !mobileSidebarOpen;
+
+      if (mobileSidebarOpen) {
+        sidebar.classList.remove('-translate-x-full');
+        mobileOverlay.classList.add('active');
+        mobileMenuToggle.setAttribute('aria-expanded', 'true');
+        const firstLink = sidebar.querySelector('a');
+        if (firstLink) firstLink.focus();
+      } else {
+        sidebar.classList.add('-translate-x-full');
+        mobileOverlay.classList.remove('active');
+        mobileMenuToggle.setAttribute('aria-expanded', 'false');
+        mobileMenuToggle.focus();
+      }
+    }
+
+    // Toggle sidebar collapse (desktop)
+    function toggleSidebarCollapse() {
+      sidebarCollapsed = !sidebarCollapsed;
+
+      if (sidebarCollapsed) {
+        sidebar.classList.add('collapsed');
+        mainContent.style.marginLeft = 'var(--sidebar-collapsed-width)';
+      } else {
+        sidebar.classList.remove('collapsed');
+        mainContent.style.marginLeft = 'var(--sidebar-width)';
+      }
+    }
+
+    // Toggle user menu
+    function toggleUserMenu() {
+      userMenuDropdown.classList.toggle('active');
+    }
+
+    // Toggle guild filter
+    function toggleGuildFilter() {
+      guildFilterMenu.classList.toggle('active');
+    }
+
+    // Select guild from filter
+    function selectGuild(guildName) {
+      document.getElementById('selectedGuild').textContent = guildName;
+      guildFilterMenu.classList.remove('active');
+      // In a real implementation, this would filter the data
+      console.log('Selected guild:', guildName);
+    }
+
+    // Set date range
+    function setDateRange(range) {
+      selectedDateRange = range;
+      document.querySelectorAll('.date-range-btn').forEach(btn => {
+        if (btn.dataset.range === range) {
+          btn.classList.remove('bg-bg-secondary', 'text-text-secondary', 'hover:bg-bg-hover');
+          btn.classList.add('bg-accent-blue/10', 'text-accent-blue', 'border-accent-blue/30');
+        } else {
+          btn.classList.add('bg-bg-secondary', 'text-text-secondary', 'hover:bg-bg-hover');
+          btn.classList.remove('bg-accent-blue/10', 'text-accent-blue', 'border-accent-blue/30');
+        }
+      });
+      // In a real implementation, this would reload the charts with new data
+      console.log('Selected date range:', range);
+    }
+
+    // Close dropdowns when clicking outside
+    document.addEventListener('click', function(event) {
+      const userButton = event.target.closest('[aria-label="User menu"]');
+      const dropdown = event.target.closest('.user-menu-dropdown');
+      const guildButton = event.target.closest('#guildFilterBtn');
+      const guildMenu = event.target.closest('#guildFilterMenu');
+
+      if (!userButton && !dropdown) {
+        userMenuDropdown.classList.remove('active');
+      }
+
+      if (!guildButton && !guildMenu) {
+        guildFilterMenu.classList.remove('active');
+      }
+    });
+
+    // Handle window resize
+    window.addEventListener('resize', function() {
+      if (window.innerWidth >= 1024) {
+        mobileSidebarOpen = false;
+        mobileOverlay.classList.remove('active');
+        sidebar.classList.remove('-translate-x-full');
+        mobileMenuToggle.setAttribute('aria-expanded', 'false');
+
+        if (sidebarCollapsed) {
+          mainContent.style.marginLeft = 'var(--sidebar-collapsed-width)';
+        } else {
+          mainContent.style.marginLeft = 'var(--sidebar-width)';
+        }
+      } else {
+        mainContent.style.marginLeft = '0';
+        if (!mobileSidebarOpen) {
+          sidebar.classList.add('-translate-x-full');
+        }
+      }
+    });
+
+    // Keyboard navigation
+    document.addEventListener('keydown', function(event) {
+      if (event.key === 'Escape') {
+        userMenuDropdown.classList.remove('active');
+        guildFilterMenu.classList.remove('active');
+        if (mobileSidebarOpen && window.innerWidth < 1024) {
+          toggleMobileSidebar();
+        }
+      }
+
+      if (event.ctrlKey && event.key === 'k') {
+        event.preventDefault();
+        const searchInput = document.querySelector('input[type="search"]');
+        if (searchInput) searchInput.focus();
+      }
+    });
+
+    // Update last updated time
+    function updateLastUpdatedTime() {
+      const now = new Date();
+      const options = { hour: 'numeric', minute: '2-digit', hour12: true };
+      const timeStr = now.toLocaleTimeString('en-US', options);
+      document.getElementById('lastUpdated').textContent = `Last updated: ${timeStr}`;
+    }
+
+    // Chart.js default configuration for dark theme
+    Chart.defaults.color = '#a8a5a3';
+    Chart.defaults.borderColor = '#3f4447';
+    Chart.defaults.font.family = '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+
+    // Activity by Guild (Horizontal Bar Chart)
+    const activityByGuildCtx = document.getElementById('activityByGuildChart').getContext('2d');
+    new Chart(activityByGuildCtx, {
+      type: 'bar',
+      data: {
+        labels: ["The Rat's Nest", 'Cheese Factory', 'Night Shift', 'Underground', 'New Server'],
+        datasets: [{
+          label: 'Total Watches',
+          data: [247, 189, 156, 134, 23],
+          backgroundColor: [
+            'rgba(203, 78, 27, 0.8)',
+            'rgba(9, 142, 207, 0.8)',
+            'rgba(16, 185, 129, 0.8)',
+            'rgba(245, 158, 11, 0.8)',
+            'rgba(6, 182, 212, 0.8)'
+          ],
+          borderColor: [
+            'rgba(203, 78, 27, 1)',
+            'rgba(9, 142, 207, 1)',
+            'rgba(16, 185, 129, 1)',
+            'rgba(245, 158, 11, 1)',
+            'rgba(6, 182, 212, 1)'
+          ],
+          borderWidth: 1,
+          borderRadius: 4
+        }]
+      },
+      options: {
+        indexAxis: 'y',
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: {
+            display: false
+          },
+          tooltip: {
+            backgroundColor: '#262a2d',
+            titleColor: '#d7d3d0',
+            bodyColor: '#a8a5a3',
+            borderColor: '#3f4447',
+            borderWidth: 1,
+            cornerRadius: 8,
+            padding: 12
+          }
+        },
+        scales: {
+          x: {
+            grid: {
+              color: '#2f3336'
+            },
+            ticks: {
+              color: '#7a7876'
+            }
+          },
+          y: {
+            grid: {
+              display: false
+            },
+            ticks: {
+              color: '#a8a5a3'
+            }
+          }
+        }
+      }
+    });
+
+    // Global Trends (Line Chart)
+    const globalTrendsCtx = document.getElementById('globalTrendsChart').getContext('2d');
+    new Chart(globalTrendsCtx, {
+      type: 'line',
+      data: {
+        labels: ['Dec 24', 'Dec 25', 'Dec 26', 'Dec 27', 'Dec 28', 'Dec 29', 'Dec 30'],
+        datasets: [{
+          label: 'Watches Created',
+          data: [18, 22, 15, 28, 32, 20, 23],
+          borderColor: 'rgba(203, 78, 27, 1)',
+          backgroundColor: 'rgba(203, 78, 27, 0.1)',
+          borderWidth: 2,
+          fill: true,
+          tension: 0.4,
+          pointBackgroundColor: 'rgba(203, 78, 27, 1)',
+          pointBorderColor: '#262a2d',
+          pointBorderWidth: 2,
+          pointRadius: 4,
+          pointHoverRadius: 6
+        }]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: {
+            display: false
+          },
+          tooltip: {
+            backgroundColor: '#262a2d',
+            titleColor: '#d7d3d0',
+            bodyColor: '#a8a5a3',
+            borderColor: '#3f4447',
+            borderWidth: 1,
+            cornerRadius: 8,
+            padding: 12
+          }
+        },
+        scales: {
+          x: {
+            grid: {
+              color: '#2f3336'
+            },
+            ticks: {
+              color: '#7a7876'
+            }
+          },
+          y: {
+            grid: {
+              color: '#2f3336'
+            },
+            ticks: {
+              color: '#7a7876'
+            },
+            beginAtZero: true
+          }
+        }
+      }
+    });
+
+    // Outcome Distribution (Doughnut Chart)
+    const outcomeDistributionCtx = document.getElementById('outcomeDistributionChart').getContext('2d');
+    new Chart(outcomeDistributionCtx, {
+      type: 'doughnut',
+      data: {
+        labels: ['Guilty', 'Not Guilty', 'Cleared Early', 'Expired', 'Cancelled'],
+        datasets: [{
+          data: [1128, 312, 287, 78, 42],
+          backgroundColor: [
+            'rgba(239, 68, 68, 0.8)',
+            'rgba(16, 185, 129, 0.8)',
+            'rgba(9, 142, 207, 0.8)',
+            'rgba(245, 158, 11, 0.8)',
+            'rgba(122, 120, 118, 0.8)'
+          ],
+          borderColor: [
+            'rgba(239, 68, 68, 1)',
+            'rgba(16, 185, 129, 1)',
+            'rgba(9, 142, 207, 1)',
+            'rgba(245, 158, 11, 1)',
+            'rgba(122, 120, 118, 1)'
+          ],
+          borderWidth: 2,
+          hoverOffset: 4
+        }]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: true,
+        cutout: '65%',
+        plugins: {
+          legend: {
+            position: 'bottom',
+            labels: {
+              padding: 16,
+              usePointStyle: true,
+              pointStyle: 'circle',
+              color: '#a8a5a3'
+            }
+          },
+          tooltip: {
+            backgroundColor: '#262a2d',
+            titleColor: '#d7d3d0',
+            bodyColor: '#a8a5a3',
+            borderColor: '#3f4447',
+            borderWidth: 1,
+            cornerRadius: 8,
+            padding: 12,
+            callbacks: {
+              label: function(context) {
+                const total = context.dataset.data.reduce((a, b) => a + b, 0);
+                const percentage = ((context.parsed / total) * 100).toFixed(1);
+                return `${context.label}: ${context.parsed.toLocaleString()} (${percentage}%)`;
+              }
+            }
+          }
+        }
+      }
+    });
+
+    // Most Active Guilds This Week (Bar Chart)
+    const mostActiveGuildsCtx = document.getElementById('mostActiveGuildsChart').getContext('2d');
+    new Chart(mostActiveGuildsCtx, {
+      type: 'bar',
+      data: {
+        labels: ["The Rat's Nest", 'Cheese Factory', 'New Server', 'Night Shift', 'Underground'],
+        datasets: [{
+          label: 'This Week',
+          data: [34, 28, 18, 12, 5],
+          backgroundColor: 'rgba(9, 142, 207, 0.8)',
+          borderColor: 'rgba(9, 142, 207, 1)',
+          borderWidth: 1,
+          borderRadius: 4
+        }, {
+          label: 'Last Week',
+          data: [29, 31, 8, 15, 9],
+          backgroundColor: 'rgba(122, 120, 118, 0.4)',
+          borderColor: 'rgba(122, 120, 118, 0.6)',
+          borderWidth: 1,
+          borderRadius: 4
+        }]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: {
+            position: 'top',
+            align: 'end',
+            labels: {
+              padding: 16,
+              usePointStyle: true,
+              pointStyle: 'circle',
+              color: '#a8a5a3'
+            }
+          },
+          tooltip: {
+            backgroundColor: '#262a2d',
+            titleColor: '#d7d3d0',
+            bodyColor: '#a8a5a3',
+            borderColor: '#3f4447',
+            borderWidth: 1,
+            cornerRadius: 8,
+            padding: 12
+          }
+        },
+        scales: {
+          x: {
+            grid: {
+              display: false
+            },
+            ticks: {
+              color: '#7a7876',
+              maxRotation: 45,
+              minRotation: 45
+            }
+          },
+          y: {
+            grid: {
+              color: '#2f3336'
+            },
+            ticks: {
+              color: '#7a7876'
+            },
+            beginAtZero: true
+          }
+        }
+      }
+    });
+
+    // Initialize
+    updateLastUpdatedTime();
+    setInterval(updateLastUpdatedTime, 60000);
+  </script>
+
+</body>
+</html>

--- a/docs/prototypes/features/rat-watch-analytics/guild-analytics.html
+++ b/docs/prototypes/features/rat-watch-analytics/guild-analytics.html
@@ -1,0 +1,1212 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Guild Rat Watch Analytics - Discord Bot Admin</title>
+
+  <!-- Shared Styles -->
+  <link rel="stylesheet" href="../../css/main.css">
+
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="../../css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
+
+  <!-- Chart.js for charts -->
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+
+  <style>
+    /* Filter panel collapse animation */
+    .filter-content {
+      max-height: 0;
+      overflow: hidden;
+      transition: max-height 0.3s ease-out;
+    }
+    .filter-content.expanded {
+      max-height: 500px;
+    }
+
+    /* Tab active state */
+    .tab-btn.active {
+      border-color: #cb4e1b;
+      color: #d7d3d0;
+    }
+
+    /* Modal styles */
+    .modal-backdrop {
+      position: fixed;
+      inset: 0;
+      z-index: 1000;
+      background-color: rgba(0, 0, 0, 0.6);
+      opacity: 0;
+      visibility: hidden;
+      transition: opacity 150ms ease-out, visibility 150ms ease-out;
+    }
+    .modal-backdrop.active {
+      opacity: 1;
+      visibility: visible;
+    }
+    .modal {
+      position: fixed;
+      z-index: 1001;
+      opacity: 0;
+      visibility: hidden;
+      transform: scale(0.95) translateY(-10px);
+      transition: opacity 150ms ease-out, transform 150ms ease-out, visibility 150ms ease-out;
+    }
+    .modal.active {
+      opacity: 1;
+      visibility: visible;
+      transform: scale(1) translateY(0);
+    }
+    .modal-centered {
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%) scale(0.95);
+    }
+    .modal-centered.active {
+      transform: translate(-50%, -50%) scale(1);
+    }
+    body.modal-open {
+      overflow: hidden;
+    }
+
+    /* Leaderboard row hover */
+    .leaderboard-row {
+      cursor: pointer;
+      transition: background-color 0.15s ease-out;
+    }
+    .leaderboard-row:hover {
+      background-color: #363a3e;
+    }
+
+    /* Activity heatmap grid */
+    .heatmap-cell {
+      width: 100%;
+      aspect-ratio: 1;
+      border-radius: 2px;
+    }
+
+    /* Chart canvas container */
+    .chart-container {
+      position: relative;
+      height: 250px;
+    }
+  </style>
+</head>
+<body class="bg-bg-primary text-text-primary font-sans antialiased">
+
+  <!-- Main Content Area (no sidebar for prototype focus) -->
+  <main class="min-h-screen">
+    <div class="p-4 lg:p-8 max-w-7xl mx-auto">
+
+      <!-- Breadcrumb Navigation -->
+      <nav aria-label="Breadcrumb" class="mb-6">
+        <ol class="flex items-center gap-2 text-sm flex-wrap">
+          <li>
+            <a href="#" class="text-text-secondary hover:text-accent-blue transition-colors">Dashboard</a>
+          </li>
+          <li class="text-text-tertiary" aria-hidden="true">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+          </li>
+          <li>
+            <a href="#" class="text-text-secondary hover:text-accent-blue transition-colors">Guilds</a>
+          </li>
+          <li class="text-text-tertiary" aria-hidden="true">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+          </li>
+          <li>
+            <a href="#" class="text-text-secondary hover:text-accent-blue transition-colors">The Rat's Nest</a>
+          </li>
+          <li class="text-text-tertiary" aria-hidden="true">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+          </li>
+          <li>
+            <span class="text-text-primary font-medium" aria-current="page">Rat Watch Analytics</span>
+          </li>
+        </ol>
+      </nav>
+
+      <!-- Page Header -->
+      <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+        <div>
+          <div class="flex items-center gap-3 mb-1">
+            <h1 class="text-2xl lg:text-3xl font-bold text-text-primary">Rat Watch Analytics</h1>
+            <span class="px-3 py-1 text-sm font-medium bg-accent-orange/20 text-accent-orange rounded-full">The Rat's Nest</span>
+          </div>
+          <p class="text-text-secondary">Accountability metrics and trends for your server</p>
+        </div>
+        <div class="flex items-center gap-3">
+          <a href="#" class="inline-flex items-center gap-2 px-4 py-2 bg-bg-secondary border border-border-primary text-text-primary hover:bg-bg-hover font-medium text-sm rounded-lg transition-colors">
+            <!-- Arrow Left Icon -->
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+            </svg>
+            Back to Settings
+          </a>
+          <a href="#" class="inline-flex items-center gap-2 px-4 py-2 bg-accent-orange hover:bg-accent-orange-hover text-white font-medium text-sm rounded-lg transition-colors">
+            <!-- Document Icon -->
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            </svg>
+            View Incidents
+          </a>
+        </div>
+      </div>
+
+      <!-- Filter Panel (Collapsible) -->
+      <div class="bg-bg-secondary border border-border-primary rounded-lg mb-6">
+        <button
+          onclick="toggleFilterPanel()"
+          class="w-full flex items-center justify-between px-5 py-4 text-left"
+          aria-expanded="false"
+          aria-controls="filterContent"
+        >
+          <div class="flex items-center gap-3">
+            <!-- Filter Icon -->
+            <svg class="w-5 h-5 text-text-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
+            </svg>
+            <span class="text-lg font-semibold text-text-primary">Filters</span>
+          </div>
+          <svg id="filterChevron" class="w-5 h-5 text-text-secondary transition-transform duration-200" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+
+        <div id="filterContent" class="filter-content border-t border-border-primary">
+          <div class="p-5">
+            <!-- Quick Date Presets -->
+            <div class="mb-4">
+              <label class="block text-sm font-medium text-text-secondary mb-2">Quick Date Range</label>
+              <div class="flex flex-wrap gap-2">
+                <button onclick="setDatePreset('today')" class="date-preset-btn px-3 py-1.5 text-xs font-medium bg-bg-tertiary text-text-secondary border border-border-primary rounded-md hover:bg-bg-hover transition-colors">Today</button>
+                <button onclick="setDatePreset('7days')" class="date-preset-btn px-3 py-1.5 text-xs font-medium bg-accent-blue/20 text-accent-blue border border-accent-blue/30 rounded-md hover:bg-accent-blue/30 transition-colors active">Last 7 Days</button>
+                <button onclick="setDatePreset('30days')" class="date-preset-btn px-3 py-1.5 text-xs font-medium bg-bg-tertiary text-text-secondary border border-border-primary rounded-md hover:bg-bg-hover transition-colors">Last 30 Days</button>
+                <button onclick="setDatePreset('custom')" class="date-preset-btn px-3 py-1.5 text-xs font-medium bg-bg-tertiary text-text-secondary border border-border-primary rounded-md hover:bg-bg-hover transition-colors">Custom</button>
+              </div>
+            </div>
+
+            <!-- Filter Grid -->
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+              <!-- Date From -->
+              <div>
+                <label for="dateFrom" class="block text-sm font-medium text-text-secondary mb-1.5">From Date</label>
+                <input
+                  type="date"
+                  id="dateFrom"
+                  class="w-full px-3 py-2 text-sm bg-bg-primary border border-border-primary rounded-md text-text-primary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors"
+                  value="2025-12-23"
+                />
+              </div>
+
+              <!-- Date To -->
+              <div>
+                <label for="dateTo" class="block text-sm font-medium text-text-secondary mb-1.5">To Date</label>
+                <input
+                  type="date"
+                  id="dateTo"
+                  class="w-full px-3 py-2 text-sm bg-bg-primary border border-border-primary rounded-md text-text-primary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors"
+                  value="2025-12-30"
+                />
+              </div>
+
+              <!-- User Filter -->
+              <div>
+                <label for="userFilter" class="block text-sm font-medium text-text-secondary mb-1.5">User</label>
+                <input
+                  type="text"
+                  id="userFilter"
+                  placeholder="Search by username..."
+                  class="w-full px-3 py-2 text-sm bg-bg-primary border border-border-primary rounded-md text-text-primary placeholder-text-tertiary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors"
+                />
+              </div>
+
+              <!-- Status Filter -->
+              <div>
+                <label for="statusFilter" class="block text-sm font-medium text-text-secondary mb-1.5">Status</label>
+                <select
+                  id="statusFilter"
+                  class="w-full px-3 py-2 text-sm bg-bg-primary border border-border-primary rounded-md text-text-primary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors appearance-none cursor-pointer"
+                  style="background-image: url(&quot;data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%23a8a5a3' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e&quot;); background-position: right 0.5rem center; background-repeat: no-repeat; background-size: 1.5em 1.5em;"
+                >
+                  <option value="">All Statuses</option>
+                  <option value="guilty">Guilty</option>
+                  <option value="notguilty">Not Guilty</option>
+                  <option value="cleared">Cleared Early</option>
+                  <option value="expired">Expired</option>
+                  <option value="cancelled">Cancelled</option>
+                </select>
+              </div>
+            </div>
+
+            <!-- Filter Actions -->
+            <div class="flex items-center gap-3 mt-4 pt-4 border-t border-border-secondary">
+              <button
+                onclick="applyFilters()"
+                class="inline-flex items-center gap-2 px-4 py-2 bg-accent-orange hover:bg-accent-orange-hover text-white font-medium text-sm rounded-lg transition-colors"
+              >
+                Apply Filters
+              </button>
+              <button
+                onclick="resetFilters()"
+                class="inline-flex items-center gap-2 px-4 py-2 bg-transparent border border-border-primary text-text-secondary hover:text-text-primary hover:bg-bg-hover font-medium text-sm rounded-lg transition-colors"
+              >
+                Reset
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Summary Stats Cards (4-column grid) -->
+      <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4 lg:gap-6 mb-8">
+        <!-- Total Watches -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-5 hover:border-accent-blue/50 transition-colors">
+          <div class="flex items-center justify-between">
+            <div>
+              <p class="text-sm font-medium text-text-secondary">Total Watches</p>
+              <p class="mt-2 text-3xl font-bold text-text-primary">247</p>
+              <p class="mt-1 text-xs text-success flex items-center gap-1">
+                <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18" />
+                </svg>
+                +23 this week
+              </p>
+            </div>
+            <div class="p-3 bg-accent-blue/10 rounded-lg">
+              <!-- Eye Icon -->
+              <svg class="w-6 h-6 text-accent-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+              </svg>
+            </div>
+          </div>
+        </div>
+
+        <!-- Guilty Rate -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-5 hover:border-error/50 transition-colors">
+          <div class="flex items-center justify-between">
+            <div>
+              <p class="text-sm font-medium text-text-secondary">Guilty Rate</p>
+              <p class="mt-2 text-3xl font-bold text-error">68%</p>
+              <p class="mt-1 text-xs text-text-tertiary">168 guilty verdicts</p>
+            </div>
+            <div class="p-3 bg-error/10 rounded-lg">
+              <!-- Scale Icon -->
+              <svg class="w-6 h-6 text-error" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3" />
+              </svg>
+            </div>
+          </div>
+        </div>
+
+        <!-- Check-in Rate -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-5 hover:border-success/50 transition-colors">
+          <div class="flex items-center justify-between">
+            <div>
+              <p class="text-sm font-medium text-text-secondary">Check-in Rate</p>
+              <p class="mt-2 text-3xl font-bold text-success">23%</p>
+              <p class="mt-1 text-xs text-text-tertiary">57 cleared early</p>
+            </div>
+            <div class="p-3 bg-success/10 rounded-lg">
+              <!-- Check Circle Icon -->
+              <svg class="w-6 h-6 text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            </div>
+          </div>
+        </div>
+
+        <!-- Avg Votes per Watch -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-5 hover:border-warning/50 transition-colors">
+          <div class="flex items-center justify-between">
+            <div>
+              <p class="text-sm font-medium text-text-secondary">Avg Votes per Watch</p>
+              <p class="mt-2 text-3xl font-bold text-warning">4.2</p>
+              <p class="mt-1 text-xs text-text-tertiary">Active community</p>
+            </div>
+            <div class="p-3 bg-warning/10 rounded-lg">
+              <!-- Hand Raised Icon -->
+              <svg class="w-6 h-6 text-warning" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 11.5V14m0-2.5v-6a1.5 1.5 0 113 0m-3 6a1.5 1.5 0 00-3 0v2a7.5 7.5 0 0015 0v-5a1.5 1.5 0 00-3 0m-6-3V11m0-5.5v-1a1.5 1.5 0 013 0v1m0 0V11m0-5.5a1.5 1.5 0 013 0v3m0 0V11" />
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Charts Grid (2x2) -->
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+        <!-- Watches Over Time -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden">
+          <div class="flex items-center justify-between px-5 py-4 border-b border-border-primary">
+            <h2 class="text-lg font-semibold text-text-primary">Watches Over Time</h2>
+            <span class="text-xs text-text-tertiary">Last 7 days</span>
+          </div>
+          <div class="p-5">
+            <div class="chart-container">
+              <canvas id="watchesOverTimeChart"></canvas>
+            </div>
+          </div>
+        </div>
+
+        <!-- Outcome Distribution -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden">
+          <div class="flex items-center justify-between px-5 py-4 border-b border-border-primary">
+            <h2 class="text-lg font-semibold text-text-primary">Outcome Distribution</h2>
+          </div>
+          <div class="p-5">
+            <div class="chart-container">
+              <canvas id="outcomeDistributionChart"></canvas>
+            </div>
+          </div>
+        </div>
+
+        <!-- Activity Heatmap -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden">
+          <div class="flex items-center justify-between px-5 py-4 border-b border-border-primary">
+            <h2 class="text-lg font-semibold text-text-primary">Activity Heatmap</h2>
+            <span class="text-xs text-text-tertiary">When watches are scheduled</span>
+          </div>
+          <div class="p-5">
+            <div id="activityHeatmap" class="overflow-x-auto">
+              <!-- Heatmap will be rendered by JavaScript -->
+            </div>
+          </div>
+        </div>
+
+        <!-- Top Users -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden">
+          <div class="flex items-center justify-between px-5 py-4 border-b border-border-primary">
+            <h2 class="text-lg font-semibold text-text-primary">Top Watched Users</h2>
+          </div>
+          <div class="p-5">
+            <div class="chart-container">
+              <canvas id="topUsersChart"></canvas>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Behavioral Insights Section -->
+      <div class="bg-bg-secondary border border-border-primary rounded-lg mb-8">
+        <div class="px-5 py-4 border-b border-border-primary">
+          <h2 class="text-lg font-semibold text-text-primary">Behavioral Insights</h2>
+        </div>
+        <div class="p-5">
+          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            <!-- Early Check-in Rate -->
+            <div class="bg-bg-primary border border-border-secondary rounded-lg p-4">
+              <div class="flex items-center gap-3 mb-2">
+                <div class="p-2 bg-success/10 rounded-lg">
+                  <svg class="w-5 h-5 text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                </div>
+                <span class="text-sm font-medium text-text-secondary">Early Check-in Rate</span>
+              </div>
+              <p class="text-2xl font-bold text-text-primary">23%</p>
+              <p class="text-xs text-text-tertiary mt-1">Cleared before voting starts</p>
+            </div>
+
+            <!-- Avg Voting Participation -->
+            <div class="bg-bg-primary border border-border-secondary rounded-lg p-4">
+              <div class="flex items-center gap-3 mb-2">
+                <div class="p-2 bg-accent-blue/10 rounded-lg">
+                  <svg class="w-5 h-5 text-accent-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+                  </svg>
+                </div>
+                <span class="text-sm font-medium text-text-secondary">Avg Voting Participation</span>
+              </div>
+              <p class="text-2xl font-bold text-text-primary">4.2</p>
+              <p class="text-xs text-text-tertiary mt-1">Voters per watch</p>
+            </div>
+
+            <!-- Avg Vote Margin -->
+            <div class="bg-bg-primary border border-border-secondary rounded-lg p-4">
+              <div class="flex items-center gap-3 mb-2">
+                <div class="p-2 bg-warning/10 rounded-lg">
+                  <svg class="w-5 h-5 text-warning" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
+                  </svg>
+                </div>
+                <span class="text-sm font-medium text-text-secondary">Avg Vote Margin</span>
+              </div>
+              <p class="text-2xl font-bold text-text-primary">2.3</p>
+              <p class="text-xs text-text-tertiary mt-1">Votes difference</p>
+            </div>
+
+            <!-- Most Common Duration -->
+            <div class="bg-bg-primary border border-border-secondary rounded-lg p-4">
+              <div class="flex items-center gap-3 mb-2">
+                <div class="p-2 bg-accent-orange/10 rounded-lg">
+                  <svg class="w-5 h-5 text-accent-orange" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                </div>
+                <span class="text-sm font-medium text-text-secondary">Most Common Duration</span>
+              </div>
+              <p class="text-2xl font-bold text-text-primary">30 min</p>
+              <p class="text-xs text-text-tertiary mt-1">Most popular check-in window</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- User Leaderboards with Tabs -->
+      <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden">
+        <div class="flex items-center gap-1 px-5 py-4 border-b border-border-primary overflow-x-auto">
+          <button
+            onclick="switchTab('mostWatched')"
+            class="tab-btn px-4 py-2 text-sm font-medium text-text-secondary border-b-2 border-transparent hover:text-text-primary transition-colors active"
+            data-tab="mostWatched"
+          >
+            Most Watched
+          </button>
+          <button
+            onclick="switchTab('topAccusers')"
+            class="tab-btn px-4 py-2 text-sm font-medium text-text-secondary border-b-2 border-transparent hover:text-text-primary transition-colors"
+            data-tab="topAccusers"
+          >
+            Top Accusers
+          </button>
+          <button
+            onclick="switchTab('biggestRats')"
+            class="tab-btn px-4 py-2 text-sm font-medium text-text-secondary border-b-2 border-transparent hover:text-text-primary transition-colors"
+            data-tab="biggestRats"
+          >
+            Biggest Rats
+          </button>
+        </div>
+
+        <!-- Tab Content: Most Watched -->
+        <div id="tabMostWatched" class="tab-content">
+          <div class="overflow-x-auto">
+            <table class="w-full">
+              <thead class="bg-bg-primary/50">
+                <tr>
+                  <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Rank</th>
+                  <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">User</th>
+                  <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Total Watches</th>
+                  <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Guilty Rate</th>
+                  <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Last Incident</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-border-primary">
+                <tr class="leaderboard-row" onclick="openUserModal('RatKing')">
+                  <td class="px-5 py-4">
+                    <span class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-warning/20 text-warning font-bold text-sm">1</span>
+                  </td>
+                  <td class="px-5 py-4">
+                    <div class="flex items-center gap-3">
+                      <div class="w-10 h-10 rounded-full bg-gradient-to-br from-yellow-500 to-orange-500 flex items-center justify-center text-white font-bold text-sm">RK</div>
+                      <div>
+                        <p class="font-medium text-text-primary">RatKing</p>
+                        <p class="text-xs text-text-tertiary">#1234</p>
+                      </div>
+                    </div>
+                  </td>
+                  <td class="px-5 py-4 text-text-primary font-medium">15</td>
+                  <td class="px-5 py-4">
+                    <span class="inline-flex items-center px-2.5 py-0.5 text-xs font-semibold text-error bg-error/10 rounded-full">67%</span>
+                  </td>
+                  <td class="px-5 py-4 text-text-secondary text-sm">2 hours ago</td>
+                </tr>
+                <tr class="leaderboard-row" onclick="openUserModal('CheeseThief')">
+                  <td class="px-5 py-4">
+                    <span class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-text-tertiary/20 text-text-secondary font-bold text-sm">2</span>
+                  </td>
+                  <td class="px-5 py-4">
+                    <div class="flex items-center gap-3">
+                      <div class="w-10 h-10 rounded-full bg-gradient-to-br from-purple-500 to-pink-500 flex items-center justify-center text-white font-bold text-sm">CT</div>
+                      <div>
+                        <p class="font-medium text-text-primary">CheeseThief</p>
+                        <p class="text-xs text-text-tertiary">#5678</p>
+                      </div>
+                    </div>
+                  </td>
+                  <td class="px-5 py-4 text-text-primary font-medium">12</td>
+                  <td class="px-5 py-4">
+                    <span class="inline-flex items-center px-2.5 py-0.5 text-xs font-semibold text-error bg-error/10 rounded-full">75%</span>
+                  </td>
+                  <td class="px-5 py-4 text-text-secondary text-sm">5 hours ago</td>
+                </tr>
+                <tr class="leaderboard-row" onclick="openUserModal('NightOwl')">
+                  <td class="px-5 py-4">
+                    <span class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-accent-orange/20 text-accent-orange font-bold text-sm">3</span>
+                  </td>
+                  <td class="px-5 py-4">
+                    <div class="flex items-center gap-3">
+                      <div class="w-10 h-10 rounded-full bg-gradient-to-br from-blue-500 to-cyan-500 flex items-center justify-center text-white font-bold text-sm">NO</div>
+                      <div>
+                        <p class="font-medium text-text-primary">NightOwl</p>
+                        <p class="text-xs text-text-tertiary">#9012</p>
+                      </div>
+                    </div>
+                  </td>
+                  <td class="px-5 py-4 text-text-primary font-medium">10</td>
+                  <td class="px-5 py-4">
+                    <span class="inline-flex items-center px-2.5 py-0.5 text-xs font-semibold text-warning bg-warning/10 rounded-full">60%</span>
+                  </td>
+                  <td class="px-5 py-4 text-text-secondary text-sm">Yesterday</td>
+                </tr>
+                <tr class="leaderboard-row" onclick="openUserModal('Procrastinator99')">
+                  <td class="px-5 py-4">
+                    <span class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-bg-tertiary text-text-tertiary font-bold text-sm">4</span>
+                  </td>
+                  <td class="px-5 py-4">
+                    <div class="flex items-center gap-3">
+                      <div class="w-10 h-10 rounded-full bg-gradient-to-br from-green-500 to-emerald-500 flex items-center justify-center text-white font-bold text-sm">P9</div>
+                      <div>
+                        <p class="font-medium text-text-primary">Procrastinator99</p>
+                        <p class="text-xs text-text-tertiary">#3456</p>
+                      </div>
+                    </div>
+                  </td>
+                  <td class="px-5 py-4 text-text-primary font-medium">8</td>
+                  <td class="px-5 py-4">
+                    <span class="inline-flex items-center px-2.5 py-0.5 text-xs font-semibold text-success bg-success/10 rounded-full">50%</span>
+                  </td>
+                  <td class="px-5 py-4 text-text-secondary text-sm">2 days ago</td>
+                </tr>
+                <tr class="leaderboard-row" onclick="openUserModal('GymSkipper')">
+                  <td class="px-5 py-4">
+                    <span class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-bg-tertiary text-text-tertiary font-bold text-sm">5</span>
+                  </td>
+                  <td class="px-5 py-4">
+                    <div class="flex items-center gap-3">
+                      <div class="w-10 h-10 rounded-full bg-gradient-to-br from-red-500 to-rose-500 flex items-center justify-center text-white font-bold text-sm">GS</div>
+                      <div>
+                        <p class="font-medium text-text-primary">GymSkipper</p>
+                        <p class="text-xs text-text-tertiary">#7890</p>
+                      </div>
+                    </div>
+                  </td>
+                  <td class="px-5 py-4 text-text-primary font-medium">7</td>
+                  <td class="px-5 py-4">
+                    <span class="inline-flex items-center px-2.5 py-0.5 text-xs font-semibold text-error bg-error/10 rounded-full">86%</span>
+                  </td>
+                  <td class="px-5 py-4 text-text-secondary text-sm">3 days ago</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <!-- Tab Content: Top Accusers -->
+        <div id="tabTopAccusers" class="tab-content hidden">
+          <div class="overflow-x-auto">
+            <table class="w-full">
+              <thead class="bg-bg-primary/50">
+                <tr>
+                  <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Rank</th>
+                  <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">User</th>
+                  <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Watches Created</th>
+                  <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Success Rate</th>
+                  <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Last Created</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-border-primary">
+                <tr class="leaderboard-row" onclick="openUserModal('WatchfulEye')">
+                  <td class="px-5 py-4">
+                    <span class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-warning/20 text-warning font-bold text-sm">1</span>
+                  </td>
+                  <td class="px-5 py-4">
+                    <div class="flex items-center gap-3">
+                      <div class="w-10 h-10 rounded-full bg-gradient-to-br from-indigo-500 to-purple-500 flex items-center justify-center text-white font-bold text-sm">WE</div>
+                      <div>
+                        <p class="font-medium text-text-primary">WatchfulEye</p>
+                        <p class="text-xs text-text-tertiary">#4321</p>
+                      </div>
+                    </div>
+                  </td>
+                  <td class="px-5 py-4 text-text-primary font-medium">32</td>
+                  <td class="px-5 py-4">
+                    <span class="inline-flex items-center px-2.5 py-0.5 text-xs font-semibold text-success bg-success/10 rounded-full">78%</span>
+                  </td>
+                  <td class="px-5 py-4 text-text-secondary text-sm">1 hour ago</td>
+                </tr>
+                <tr class="leaderboard-row" onclick="openUserModal('AccountabilityKing')">
+                  <td class="px-5 py-4">
+                    <span class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-text-tertiary/20 text-text-secondary font-bold text-sm">2</span>
+                  </td>
+                  <td class="px-5 py-4">
+                    <div class="flex items-center gap-3">
+                      <div class="w-10 h-10 rounded-full bg-gradient-to-br from-teal-500 to-cyan-500 flex items-center justify-center text-white font-bold text-sm">AK</div>
+                      <div>
+                        <p class="font-medium text-text-primary">AccountabilityKing</p>
+                        <p class="text-xs text-text-tertiary">#8765</p>
+                      </div>
+                    </div>
+                  </td>
+                  <td class="px-5 py-4 text-text-primary font-medium">28</td>
+                  <td class="px-5 py-4">
+                    <span class="inline-flex items-center px-2.5 py-0.5 text-xs font-semibold text-success bg-success/10 rounded-full">82%</span>
+                  </td>
+                  <td class="px-5 py-4 text-text-secondary text-sm">4 hours ago</td>
+                </tr>
+                <tr class="leaderboard-row" onclick="openUserModal('TruthSeeker')">
+                  <td class="px-5 py-4">
+                    <span class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-accent-orange/20 text-accent-orange font-bold text-sm">3</span>
+                  </td>
+                  <td class="px-5 py-4">
+                    <div class="flex items-center gap-3">
+                      <div class="w-10 h-10 rounded-full bg-gradient-to-br from-amber-500 to-yellow-500 flex items-center justify-center text-white font-bold text-sm">TS</div>
+                      <div>
+                        <p class="font-medium text-text-primary">TruthSeeker</p>
+                        <p class="text-xs text-text-tertiary">#2468</p>
+                      </div>
+                    </div>
+                  </td>
+                  <td class="px-5 py-4 text-text-primary font-medium">21</td>
+                  <td class="px-5 py-4">
+                    <span class="inline-flex items-center px-2.5 py-0.5 text-xs font-semibold text-warning bg-warning/10 rounded-full">65%</span>
+                  </td>
+                  <td class="px-5 py-4 text-text-secondary text-sm">Yesterday</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <!-- Tab Content: Biggest Rats -->
+        <div id="tabBiggestRats" class="tab-content hidden">
+          <div class="overflow-x-auto">
+            <table class="w-full">
+              <thead class="bg-bg-primary/50">
+                <tr>
+                  <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Rank</th>
+                  <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">User</th>
+                  <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Guilty Verdicts</th>
+                  <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Total Watches</th>
+                  <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Last Guilty</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-border-primary">
+                <tr class="leaderboard-row" onclick="openUserModal('RatKing')">
+                  <td class="px-5 py-4">
+                    <span class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-warning/20 text-warning font-bold text-sm">1</span>
+                  </td>
+                  <td class="px-5 py-4">
+                    <div class="flex items-center gap-3">
+                      <div class="w-10 h-10 rounded-full bg-gradient-to-br from-yellow-500 to-orange-500 flex items-center justify-center text-white font-bold text-sm">RK</div>
+                      <div>
+                        <p class="font-medium text-text-primary">RatKing</p>
+                        <p class="text-xs text-text-tertiary">#1234</p>
+                      </div>
+                    </div>
+                  </td>
+                  <td class="px-5 py-4">
+                    <span class="text-2xl font-bold text-error">10</span>
+                  </td>
+                  <td class="px-5 py-4 text-text-secondary">15</td>
+                  <td class="px-5 py-4 text-text-secondary text-sm">2 hours ago</td>
+                </tr>
+                <tr class="leaderboard-row" onclick="openUserModal('CheeseThief')">
+                  <td class="px-5 py-4">
+                    <span class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-text-tertiary/20 text-text-secondary font-bold text-sm">2</span>
+                  </td>
+                  <td class="px-5 py-4">
+                    <div class="flex items-center gap-3">
+                      <div class="w-10 h-10 rounded-full bg-gradient-to-br from-purple-500 to-pink-500 flex items-center justify-center text-white font-bold text-sm">CT</div>
+                      <div>
+                        <p class="font-medium text-text-primary">CheeseThief</p>
+                        <p class="text-xs text-text-tertiary">#5678</p>
+                      </div>
+                    </div>
+                  </td>
+                  <td class="px-5 py-4">
+                    <span class="text-2xl font-bold text-error">9</span>
+                  </td>
+                  <td class="px-5 py-4 text-text-secondary">12</td>
+                  <td class="px-5 py-4 text-text-secondary text-sm">5 hours ago</td>
+                </tr>
+                <tr class="leaderboard-row" onclick="openUserModal('GymSkipper')">
+                  <td class="px-5 py-4">
+                    <span class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-accent-orange/20 text-accent-orange font-bold text-sm">3</span>
+                  </td>
+                  <td class="px-5 py-4">
+                    <div class="flex items-center gap-3">
+                      <div class="w-10 h-10 rounded-full bg-gradient-to-br from-red-500 to-rose-500 flex items-center justify-center text-white font-bold text-sm">GS</div>
+                      <div>
+                        <p class="font-medium text-text-primary">GymSkipper</p>
+                        <p class="text-xs text-text-tertiary">#7890</p>
+                      </div>
+                    </div>
+                  </td>
+                  <td class="px-5 py-4">
+                    <span class="text-2xl font-bold text-error">6</span>
+                  </td>
+                  <td class="px-5 py-4 text-text-secondary">7</td>
+                  <td class="px-5 py-4 text-text-secondary text-sm">3 days ago</td>
+                </tr>
+                <tr class="leaderboard-row" onclick="openUserModal('NightOwl')">
+                  <td class="px-5 py-4">
+                    <span class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-bg-tertiary text-text-tertiary font-bold text-sm">4</span>
+                  </td>
+                  <td class="px-5 py-4">
+                    <div class="flex items-center gap-3">
+                      <div class="w-10 h-10 rounded-full bg-gradient-to-br from-blue-500 to-cyan-500 flex items-center justify-center text-white font-bold text-sm">NO</div>
+                      <div>
+                        <p class="font-medium text-text-primary">NightOwl</p>
+                        <p class="text-xs text-text-tertiary">#9012</p>
+                      </div>
+                    </div>
+                  </td>
+                  <td class="px-5 py-4">
+                    <span class="text-2xl font-bold text-error">6</span>
+                  </td>
+                  <td class="px-5 py-4 text-text-secondary">10</td>
+                  <td class="px-5 py-4 text-text-secondary text-sm">Yesterday</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </main>
+
+  <!-- User Detail Modal -->
+  <div id="userDetailBackdrop" class="modal-backdrop" onclick="closeUserModal()"></div>
+  <div id="userDetailModal" class="modal modal-centered w-full max-w-lg mx-4 bg-bg-secondary border border-border-primary rounded-lg shadow-2xl max-h-[90vh] overflow-hidden flex flex-col">
+    <div class="flex items-center justify-between px-6 py-4 border-b border-border-primary shrink-0">
+      <h2 class="text-lg font-semibold text-text-primary">User Details</h2>
+      <button onclick="closeUserModal()" class="p-1 text-text-tertiary hover:text-text-primary hover:bg-bg-hover rounded transition-colors" aria-label="Close modal">
+        <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+
+    <div class="p-6 overflow-y-auto flex-1" id="userDetailContent">
+      <!-- User Header -->
+      <div class="flex items-center gap-4 mb-6">
+        <div class="w-16 h-16 rounded-full bg-gradient-to-br from-yellow-500 to-orange-500 flex items-center justify-center text-white font-bold text-xl">RK</div>
+        <div>
+          <h3 class="text-xl font-bold text-text-primary">RatKing</h3>
+          <p class="text-sm text-text-tertiary">#1234</p>
+        </div>
+      </div>
+
+      <!-- Stats Grid -->
+      <div class="grid grid-cols-2 gap-4 mb-6">
+        <div class="bg-bg-primary border border-border-secondary rounded-lg p-4 text-center">
+          <p class="text-2xl font-bold text-text-primary">15</p>
+          <p class="text-xs text-text-tertiary">Total Watches</p>
+        </div>
+        <div class="bg-bg-primary border border-border-secondary rounded-lg p-4 text-center">
+          <p class="text-2xl font-bold text-error">10</p>
+          <p class="text-xs text-text-tertiary">Guilty Verdicts</p>
+        </div>
+        <div class="bg-bg-primary border border-border-secondary rounded-lg p-4 text-center">
+          <p class="text-2xl font-bold text-success">2</p>
+          <p class="text-xs text-text-tertiary">Early Check-ins</p>
+        </div>
+        <div class="bg-bg-primary border border-border-secondary rounded-lg p-4 text-center">
+          <p class="text-2xl font-bold text-warning">33%</p>
+          <p class="text-xs text-text-tertiary">Accountability Score</p>
+        </div>
+      </div>
+
+      <!-- Trend Indicator -->
+      <div class="bg-error/10 border border-error/30 rounded-lg p-4 mb-6">
+        <div class="flex items-center gap-2">
+          <svg class="w-5 h-5 text-error" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 17h8m0 0V9m0 8l-8-8-4 4-6-6" />
+          </svg>
+          <span class="text-sm font-medium text-error">Declining Accountability</span>
+        </div>
+        <p class="text-xs text-text-secondary mt-1">3 guilty verdicts in the last 7 days</p>
+      </div>
+
+      <!-- Recent Incidents -->
+      <h4 class="text-sm font-semibold text-text-secondary uppercase tracking-wider mb-3">Recent Incidents</h4>
+      <div class="space-y-2">
+        <div class="flex items-center justify-between p-3 bg-bg-primary border border-border-secondary rounded-lg">
+          <div class="flex items-center gap-3">
+            <span class="inline-flex items-center px-2 py-0.5 text-xs font-semibold text-error bg-error/10 rounded">Guilty</span>
+            <span class="text-sm text-text-primary">Failed gym check-in</span>
+          </div>
+          <span class="text-xs text-text-tertiary">2 hours ago</span>
+        </div>
+        <div class="flex items-center justify-between p-3 bg-bg-primary border border-border-secondary rounded-lg">
+          <div class="flex items-center gap-3">
+            <span class="inline-flex items-center px-2 py-0.5 text-xs font-semibold text-error bg-error/10 rounded">Guilty</span>
+            <span class="text-sm text-text-primary">Missed homework deadline</span>
+          </div>
+          <span class="text-xs text-text-tertiary">Yesterday</span>
+        </div>
+        <div class="flex items-center justify-between p-3 bg-bg-primary border border-border-secondary rounded-lg">
+          <div class="flex items-center gap-3">
+            <span class="inline-flex items-center px-2 py-0.5 text-xs font-semibold text-success bg-success/10 rounded">Cleared</span>
+            <span class="text-sm text-text-primary">Morning run</span>
+          </div>
+          <span class="text-xs text-text-tertiary">3 days ago</span>
+        </div>
+        <div class="flex items-center justify-between p-3 bg-bg-primary border border-border-secondary rounded-lg">
+          <div class="flex items-center gap-3">
+            <span class="inline-flex items-center px-2 py-0.5 text-xs font-semibold text-error bg-error/10 rounded">Guilty</span>
+            <span class="text-sm text-text-primary">Clean room promise</span>
+          </div>
+          <span class="text-xs text-text-tertiary">5 days ago</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="flex justify-end gap-3 px-6 py-4 border-t border-border-primary bg-bg-primary/30 shrink-0">
+      <button
+        onclick="closeUserModal()"
+        class="inline-flex items-center gap-2 px-4 py-2 bg-bg-tertiary border border-border-primary text-text-primary hover:bg-bg-hover font-medium text-sm rounded-lg transition-colors"
+      >
+        Close
+      </button>
+      <button
+        class="inline-flex items-center gap-2 px-4 py-2 bg-accent-blue hover:bg-accent-blue-hover text-white font-medium text-sm rounded-lg transition-colors"
+      >
+        View All Incidents
+      </button>
+    </div>
+  </div>
+
+  <!-- JavaScript -->
+  <script>
+    // Filter Panel Toggle
+    function toggleFilterPanel() {
+      const content = document.getElementById('filterContent');
+      const chevron = document.getElementById('filterChevron');
+      const isExpanded = content.classList.contains('expanded');
+
+      content.classList.toggle('expanded');
+      chevron.classList.toggle('rotate-180');
+    }
+
+    // Date Preset Buttons
+    function setDatePreset(preset) {
+      const today = new Date();
+      const dateFrom = document.getElementById('dateFrom');
+      const dateTo = document.getElementById('dateTo');
+
+      // Update button active states
+      document.querySelectorAll('.date-preset-btn').forEach(btn => {
+        btn.classList.remove('bg-accent-blue/20', 'text-accent-blue', 'border-accent-blue/30');
+        btn.classList.add('bg-bg-tertiary', 'text-text-secondary', 'border-border-primary');
+      });
+      event.target.classList.remove('bg-bg-tertiary', 'text-text-secondary', 'border-border-primary');
+      event.target.classList.add('bg-accent-blue/20', 'text-accent-blue', 'border-accent-blue/30');
+
+      dateTo.value = today.toISOString().split('T')[0];
+
+      switch (preset) {
+        case 'today':
+          dateFrom.value = today.toISOString().split('T')[0];
+          break;
+        case '7days':
+          const weekAgo = new Date(today);
+          weekAgo.setDate(weekAgo.getDate() - 7);
+          dateFrom.value = weekAgo.toISOString().split('T')[0];
+          break;
+        case '30days':
+          const monthAgo = new Date(today);
+          monthAgo.setDate(monthAgo.getDate() - 30);
+          dateFrom.value = monthAgo.toISOString().split('T')[0];
+          break;
+        case 'custom':
+          dateFrom.focus();
+          break;
+      }
+    }
+
+    // Apply/Reset Filters
+    function applyFilters() {
+      alert('Filters applied! (This is a prototype)');
+    }
+
+    function resetFilters() {
+      document.getElementById('dateFrom').value = '';
+      document.getElementById('dateTo').value = '';
+      document.getElementById('userFilter').value = '';
+      document.getElementById('statusFilter').value = '';
+    }
+
+    // Tab Switching
+    function switchTab(tabName) {
+      // Hide all tab contents
+      document.querySelectorAll('.tab-content').forEach(content => {
+        content.classList.add('hidden');
+      });
+
+      // Remove active state from all tabs
+      document.querySelectorAll('.tab-btn').forEach(btn => {
+        btn.classList.remove('active', 'border-accent-orange', 'text-text-primary');
+        btn.classList.add('border-transparent', 'text-text-secondary');
+      });
+
+      // Show selected tab content
+      const tabContent = document.getElementById('tab' + tabName.charAt(0).toUpperCase() + tabName.slice(1));
+      if (tabContent) {
+        tabContent.classList.remove('hidden');
+      }
+
+      // Activate selected tab button
+      const tabBtn = document.querySelector(`[data-tab="${tabName}"]`);
+      if (tabBtn) {
+        tabBtn.classList.add('active', 'border-accent-orange', 'text-text-primary');
+        tabBtn.classList.remove('border-transparent', 'text-text-secondary');
+      }
+    }
+
+    // User Modal
+    function openUserModal(username) {
+      document.getElementById('userDetailBackdrop').classList.add('active');
+      document.getElementById('userDetailModal').classList.add('active');
+      document.body.classList.add('modal-open');
+    }
+
+    function closeUserModal() {
+      document.getElementById('userDetailBackdrop').classList.remove('active');
+      document.getElementById('userDetailModal').classList.remove('active');
+      document.body.classList.remove('modal-open');
+    }
+
+    // Keyboard navigation
+    document.addEventListener('keydown', function(event) {
+      if (event.key === 'Escape') {
+        closeUserModal();
+      }
+    });
+
+    // Initialize Charts
+    document.addEventListener('DOMContentLoaded', function() {
+      // Chart.js default dark theme settings
+      Chart.defaults.color = '#a8a5a3';
+      Chart.defaults.borderColor = '#3f4447';
+
+      // Watches Over Time Chart (Line)
+      const watchesCtx = document.getElementById('watchesOverTimeChart').getContext('2d');
+      new Chart(watchesCtx, {
+        type: 'line',
+        data: {
+          labels: ['Dec 24', 'Dec 25', 'Dec 26', 'Dec 27', 'Dec 28', 'Dec 29', 'Dec 30'],
+          datasets: [
+            {
+              label: 'Total Watches',
+              data: [12, 8, 15, 22, 18, 25, 23],
+              borderColor: '#098ecf',
+              backgroundColor: 'rgba(9, 142, 207, 0.1)',
+              fill: true,
+              tension: 0.4
+            },
+            {
+              label: 'Guilty',
+              data: [8, 5, 10, 15, 12, 17, 15],
+              borderColor: '#ef4444',
+              backgroundColor: 'rgba(239, 68, 68, 0.1)',
+              fill: true,
+              tension: 0.4
+            },
+            {
+              label: 'Cleared Early',
+              data: [3, 2, 3, 5, 4, 6, 5],
+              borderColor: '#10b981',
+              backgroundColor: 'rgba(16, 185, 129, 0.1)',
+              fill: true,
+              tension: 0.4
+            }
+          ]
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+            legend: {
+              position: 'bottom',
+              labels: {
+                boxWidth: 12,
+                padding: 15
+              }
+            }
+          },
+          scales: {
+            y: {
+              beginAtZero: true,
+              grid: {
+                color: '#2f3336'
+              }
+            },
+            x: {
+              grid: {
+                display: false
+              }
+            }
+          }
+        }
+      });
+
+      // Outcome Distribution Chart (Doughnut)
+      const outcomeCtx = document.getElementById('outcomeDistributionChart').getContext('2d');
+      new Chart(outcomeCtx, {
+        type: 'doughnut',
+        data: {
+          labels: ['Guilty', 'Not Guilty', 'Cleared Early', 'Expired', 'Cancelled'],
+          datasets: [{
+            data: [168, 22, 57, 12, 8],
+            backgroundColor: [
+              '#ef4444',
+              '#10b981',
+              '#098ecf',
+              '#7a7876',
+              '#3f4447'
+            ],
+            borderWidth: 0
+          }]
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          cutout: '60%',
+          plugins: {
+            legend: {
+              position: 'right',
+              labels: {
+                boxWidth: 12,
+                padding: 10
+              }
+            }
+          }
+        }
+      });
+
+      // Top Users Chart (Horizontal Bar)
+      const topUsersCtx = document.getElementById('topUsersChart').getContext('2d');
+      new Chart(topUsersCtx, {
+        type: 'bar',
+        data: {
+          labels: ['RatKing', 'CheeseThief', 'NightOwl', 'Procrastinator99', 'GymSkipper'],
+          datasets: [{
+            label: 'Watches',
+            data: [15, 12, 10, 8, 7],
+            backgroundColor: '#cb4e1b',
+            borderRadius: 4
+          }]
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          indexAxis: 'y',
+          plugins: {
+            legend: {
+              display: false
+            }
+          },
+          scales: {
+            x: {
+              beginAtZero: true,
+              grid: {
+                color: '#2f3336'
+              }
+            },
+            y: {
+              grid: {
+                display: false
+              }
+            }
+          }
+        }
+      });
+
+      // Activity Heatmap
+      renderActivityHeatmap();
+
+      // Initialize first tab as active
+      switchTab('mostWatched');
+    });
+
+    // Render Activity Heatmap
+    function renderActivityHeatmap() {
+      const container = document.getElementById('activityHeatmap');
+      const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+      const hours = Array.from({ length: 24 }, (_, i) => i);
+
+      // Sample heatmap data (day x hour)
+      const heatmapData = [
+        [0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 4, 3, 4, 5, 6, 7, 8, 9, 10, 8, 6, 3, 1], // Sun
+        [0, 0, 0, 0, 0, 1, 2, 3, 5, 6, 5, 4, 5, 6, 7, 8, 9, 10, 11, 12, 10, 8, 4, 2], // Mon
+        [0, 0, 0, 0, 0, 1, 2, 4, 6, 7, 6, 5, 6, 7, 8, 9, 10, 12, 13, 14, 11, 9, 5, 2], // Tue
+        [0, 0, 0, 0, 0, 1, 2, 3, 5, 6, 5, 4, 5, 6, 7, 8, 9, 11, 12, 13, 10, 8, 4, 2], // Wed
+        [0, 0, 0, 0, 0, 1, 2, 4, 6, 7, 6, 5, 6, 7, 8, 9, 10, 12, 13, 14, 11, 9, 5, 2], // Thu
+        [0, 0, 0, 0, 0, 1, 2, 3, 5, 6, 5, 4, 5, 6, 7, 8, 9, 10, 11, 12, 10, 8, 4, 2], // Fri
+        [0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 4, 3, 4, 5, 6, 7, 8, 9, 10, 11, 9, 7, 4, 1]  // Sat
+      ];
+
+      const maxValue = Math.max(...heatmapData.flat());
+
+      let html = '<div class="min-w-[600px]">';
+
+      // Header row with hours
+      html += '<div class="flex items-center gap-0.5 mb-1">';
+      html += '<div class="w-10 shrink-0"></div>'; // Empty corner
+      hours.forEach((hour, i) => {
+        if (i % 3 === 0) {
+          html += `<div class="flex-1 text-center text-xs text-text-tertiary">${hour}</div>`;
+        } else {
+          html += '<div class="flex-1"></div>';
+        }
+      });
+      html += '</div>';
+
+      // Rows for each day
+      days.forEach((day, dayIndex) => {
+        html += '<div class="flex items-center gap-0.5 mb-0.5">';
+        html += `<div class="w-10 shrink-0 text-xs text-text-tertiary">${day}</div>`;
+
+        hours.forEach((hour) => {
+          const value = heatmapData[dayIndex][hour];
+          const intensity = value / maxValue;
+          let bgColor;
+
+          if (intensity === 0) {
+            bgColor = '#2f3336';
+          } else if (intensity < 0.25) {
+            bgColor = 'rgba(203, 78, 27, 0.2)';
+          } else if (intensity < 0.5) {
+            bgColor = 'rgba(203, 78, 27, 0.4)';
+          } else if (intensity < 0.75) {
+            bgColor = 'rgba(203, 78, 27, 0.6)';
+          } else {
+            bgColor = 'rgba(203, 78, 27, 0.9)';
+          }
+
+          html += `<div class="heatmap-cell flex-1" style="background-color: ${bgColor};" title="${day} ${hour}:00 - ${value} watches"></div>`;
+        });
+
+        html += '</div>';
+      });
+
+      // Legend
+      html += '<div class="flex items-center justify-end gap-2 mt-3">';
+      html += '<span class="text-xs text-text-tertiary">Less</span>';
+      ['#2f3336', 'rgba(203, 78, 27, 0.2)', 'rgba(203, 78, 27, 0.4)', 'rgba(203, 78, 27, 0.6)', 'rgba(203, 78, 27, 0.9)'].forEach(color => {
+        html += `<div class="w-3 h-3 rounded-sm" style="background-color: ${color};"></div>`;
+      });
+      html += '<span class="text-xs text-text-tertiary">More</span>';
+      html += '</div>';
+
+      html += '</div>';
+
+      container.innerHTML = html;
+    }
+  </script>
+
+</body>
+</html>

--- a/docs/prototypes/features/rat-watch-analytics/incidents-browser.html
+++ b/docs/prototypes/features/rat-watch-analytics/incidents-browser.html
@@ -1,0 +1,1049 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Rat Watch Incidents - Discord Bot Admin</title>
+
+  <!-- Shared Styles -->
+  <link rel="stylesheet" href="../../css/main.css">
+
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="../../css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
+
+  <style>
+    /* Custom date input styling */
+    input[type="date"]::-webkit-calendar-picker-indicator {
+      filter: invert(0.7);
+      cursor: pointer;
+    }
+
+    /* Checkbox styling */
+    input[type="checkbox"] {
+      accent-color: #cb4e1b;
+    }
+
+    /* Sort indicator */
+    .sort-icon {
+      transition: transform 0.15s ease;
+    }
+    .sort-asc .sort-icon {
+      transform: rotate(180deg);
+    }
+
+    /* Filter panel animation */
+    .filter-panel {
+      max-height: 1000px;
+      overflow: hidden;
+      transition: max-height 0.3s ease-out, opacity 0.3s ease-out;
+    }
+    .filter-panel.collapsed {
+      max-height: 0;
+      opacity: 0;
+    }
+
+    /* Dropdown animation */
+    .preset-dropdown {
+      max-height: 0;
+      overflow: hidden;
+      transition: max-height 0.2s ease-out;
+    }
+    .preset-dropdown.open {
+      max-height: 300px;
+    }
+  </style>
+</head>
+<body class="bg-bg-primary text-text-primary min-h-screen">
+  <!-- Navigation Header -->
+  <nav class="bg-bg-secondary border-b border-border-primary">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="flex items-center justify-between h-16">
+        <div class="flex items-center gap-8">
+          <div class="flex items-center gap-3">
+            <div class="w-8 h-8 bg-accent-orange rounded-lg flex items-center justify-center">
+              <svg class="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515.074.074 0 00-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0 12.64 12.64 0 00-.617-1.25.077.077 0 00-.079-.037A19.736 19.736 0 003.677 4.37a.07.07 0 00-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 00.031.057 19.9 19.9 0 005.993 3.03.078.078 0 00.084-.028c.462-.63.874-1.295 1.226-1.994.021-.041.001-.09-.041-.106a13.107 13.107 0 01-1.872-.892.077.077 0 01-.008-.128 10.2 10.2 0 00.372-.292.074.074 0 01.077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 01.078.01c.12.098.246.198.373.292a.077.077 0 01-.006.127 12.299 12.299 0 01-1.873.892.077.077 0 00-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 00.084.028 19.839 19.839 0 006.002-3.03.077.077 0 00.032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 00-.031-.03z"/>
+              </svg>
+            </div>
+            <span class="text-lg font-bold text-text-primary">Bot Admin</span>
+          </div>
+          <div class="hidden md:flex items-center gap-1">
+            <a href="#" class="px-3 py-2 text-sm font-medium text-text-secondary hover:text-text-primary hover:bg-bg-hover rounded-md transition-colors">Dashboard</a>
+            <a href="#" class="px-3 py-2 text-sm font-medium text-text-secondary hover:text-text-primary hover:bg-bg-hover rounded-md transition-colors">Guilds</a>
+            <a href="#" class="px-3 py-2 text-sm font-medium text-accent-orange bg-accent-orange/10 rounded-md">Rat Watch</a>
+            <a href="#" class="px-3 py-2 text-sm font-medium text-text-secondary hover:text-text-primary hover:bg-bg-hover rounded-md transition-colors">Settings</a>
+          </div>
+        </div>
+        <div class="flex items-center gap-3">
+          <div class="w-8 h-8 rounded-full bg-accent-blue flex items-center justify-center">
+            <span class="text-white font-medium text-sm">A</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <!-- Main Content -->
+  <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <!-- Breadcrumb -->
+    <nav aria-label="Breadcrumb" class="mb-6">
+      <ol class="flex items-center gap-2 text-sm">
+        <li>
+          <a href="#" class="text-text-secondary hover:text-accent-blue transition-colors">Guilds</a>
+        </li>
+        <li class="text-text-tertiary">/</li>
+        <li>
+          <a href="#" class="text-text-secondary hover:text-accent-blue transition-colors">Gaming Hub</a>
+        </li>
+        <li class="text-text-tertiary">/</li>
+        <li>
+          <a href="#" class="text-text-secondary hover:text-accent-blue transition-colors">Rat Watch</a>
+        </li>
+        <li class="text-text-tertiary">/</li>
+        <li class="text-text-primary font-medium">Incidents</li>
+      </ol>
+    </nav>
+
+    <!-- Header -->
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+      <div>
+        <h1 class="text-2xl font-bold text-text-primary">Rat Watch Incidents</h1>
+        <p class="mt-1 text-sm text-text-secondary">Gaming Hub - Browse and search historical incidents</p>
+      </div>
+      <div class="flex items-center gap-3">
+        <a href="#" class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-text-secondary bg-bg-secondary border border-border-primary rounded-md hover:bg-bg-hover transition-colors">
+          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+          </svg>
+          Back to Analytics
+        </a>
+        <button class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-accent-orange border border-accent-orange rounded-md hover:bg-accent-orange-hover transition-colors" aria-label="Export incidents to CSV">
+          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+          </svg>
+          Export CSV
+        </button>
+      </div>
+    </div>
+
+    <!-- Filters Section -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg mb-6">
+      <div class="flex items-center justify-between p-4 border-b border-border-primary">
+        <h2 class="text-sm font-semibold text-text-primary flex items-center gap-2">
+          <svg class="w-4 h-4 text-text-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
+          </svg>
+          Advanced Filters
+        </h2>
+        <div class="flex items-center gap-3">
+          <!-- Saved Presets Dropdown -->
+          <div class="relative">
+            <button id="presetDropdownBtn" class="inline-flex items-center gap-2 px-3 py-1.5 text-sm text-text-secondary bg-bg-tertiary border border-border-primary rounded-md hover:bg-bg-hover transition-colors">
+              <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+              </svg>
+              <span>Saved Presets</span>
+              <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+              </svg>
+            </button>
+            <div id="presetDropdown" class="preset-dropdown absolute right-0 top-full mt-1 w-56 bg-bg-tertiary border border-border-primary rounded-lg shadow-lg z-10">
+              <div class="py-1">
+                <button class="w-full px-4 py-2 text-left text-sm text-text-primary hover:bg-bg-hover transition-colors">
+                  Recent Guilty Verdicts
+                </button>
+                <button class="w-full px-4 py-2 text-left text-sm text-text-primary hover:bg-bg-hover transition-colors">
+                  Active Voting
+                </button>
+                <button class="w-full px-4 py-2 text-left text-sm text-text-primary hover:bg-bg-hover transition-colors">
+                  Pending This Week
+                </button>
+                <button class="w-full px-4 py-2 text-left text-sm text-text-primary hover:bg-bg-hover transition-colors">
+                  High Vote Count
+                </button>
+              </div>
+              <div class="border-t border-border-primary py-1">
+                <button class="w-full px-4 py-2 text-left text-sm text-accent-blue hover:bg-bg-hover transition-colors flex items-center gap-2">
+                  <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+                  </svg>
+                  Save Current Filter
+                </button>
+              </div>
+            </div>
+          </div>
+          <!-- Toggle Button -->
+          <button id="toggleFiltersBtn" class="text-sm text-accent-blue hover:text-accent-blue-hover transition-colors flex items-center gap-1" aria-expanded="true" aria-controls="filtersPanel">
+            <span id="toggleFiltersText">Hide Filters</span>
+            <svg id="toggleFiltersIcon" class="w-4 h-4 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      <div id="filtersPanel" class="filter-panel p-4">
+        <form id="filtersForm" class="space-y-4">
+          <!-- Row 1: Status Multi-select -->
+          <div>
+            <label class="block text-sm font-medium text-text-primary mb-2">Status</label>
+            <div class="flex flex-wrap items-center gap-4">
+              <label class="flex items-center gap-2 cursor-pointer">
+                <input type="checkbox" name="status" value="pending" checked class="w-4 h-4 rounded">
+                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-warning text-white">
+                  Pending
+                </span>
+              </label>
+              <label class="flex items-center gap-2 cursor-pointer">
+                <input type="checkbox" name="status" value="cleared" checked class="w-4 h-4 rounded">
+                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-success text-white">
+                  Cleared Early
+                </span>
+              </label>
+              <label class="flex items-center gap-2 cursor-pointer">
+                <input type="checkbox" name="status" value="voting" checked class="w-4 h-4 rounded">
+                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-accent-blue text-white">
+                  Voting
+                </span>
+              </label>
+              <label class="flex items-center gap-2 cursor-pointer">
+                <input type="checkbox" name="status" value="guilty" checked class="w-4 h-4 rounded">
+                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-error text-white">
+                  Guilty
+                </span>
+              </label>
+              <label class="flex items-center gap-2 cursor-pointer">
+                <input type="checkbox" name="status" value="notguilty" checked class="w-4 h-4 rounded">
+                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-success text-white">
+                  Not Guilty
+                </span>
+              </label>
+              <label class="flex items-center gap-2 cursor-pointer">
+                <input type="checkbox" name="status" value="expired" checked class="w-4 h-4 rounded">
+                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-bg-tertiary text-text-secondary">
+                  Expired
+                </span>
+              </label>
+              <label class="flex items-center gap-2 cursor-pointer">
+                <input type="checkbox" name="status" value="cancelled" checked class="w-4 h-4 rounded">
+                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-bg-tertiary text-text-secondary">
+                  Cancelled
+                </span>
+              </label>
+            </div>
+          </div>
+
+          <!-- Row 2: Date Range with Quick Presets -->
+          <div>
+            <label class="block text-sm font-medium text-text-primary mb-2">Date Range</label>
+            <div class="flex flex-wrap items-center gap-3">
+              <div class="flex items-center gap-2">
+                <input
+                  type="date"
+                  id="startDate"
+                  name="startDate"
+                  class="form-input py-2 px-3 text-sm text-text-primary bg-bg-primary border border-border-primary rounded-md transition-colors"
+                />
+                <span class="text-text-tertiary">to</span>
+                <input
+                  type="date"
+                  id="endDate"
+                  name="endDate"
+                  class="form-input py-2 px-3 text-sm text-text-primary bg-bg-primary border border-border-primary rounded-md transition-colors"
+                />
+              </div>
+              <div class="flex items-center gap-2">
+                <button type="button" class="quick-date-btn px-3 py-1.5 text-xs font-medium text-text-secondary bg-bg-tertiary border border-border-primary rounded-md hover:bg-bg-hover transition-colors" data-range="today">
+                  Today
+                </button>
+                <button type="button" class="quick-date-btn px-3 py-1.5 text-xs font-medium text-text-secondary bg-bg-tertiary border border-border-primary rounded-md hover:bg-bg-hover transition-colors" data-range="7days">
+                  Last 7 Days
+                </button>
+                <button type="button" class="quick-date-btn px-3 py-1.5 text-xs font-medium text-accent-orange bg-accent-orange-muted border border-accent-orange/30 rounded-md hover:bg-accent-orange/20 transition-colors" data-range="30days">
+                  Last 30 Days
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <!-- Row 3: User Filters -->
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label for="accusedUser" class="block text-sm font-medium text-text-primary mb-1">Accused User</label>
+              <input
+                type="text"
+                id="accusedUser"
+                name="accusedUser"
+                placeholder="Search by username or ID..."
+                class="form-input w-full py-2 px-3 text-sm text-text-primary bg-bg-primary border border-border-primary rounded-md placeholder-text-tertiary transition-colors"
+              />
+              <p class="mt-1 text-xs text-text-tertiary">Start typing to search users</p>
+            </div>
+            <div>
+              <label for="initiatorUser" class="block text-sm font-medium text-text-primary mb-1">Initiator User</label>
+              <input
+                type="text"
+                id="initiatorUser"
+                name="initiatorUser"
+                placeholder="Search by username or ID..."
+                class="form-input w-full py-2 px-3 text-sm text-text-primary bg-bg-primary border border-border-primary rounded-md placeholder-text-tertiary transition-colors"
+              />
+              <p class="mt-1 text-xs text-text-tertiary">Start typing to search users</p>
+            </div>
+          </div>
+
+          <!-- Row 4: Additional Filters -->
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label for="voteThreshold" class="block text-sm font-medium text-text-primary mb-1">Minimum Total Votes</label>
+              <input
+                type="number"
+                id="voteThreshold"
+                name="voteThreshold"
+                min="0"
+                placeholder="e.g., 5"
+                class="form-input w-full py-2 px-3 text-sm text-text-primary bg-bg-primary border border-border-primary rounded-md placeholder-text-tertiary transition-colors"
+              />
+            </div>
+            <div>
+              <label for="keywordSearch" class="block text-sm font-medium text-text-primary mb-1">Keyword Search</label>
+              <input
+                type="text"
+                id="keywordSearch"
+                name="keywordSearch"
+                placeholder="Search in custom messages..."
+                class="form-input w-full py-2 px-3 text-sm text-text-primary bg-bg-primary border border-border-primary rounded-md placeholder-text-tertiary transition-colors"
+              />
+            </div>
+          </div>
+
+          <!-- Filter Actions -->
+          <div class="flex flex-col sm:flex-row justify-end gap-2 pt-2">
+            <button type="button" id="clearFiltersBtn" class="px-4 py-2 text-sm font-medium text-text-secondary bg-transparent border border-border-primary rounded-md hover:bg-bg-hover transition-colors">
+              Clear Filters
+            </button>
+            <button type="submit" class="px-4 py-2 text-sm font-medium text-white bg-accent-orange border border-accent-orange rounded-md hover:bg-accent-orange-hover transition-colors">
+              <span class="flex items-center justify-center gap-2">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                </svg>
+                Apply Filters
+              </span>
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <!-- Results Summary -->
+    <div class="flex items-center justify-between mb-4">
+      <p class="text-sm text-text-secondary">
+        Showing <span class="font-medium text-text-primary">1-25</span> of <span class="font-medium text-text-primary">142</span> incidents
+      </p>
+      <div class="flex items-center gap-2">
+        <span class="text-sm text-text-tertiary">2 filters active</span>
+        <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-accent-blue-muted text-accent-blue">
+          Last 30 Days
+        </span>
+      </div>
+    </div>
+
+    <!-- Incidents Table -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden">
+      <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-border-primary">
+          <thead class="bg-bg-tertiary">
+            <tr>
+              <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider cursor-pointer hover:text-text-primary transition-colors group" data-sort="status">
+                <div class="flex items-center gap-1">
+                  Status
+                  <svg class="w-4 h-4 text-text-tertiary group-hover:text-text-secondary sort-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                  </svg>
+                </div>
+              </th>
+              <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider cursor-pointer hover:text-text-primary transition-colors group" data-sort="accused">
+                <div class="flex items-center gap-1">
+                  Accused
+                  <svg class="w-4 h-4 text-text-tertiary group-hover:text-text-secondary sort-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                  </svg>
+                </div>
+              </th>
+              <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider cursor-pointer hover:text-text-primary transition-colors group" data-sort="initiator">
+                <div class="flex items-center gap-1">
+                  Initiator
+                  <svg class="w-4 h-4 text-text-tertiary group-hover:text-text-secondary sort-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                  </svg>
+                </div>
+              </th>
+              <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider cursor-pointer hover:text-text-primary transition-colors sort-asc group" data-sort="scheduled">
+                <div class="flex items-center gap-1">
+                  Scheduled
+                  <svg class="w-4 h-4 text-accent-orange sort-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                  </svg>
+                </div>
+              </th>
+              <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
+                Outcome
+              </th>
+              <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-text-secondary uppercase tracking-wider">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-border-primary">
+            <!-- Row 1 - Guilty -->
+            <tr class="hover:bg-bg-tertiary/50 transition-colors cursor-pointer incident-row" data-incident-id="1">
+              <td class="px-6 py-4 whitespace-nowrap">
+                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-error text-white">
+                  Guilty
+                </span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <div class="flex items-center">
+                  <div class="h-8 w-8 rounded-full bg-accent-orange flex items-center justify-center">
+                    <span class="text-white font-medium text-xs">RK</span>
+                  </div>
+                  <span class="ml-2 text-sm text-text-primary">RatKing#1234</span>
+                </div>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <div class="flex items-center">
+                  <div class="h-8 w-8 rounded-full bg-accent-blue flex items-center justify-center">
+                    <span class="text-white font-medium text-xs">CT</span>
+                  </div>
+                  <span class="ml-2 text-sm text-text-primary">CheeseThief#5678</span>
+                </div>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <span class="text-sm text-text-secondary" title="Dec 30, 2025 10:30 AM">2 hours ago</span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <span class="text-sm text-text-primary">5-2 Guilty</span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-right">
+                <button class="view-incident-btn text-accent-blue hover:text-accent-blue-hover transition-colors" aria-label="View incident details" data-incident-id="1">
+                  <svg class="w-5 h-5 inline-block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                  </svg>
+                </button>
+              </td>
+            </tr>
+
+            <!-- Row 2 - Voting -->
+            <tr class="hover:bg-bg-tertiary/50 transition-colors cursor-pointer incident-row" data-incident-id="2">
+              <td class="px-6 py-4 whitespace-nowrap">
+                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-accent-blue text-white">
+                  Voting
+                </span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <div class="flex items-center">
+                  <div class="h-8 w-8 rounded-full bg-success flex items-center justify-center">
+                    <span class="text-white font-medium text-xs">NO</span>
+                  </div>
+                  <span class="ml-2 text-sm text-text-primary">NightOwl#9012</span>
+                </div>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <div class="flex items-center">
+                  <div class="h-8 w-8 rounded-full bg-accent-orange flex items-center justify-center">
+                    <span class="text-white font-medium text-xs">RK</span>
+                  </div>
+                  <span class="ml-2 text-sm text-text-primary">RatKing#1234</span>
+                </div>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <span class="text-sm text-text-secondary" title="Dec 30, 2025 12:00 PM">30 min ago</span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <span class="text-sm text-accent-blue">3-1 (voting)</span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-right">
+                <button class="view-incident-btn text-accent-blue hover:text-accent-blue-hover transition-colors" aria-label="View incident details" data-incident-id="2">
+                  <svg class="w-5 h-5 inline-block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                  </svg>
+                </button>
+              </td>
+            </tr>
+
+            <!-- Row 3 - Cleared Early -->
+            <tr class="hover:bg-bg-tertiary/50 transition-colors cursor-pointer incident-row" data-incident-id="3">
+              <td class="px-6 py-4 whitespace-nowrap">
+                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-success text-white">
+                  Cleared Early
+                </span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <div class="flex items-center">
+                  <div class="h-8 w-8 rounded-full bg-warning flex items-center justify-center">
+                    <span class="text-white font-medium text-xs">SP</span>
+                  </div>
+                  <span class="ml-2 text-sm text-text-primary">SneakyPete#3456</span>
+                </div>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <div class="flex items-center">
+                  <div class="h-8 w-8 rounded-full bg-error flex items-center justify-center">
+                    <span class="text-white font-medium text-xs">AD</span>
+                  </div>
+                  <span class="ml-2 text-sm text-text-primary">Admin#0001</span>
+                </div>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <span class="text-sm text-text-secondary" title="Dec 29, 2025 3:15 PM">1 day ago</span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <span class="text-sm text-success">Cleared Early</span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-right">
+                <button class="view-incident-btn text-accent-blue hover:text-accent-blue-hover transition-colors" aria-label="View incident details" data-incident-id="3">
+                  <svg class="w-5 h-5 inline-block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                  </svg>
+                </button>
+              </td>
+            </tr>
+
+            <!-- Row 4 - Pending -->
+            <tr class="hover:bg-bg-tertiary/50 transition-colors cursor-pointer incident-row" data-incident-id="4">
+              <td class="px-6 py-4 whitespace-nowrap">
+                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-warning text-white">
+                  Pending
+                </span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <div class="flex items-center">
+                  <div class="h-8 w-8 rounded-full bg-info flex items-center justify-center">
+                    <span class="text-white font-medium text-xs">NR</span>
+                  </div>
+                  <span class="ml-2 text-sm text-text-primary">NewRat#7890</span>
+                </div>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <div class="flex items-center">
+                  <div class="h-8 w-8 rounded-full bg-accent-blue flex items-center justify-center">
+                    <span class="text-white font-medium text-xs">MD</span>
+                  </div>
+                  <span class="ml-2 text-sm text-text-primary">Mod#1111</span>
+                </div>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <span class="text-sm text-warning" title="Dec 30, 2025 2:30 PM">In 2 hours</span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <span class="text-sm text-text-tertiary">-</span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-right">
+                <div class="flex items-center justify-end gap-2">
+                  <button class="view-incident-btn text-accent-blue hover:text-accent-blue-hover transition-colors" aria-label="View incident details" data-incident-id="4">
+                    <svg class="w-5 h-5 inline-block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                    </svg>
+                  </button>
+                  <button class="text-error hover:text-error/80 transition-colors" aria-label="Cancel incident">
+                    <svg class="w-5 h-5 inline-block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                </div>
+              </td>
+            </tr>
+
+            <!-- Row 5 - Not Guilty -->
+            <tr class="hover:bg-bg-tertiary/50 transition-colors cursor-pointer incident-row" data-incident-id="5">
+              <td class="px-6 py-4 whitespace-nowrap">
+                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-success text-white">
+                  Not Guilty
+                </span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <div class="flex items-center">
+                  <div class="h-8 w-8 rounded-full bg-bg-tertiary flex items-center justify-center">
+                    <span class="text-text-secondary font-medium text-xs">IO</span>
+                  </div>
+                  <span class="ml-2 text-sm text-text-primary">InnocentOne#2222</span>
+                </div>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <div class="flex items-center">
+                  <div class="h-8 w-8 rounded-full bg-warning flex items-center justify-center">
+                    <span class="text-white font-medium text-xs">JG</span>
+                  </div>
+                  <span class="ml-2 text-sm text-text-primary">Judge#3333</span>
+                </div>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <span class="text-sm text-text-secondary" title="Dec 27, 2025 9:00 AM">3 days ago</span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <span class="text-sm text-text-primary">2-5 Not Guilty</span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-right">
+                <button class="view-incident-btn text-accent-blue hover:text-accent-blue-hover transition-colors" aria-label="View incident details" data-incident-id="5">
+                  <svg class="w-5 h-5 inline-block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                  </svg>
+                </button>
+              </td>
+            </tr>
+
+            <!-- Row 6 - Expired -->
+            <tr class="hover:bg-bg-tertiary/50 transition-colors cursor-pointer incident-row" data-incident-id="6">
+              <td class="px-6 py-4 whitespace-nowrap">
+                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-bg-tertiary text-text-secondary">
+                  Expired
+                </span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <div class="flex items-center">
+                  <div class="h-8 w-8 rounded-full bg-bg-tertiary flex items-center justify-center">
+                    <span class="text-text-secondary font-medium text-xs">LR</span>
+                  </div>
+                  <span class="ml-2 text-sm text-text-primary">LazyRat#4444</span>
+                </div>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <div class="flex items-center">
+                  <div class="h-8 w-8 rounded-full bg-accent-orange flex items-center justify-center">
+                    <span class="text-white font-medium text-xs">BS</span>
+                  </div>
+                  <span class="ml-2 text-sm text-text-primary">Boss#5555</span>
+                </div>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <span class="text-sm text-text-secondary" title="Dec 23, 2025 11:00 AM">1 week ago</span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <span class="text-sm text-text-tertiary">Expired</span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-right">
+                <button class="view-incident-btn text-accent-blue hover:text-accent-blue-hover transition-colors" aria-label="View incident details" data-incident-id="6">
+                  <svg class="w-5 h-5 inline-block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                  </svg>
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Pagination -->
+      <div class="px-6 py-4 border-t border-border-primary">
+        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div class="flex items-center gap-3">
+            <label for="pageSize" class="text-sm text-text-secondary">Show:</label>
+            <select id="pageSize" class="px-3 py-1.5 text-sm bg-bg-primary border border-border-primary rounded-md text-text-primary focus:border-accent-blue focus:outline-none">
+              <option value="10">10</option>
+              <option value="25" selected>25</option>
+              <option value="50">50</option>
+              <option value="100">100</option>
+            </select>
+          </div>
+          <nav aria-label="Pagination" class="flex items-center gap-1">
+            <!-- First Page -->
+            <a href="#" class="px-2 py-2 text-sm text-text-secondary hover:bg-bg-hover rounded-md transition-colors pointer-events-none opacity-50" aria-label="First page" aria-disabled="true">
+              <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 19l-7-7 7-7m8 14l-7-7 7-7" />
+              </svg>
+            </a>
+            <!-- Previous -->
+            <a href="#" class="px-2 py-2 text-sm text-text-secondary hover:bg-bg-hover rounded-md transition-colors pointer-events-none opacity-50" aria-label="Previous page" aria-disabled="true">
+              <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+              </svg>
+            </a>
+            <!-- Page Numbers -->
+            <span class="px-3 py-2 text-sm font-medium text-white bg-accent-orange rounded-md" aria-current="page">1</span>
+            <a href="#" class="px-3 py-2 text-sm text-text-secondary hover:bg-bg-hover rounded-md transition-colors">2</a>
+            <a href="#" class="px-3 py-2 text-sm text-text-secondary hover:bg-bg-hover rounded-md transition-colors">3</a>
+            <a href="#" class="px-3 py-2 text-sm text-text-secondary hover:bg-bg-hover rounded-md transition-colors">4</a>
+            <a href="#" class="px-3 py-2 text-sm text-text-secondary hover:bg-bg-hover rounded-md transition-colors">5</a>
+            <span class="px-2 py-2 text-text-tertiary">...</span>
+            <a href="#" class="px-3 py-2 text-sm text-text-secondary hover:bg-bg-hover rounded-md transition-colors">6</a>
+            <!-- Next -->
+            <a href="#" class="px-2 py-2 text-sm text-text-secondary hover:bg-bg-hover rounded-md transition-colors" aria-label="Next page">
+              <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+              </svg>
+            </a>
+            <!-- Last Page -->
+            <a href="#" class="px-2 py-2 text-sm text-text-secondary hover:bg-bg-hover rounded-md transition-colors" aria-label="Last page">
+              <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 5l7 7-7 7M5 5l7 7-7 7" />
+              </svg>
+            </a>
+          </nav>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <!-- Incident Detail Modal Backdrop -->
+  <div id="modalBackdrop" class="modal-backdrop" aria-hidden="true"></div>
+
+  <!-- Incident Detail Modal -->
+  <div id="incidentModal" class="modal modal-centered modal-lg bg-bg-secondary rounded-lg shadow-xl" role="dialog" aria-labelledby="modalTitle" aria-modal="true">
+    <!-- Modal Header -->
+    <div class="modal-header">
+      <div class="flex items-center gap-3">
+        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-error text-white">
+          Guilty
+        </span>
+        <h2 id="modalTitle" class="text-lg font-semibold text-text-primary">Incident #RW-2025-001234</h2>
+      </div>
+      <button id="modalCloseBtn" class="modal-close" aria-label="Close modal">
+        <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+
+    <!-- Modal Body -->
+    <div class="modal-body modal-body-scroll">
+      <!-- Users Section -->
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+        <!-- Accused User -->
+        <div class="bg-bg-primary border border-border-primary rounded-lg p-4">
+          <h3 class="text-xs font-medium text-text-tertiary uppercase tracking-wider mb-3">Accused</h3>
+          <div class="flex items-center gap-3">
+            <div class="h-12 w-12 rounded-full bg-accent-orange flex items-center justify-center">
+              <span class="text-white font-bold text-lg">RK</span>
+            </div>
+            <div>
+              <p class="text-sm font-medium text-text-primary">RatKing#1234</p>
+              <p class="text-xs text-text-tertiary font-mono">123456789012345678</p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Initiator User -->
+        <div class="bg-bg-primary border border-border-primary rounded-lg p-4">
+          <h3 class="text-xs font-medium text-text-tertiary uppercase tracking-wider mb-3">Initiated By</h3>
+          <div class="flex items-center gap-3">
+            <div class="h-12 w-12 rounded-full bg-accent-blue flex items-center justify-center">
+              <span class="text-white font-bold text-lg">CT</span>
+            </div>
+            <div>
+              <p class="text-sm font-medium text-text-primary">CheeseThief#5678</p>
+              <p class="text-xs text-text-tertiary font-mono">234567890123456789</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Details Section -->
+      <div class="bg-bg-primary border border-border-primary rounded-lg p-4 mb-6">
+        <h3 class="text-xs font-medium text-text-tertiary uppercase tracking-wider mb-3">Details</h3>
+        <div class="grid grid-cols-2 gap-4 text-sm">
+          <div>
+            <span class="text-text-tertiary">Scheduled Time:</span>
+            <span class="ml-2 text-text-primary">Dec 30, 2025 10:30 AM EST</span>
+          </div>
+          <div>
+            <span class="text-text-tertiary">Duration:</span>
+            <span class="ml-2 text-text-primary">2 hours</span>
+          </div>
+        </div>
+        <div class="mt-4">
+          <span class="text-xs font-medium text-text-tertiary uppercase tracking-wider">Custom Message</span>
+          <p class="mt-1 text-sm text-text-primary bg-bg-tertiary border border-border-secondary rounded p-3">
+            "I'll definitely go to the gym today, no excuses!"
+          </p>
+        </div>
+      </div>
+
+      <!-- Vote Breakdown Section -->
+      <div class="bg-bg-primary border border-border-primary rounded-lg p-4 mb-6">
+        <h3 class="text-xs font-medium text-text-tertiary uppercase tracking-wider mb-3">Vote Breakdown</h3>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <!-- Guilty Votes -->
+          <div class="bg-error-bg border border-error-border rounded-lg p-3">
+            <div class="flex items-center justify-between mb-2">
+              <span class="text-sm font-medium text-error">Guilty (Rat)</span>
+              <span class="text-lg font-bold text-error">5</span>
+            </div>
+            <div class="space-y-1 text-xs text-text-secondary">
+              <p>CheeseThief#5678</p>
+              <p>Judge#3333</p>
+              <p>Mod#1111</p>
+              <p>Witness#6666</p>
+              <p>Observer#7777</p>
+            </div>
+          </div>
+
+          <!-- Not Guilty Votes -->
+          <div class="bg-success-bg border border-success-border rounded-lg p-3">
+            <div class="flex items-center justify-between mb-2">
+              <span class="text-sm font-medium text-success">Not Guilty</span>
+              <span class="text-lg font-bold text-success">2</span>
+            </div>
+            <div class="space-y-1 text-xs text-text-secondary">
+              <p>Defender#8888</p>
+              <p>Friend#9999</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Timeline Section -->
+      <div class="bg-bg-primary border border-border-primary rounded-lg p-4 mb-6">
+        <h3 class="text-xs font-medium text-text-tertiary uppercase tracking-wider mb-3">Timeline</h3>
+        <div class="space-y-3">
+          <div class="flex items-start gap-3">
+            <div class="w-2 h-2 mt-1.5 rounded-full bg-success"></div>
+            <div>
+              <p class="text-sm text-text-primary">Created</p>
+              <p class="text-xs text-text-tertiary">Dec 30, 2025 8:30 AM</p>
+            </div>
+          </div>
+          <div class="flex items-start gap-3">
+            <div class="w-2 h-2 mt-1.5 rounded-full bg-accent-blue"></div>
+            <div>
+              <p class="text-sm text-text-primary">Voting Started</p>
+              <p class="text-xs text-text-tertiary">Dec 30, 2025 10:30 AM</p>
+            </div>
+          </div>
+          <div class="flex items-start gap-3">
+            <div class="w-2 h-2 mt-1.5 rounded-full bg-error"></div>
+            <div>
+              <p class="text-sm text-text-primary">Ended - Guilty Verdict</p>
+              <p class="text-xs text-text-tertiary">Dec 30, 2025 10:35 AM</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Link to Original Message -->
+      <div class="flex items-center justify-between p-3 bg-bg-tertiary border border-border-secondary rounded-lg">
+        <span class="text-sm text-text-secondary">Original Discord Message</span>
+        <a href="#" class="inline-flex items-center gap-1 text-sm text-accent-blue hover:text-accent-blue-hover transition-colors">
+          View in Discord
+          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+          </svg>
+        </a>
+      </div>
+    </div>
+
+    <!-- Modal Footer -->
+    <div class="modal-footer">
+      <button id="modalCloseFooterBtn" class="px-4 py-2 text-sm font-medium text-text-secondary bg-bg-tertiary border border-border-primary rounded-md hover:bg-bg-hover transition-colors">
+        Close
+      </button>
+    </div>
+  </div>
+
+  <script>
+    // ========================================
+    // Filter Panel Toggle
+    // ========================================
+    const toggleFiltersBtn = document.getElementById('toggleFiltersBtn');
+    const toggleFiltersText = document.getElementById('toggleFiltersText');
+    const toggleFiltersIcon = document.getElementById('toggleFiltersIcon');
+    const filtersPanel = document.getElementById('filtersPanel');
+
+    toggleFiltersBtn.addEventListener('click', function() {
+      const isExpanded = this.getAttribute('aria-expanded') === 'true';
+      filtersPanel.classList.toggle('collapsed');
+      this.setAttribute('aria-expanded', !isExpanded);
+      toggleFiltersText.textContent = isExpanded ? 'Show Filters' : 'Hide Filters';
+      toggleFiltersIcon.style.transform = isExpanded ? 'rotate(180deg)' : 'rotate(0deg)';
+    });
+
+    // ========================================
+    // Saved Presets Dropdown
+    // ========================================
+    const presetDropdownBtn = document.getElementById('presetDropdownBtn');
+    const presetDropdown = document.getElementById('presetDropdown');
+
+    presetDropdownBtn.addEventListener('click', function(e) {
+      e.stopPropagation();
+      presetDropdown.classList.toggle('open');
+    });
+
+    document.addEventListener('click', function() {
+      presetDropdown.classList.remove('open');
+    });
+
+    // ========================================
+    // Quick Date Preset Buttons
+    // ========================================
+    const quickDateBtns = document.querySelectorAll('.quick-date-btn');
+
+    quickDateBtns.forEach(btn => {
+      btn.addEventListener('click', function() {
+        // Remove active state from all buttons
+        quickDateBtns.forEach(b => {
+          b.classList.remove('text-accent-orange', 'bg-accent-orange-muted', 'border-accent-orange/30');
+          b.classList.add('text-text-secondary', 'bg-bg-tertiary', 'border-border-primary');
+        });
+
+        // Add active state to clicked button
+        this.classList.remove('text-text-secondary', 'bg-bg-tertiary', 'border-border-primary');
+        this.classList.add('text-accent-orange', 'bg-accent-orange-muted', 'border-accent-orange/30');
+
+        // Set date range based on selection
+        const range = this.dataset.range;
+        const today = new Date();
+        const endDate = today.toISOString().split('T')[0];
+        let startDate;
+
+        if (range === 'today') {
+          startDate = endDate;
+        } else if (range === '7days') {
+          const weekAgo = new Date(today);
+          weekAgo.setDate(today.getDate() - 7);
+          startDate = weekAgo.toISOString().split('T')[0];
+        } else if (range === '30days') {
+          const monthAgo = new Date(today);
+          monthAgo.setDate(today.getDate() - 30);
+          startDate = monthAgo.toISOString().split('T')[0];
+        }
+
+        document.getElementById('startDate').value = startDate;
+        document.getElementById('endDate').value = endDate;
+      });
+    });
+
+    // ========================================
+    // Clear Filters
+    // ========================================
+    document.getElementById('clearFiltersBtn').addEventListener('click', function() {
+      // Reset all checkboxes to checked
+      document.querySelectorAll('input[name="status"]').forEach(cb => cb.checked = true);
+
+      // Clear text inputs
+      document.getElementById('startDate').value = '';
+      document.getElementById('endDate').value = '';
+      document.getElementById('accusedUser').value = '';
+      document.getElementById('initiatorUser').value = '';
+      document.getElementById('voteThreshold').value = '';
+      document.getElementById('keywordSearch').value = '';
+
+      // Reset quick date buttons
+      quickDateBtns.forEach(b => {
+        b.classList.remove('text-accent-orange', 'bg-accent-orange-muted', 'border-accent-orange/30');
+        b.classList.add('text-text-secondary', 'bg-bg-tertiary', 'border-border-primary');
+      });
+    });
+
+    // ========================================
+    // Form Submit Handler
+    // ========================================
+    document.getElementById('filtersForm').addEventListener('submit', function(e) {
+      e.preventDefault();
+      console.log('Filters applied:', {
+        statuses: Array.from(document.querySelectorAll('input[name="status"]:checked')).map(cb => cb.value),
+        startDate: document.getElementById('startDate').value,
+        endDate: document.getElementById('endDate').value,
+        accusedUser: document.getElementById('accusedUser').value,
+        initiatorUser: document.getElementById('initiatorUser').value,
+        voteThreshold: document.getElementById('voteThreshold').value,
+        keywordSearch: document.getElementById('keywordSearch').value
+      });
+      // In a real implementation, this would trigger a search
+    });
+
+    // ========================================
+    // Sortable Column Headers
+    // ========================================
+    document.querySelectorAll('th[data-sort]').forEach(th => {
+      th.addEventListener('click', function() {
+        const currentSort = this.classList.contains('sort-asc');
+
+        // Remove sort classes from all headers
+        document.querySelectorAll('th[data-sort]').forEach(header => {
+          header.classList.remove('sort-asc', 'sort-desc');
+          const icon = header.querySelector('.sort-icon');
+          if (icon) {
+            icon.classList.remove('text-accent-orange');
+            icon.classList.add('text-text-tertiary');
+          }
+        });
+
+        // Toggle sort direction
+        this.classList.add(currentSort ? 'sort-desc' : 'sort-asc');
+        const icon = this.querySelector('.sort-icon');
+        if (icon) {
+          icon.classList.remove('text-text-tertiary');
+          icon.classList.add('text-accent-orange');
+        }
+
+        console.log('Sort by:', this.dataset.sort, currentSort ? 'desc' : 'asc');
+      });
+    });
+
+    // ========================================
+    // Modal Functionality
+    // ========================================
+    const modalBackdrop = document.getElementById('modalBackdrop');
+    const incidentModal = document.getElementById('incidentModal');
+    const modalCloseBtn = document.getElementById('modalCloseBtn');
+    const modalCloseFooterBtn = document.getElementById('modalCloseFooterBtn');
+
+    function openModal() {
+      modalBackdrop.classList.add('active');
+      incidentModal.classList.add('active');
+      document.body.classList.add('modal-open');
+    }
+
+    function closeModal() {
+      modalBackdrop.classList.remove('active');
+      incidentModal.classList.remove('active');
+      document.body.classList.remove('modal-open');
+    }
+
+    // Open modal on View button click
+    document.querySelectorAll('.view-incident-btn').forEach(btn => {
+      btn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        const incidentId = this.dataset.incidentId;
+        console.log('View incident:', incidentId);
+        openModal();
+      });
+    });
+
+    // Open modal on row click
+    document.querySelectorAll('.incident-row').forEach(row => {
+      row.addEventListener('click', function(e) {
+        // Don't open modal if clicking on a button
+        if (e.target.closest('button')) return;
+        const incidentId = this.dataset.incidentId;
+        console.log('View incident:', incidentId);
+        openModal();
+      });
+    });
+
+    // Close modal handlers
+    modalCloseBtn.addEventListener('click', closeModal);
+    modalCloseFooterBtn.addEventListener('click', closeModal);
+    modalBackdrop.addEventListener('click', closeModal);
+
+    // Close modal on Escape key
+    document.addEventListener('keydown', function(e) {
+      if (e.key === 'Escape' && incidentModal.classList.contains('active')) {
+        closeModal();
+      }
+    });
+
+    // Prevent modal close when clicking inside modal
+    incidentModal.addEventListener('click', function(e) {
+      e.stopPropagation();
+    });
+  </script>
+</body>
+</html>

--- a/docs/prototypes/features/rat-watch-analytics/public-leaderboard.html
+++ b/docs/prototypes/features/rat-watch-analytics/public-leaderboard.html
@@ -1,0 +1,832 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hall of Shame - The Rat's Nest</title>
+
+  <!-- Open Graph tags for social sharing -->
+  <meta property="og:title" content="Hall of Shame - The Rat's Nest">
+  <meta property="og:description" content="Check out who's been caught being a rat!">
+  <meta property="og:type" content="website">
+
+  <!-- Shared Styles -->
+  <link rel="stylesheet" href="../../css/main.css">
+
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="../../css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
+
+  <style>
+    /* Custom animations */
+    @keyframes wiggle {
+      0%, 100% { transform: rotate(-3deg); }
+      50% { transform: rotate(3deg); }
+    }
+
+    @keyframes float {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-5px); }
+    }
+
+    .animate-wiggle {
+      animation: wiggle 0.5s ease-in-out infinite;
+    }
+
+    .animate-float {
+      animation: float 3s ease-in-out infinite;
+    }
+
+    /* Medal styling */
+    .medal-gold {
+      background: linear-gradient(135deg, #ffd700 0%, #ffec4f 50%, #ffd700 100%);
+      box-shadow: 0 4px 15px rgba(255, 215, 0, 0.4);
+    }
+
+    .medal-silver {
+      background: linear-gradient(135deg, #c0c0c0 0%, #e8e8e8 50%, #c0c0c0 100%);
+      box-shadow: 0 4px 15px rgba(192, 192, 192, 0.4);
+    }
+
+    .medal-bronze {
+      background: linear-gradient(135deg, #cd7f32 0%, #e6a45c 50%, #cd7f32 100%);
+      box-shadow: 0 4px 15px rgba(205, 127, 50, 0.4);
+    }
+
+    /* Rank row highlights */
+    .rank-gold {
+      background: linear-gradient(90deg, rgba(255, 215, 0, 0.1) 0%, transparent 100%);
+      border-left: 3px solid #ffd700;
+    }
+
+    .rank-silver {
+      background: linear-gradient(90deg, rgba(192, 192, 192, 0.1) 0%, transparent 100%);
+      border-left: 3px solid #c0c0c0;
+    }
+
+    .rank-bronze {
+      background: linear-gradient(90deg, rgba(205, 127, 50, 0.1) 0%, transparent 100%);
+      border-left: 3px solid #cd7f32;
+    }
+
+    /* Fun stat card glow effects */
+    .stat-card-flame {
+      background: linear-gradient(135deg, rgba(239, 68, 68, 0.1) 0%, rgba(251, 146, 60, 0.1) 100%);
+      border: 1px solid rgba(239, 68, 68, 0.2);
+    }
+
+    .stat-card-lightning {
+      background: linear-gradient(135deg, rgba(251, 191, 36, 0.1) 0%, rgba(245, 158, 11, 0.1) 100%);
+      border: 1px solid rgba(251, 191, 36, 0.2);
+    }
+
+    .stat-card-speed {
+      background: linear-gradient(135deg, rgba(6, 182, 212, 0.1) 0%, rgba(34, 211, 238, 0.1) 100%);
+      border: 1px solid rgba(6, 182, 212, 0.2);
+    }
+
+    .stat-card-luck {
+      background: linear-gradient(135deg, rgba(168, 85, 247, 0.1) 0%, rgba(192, 132, 252, 0.1) 100%);
+      border: 1px solid rgba(168, 85, 247, 0.2);
+    }
+
+    /* Incident feed styling */
+    .verdict-guilty {
+      color: #ef4444;
+    }
+
+    .verdict-not-guilty {
+      color: #10b981;
+    }
+
+    /* Mobile responsive table */
+    @media (max-width: 640px) {
+      .leaderboard-table {
+        display: block;
+      }
+
+      .leaderboard-table thead {
+        display: none;
+      }
+
+      .leaderboard-table tbody {
+        display: block;
+      }
+
+      .leaderboard-table tr {
+        display: flex;
+        flex-wrap: wrap;
+        padding: 1rem;
+        border-bottom: 1px solid var(--color-border-primary);
+      }
+
+      .leaderboard-table td {
+        padding: 0.25rem 0;
+        border: none;
+      }
+
+      .leaderboard-table td[data-label]::before {
+        content: attr(data-label) ": ";
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        margin-right: 0.5rem;
+      }
+    }
+
+    /* Header gradient effect */
+    .header-gradient {
+      background: linear-gradient(135deg, var(--color-bg-secondary) 0%, var(--color-bg-tertiary) 100%);
+    }
+
+    /* Lock icon animation */
+    .lock-bounce {
+      animation: float 2s ease-in-out infinite;
+    }
+  </style>
+</head>
+<body class="bg-bg-primary text-text-primary font-sans antialiased min-h-screen">
+
+  <!-- Toggle Button for Demo States -->
+  <div class="fixed top-4 right-4 z-50">
+    <button
+      id="toggleStateBtn"
+      onclick="togglePageState()"
+      class="px-4 py-2 bg-bg-tertiary border border-border-primary rounded-lg text-sm text-text-secondary hover:text-text-primary hover:bg-bg-hover transition-colors"
+    >
+      Toggle: Not Public State
+    </button>
+  </div>
+
+  <!-- Main Public Leaderboard Content -->
+  <div id="publicContent" class="min-h-screen flex flex-col">
+
+    <!-- Header -->
+    <header class="header-gradient border-b border-border-primary">
+      <div class="max-w-5xl mx-auto px-4 py-8 sm:py-12">
+        <div class="flex flex-col sm:flex-row items-center gap-4 sm:gap-6 text-center sm:text-left">
+          <!-- Guild Icon -->
+          <div class="relative">
+            <div class="w-20 h-20 sm:w-24 sm:h-24 rounded-2xl bg-gradient-to-br from-purple-600 to-pink-600 flex items-center justify-center text-white font-bold text-2xl sm:text-3xl shadow-xl">
+              RN
+            </div>
+            <div class="absolute -bottom-2 -right-2 text-3xl animate-wiggle">
+              <span role="img" aria-label="rat">&#x1F400;</span>
+            </div>
+          </div>
+
+          <!-- Title -->
+          <div class="flex-1">
+            <div class="flex items-center justify-center sm:justify-start gap-2 mb-2">
+              <span class="text-2xl" role="img" aria-label="warning">&#x26A0;&#xFE0F;</span>
+              <h1 class="text-3xl sm:text-4xl font-bold text-text-primary">Hall of Shame</h1>
+              <span class="text-2xl" role="img" aria-label="warning">&#x26A0;&#xFE0F;</span>
+            </div>
+            <p class="text-lg sm:text-xl text-text-secondary">The Rat's Nest</p>
+            <p class="text-sm text-text-tertiary mt-2">Who's been caught breaking their promises?</p>
+          </div>
+
+          <!-- Stats Summary -->
+          <div class="flex gap-4 sm:gap-6 text-center">
+            <div>
+              <p class="text-2xl sm:text-3xl font-bold text-accent-orange">47</p>
+              <p class="text-xs text-text-tertiary uppercase tracking-wide">Total Incidents</p>
+            </div>
+            <div>
+              <p class="text-2xl sm:text-3xl font-bold text-error">32</p>
+              <p class="text-xs text-text-tertiary uppercase tracking-wide">Guilty Verdicts</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <!-- Main Content -->
+    <main class="flex-1 max-w-5xl mx-auto px-4 py-8 w-full">
+
+      <!-- Fun Stats Highlight Cards -->
+      <section class="mb-10">
+        <h2 class="text-lg font-semibold text-text-primary mb-4 flex items-center gap-2">
+          <span role="img" aria-label="trophy">&#x1F3C6;</span>
+          Shameful Achievements
+        </h2>
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+
+          <!-- Longest Streak -->
+          <div class="stat-card-flame rounded-xl p-5 transition-transform hover:scale-105">
+            <div class="flex items-center gap-3 mb-3">
+              <div class="w-10 h-10 rounded-lg bg-error/20 flex items-center justify-center">
+                <span class="text-xl" role="img" aria-label="fire">&#x1F525;</span>
+              </div>
+              <div class="text-sm font-semibold text-error uppercase tracking-wide">Longest Streak</div>
+            </div>
+            <div class="flex items-center gap-3">
+              <div class="w-8 h-8 rounded-full bg-gradient-to-br from-red-500 to-orange-500 flex items-center justify-center text-white text-sm font-bold">RK</div>
+              <div>
+                <p class="font-semibold text-text-primary">RatKing#1234</p>
+                <p class="text-sm text-text-secondary">5 guilty verdicts in a row!</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- Biggest Landslide -->
+          <div class="stat-card-lightning rounded-xl p-5 transition-transform hover:scale-105">
+            <div class="flex items-center gap-3 mb-3">
+              <div class="w-10 h-10 rounded-lg bg-warning/20 flex items-center justify-center">
+                <span class="text-xl" role="img" aria-label="lightning">&#x26A1;</span>
+              </div>
+              <div class="text-sm font-semibold text-warning uppercase tracking-wide">Biggest Landslide</div>
+            </div>
+            <div class="flex items-center gap-3">
+              <div class="w-8 h-8 rounded-full bg-gradient-to-br from-yellow-500 to-amber-500 flex items-center justify-center text-white text-sm font-bold">CT</div>
+              <div>
+                <p class="font-semibold text-text-primary">CheeseThief#5678</p>
+                <p class="text-sm text-text-secondary">10-0 unanimous guilty!</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- Speed Demon -->
+          <div class="stat-card-speed rounded-xl p-5 transition-transform hover:scale-105">
+            <div class="flex items-center gap-3 mb-3">
+              <div class="w-10 h-10 rounded-lg bg-info/20 flex items-center justify-center">
+                <span class="text-xl" role="img" aria-label="clock">&#x23F1;&#xFE0F;</span>
+              </div>
+              <div class="text-sm font-semibold text-info uppercase tracking-wide">Speed Demon</div>
+            </div>
+            <div class="flex items-center gap-3">
+              <div class="w-8 h-8 rounded-full bg-gradient-to-br from-cyan-500 to-blue-500 flex items-center justify-center text-white text-sm font-bold">SP</div>
+              <div>
+                <p class="font-semibold text-text-primary">SneakyPete#3456</p>
+                <p class="text-sm text-text-secondary">Cleared in 23 seconds!</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- Closest Call -->
+          <div class="stat-card-luck rounded-xl p-5 transition-transform hover:scale-105">
+            <div class="flex items-center gap-3 mb-3">
+              <div class="w-10 h-10 rounded-lg bg-purple-500/20 flex items-center justify-center">
+                <span class="text-xl" role="img" aria-label="dice">&#x1F3B2;</span>
+              </div>
+              <div class="text-sm font-semibold text-purple-400 uppercase tracking-wide">Closest Call</div>
+            </div>
+            <div class="flex items-center gap-3">
+              <div class="w-8 h-8 rounded-full bg-gradient-to-br from-purple-500 to-pink-500 flex items-center justify-center text-white text-sm font-bold">LR</div>
+              <div>
+                <p class="font-semibold text-text-primary">LuckyRat#7890</p>
+                <p class="text-sm text-text-secondary">4-5 escaped by 1 vote!</p>
+              </div>
+            </div>
+          </div>
+
+        </div>
+      </section>
+
+      <!-- Main Grid: Leaderboard and Recent Incidents -->
+      <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+
+        <!-- Leaderboard Table -->
+        <section class="lg:col-span-2">
+          <div class="bg-bg-secondary border border-border-primary rounded-xl overflow-hidden">
+            <div class="px-6 py-4 border-b border-border-primary flex items-center gap-2">
+              <span class="text-xl" role="img" aria-label="cheese">&#x1F9C0;</span>
+              <h2 class="text-lg font-semibold text-text-primary">Wall of Shame</h2>
+              <span class="text-xs text-text-tertiary ml-auto">Top 25</span>
+            </div>
+
+            <div class="overflow-x-auto">
+              <table class="leaderboard-table w-full">
+                <thead class="bg-bg-primary/50">
+                  <tr>
+                    <th class="px-4 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider w-16">Rank</th>
+                    <th class="px-4 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">User</th>
+                    <th class="px-4 py-3 text-center text-xs font-semibold text-text-secondary uppercase tracking-wider">Rat Count</th>
+                    <th class="px-4 py-3 text-center text-xs font-semibold text-text-secondary uppercase tracking-wider">Guilty %</th>
+                    <th class="px-4 py-3 text-right text-xs font-semibold text-text-secondary uppercase tracking-wider">Last Caught</th>
+                  </tr>
+                </thead>
+                <tbody class="divide-y divide-border-primary">
+                  <!-- Rank 1 - Gold -->
+                  <tr class="rank-gold hover:bg-bg-hover/50 transition-colors">
+                    <td class="px-4 py-4" data-label="Rank">
+                      <div class="flex items-center gap-2">
+                        <div class="medal-gold w-8 h-8 rounded-full flex items-center justify-center text-black font-bold text-sm">1</div>
+                        <span class="text-lg" role="img" aria-label="first">&#x1F947;</span>
+                      </div>
+                    </td>
+                    <td class="px-4 py-4" data-label="User">
+                      <div class="flex items-center gap-3">
+                        <div class="w-10 h-10 rounded-full bg-gradient-to-br from-red-500 to-orange-500 flex items-center justify-center text-white font-bold text-sm">RK</div>
+                        <div>
+                          <p class="font-semibold text-text-primary">RatKing#1234</p>
+                          <p class="text-xs text-text-tertiary">The undisputed champion</p>
+                        </div>
+                      </div>
+                    </td>
+                    <td class="px-4 py-4 text-center" data-label="Rat Count">
+                      <span class="inline-flex items-center justify-center px-3 py-1 bg-error/20 text-error font-bold rounded-full">15</span>
+                    </td>
+                    <td class="px-4 py-4 text-center" data-label="Guilty Rate">
+                      <span class="text-text-secondary">67%</span>
+                    </td>
+                    <td class="px-4 py-4 text-right text-sm text-text-secondary" data-label="Last Caught">
+                      <span id="lastCaught1">2 days ago</span>
+                    </td>
+                  </tr>
+
+                  <!-- Rank 2 - Silver -->
+                  <tr class="rank-silver hover:bg-bg-hover/50 transition-colors">
+                    <td class="px-4 py-4" data-label="Rank">
+                      <div class="flex items-center gap-2">
+                        <div class="medal-silver w-8 h-8 rounded-full flex items-center justify-center text-black font-bold text-sm">2</div>
+                        <span class="text-lg" role="img" aria-label="second">&#x1F948;</span>
+                      </div>
+                    </td>
+                    <td class="px-4 py-4" data-label="User">
+                      <div class="flex items-center gap-3">
+                        <div class="w-10 h-10 rounded-full bg-gradient-to-br from-yellow-500 to-amber-500 flex items-center justify-center text-white font-bold text-sm">CT</div>
+                        <div>
+                          <p class="font-semibold text-text-primary">CheeseThief#5678</p>
+                          <p class="text-xs text-text-tertiary">Always suspicious</p>
+                        </div>
+                      </div>
+                    </td>
+                    <td class="px-4 py-4 text-center" data-label="Rat Count">
+                      <span class="inline-flex items-center justify-center px-3 py-1 bg-error/20 text-error font-bold rounded-full">12</span>
+                    </td>
+                    <td class="px-4 py-4 text-center" data-label="Guilty Rate">
+                      <span class="text-text-secondary">75%</span>
+                    </td>
+                    <td class="px-4 py-4 text-right text-sm text-text-secondary" data-label="Last Caught">
+                      <span id="lastCaught2">1 week ago</span>
+                    </td>
+                  </tr>
+
+                  <!-- Rank 3 - Bronze -->
+                  <tr class="rank-bronze hover:bg-bg-hover/50 transition-colors">
+                    <td class="px-4 py-4" data-label="Rank">
+                      <div class="flex items-center gap-2">
+                        <div class="medal-bronze w-8 h-8 rounded-full flex items-center justify-center text-black font-bold text-sm">3</div>
+                        <span class="text-lg" role="img" aria-label="third">&#x1F949;</span>
+                      </div>
+                    </td>
+                    <td class="px-4 py-4" data-label="User">
+                      <div class="flex items-center gap-3">
+                        <div class="w-10 h-10 rounded-full bg-gradient-to-br from-blue-500 to-indigo-500 flex items-center justify-center text-white font-bold text-sm">NO</div>
+                        <div>
+                          <p class="font-semibold text-text-primary">NightOwl#9012</p>
+                          <p class="text-xs text-text-tertiary">Night shift rat</p>
+                        </div>
+                      </div>
+                    </td>
+                    <td class="px-4 py-4 text-center" data-label="Rat Count">
+                      <span class="inline-flex items-center justify-center px-3 py-1 bg-error/20 text-error font-bold rounded-full">10</span>
+                    </td>
+                    <td class="px-4 py-4 text-center" data-label="Guilty Rate">
+                      <span class="text-text-secondary">60%</span>
+                    </td>
+                    <td class="px-4 py-4 text-right text-sm text-text-secondary" data-label="Last Caught">
+                      <span id="lastCaught3">3 days ago</span>
+                    </td>
+                  </tr>
+
+                  <!-- Rank 4 -->
+                  <tr class="hover:bg-bg-hover/50 transition-colors">
+                    <td class="px-4 py-4" data-label="Rank">
+                      <div class="w-8 h-8 rounded-full bg-bg-tertiary flex items-center justify-center text-text-secondary font-semibold text-sm">4</div>
+                    </td>
+                    <td class="px-4 py-4" data-label="User">
+                      <div class="flex items-center gap-3">
+                        <div class="w-10 h-10 rounded-full bg-gradient-to-br from-cyan-500 to-blue-500 flex items-center justify-center text-white font-bold text-sm">SP</div>
+                        <div>
+                          <p class="font-medium text-text-primary">SneakyPete#3456</p>
+                        </div>
+                      </div>
+                    </td>
+                    <td class="px-4 py-4 text-center" data-label="Rat Count">
+                      <span class="inline-flex items-center justify-center px-3 py-1 bg-bg-tertiary text-text-primary font-semibold rounded-full">8</span>
+                    </td>
+                    <td class="px-4 py-4 text-center" data-label="Guilty Rate">
+                      <span class="text-text-secondary">50%</span>
+                    </td>
+                    <td class="px-4 py-4 text-right text-sm text-text-secondary" data-label="Last Caught">
+                      <span id="lastCaught4">5 days ago</span>
+                    </td>
+                  </tr>
+
+                  <!-- Rank 5 -->
+                  <tr class="hover:bg-bg-hover/50 transition-colors">
+                    <td class="px-4 py-4" data-label="Rank">
+                      <div class="w-8 h-8 rounded-full bg-bg-tertiary flex items-center justify-center text-text-secondary font-semibold text-sm">5</div>
+                    </td>
+                    <td class="px-4 py-4" data-label="User">
+                      <div class="flex items-center gap-3">
+                        <div class="w-10 h-10 rounded-full bg-gradient-to-br from-green-500 to-emerald-500 flex items-center justify-center text-white font-bold text-sm">NR</div>
+                        <div>
+                          <p class="font-medium text-text-primary">NewRat#7890</p>
+                          <p class="text-xs text-error">Rising star!</p>
+                        </div>
+                      </div>
+                    </td>
+                    <td class="px-4 py-4 text-center" data-label="Rat Count">
+                      <span class="inline-flex items-center justify-center px-3 py-1 bg-bg-tertiary text-text-primary font-semibold rounded-full">6</span>
+                    </td>
+                    <td class="px-4 py-4 text-center" data-label="Guilty Rate">
+                      <span class="text-error font-medium">83%</span>
+                    </td>
+                    <td class="px-4 py-4 text-right text-sm text-text-secondary" data-label="Last Caught">
+                      <span id="lastCaught5">Yesterday</span>
+                    </td>
+                  </tr>
+
+                  <!-- Rank 6 -->
+                  <tr class="hover:bg-bg-hover/50 transition-colors">
+                    <td class="px-4 py-4" data-label="Rank">
+                      <div class="w-8 h-8 rounded-full bg-bg-tertiary flex items-center justify-center text-text-secondary font-semibold text-sm">6</div>
+                    </td>
+                    <td class="px-4 py-4" data-label="User">
+                      <div class="flex items-center gap-3">
+                        <div class="w-10 h-10 rounded-full bg-gradient-to-br from-pink-500 to-rose-500 flex items-center justify-center text-white font-bold text-sm">GG</div>
+                        <div>
+                          <p class="font-medium text-text-primary">GymGhost#2468</p>
+                        </div>
+                      </div>
+                    </td>
+                    <td class="px-4 py-4 text-center" data-label="Rat Count">
+                      <span class="inline-flex items-center justify-center px-3 py-1 bg-bg-tertiary text-text-primary font-semibold rounded-full">5</span>
+                    </td>
+                    <td class="px-4 py-4 text-center" data-label="Guilty Rate">
+                      <span class="text-text-secondary">55%</span>
+                    </td>
+                    <td class="px-4 py-4 text-right text-sm text-text-secondary" data-label="Last Caught">
+                      <span id="lastCaught6">1 week ago</span>
+                    </td>
+                  </tr>
+
+                  <!-- Rank 7 -->
+                  <tr class="hover:bg-bg-hover/50 transition-colors">
+                    <td class="px-4 py-4" data-label="Rank">
+                      <div class="w-8 h-8 rounded-full bg-bg-tertiary flex items-center justify-center text-text-secondary font-semibold text-sm">7</div>
+                    </td>
+                    <td class="px-4 py-4" data-label="User">
+                      <div class="flex items-center gap-3">
+                        <div class="w-10 h-10 rounded-full bg-gradient-to-br from-violet-500 to-purple-500 flex items-center justify-center text-white font-bold text-sm">LM</div>
+                        <div>
+                          <p class="font-medium text-text-primary">LazyMouse#1357</p>
+                        </div>
+                      </div>
+                    </td>
+                    <td class="px-4 py-4 text-center" data-label="Rat Count">
+                      <span class="inline-flex items-center justify-center px-3 py-1 bg-bg-tertiary text-text-primary font-semibold rounded-full">4</span>
+                    </td>
+                    <td class="px-4 py-4 text-center" data-label="Guilty Rate">
+                      <span class="text-text-secondary">44%</span>
+                    </td>
+                    <td class="px-4 py-4 text-right text-sm text-text-secondary" data-label="Last Caught">
+                      <span id="lastCaught7">2 weeks ago</span>
+                    </td>
+                  </tr>
+
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+
+        <!-- Recent Incidents Feed -->
+        <section class="lg:col-span-1">
+          <div class="bg-bg-secondary border border-border-primary rounded-xl overflow-hidden">
+            <div class="px-6 py-4 border-b border-border-primary flex items-center gap-2">
+              <span class="text-xl" role="img" aria-label="siren">&#x1F6A8;</span>
+              <h2 class="text-lg font-semibold text-text-primary">Recent Incidents</h2>
+            </div>
+
+            <div class="divide-y divide-border-primary max-h-[500px] overflow-y-auto">
+              <!-- Incident 1 - Guilty -->
+              <div class="px-4 py-3 hover:bg-bg-hover/50 transition-colors">
+                <div class="flex items-start gap-3">
+                  <div class="w-8 h-8 rounded-full bg-gradient-to-br from-red-500 to-orange-500 flex items-center justify-center text-white text-xs font-bold flex-shrink-0">RK</div>
+                  <div class="flex-1 min-w-0">
+                    <p class="text-sm">
+                      <span class="font-semibold text-text-primary">RatKing#1234</span>
+                      <span class="text-text-secondary"> was found </span>
+                      <span class="verdict-guilty font-semibold">GUILTY</span>
+                    </p>
+                    <div class="flex items-center gap-2 mt-1">
+                      <span class="text-xs px-2 py-0.5 bg-error/20 text-error rounded-full">5-2</span>
+                      <span class="text-xs text-text-tertiary" id="incident1Time">2 days ago</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Incident 2 - Guilty (Landslide) -->
+              <div class="px-4 py-3 hover:bg-bg-hover/50 transition-colors">
+                <div class="flex items-start gap-3">
+                  <div class="w-8 h-8 rounded-full bg-gradient-to-br from-yellow-500 to-amber-500 flex items-center justify-center text-white text-xs font-bold flex-shrink-0">CT</div>
+                  <div class="flex-1 min-w-0">
+                    <p class="text-sm">
+                      <span class="font-semibold text-text-primary">CheeseThief#5678</span>
+                      <span class="text-text-secondary"> was found </span>
+                      <span class="verdict-guilty font-semibold">GUILTY</span>
+                    </p>
+                    <div class="flex items-center gap-2 mt-1">
+                      <span class="text-xs px-2 py-0.5 bg-error/20 text-error rounded-full">10-0</span>
+                      <span class="text-xs text-warning">Landslide!</span>
+                      <span class="text-xs text-text-tertiary" id="incident2Time">1 week ago</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Incident 3 - Not Guilty -->
+              <div class="px-4 py-3 hover:bg-bg-hover/50 transition-colors">
+                <div class="flex items-start gap-3">
+                  <div class="w-8 h-8 rounded-full bg-gradient-to-br from-blue-500 to-indigo-500 flex items-center justify-center text-white text-xs font-bold flex-shrink-0">NO</div>
+                  <div class="flex-1 min-w-0">
+                    <p class="text-sm">
+                      <span class="font-semibold text-text-primary">NightOwl#9012</span>
+                      <span class="text-text-secondary"> was found </span>
+                      <span class="verdict-not-guilty font-semibold">NOT GUILTY</span>
+                    </p>
+                    <div class="flex items-center gap-2 mt-1">
+                      <span class="text-xs px-2 py-0.5 bg-success/20 text-success rounded-full">3-4</span>
+                      <span class="text-xs text-text-tertiary" id="incident3Time">3 days ago</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Incident 4 - Guilty -->
+              <div class="px-4 py-3 hover:bg-bg-hover/50 transition-colors">
+                <div class="flex items-start gap-3">
+                  <div class="w-8 h-8 rounded-full bg-gradient-to-br from-green-500 to-emerald-500 flex items-center justify-center text-white text-xs font-bold flex-shrink-0">NR</div>
+                  <div class="flex-1 min-w-0">
+                    <p class="text-sm">
+                      <span class="font-semibold text-text-primary">NewRat#7890</span>
+                      <span class="text-text-secondary"> was found </span>
+                      <span class="verdict-guilty font-semibold">GUILTY</span>
+                    </p>
+                    <div class="flex items-center gap-2 mt-1">
+                      <span class="text-xs px-2 py-0.5 bg-error/20 text-error rounded-full">6-1</span>
+                      <span class="text-xs text-text-tertiary" id="incident4Time">Yesterday</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Incident 5 - Guilty -->
+              <div class="px-4 py-3 hover:bg-bg-hover/50 transition-colors">
+                <div class="flex items-start gap-3">
+                  <div class="w-8 h-8 rounded-full bg-gradient-to-br from-pink-500 to-rose-500 flex items-center justify-center text-white text-xs font-bold flex-shrink-0">GG</div>
+                  <div class="flex-1 min-w-0">
+                    <p class="text-sm">
+                      <span class="font-semibold text-text-primary">GymGhost#2468</span>
+                      <span class="text-text-secondary"> was found </span>
+                      <span class="verdict-guilty font-semibold">GUILTY</span>
+                    </p>
+                    <div class="flex items-center gap-2 mt-1">
+                      <span class="text-xs px-2 py-0.5 bg-error/20 text-error rounded-full">4-3</span>
+                      <span class="text-xs text-text-tertiary" id="incident5Time">1 week ago</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Incident 6 - Not Guilty -->
+              <div class="px-4 py-3 hover:bg-bg-hover/50 transition-colors">
+                <div class="flex items-start gap-3">
+                  <div class="w-8 h-8 rounded-full bg-gradient-to-br from-cyan-500 to-blue-500 flex items-center justify-center text-white text-xs font-bold flex-shrink-0">SP</div>
+                  <div class="flex-1 min-w-0">
+                    <p class="text-sm">
+                      <span class="font-semibold text-text-primary">SneakyPete#3456</span>
+                      <span class="text-text-secondary"> was found </span>
+                      <span class="verdict-not-guilty font-semibold">NOT GUILTY</span>
+                    </p>
+                    <div class="flex items-center gap-2 mt-1">
+                      <span class="text-xs px-2 py-0.5 bg-success/20 text-success rounded-full">2-5</span>
+                      <span class="text-xs text-text-tertiary" id="incident6Time">2 weeks ago</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Incident 7 - Guilty -->
+              <div class="px-4 py-3 hover:bg-bg-hover/50 transition-colors">
+                <div class="flex items-start gap-3">
+                  <div class="w-8 h-8 rounded-full bg-gradient-to-br from-red-500 to-orange-500 flex items-center justify-center text-white text-xs font-bold flex-shrink-0">RK</div>
+                  <div class="flex-1 min-w-0">
+                    <p class="text-sm">
+                      <span class="font-semibold text-text-primary">RatKing#1234</span>
+                      <span class="text-text-secondary"> was found </span>
+                      <span class="verdict-guilty font-semibold">GUILTY</span>
+                    </p>
+                    <div class="flex items-center gap-2 mt-1">
+                      <span class="text-xs px-2 py-0.5 bg-error/20 text-error rounded-full">7-2</span>
+                      <span class="text-xs text-text-tertiary" id="incident7Time">2 weeks ago</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Incident 8 - Cleared Early -->
+              <div class="px-4 py-3 hover:bg-bg-hover/50 transition-colors">
+                <div class="flex items-start gap-3">
+                  <div class="w-8 h-8 rounded-full bg-gradient-to-br from-violet-500 to-purple-500 flex items-center justify-center text-white text-xs font-bold flex-shrink-0">LM</div>
+                  <div class="flex-1 min-w-0">
+                    <p class="text-sm">
+                      <span class="font-semibold text-text-primary">LazyMouse#1357</span>
+                      <span class="text-text-secondary"> </span>
+                      <span class="text-info font-semibold">cleared early</span>
+                    </p>
+                    <div class="flex items-center gap-2 mt-1">
+                      <span class="text-xs px-2 py-0.5 bg-info/20 text-info rounded-full">Checked in!</span>
+                      <span class="text-xs text-text-tertiary" id="incident8Time">3 weeks ago</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+            </div>
+
+            <div class="px-4 py-3 border-t border-border-primary bg-bg-primary/30">
+              <p class="text-xs text-text-tertiary text-center">Showing last 10 incidents</p>
+            </div>
+          </div>
+        </section>
+
+      </div>
+
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-border-primary mt-auto">
+      <div class="max-w-5xl mx-auto px-4 py-6">
+        <div class="flex flex-col sm:flex-row items-center justify-between gap-4 text-center sm:text-left">
+          <!-- Bot Branding -->
+          <div class="flex items-center gap-3">
+            <div class="w-10 h-10 rounded-lg bg-accent-orange flex items-center justify-center">
+              <svg class="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M20.317 4.492c-1.53-.69-3.17-1.2-4.885-1.49a.075.075 0 0 0-.079.036c-.21.369-.444.85-.608 1.23a18.566 18.566 0 0 0-5.487 0 12.36 12.36 0 0 0-.617-1.23A.077.077 0 0 0 8.562 3c-1.714.29-3.354.8-4.885 1.491a.07.07 0 0 0-.032.027C.533 9.093-.32 13.555.099 17.961a.08.08 0 0 0 .031.055 20.03 20.03 0 0 0 5.993 2.98.078.078 0 0 0 .084-.026c.36-.687.772-1.341 1.225-1.962a.077.077 0 0 0-.041-.104 13.201 13.201 0 0 1-1.872-.878.075.075 0 0 1-.008-.125c.126-.093.252-.19.372-.287a.075.075 0 0 1 .078-.01c3.927 1.764 8.18 1.764 12.061 0a.075.075 0 0 1 .079.009c.12.098.245.195.372.288a.075.075 0 0 1-.006.125c-.598.344-1.22.635-1.873.877a.075.075 0 0 0-.041.105c.36.687.772 1.341 1.225 1.962a.077.077 0 0 0 .084.028 19.963 19.963 0 0 0 6.002-2.981.076.076 0 0 0 .032-.054c.5-5.094-.838-9.52-3.549-13.442a.06.06 0 0 0-.031-.028zM8.02 15.278c-1.182 0-2.157-1.069-2.157-2.38 0-1.312.956-2.38 2.157-2.38 1.21 0 2.176 1.077 2.157 2.38 0 1.312-.956 2.38-2.157 2.38zm7.975 0c-1.183 0-2.157-1.069-2.157-2.38 0-1.312.955-2.38 2.157-2.38 1.21 0 2.176 1.077 2.157 2.38 0 1.312-.946 2.38-2.157 2.38z"/>
+              </svg>
+            </div>
+            <div>
+              <p class="text-sm font-semibold text-text-primary">Powered by RatBot</p>
+              <p class="text-xs text-text-tertiary">Keeping communities accountable since 2025</p>
+            </div>
+          </div>
+
+          <!-- Links -->
+          <div class="flex items-center gap-6 text-sm">
+            <a href="#" class="text-accent-blue hover:text-accent-blue-hover transition-colors flex items-center gap-1">
+              <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+              </svg>
+              Add to your server
+            </a>
+          </div>
+
+          <!-- Privacy Note -->
+          <div class="text-xs text-text-tertiary">
+            <span class="inline-flex items-center gap-1">
+              <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+              </svg>
+              Only usernames shown, no personal data
+            </span>
+          </div>
+        </div>
+      </div>
+    </footer>
+
+  </div>
+
+  <!-- "Leaderboard Not Public" State -->
+  <div id="notPublicContent" class="min-h-screen flex flex-col hidden">
+    <div class="flex-1 flex items-center justify-center p-8">
+      <div class="text-center max-w-md">
+        <!-- Lock Icon -->
+        <div class="w-24 h-24 mx-auto mb-6 rounded-full bg-bg-secondary border border-border-primary flex items-center justify-center lock-bounce">
+          <svg class="w-12 h-12 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+          </svg>
+        </div>
+
+        <!-- Message -->
+        <h1 class="text-2xl font-bold text-text-primary mb-2">Leaderboard Not Public</h1>
+        <p class="text-text-secondary mb-6">
+          This guild's Hall of Shame leaderboard is not publicly accessible.
+        </p>
+        <p class="text-sm text-text-tertiary mb-8">
+          Ask your server admin to enable public leaderboards in the Rat Watch settings!
+        </p>
+
+        <!-- Guild Info (placeholder) -->
+        <div class="inline-flex items-center gap-3 px-4 py-3 bg-bg-secondary border border-border-primary rounded-xl">
+          <div class="w-10 h-10 rounded-lg bg-gradient-to-br from-purple-600 to-pink-600 flex items-center justify-center text-white font-bold text-sm">
+            RN
+          </div>
+          <div class="text-left">
+            <p class="font-semibold text-text-primary">The Rat's Nest</p>
+            <p class="text-xs text-text-tertiary">Private leaderboard</p>
+          </div>
+        </div>
+
+        <!-- CTA -->
+        <div class="mt-8">
+          <a href="#" class="inline-flex items-center gap-2 px-5 py-3 bg-accent-orange hover:bg-accent-orange-hover text-white font-medium rounded-lg transition-colors shadow-lg shadow-accent-orange/20">
+            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+              <path d="M20.317 4.492c-1.53-.69-3.17-1.2-4.885-1.49a.075.075 0 0 0-.079.036c-.21.369-.444.85-.608 1.23a18.566 18.566 0 0 0-5.487 0 12.36 12.36 0 0 0-.617-1.23A.077.077 0 0 0 8.562 3c-1.714.29-3.354.8-4.885 1.491a.07.07 0 0 0-.032.027C.533 9.093-.32 13.555.099 17.961a.08.08 0 0 0 .031.055 20.03 20.03 0 0 0 5.993 2.98.078.078 0 0 0 .084-.026c.36-.687.772-1.341 1.225-1.962a.077.077 0 0 0-.041-.104 13.201 13.201 0 0 1-1.872-.878.075.075 0 0 1-.008-.125c.126-.093.252-.19.372-.287a.075.075 0 0 1 .078-.01c3.927 1.764 8.18 1.764 12.061 0a.075.075 0 0 1 .079.009c.12.098.245.195.372.288a.075.075 0 0 1-.006.125c-.598.344-1.22.635-1.873.877a.075.075 0 0 0-.041.105c.36.687.772 1.341 1.225 1.962a.077.077 0 0 0 .084.028 19.963 19.963 0 0 0 6.002-2.981.076.076 0 0 0 .032-.054c.5-5.094-.838-9.52-3.549-13.442a.06.06 0 0 0-.031-.028zM8.02 15.278c-1.182 0-2.157-1.069-2.157-2.38 0-1.312.956-2.38 2.157-2.38 1.21 0 2.176 1.077 2.157 2.38 0 1.312-.956 2.38-2.157 2.38zm7.975 0c-1.183 0-2.157-1.069-2.157-2.38 0-1.312.955-2.38 2.157-2.38 1.21 0 2.176 1.077 2.157 2.38 0 1.312-.946 2.38-2.157 2.38z"/>
+            </svg>
+            Add RatBot to your server
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- JavaScript -->
+  <script>
+    // State toggle for demo
+    let isPublic = true;
+
+    function togglePageState() {
+      isPublic = !isPublic;
+      const publicContent = document.getElementById('publicContent');
+      const notPublicContent = document.getElementById('notPublicContent');
+      const toggleBtn = document.getElementById('toggleStateBtn');
+
+      if (isPublic) {
+        publicContent.classList.remove('hidden');
+        notPublicContent.classList.add('hidden');
+        toggleBtn.textContent = 'Toggle: Not Public State';
+      } else {
+        publicContent.classList.add('hidden');
+        notPublicContent.classList.remove('hidden');
+        toggleBtn.textContent = 'Toggle: Public State';
+      }
+    }
+
+    // Format relative time (simulating conversion from UTC to local)
+    function formatRelativeTime(daysAgo) {
+      const now = new Date();
+      const pastDate = new Date(now.getTime() - (daysAgo * 24 * 60 * 60 * 1000));
+
+      const diffMs = now - pastDate;
+      const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+      const diffWeeks = Math.floor(diffDays / 7);
+
+      if (diffDays === 0) return 'Today';
+      if (diffDays === 1) return 'Yesterday';
+      if (diffDays < 7) return `${diffDays} days ago`;
+      if (diffWeeks === 1) return '1 week ago';
+      if (diffWeeks < 4) return `${diffWeeks} weeks ago`;
+
+      return pastDate.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+    }
+
+    // Update all time displays to local timezone
+    function updateTimeDisplays() {
+      // Leaderboard last caught times
+      const lastCaughtData = [
+        { id: 'lastCaught1', days: 2 },
+        { id: 'lastCaught2', days: 7 },
+        { id: 'lastCaught3', days: 3 },
+        { id: 'lastCaught4', days: 5 },
+        { id: 'lastCaught5', days: 1 },
+        { id: 'lastCaught6', days: 7 },
+        { id: 'lastCaught7', days: 14 },
+      ];
+
+      lastCaughtData.forEach(item => {
+        const el = document.getElementById(item.id);
+        if (el) el.textContent = formatRelativeTime(item.days);
+      });
+
+      // Incident times
+      const incidentData = [
+        { id: 'incident1Time', days: 2 },
+        { id: 'incident2Time', days: 7 },
+        { id: 'incident3Time', days: 3 },
+        { id: 'incident4Time', days: 1 },
+        { id: 'incident5Time', days: 7 },
+        { id: 'incident6Time', days: 14 },
+        { id: 'incident7Time', days: 14 },
+        { id: 'incident8Time', days: 21 },
+      ];
+
+      incidentData.forEach(item => {
+        const el = document.getElementById(item.id);
+        if (el) el.textContent = formatRelativeTime(item.days);
+      });
+    }
+
+    // Initialize
+    document.addEventListener('DOMContentLoaded', function() {
+      updateTimeDisplays();
+    });
+  </script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Create four HTML prototypes for Rat Watch Analytics feature validation:
  - **Guild Analytics** (`guild-analytics.html`) - Guild-specific dashboard with stats, charts, and user leaderboards
  - **Incidents Browser** (`incidents-browser.html`) - Searchable/filterable incidents list with detail modal
  - **Global Analytics** (`global-analytics.html`) - Cross-guild admin dashboard for bot administrators
  - **Public Leaderboard** (`public-leaderboard.html`) - Fun, shareable "Hall of Shame" page for guild members
- All prototypes use Chart.js for visualizations and follow the existing design system
- Includes interactive JavaScript for filter toggles, modals, and tab switching
- Mobile-responsive layouts, especially for the public leaderboard

## Test plan

- [ ] Open each prototype directly in a browser (no build step required)
- [ ] Verify guild-analytics.html: filter panel toggles, tabs switch content, modal opens/closes
- [ ] Verify incidents-browser.html: filters toggle, presets dropdown works, modal opens on row click
- [ ] Verify global-analytics.html: guild filter dropdown works, charts render
- [ ] Verify public-leaderboard.html: "Toggle Public State" shows disabled view, mobile layout works
- [ ] Verify all prototypes match the design system (colors, spacing, typography)

Closes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)