### PR TITLE
feat(ratwatch): Enhance Rat Watch admin page and add dashboard activity

### DIFF
--- a/src/DiscordBot.Bot/Commands/RatWatchComponentModule.cs
+++ b/src/DiscordBot.Bot/Commands/RatWatchComponentModule.cs
@@ -16,6 +16,7 @@ public class RatWatchComponentModule : InteractionModuleBase<SocketInteractionCo
 {
     private readonly IRatWatchService _ratWatchService;
     private readonly IRatWatchStatusService _ratWatchStatusService;
+    private readonly IDashboardUpdateService _dashboardUpdateService;
     private readonly ILogger<RatWatchComponentModule> _logger;
 
     /// <summary>
@@ -24,10 +25,12 @@ public class RatWatchComponentModule : InteractionModuleBase<SocketInteractionCo
     public RatWatchComponentModule(
         IRatWatchService ratWatchService,
         IRatWatchStatusService ratWatchStatusService,
+        IDashboardUpdateService dashboardUpdateService,
         ILogger<RatWatchComponentModule> logger)
     {
         _ratWatchService = ratWatchService;
         _ratWatchStatusService = ratWatchStatusService;
+        _dashboardUpdateService = dashboardUpdateService;
         _logger = logger;
     }
 
@@ -96,6 +99,13 @@ public class RatWatchComponentModule : InteractionModuleBase<SocketInteractionCo
 
                 // Notify that a watch was cleared - may need to update bot status
                 _ratWatchStatusService.RequestStatusUpdate();
+
+                // Broadcast Rat Watch check-in event to dashboard
+                await _dashboardUpdateService.BroadcastRatWatchActivityAsync(
+                    Context.Guild.Id,
+                    Context.Guild.Name,
+                    "RatWatchCheckIn",
+                    Context.User.Username);
 
                 _logger.LogDebug("Rat Watch check-in message updated successfully");
             }

--- a/src/DiscordBot.Bot/Commands/RatWatchModule.cs
+++ b/src/DiscordBot.Bot/Commands/RatWatchModule.cs
@@ -17,6 +17,7 @@ public class RatWatchModule : InteractionModuleBase<SocketInteractionContext>
 {
     private readonly IRatWatchService _ratWatchService;
     private readonly IRatWatchStatusService _ratWatchStatusService;
+    private readonly IDashboardUpdateService _dashboardUpdateService;
     private readonly DiscordSocketClient _client;
     private readonly ILogger<RatWatchModule> _logger;
 
@@ -26,11 +27,13 @@ public class RatWatchModule : InteractionModuleBase<SocketInteractionContext>
     public RatWatchModule(
         IRatWatchService ratWatchService,
         IRatWatchStatusService ratWatchStatusService,
+        IDashboardUpdateService dashboardUpdateService,
         DiscordSocketClient client,
         ILogger<RatWatchModule> logger)
     {
         _ratWatchService = ratWatchService;
         _ratWatchStatusService = ratWatchStatusService;
+        _dashboardUpdateService = dashboardUpdateService;
         _client = client;
         _logger = logger;
     }
@@ -229,6 +232,13 @@ public class RatWatchModule : InteractionModuleBase<SocketInteractionContext>
 
             // Notify that a new watch was created - may need to update bot status
             _ratWatchStatusService.RequestStatusUpdate();
+
+            // Broadcast Rat Watch created event to dashboard
+            await _dashboardUpdateService.BroadcastRatWatchActivityAsync(
+                Context.Guild.Id,
+                Context.Guild.Name,
+                "RatWatchCreated",
+                watch.AccusedUsername);
 
             _logger.LogDebug("Rat Watch confirmation message sent with check-in button");
         }

--- a/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Index.cshtml
@@ -223,7 +223,7 @@
             </div>
 
             <div class="table-container overflow-x-auto">
-                <table class="w-full min-w-[800px]">
+                <table class="w-full min-w-[900px]">
                     <thead class="bg-bg-tertiary border-b border-border-primary">
                         <tr>
                             <th class="px-6 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">
@@ -240,6 +240,9 @@
                             </th>
                             <th class="px-6 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">
                                 Scheduled
+                            </th>
+                            <th class="px-6 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">
+                                Vote Ends
                             </th>
                             <th class="px-6 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">
                                 Votes
@@ -298,6 +301,16 @@
                                     <span class="text-sm text-text-primary" data-utc="@watch.ScheduledAtUtcIso" data-format="datetime-short"></span>
                                 </td>
                                 <td class="px-6 py-4">
+                                    @if (watch.VoteEndsAtUtcIso != null)
+                                    {
+                                        <span class="text-sm text-text-primary" data-utc="@watch.VoteEndsAtUtcIso" data-format="datetime-short"></span>
+                                    }
+                                    else
+                                    {
+                                        <span class="text-sm text-text-tertiary">--</span>
+                                    }
+                                </td>
+                                <td class="px-6 py-4">
                                     @if (watch.TotalVotes > 0)
                                     {
                                         <div class="flex items-center gap-2 text-sm">
@@ -313,6 +326,19 @@
                                 </td>
                                 <td class="px-6 py-4">
                                     <div class="flex items-center justify-end gap-1 row-actions">
+                                        @if (watch.CanEndVote)
+                                        {
+                                            <button
+                                                type="button"
+                                                onclick="showEndVoteModal('@watch.Id', '@watch.AccusedUsername', @watch.GuiltyVotes, @watch.NotGuiltyVotes)"
+                                                class="p-2 text-text-secondary hover:text-accent-blue hover:bg-accent-blue/10 rounded-md transition-colors"
+                                                title="End Vote"
+                                            >
+                                                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+                                                </svg>
+                                            </button>
+                                        }
                                         @if (watch.CanCancel)
                                         {
                                             <button
@@ -434,6 +460,50 @@
     </div>
 </div>
 
+<!-- End Vote Confirmation Modal -->
+<div id="end-vote-modal" class="hidden fixed inset-0 z-50 overflow-y-auto" aria-labelledby="end-vote-modal-title" role="dialog" aria-modal="true">
+    <div class="flex items-center justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:block sm:p-0">
+        <div class="modal-overlay fixed inset-0 transition-opacity" aria-hidden="true" onclick="hideEndVoteModal()"></div>
+        <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+        <div class="inline-block align-bottom bg-bg-secondary rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full border border-border-primary">
+            <div class="px-6 py-5">
+                <div class="flex items-start gap-4">
+                    <div class="flex-shrink-0 w-10 h-10 rounded-full bg-accent-blue/20 flex items-center justify-center">
+                        <svg class="w-5 h-5 text-accent-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+                        </svg>
+                    </div>
+                    <div class="flex-1">
+                        <h3 id="end-vote-modal-title" class="text-lg font-semibold text-text-primary">End Vote Early</h3>
+                        <p class="mt-2 text-sm text-text-secondary">
+                            Are you sure you want to end voting for <span id="end-vote-username" class="font-medium text-text-primary"></span>?
+                        </p>
+                        <p class="mt-2 text-sm text-text-secondary">
+                            Current tally: <span id="end-vote-guilty" class="font-medium text-error"></span> Guilty, <span id="end-vote-notguilty" class="font-medium text-success"></span> Not Guilty
+                        </p>
+                        <p class="mt-1 text-xs text-text-tertiary">
+                            The verdict will be determined based on current votes. This action cannot be undone.
+                        </p>
+                    </div>
+                </div>
+            </div>
+            <div class="px-6 py-4 bg-bg-primary flex flex-col-reverse sm:flex-row sm:justify-end gap-3">
+                <button type="button" onclick="hideEndVoteModal()"
+                        class="inline-flex justify-center px-4 py-2 text-sm font-medium text-text-primary bg-transparent border border-border-primary rounded-md hover:bg-bg-hover transition-colors">
+                    Continue Voting
+                </button>
+                <form id="end-vote-form" method="post" asp-page="Index" asp-page-handler="EndVote" asp-route-guildId="@Model.ViewModel.GuildId">
+                    <input type="hidden" id="end-vote-watch-id" name="watchId" value="" />
+                    <button type="submit"
+                            class="inline-flex justify-center px-4 py-2 text-sm font-medium text-white bg-accent-blue border border-accent-blue rounded-md hover:bg-blue-600 transition-colors">
+                        End Vote Now
+                    </button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
 @section Scripts {
     <style>
         .modal-overlay {
@@ -473,9 +543,28 @@
             document.body.style.overflow = '';
         }
 
+        function showEndVoteModal(watchId, username, guiltyVotes, notGuiltyVotes) {
+            document.getElementById('end-vote-watch-id').value = watchId;
+            document.getElementById('end-vote-username').textContent = username;
+            document.getElementById('end-vote-guilty').textContent = guiltyVotes;
+            document.getElementById('end-vote-notguilty').textContent = notGuiltyVotes;
+            document.getElementById('end-vote-modal').classList.remove('hidden');
+            document.body.style.overflow = 'hidden';
+        }
+
+        function hideEndVoteModal() {
+            document.getElementById('end-vote-modal').classList.add('hidden');
+            document.body.style.overflow = '';
+        }
+
         document.addEventListener('keydown', function(e) {
-            if (e.key === 'Escape' && !document.getElementById('cancel-modal').classList.contains('hidden')) {
-                hideCancelModal();
+            if (e.key === 'Escape') {
+                if (!document.getElementById('cancel-modal').classList.contains('hidden')) {
+                    hideCancelModal();
+                }
+                if (!document.getElementById('end-vote-modal').classList.contains('hidden')) {
+                    hideEndVoteModal();
+                }
             }
         });
     </script>

--- a/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Index.cshtml.cs
@@ -143,6 +143,41 @@ public class IndexModel : PageModel
     }
 
     /// <summary>
+    /// Handles POST requests to end voting early on a Rat Watch.
+    /// </summary>
+    /// <param name="guildId">The guild's Discord snowflake ID from route parameter.</param>
+    /// <param name="watchId">The watch ID to end voting on.</param>
+    /// <param name="page">The current page number to return to.</param>
+    /// <param name="pageSize">The current page size.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Redirect to the index page.</returns>
+    public async Task<IActionResult> OnPostEndVoteAsync(
+        ulong guildId,
+        Guid watchId,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 20,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("User attempting to end vote on Rat Watch {WatchId} for guild {GuildId}",
+            watchId, guildId);
+
+        var success = await _ratWatchService.FinalizeVotingAsync(watchId, cancellationToken);
+
+        if (success)
+        {
+            _logger.LogInformation("Successfully ended voting on Rat Watch {WatchId}", watchId);
+            SuccessMessage = "Voting ended and verdict determined.";
+        }
+        else
+        {
+            _logger.LogWarning("Failed to end voting on Rat Watch {WatchId} - not found or not in voting status", watchId);
+            ErrorMessage = "Could not end voting. The watch may not be in voting status.";
+        }
+
+        return RedirectToPage("Index", new { guildId, page, pageSize });
+    }
+
+    /// <summary>
     /// Handles POST requests to update Rat Watch settings.
     /// </summary>
     /// <param name="guildId">The guild's Discord snowflake ID from route parameter.</param>

--- a/src/DiscordBot.Bot/Services/DashboardUpdateService.cs
+++ b/src/DiscordBot.Bot/Services/DashboardUpdateService.cs
@@ -165,6 +165,34 @@ public class DashboardUpdateService : IDashboardUpdateService
         }
     }
 
+    /// <inheritdoc/>
+    public async Task BroadcastRatWatchActivityAsync(
+        ulong guildId,
+        string guildName,
+        string eventType,
+        string username,
+        string? details = null,
+        CancellationToken cancellationToken = default)
+    {
+        var update = new GuildActivityUpdateDto
+        {
+            GuildId = guildId,
+            GuildName = guildName,
+            EventType = eventType,
+            Username = username,
+            Details = details,
+            Timestamp = DateTime.UtcNow
+        };
+
+        _logger.LogDebug(
+            "Broadcasting Rat Watch activity: GuildId={GuildId}, EventType={EventType}, Username={Username}",
+            guildId,
+            eventType,
+            username);
+
+        await BroadcastGuildActivityAsync(update, cancellationToken);
+    }
+
     /// <summary>
     /// Gets the SignalR group name for a guild.
     /// </summary>

--- a/src/DiscordBot.Bot/Services/RatWatchService.cs
+++ b/src/DiscordBot.Bot/Services/RatWatchService.cs
@@ -659,6 +659,7 @@ public class RatWatchService : IRatWatchService
             CreatedAt = watch.CreatedAt,
             Status = watch.Status,
             VotingMessageId = watch.VotingMessageId,
+            VotingStartedAt = watch.VotingStartedAt,
             GuiltyVotes = guiltyVotes,
             NotGuiltyVotes = notGuiltyVotes
         };

--- a/src/DiscordBot.Bot/Services/RatWatchStatusService.cs
+++ b/src/DiscordBot.Bot/Services/RatWatchStatusService.cs
@@ -97,7 +97,7 @@ public class RatWatchStatusService : IRatWatchStatusService
     {
         try
         {
-            await _client.SetActivityAsync(new Game("for rats...", ActivityType.Watching));
+            await _client.SetGameAsync("Watching for rats...");
             _logger.LogDebug("Bot activity set to 'Watching for rats...'");
         }
         catch (Exception ex)

--- a/src/DiscordBot.Bot/wwwroot/js/dashboard-realtime.js
+++ b/src/DiscordBot.Bot/wwwroot/js/dashboard-realtime.js
@@ -132,7 +132,12 @@ const DashboardRealtime = (function() {
             'MemberLeft': '➖',
             'MessageSent': '💬',
             'MessageDeleted': '🗑️',
-            'MessageEdited': '✏️'
+            'MessageEdited': '✏️',
+            'RatWatchCreated': '🐀',
+            'RatWatchVotingStarted': '🗳️',
+            'RatWatchVotingEnded': '⚖️',
+            'RatWatchCheckIn': '✅',
+            'RatWatchCancelled': '❌'
         };
 
         addActivityItem({
@@ -301,6 +306,24 @@ const DashboardRealtime = (function() {
     }
 
     function formatGuildEventDescription(data) {
+        // Handle Rat Watch events with dynamic content
+        if (data.eventType === 'RatWatchCreated') {
+            return `Rat Watch created for <span class="text-accent-blue font-medium">@${escapeHtml(data.username || 'Unknown')}</span>`;
+        }
+        if (data.eventType === 'RatWatchVotingStarted') {
+            return `Voting started for <span class="text-accent-blue font-medium">@${escapeHtml(data.username || 'Unknown')}</span>`;
+        }
+        if (data.eventType === 'RatWatchVotingEnded') {
+            const verdictClass = data.details === 'Guilty' ? 'text-error' : 'text-success';
+            return `Verdict: <span class="font-semibold ${verdictClass}">${escapeHtml(data.details || 'Unknown')}</span> for @${escapeHtml(data.username || 'Unknown')}`;
+        }
+        if (data.eventType === 'RatWatchCheckIn') {
+            return `<span class="text-accent-blue font-medium">@${escapeHtml(data.username || 'Unknown')}</span> checked in early!`;
+        }
+        if (data.eventType === 'RatWatchCancelled') {
+            return `Rat Watch cancelled for @${escapeHtml(data.username || 'Unknown')}`;
+        }
+
         const eventDescriptions = {
             'MemberJoined': `<span class="text-accent-blue font-medium">New member</span> joined the server`,
             'MemberLeft': `A member left the server`,

--- a/src/DiscordBot.Core/DTOs/GuildActivityUpdateDto.cs
+++ b/src/DiscordBot.Core/DTOs/GuildActivityUpdateDto.cs
@@ -17,7 +17,7 @@ public class GuildActivityUpdateDto
 
     /// <summary>
     /// Gets or sets the type of event that occurred.
-    /// Examples: "MemberJoined", "MemberLeft", "MessageSent"
+    /// Examples: "MemberJoined", "MemberLeft", "MessageSent", "RatWatchCreated", "RatWatchVotingStarted"
     /// </summary>
     public string EventType { get; set; } = string.Empty;
 
@@ -25,4 +25,16 @@ public class GuildActivityUpdateDto
     /// Gets or sets the timestamp when the event occurred.
     /// </summary>
     public DateTime Timestamp { get; set; }
+
+    /// <summary>
+    /// Gets or sets the username associated with the event (optional).
+    /// Used for events like Rat Watch where a user is involved.
+    /// </summary>
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// Gets or sets additional details about the event (optional).
+    /// For Rat Watch: verdict result ("Guilty" or "Not Guilty"), etc.
+    /// </summary>
+    public string? Details { get; set; }
 }

--- a/src/DiscordBot.Core/DTOs/RatWatchDtos.cs
+++ b/src/DiscordBot.Core/DTOs/RatWatchDtos.cs
@@ -117,6 +117,12 @@ public record RatWatchDto
     public ulong? VotingMessageId { get; init; }
 
     /// <summary>
+    /// Timestamp when voting started (UTC).
+    /// Null if voting has not started yet.
+    /// </summary>
+    public DateTime? VotingStartedAt { get; init; }
+
+    /// <summary>
     /// Number of guilty votes cast.
     /// </summary>
     public int GuiltyVotes { get; init; }

--- a/src/DiscordBot.Core/Interfaces/IDashboardUpdateService.cs
+++ b/src/DiscordBot.Core/Interfaces/IDashboardUpdateService.cs
@@ -49,4 +49,23 @@ public interface IDashboardUpdateService
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     Task BroadcastGuildActivityToGuildAsync(ulong guildId, GuildActivityUpdateDto update, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Broadcasts a Rat Watch activity event to all connected dashboard clients.
+    /// This is a convenience method that creates a GuildActivityUpdateDto with Rat Watch-specific fields.
+    /// </summary>
+    /// <param name="guildId">The guild ID where the event occurred.</param>
+    /// <param name="guildName">The guild name.</param>
+    /// <param name="eventType">Type of Rat Watch event (RatWatchCreated, RatWatchVotingStarted, etc.).</param>
+    /// <param name="username">The username involved in the event.</param>
+    /// <param name="details">Optional additional details (e.g., verdict result).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task BroadcastRatWatchActivityAsync(
+        ulong guildId,
+        string guildName,
+        string eventType,
+        string username,
+        string? details = null,
+        CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
## Summary

This PR implements four related Rat Watch enhancements as sub-issues of #418:

- **#415 - Bot Status Bug Fix**: Fixed bot status display showing "for rats..." instead of "Watching for rats..." by switching from `SetActivityAsync` with `ActivityType.Watching` to `SetGameAsync`
- **#416 - Vote End Time Column**: Added a new "Vote Ends" column to the Rat Watch admin table, showing when voting will conclude for watches in Voting status
- **#417 - End Vote Button**: Added an "End Vote" button allowing admins to finalize voting early, with a confirmation modal showing current vote tallies
- **#414 - Dashboard Activity Feed**: Integrated Rat Watch events (created, voting started, voting ended, check-in) into the dashboard activity feed

## Changes

### Core/DTOs
- Added `VotingStartedAt` property to `RatWatchDto`
- Extended `GuildActivityUpdateDto` with `Username` and `Details` optional fields

### Interfaces
- Added `BroadcastRatWatchActivityAsync` convenience method to `IDashboardUpdateService`

### Services
- Implemented `BroadcastRatWatchActivityAsync` in `DashboardUpdateService`
- Added event broadcasting to `RatWatchExecutionService` (voting started/ended)
- Fixed bot status in `RatWatchStatusService`
- Added `VotingStartedAt` to DTO mapping in `RatWatchService`

### Commands
- Added dashboard broadcasting to `RatWatchModule` (created event)
- Added dashboard broadcasting to `RatWatchComponentModule` (check-in event)

### UI
- Extended `RatWatchItemViewModel` with `VotingStartedAt`, `VoteEndsAt`, `VoteEndsAtUtcIso`, and `CanEndVote`
- Added "Vote Ends" column and "End Vote" button/modal to Rat Watch admin page
- Added `OnPostEndVoteAsync` handler to page model
- Updated `dashboard-realtime.js` with Rat Watch event icons and descriptions

## Test plan
- [ ] Build succeeds without new warnings
- [ ] All existing tests pass
- [ ] Create a Rat Watch and verify bot status shows "Watching for rats..." correctly
- [ ] Verify "Vote Ends" column shows correct time for watches in Voting status
- [ ] Verify "End Vote" button appears only for Voting status and confirmation modal shows vote counts
- [ ] Verify dashboard activity feed shows Rat Watch events (created, voting, check-in)

Closes #414
Closes #415
Closes #416
Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)