### PR TITLE
feat(ratwatch): Add analytics DTOs and repository methods

### DIFF
--- a/src/DiscordBot.Core/DTOs/RatWatchAnalyticsDtos.cs
+++ b/src/DiscordBot.Core/DTOs/RatWatchAnalyticsDtos.cs
@@ -1,0 +1,224 @@
+namespace DiscordBot.Core.DTOs;
+
+/// <summary>
+/// Analytics summary for Rat Watch dashboard cards.
+/// </summary>
+public record RatWatchAnalyticsSummaryDto
+{
+    /// <summary>
+    /// Total number of Rat Watches in the time period.
+    /// </summary>
+    public int TotalWatches { get; init; }
+
+    /// <summary>
+    /// Number of Rat Watches currently active (Pending or Voting status).
+    /// </summary>
+    public int ActiveWatches { get; init; }
+
+    /// <summary>
+    /// Number of watches that resulted in guilty verdicts.
+    /// </summary>
+    public int GuiltyCount { get; init; }
+
+    /// <summary>
+    /// Number of watches where the user checked in early (cleared before voting).
+    /// </summary>
+    public int ClearedEarlyCount { get; init; }
+
+    /// <summary>
+    /// Percentage of completed watches that resulted in guilty verdicts.
+    /// </summary>
+    public double GuiltyRate { get; init; }
+
+    /// <summary>
+    /// Percentage of watches where users checked in early.
+    /// </summary>
+    public double EarlyCheckInRate { get; init; }
+
+    /// <summary>
+    /// Average number of total votes per watch that went to voting.
+    /// </summary>
+    public double AvgVotingParticipation { get; init; }
+
+    /// <summary>
+    /// Average vote margin (difference between guilty and not guilty votes).
+    /// </summary>
+    public double AvgVoteMargin { get; init; }
+}
+
+/// <summary>
+/// Time series data point for trend charts.
+/// </summary>
+public record RatWatchTimeSeriesDto
+{
+    /// <summary>
+    /// Date for this data point (day level granularity).
+    /// </summary>
+    public DateTime Date { get; init; }
+
+    /// <summary>
+    /// Total number of watches on this date.
+    /// </summary>
+    public int TotalCount { get; init; }
+
+    /// <summary>
+    /// Number of guilty verdicts on this date.
+    /// </summary>
+    public int GuiltyCount { get; init; }
+
+    /// <summary>
+    /// Number of early check-ins on this date.
+    /// </summary>
+    public int ClearedCount { get; init; }
+}
+
+/// <summary>
+/// User metrics for leaderboard views.
+/// </summary>
+public record RatWatchUserMetricsDto
+{
+    /// <summary>
+    /// Discord user snowflake ID.
+    /// </summary>
+    public ulong UserId { get; init; }
+
+    /// <summary>
+    /// Username (populated by service layer, not repository).
+    /// </summary>
+    public string Username { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Total number of watches created against this user.
+    /// </summary>
+    public int WatchesAgainst { get; init; }
+
+    /// <summary>
+    /// Number of guilty verdicts for this user.
+    /// </summary>
+    public int GuiltyCount { get; init; }
+
+    /// <summary>
+    /// Number of times this user checked in early.
+    /// </summary>
+    public int EarlyCheckInCount { get; init; }
+
+    /// <summary>
+    /// Accountability score: percentage of watches where user checked in early.
+    /// </summary>
+    public double AccountabilityScore { get; init; }
+
+    /// <summary>
+    /// Date of the most recent incident (guilty verdict or watch created).
+    /// </summary>
+    public DateTime? LastIncidentDate { get; init; }
+}
+
+/// <summary>
+/// Fun stats container for public leaderboard.
+/// </summary>
+public record RatWatchFunStatsDto
+{
+    /// <summary>
+    /// User with the longest streak of consecutive guilty verdicts.
+    /// </summary>
+    public UserStreakDto? LongestGuiltyStreak { get; init; }
+
+    /// <summary>
+    /// User with the longest streak of consecutive early check-ins.
+    /// </summary>
+    public UserStreakDto? LongestCleanStreak { get; init; }
+
+    /// <summary>
+    /// Watch with the biggest vote margin (landslide victory).
+    /// </summary>
+    public IncidentHighlightDto? BiggestLandslide { get; init; }
+
+    /// <summary>
+    /// Watch with the closest vote (smallest margin that still resulted in guilty).
+    /// </summary>
+    public IncidentHighlightDto? ClosestCall { get; init; }
+
+    /// <summary>
+    /// Watch with the fastest check-in time (from creation to early clear).
+    /// </summary>
+    public IncidentHighlightDto? FastestCheckIn { get; init; }
+
+    /// <summary>
+    /// Watch where the user checked in latest but still before deadline.
+    /// </summary>
+    public IncidentHighlightDto? LatestCheckIn { get; init; }
+}
+
+/// <summary>
+/// User streak information (consecutive guilty or clean records).
+/// </summary>
+public record UserStreakDto
+{
+    /// <summary>
+    /// Discord user snowflake ID.
+    /// </summary>
+    public ulong UserId { get; init; }
+
+    /// <summary>
+    /// Username (populated by service layer).
+    /// </summary>
+    public string Username { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Number of consecutive records in the streak.
+    /// </summary>
+    public int StreakCount { get; init; }
+}
+
+/// <summary>
+/// Highlight of a specific incident for fun stats.
+/// </summary>
+public record IncidentHighlightDto
+{
+    /// <summary>
+    /// Unique identifier of the Rat Watch.
+    /// </summary>
+    public Guid WatchId { get; init; }
+
+    /// <summary>
+    /// Discord user snowflake ID involved in the incident.
+    /// </summary>
+    public ulong UserId { get; init; }
+
+    /// <summary>
+    /// Username (populated by service layer).
+    /// </summary>
+    public string Username { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Human-readable description of the highlight.
+    /// Examples: "10-1 Guilty", "Cleared in 23 seconds"
+    /// </summary>
+    public string Description { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Date when this incident occurred.
+    /// </summary>
+    public DateTime Date { get; init; }
+}
+
+/// <summary>
+/// Activity heatmap data point (day of week + hour).
+/// </summary>
+public record ActivityHeatmapDto
+{
+    /// <summary>
+    /// Day of the week (0=Sunday through 6=Saturday).
+    /// </summary>
+    public int DayOfWeek { get; init; }
+
+    /// <summary>
+    /// Hour of the day (0-23).
+    /// </summary>
+    public int Hour { get; init; }
+
+    /// <summary>
+    /// Number of watches scheduled at this day/hour combination.
+    /// </summary>
+    public int Count { get; init; }
+}

--- a/src/DiscordBot.Core/Interfaces/IRatRecordRepository.cs
+++ b/src/DiscordBot.Core/Interfaces/IRatRecordRepository.cs
@@ -1,3 +1,4 @@
+using DiscordBot.Core.DTOs;
 using DiscordBot.Core.Entities;
 
 namespace DiscordBot.Core.Interfaces;
@@ -43,5 +44,29 @@ public interface IRatRecordRepository : IRepository<RatRecord>
     Task<IEnumerable<(ulong UserId, int GuiltyCount)>> GetLeaderboardAsync(
         ulong guildId,
         int limit = 10,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets user metrics for leaderboard views.
+    /// </summary>
+    /// <param name="guildId">Discord guild ID.</param>
+    /// <param name="sortBy">Sort field: "watched", "guilty", "accountability".</param>
+    /// <param name="limit">Maximum number of entries to return.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Collection of user metrics ordered by the specified field.</returns>
+    Task<IEnumerable<RatWatchUserMetricsDto>> GetUserMetricsAsync(
+        ulong guildId,
+        string sortBy,
+        int limit,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets fun stats for public leaderboard.
+    /// </summary>
+    /// <param name="guildId">Discord guild ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Fun stats including streaks and highlights.</returns>
+    Task<RatWatchFunStatsDto> GetFunStatsAsync(
+        ulong guildId,
         CancellationToken cancellationToken = default);
 }

--- a/src/DiscordBot.Core/Interfaces/IRatWatchRepository.cs
+++ b/src/DiscordBot.Core/Interfaces/IRatWatchRepository.cs
@@ -1,3 +1,4 @@
+using DiscordBot.Core.DTOs;
 using DiscordBot.Core.Entities;
 
 namespace DiscordBot.Core.Interfaces;
@@ -81,4 +82,46 @@ public interface IRatWatchRepository : IRepository<RatWatch>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>True if there are any active watches, false otherwise.</returns>
     Task<bool> HasActiveWatchesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets analytics summary statistics for Rat Watch dashboard.
+    /// </summary>
+    /// <param name="guildId">Optional guild ID to filter by. Null for all guilds.</param>
+    /// <param name="startDate">Optional start date filter. Null for no start date limit.</param>
+    /// <param name="endDate">Optional end date filter. Null for no end date limit.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Analytics summary with counts, rates, and averages.</returns>
+    Task<RatWatchAnalyticsSummaryDto> GetAnalyticsSummaryAsync(
+        ulong? guildId,
+        DateTime? startDate,
+        DateTime? endDate,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets time series data for trend charts.
+    /// </summary>
+    /// <param name="guildId">Optional guild ID to filter by. Null for all guilds.</param>
+    /// <param name="startDate">Start date for the time series.</param>
+    /// <param name="endDate">End date for the time series.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Collection of time series data points ordered by date.</returns>
+    Task<IEnumerable<RatWatchTimeSeriesDto>> GetTimeSeriesAsync(
+        ulong? guildId,
+        DateTime startDate,
+        DateTime endDate,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets activity heatmap data (day of week + hour).
+    /// </summary>
+    /// <param name="guildId">Guild ID to filter by.</param>
+    /// <param name="startDate">Start date for the heatmap data.</param>
+    /// <param name="endDate">End date for the heatmap data.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Collection of heatmap data points with counts per day/hour cell.</returns>
+    Task<IEnumerable<ActivityHeatmapDto>> GetActivityHeatmapAsync(
+        ulong guildId,
+        DateTime startDate,
+        DateTime endDate,
+        CancellationToken cancellationToken = default);
 }

--- a/src/DiscordBot.Infrastructure/Data/Repositories/RatRecordRepository.cs
+++ b/src/DiscordBot.Infrastructure/Data/Repositories/RatRecordRepository.cs
@@ -1,4 +1,6 @@
+using DiscordBot.Core.DTOs;
 using DiscordBot.Core.Entities;
+using DiscordBot.Core.Enums;
 using DiscordBot.Core.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -82,5 +84,248 @@ public class RatRecordRepository : Repository<RatRecord>, IRatRecordRepository
 
         _logger.LogDebug("Retrieved {Count} leaderboard entries for guild {GuildId}", result.Count(), guildId);
         return result;
+    }
+
+    public async Task<IEnumerable<RatWatchUserMetricsDto>> GetUserMetricsAsync(
+        ulong guildId,
+        string sortBy,
+        int limit,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug(
+            "Retrieving user metrics for guild {GuildId}, sorted by {SortBy}, limit {Limit}",
+            guildId, sortBy, limit);
+
+        // Get all watches for the guild with their statuses
+        var watches = Context.Set<RatWatch>()
+            .AsNoTracking()
+            .Where(w => w.GuildId == guildId);
+
+        // Group by accused user and calculate metrics
+        var metricsQuery = watches
+            .GroupBy(w => w.AccusedUserId)
+            .Select(g => new
+            {
+                UserId = g.Key,
+                WatchesAgainst = g.Count(),
+                GuiltyCount = g.Count(w => w.Status == RatWatchStatus.Guilty),
+                EarlyCheckInCount = g.Count(w => w.Status == RatWatchStatus.ClearedEarly),
+                LastIncidentDate = g.OrderByDescending(w => w.CreatedAt).Select(w => w.CreatedAt).FirstOrDefault()
+            });
+
+        // Calculate accountability score and project to DTO
+        var metrics = await metricsQuery
+            .ToListAsync(cancellationToken);
+
+        var userMetrics = metrics.Select(m => new RatWatchUserMetricsDto
+        {
+            UserId = m.UserId,
+            Username = string.Empty, // Populated by service layer
+            WatchesAgainst = m.WatchesAgainst,
+            GuiltyCount = m.GuiltyCount,
+            EarlyCheckInCount = m.EarlyCheckInCount,
+            AccountabilityScore = m.WatchesAgainst > 0 ? (double)m.EarlyCheckInCount / m.WatchesAgainst * 100 : 0,
+            LastIncidentDate = m.LastIncidentDate
+        });
+
+        // Apply sorting
+        var sortedMetrics = sortBy.ToLowerInvariant() switch
+        {
+            "watched" => userMetrics.OrderByDescending(m => m.WatchesAgainst),
+            "guilty" => userMetrics.OrderByDescending(m => m.GuiltyCount),
+            "accountability" => userMetrics.OrderByDescending(m => m.AccountabilityScore),
+            _ => userMetrics.OrderByDescending(m => m.WatchesAgainst)
+        };
+
+        var result = sortedMetrics.Take(limit).ToList();
+
+        _logger.LogDebug("Retrieved {Count} user metrics for guild {GuildId}", result.Count, guildId);
+        return result;
+    }
+
+    public async Task<RatWatchFunStatsDto> GetFunStatsAsync(
+        ulong guildId,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Retrieving fun stats for guild {GuildId}", guildId);
+
+        var watches = await Context.Set<RatWatch>()
+            .AsNoTracking()
+            .Where(w => w.GuildId == guildId)
+            .Include(w => w.Votes)
+            .OrderBy(w => w.CreatedAt)
+            .ToListAsync(cancellationToken);
+
+        // Calculate streaks (in-memory due to complexity)
+        var guiltyStreak = CalculateLongestStreak(
+            watches,
+            w => w.Status == RatWatchStatus.Guilty);
+
+        var cleanStreak = CalculateLongestStreak(
+            watches,
+            w => w.Status == RatWatchStatus.ClearedEarly);
+
+        // Find biggest landslide (largest vote margin)
+        var votingWatches = watches
+            .Where(w => w.Status == RatWatchStatus.Guilty || w.Status == RatWatchStatus.NotGuilty)
+            .ToList();
+
+        var biggestLandslide = votingWatches
+            .Select(w => new
+            {
+                Watch = w,
+                GuiltyVotes = w.Votes.Count(v => v.IsGuiltyVote),
+                NotGuiltyVotes = w.Votes.Count(v => !v.IsGuiltyVote)
+            })
+            .OrderByDescending(x => Math.Abs(x.GuiltyVotes - x.NotGuiltyVotes))
+            .FirstOrDefault();
+
+        // Find closest call (smallest margin that still resulted in guilty)
+        var guiltyVotes = votingWatches
+            .Where(w => w.Status == RatWatchStatus.Guilty)
+            .Select(w => new
+            {
+                Watch = w,
+                GuiltyVotes = w.Votes.Count(v => v.IsGuiltyVote),
+                NotGuiltyVotes = w.Votes.Count(v => !v.IsGuiltyVote)
+            })
+            .OrderBy(x => Math.Abs(x.GuiltyVotes - x.NotGuiltyVotes))
+            .FirstOrDefault();
+
+        // Find fastest check-in
+        var clearedEarlyWatches = watches
+            .Where(w => w.Status == RatWatchStatus.ClearedEarly && w.ClearedAt.HasValue)
+            .Select(w => new
+            {
+                Watch = w,
+                Duration = w.ClearedAt!.Value - w.CreatedAt
+            })
+            .OrderBy(x => x.Duration)
+            .FirstOrDefault();
+
+        // Find latest check-in (closest to deadline but still early)
+        var latestCheckIn = watches
+            .Where(w => w.Status == RatWatchStatus.ClearedEarly && w.ClearedAt.HasValue)
+            .Select(w => new
+            {
+                Watch = w,
+                TimeBeforeDeadline = w.ScheduledAt - w.ClearedAt!.Value
+            })
+            .OrderBy(x => x.TimeBeforeDeadline)
+            .FirstOrDefault();
+
+        _logger.LogDebug("Calculated fun stats for guild {GuildId}", guildId);
+
+        return new RatWatchFunStatsDto
+        {
+            LongestGuiltyStreak = guiltyStreak != null ? new UserStreakDto
+            {
+                UserId = guiltyStreak.Value.UserId,
+                Username = string.Empty, // Populated by service layer
+                StreakCount = guiltyStreak.Value.Count
+            } : null,
+            LongestCleanStreak = cleanStreak != null ? new UserStreakDto
+            {
+                UserId = cleanStreak.Value.UserId,
+                Username = string.Empty, // Populated by service layer
+                StreakCount = cleanStreak.Value.Count
+            } : null,
+            BiggestLandslide = biggestLandslide != null ? new IncidentHighlightDto
+            {
+                WatchId = biggestLandslide.Watch.Id,
+                UserId = biggestLandslide.Watch.AccusedUserId,
+                Username = string.Empty, // Populated by service layer
+                Description = $"{biggestLandslide.GuiltyVotes}-{biggestLandslide.NotGuiltyVotes} {(biggestLandslide.Watch.Status == RatWatchStatus.Guilty ? "Guilty" : "Not Guilty")}",
+                Date = biggestLandslide.Watch.CreatedAt
+            } : null,
+            ClosestCall = guiltyVotes != null ? new IncidentHighlightDto
+            {
+                WatchId = guiltyVotes.Watch.Id,
+                UserId = guiltyVotes.Watch.AccusedUserId,
+                Username = string.Empty, // Populated by service layer
+                Description = $"{guiltyVotes.GuiltyVotes}-{guiltyVotes.NotGuiltyVotes} Guilty",
+                Date = guiltyVotes.Watch.CreatedAt
+            } : null,
+            FastestCheckIn = clearedEarlyWatches != null ? new IncidentHighlightDto
+            {
+                WatchId = clearedEarlyWatches.Watch.Id,
+                UserId = clearedEarlyWatches.Watch.AccusedUserId,
+                Username = string.Empty, // Populated by service layer
+                Description = $"Cleared in {FormatDuration(clearedEarlyWatches.Duration)}",
+                Date = clearedEarlyWatches.Watch.CreatedAt
+            } : null,
+            LatestCheckIn = latestCheckIn != null ? new IncidentHighlightDto
+            {
+                WatchId = latestCheckIn.Watch.Id,
+                UserId = latestCheckIn.Watch.AccusedUserId,
+                Username = string.Empty, // Populated by service layer
+                Description = $"Cleared {FormatDuration(latestCheckIn.TimeBeforeDeadline)} before deadline",
+                Date = latestCheckIn.Watch.CreatedAt
+            } : null
+        };
+    }
+
+    /// <summary>
+    /// Calculates the longest streak for a given condition grouped by user.
+    /// Returns the user with the longest streak and the count.
+    /// </summary>
+    private (ulong UserId, int Count)? CalculateLongestStreak(
+        List<RatWatch> watches,
+        Func<RatWatch, bool> condition)
+    {
+        var userStreaks = new Dictionary<ulong, int>();
+        var currentStreaks = new Dictionary<ulong, int>();
+
+        // Group by user and process in chronological order
+        var watchesByUser = watches
+            .GroupBy(w => w.AccusedUserId)
+            .ToDictionary(g => g.Key, g => g.OrderBy(w => w.CreatedAt).ToList());
+
+        foreach (var (userId, userWatches) in watchesByUser)
+        {
+            var currentStreak = 0;
+            var maxStreak = 0;
+
+            foreach (var watch in userWatches)
+            {
+                if (condition(watch))
+                {
+                    currentStreak++;
+                    maxStreak = Math.Max(maxStreak, currentStreak);
+                }
+                else
+                {
+                    currentStreak = 0;
+                }
+            }
+
+            if (maxStreak > 0)
+            {
+                userStreaks[userId] = maxStreak;
+            }
+        }
+
+        if (userStreaks.Count == 0)
+            return null;
+
+        var longestStreak = userStreaks.OrderByDescending(x => x.Value).First();
+        return (longestStreak.Key, longestStreak.Value);
+    }
+
+    /// <summary>
+    /// Formats a TimeSpan into a human-readable string.
+    /// </summary>
+    private string FormatDuration(TimeSpan duration)
+    {
+        if (duration.TotalSeconds < 60)
+            return $"{(int)duration.TotalSeconds} seconds";
+
+        if (duration.TotalMinutes < 60)
+            return $"{(int)duration.TotalMinutes} minutes";
+
+        if (duration.TotalHours < 24)
+            return $"{duration.Hours} hours {duration.Minutes} minutes";
+
+        return $"{(int)duration.TotalDays} days {duration.Hours} hours";
     }
 }

--- a/tests/DiscordBot.Tests/Data/Repositories/RatRecordRepositoryAnalyticsTests.cs
+++ b/tests/DiscordBot.Tests/Data/Repositories/RatRecordRepositoryAnalyticsTests.cs
@@ -1,0 +1,776 @@
+using DiscordBot.Core.Entities;
+using DiscordBot.Core.Enums;
+using DiscordBot.Infrastructure.Data;
+using DiscordBot.Infrastructure.Data.Repositories;
+using DiscordBot.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace DiscordBot.Tests.Data.Repositories;
+
+/// <summary>
+/// Unit tests for RatRecordRepository analytics methods.
+/// Tests cover GetUserMetricsAsync and GetFunStatsAsync.
+/// </summary>
+public class RatRecordRepositoryAnalyticsTests : IDisposable
+{
+    private readonly BotDbContext _context;
+    private readonly SqliteConnection _connection;
+    private readonly RatRecordRepository _repository;
+    private readonly Mock<ILogger<RatRecordRepository>> _mockLogger;
+    private readonly Mock<ILogger<Repository<RatRecord>>> _mockBaseLogger;
+
+    public RatRecordRepositoryAnalyticsTests()
+    {
+        (_context, _connection) = TestDbContextFactory.CreateContext();
+        _mockLogger = new Mock<ILogger<RatRecordRepository>>();
+        _mockBaseLogger = new Mock<ILogger<Repository<RatRecord>>>();
+        _repository = new RatRecordRepository(_context, _mockLogger.Object, _mockBaseLogger.Object);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+    }
+
+    private async Task<Guild> SeedGuildAsync(ulong id = 123456789)
+    {
+        var guild = new Guild
+        {
+            Id = id,
+            Name = $"Test Guild {id}",
+            JoinedAt = DateTime.UtcNow,
+            IsActive = true
+        };
+        await _context.Guilds.AddAsync(guild);
+        await _context.SaveChangesAsync();
+        return guild;
+    }
+
+    private async Task<RatWatch> CreateRatWatchAsync(
+        ulong guildId,
+        ulong accusedUserId,
+        RatWatchStatus status,
+        DateTime? createdAt = null,
+        int guiltyVotes = 0,
+        int notGuiltyVotes = 0)
+    {
+        var now = createdAt ?? DateTime.UtcNow;
+
+        var watch = new RatWatch
+        {
+            Id = Guid.NewGuid(),
+            GuildId = guildId,
+            ChannelId = 111111111,
+            AccusedUserId = accusedUserId,
+            InitiatorUserId = 333333333,
+            OriginalMessageId = 444444444,
+            ScheduledAt = now.AddHours(1),
+            CreatedAt = now,
+            Status = status
+        };
+
+        if (status == RatWatchStatus.ClearedEarly)
+        {
+            watch.ClearedAt = watch.CreatedAt.AddMinutes(30);
+        }
+
+        if (status == RatWatchStatus.Voting || status == RatWatchStatus.Guilty || status == RatWatchStatus.NotGuilty)
+        {
+            watch.VotingStartedAt = watch.ScheduledAt;
+        }
+
+        if (status == RatWatchStatus.Guilty || status == RatWatchStatus.NotGuilty)
+        {
+            watch.VotingEndedAt = watch.VotingStartedAt!.Value.AddMinutes(30);
+        }
+
+        await _context.RatWatches.AddAsync(watch);
+
+        // Add votes if specified
+        if (guiltyVotes > 0 || notGuiltyVotes > 0)
+        {
+            ulong voterIdBase = 500000000 + (ulong)Random.Shared.Next(1000000);
+            for (int i = 0; i < guiltyVotes; i++)
+            {
+                await _context.RatVotes.AddAsync(new RatVote
+                {
+                    Id = Guid.NewGuid(),
+                    RatWatchId = watch.Id,
+                    VoterUserId = voterIdBase++,
+                    IsGuiltyVote = true,
+                    VotedAt = watch.VotingStartedAt!.Value.AddMinutes(5)
+                });
+            }
+
+            for (int i = 0; i < notGuiltyVotes; i++)
+            {
+                await _context.RatVotes.AddAsync(new RatVote
+                {
+                    Id = Guid.NewGuid(),
+                    RatWatchId = watch.Id,
+                    VoterUserId = voterIdBase++,
+                    IsGuiltyVote = false,
+                    VotedAt = watch.VotingStartedAt!.Value.AddMinutes(5)
+                });
+            }
+        }
+
+        await _context.SaveChangesAsync();
+        return watch;
+    }
+
+    #region GetUserMetricsAsync Tests
+
+    [Fact]
+    public async Task GetUserMetricsAsync_WithEmptyDataset_ReturnsEmptyList()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+
+        // Act
+        var result = await _repository.GetUserMetricsAsync(guild.Id, "watched", 10);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetUserMetricsAsync_CalculatesWatchesAgainst()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var userId = 222222222ul;
+
+        await CreateRatWatchAsync(guild.Id, userId, RatWatchStatus.Guilty, guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, userId, RatWatchStatus.ClearedEarly);
+        await CreateRatWatchAsync(guild.Id, userId, RatWatchStatus.Pending);
+
+        // Act
+        var result = await _repository.GetUserMetricsAsync(guild.Id, "watched", 10);
+
+        // Assert
+        var metrics = result.Single();
+        metrics.UserId.Should().Be(userId);
+        metrics.WatchesAgainst.Should().Be(3, "total watches against this user");
+    }
+
+    [Fact]
+    public async Task GetUserMetricsAsync_CalculatesGuiltyCount()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var userId = 222222222ul;
+
+        await CreateRatWatchAsync(guild.Id, userId, RatWatchStatus.Guilty, guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, userId, RatWatchStatus.Guilty, guiltyVotes: 3, notGuiltyVotes: 1);
+        await CreateRatWatchAsync(guild.Id, userId, RatWatchStatus.NotGuilty, guiltyVotes: 1, notGuiltyVotes: 4);
+        await CreateRatWatchAsync(guild.Id, userId, RatWatchStatus.ClearedEarly);
+
+        // Act
+        var result = await _repository.GetUserMetricsAsync(guild.Id, "guilty", 10);
+
+        // Assert
+        var metrics = result.Single();
+        metrics.GuiltyCount.Should().Be(2, "two guilty verdicts");
+    }
+
+    [Fact]
+    public async Task GetUserMetricsAsync_CalculatesEarlyCheckInCount()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var userId = 222222222ul;
+
+        await CreateRatWatchAsync(guild.Id, userId, RatWatchStatus.ClearedEarly);
+        await CreateRatWatchAsync(guild.Id, userId, RatWatchStatus.ClearedEarly);
+        await CreateRatWatchAsync(guild.Id, userId, RatWatchStatus.ClearedEarly);
+        await CreateRatWatchAsync(guild.Id, userId, RatWatchStatus.Guilty, guiltyVotes: 5, notGuiltyVotes: 2);
+
+        // Act
+        var result = await _repository.GetUserMetricsAsync(guild.Id, "accountability", 10);
+
+        // Assert
+        var metrics = result.Single();
+        metrics.EarlyCheckInCount.Should().Be(3, "three early check-ins");
+    }
+
+    [Fact]
+    public async Task GetUserMetricsAsync_CalculatesAccountabilityScore()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var userId = 222222222ul;
+
+        // 3 early check-ins out of 5 total watches = 60%
+        await CreateRatWatchAsync(guild.Id, userId, RatWatchStatus.ClearedEarly);
+        await CreateRatWatchAsync(guild.Id, userId, RatWatchStatus.ClearedEarly);
+        await CreateRatWatchAsync(guild.Id, userId, RatWatchStatus.ClearedEarly);
+        await CreateRatWatchAsync(guild.Id, userId, RatWatchStatus.Guilty, guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, userId, RatWatchStatus.NotGuilty, guiltyVotes: 1, notGuiltyVotes: 4);
+
+        // Act
+        var result = await _repository.GetUserMetricsAsync(guild.Id, "accountability", 10);
+
+        // Assert
+        var metrics = result.Single();
+        metrics.AccountabilityScore.Should().BeApproximately(60.0, 0.01, "3 early out of 5 total = 60%");
+    }
+
+    [Fact]
+    public async Task GetUserMetricsAsync_HandlesZeroWatches_AccountabilityScore()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+
+        // No watches exist, so no users to return
+        // Act
+        var result = await _repository.GetUserMetricsAsync(guild.Id, "accountability", 10);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetUserMetricsAsync_SetsLastIncidentDate()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var userId = 222222222ul;
+        var now = DateTime.UtcNow;
+
+        await CreateRatWatchAsync(guild.Id, userId, RatWatchStatus.Guilty, createdAt: now.AddDays(-5), guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, userId, RatWatchStatus.ClearedEarly, createdAt: now.AddDays(-2));
+        await CreateRatWatchAsync(guild.Id, userId, RatWatchStatus.Pending, createdAt: now); // Most recent
+
+        // Act
+        var result = await _repository.GetUserMetricsAsync(guild.Id, "watched", 10);
+
+        // Assert
+        var metrics = result.Single();
+        metrics.LastIncidentDate.Should().NotBeNull();
+        metrics.LastIncidentDate!.Value.Should().BeCloseTo(now, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task GetUserMetricsAsync_SortsByWatched()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var user1 = 100000001ul;
+        var user2 = 100000002ul;
+        var user3 = 100000003ul;
+
+        // User1: 3 watches
+        await CreateRatWatchAsync(guild.Id, user1, RatWatchStatus.Guilty, guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, user1, RatWatchStatus.ClearedEarly);
+        await CreateRatWatchAsync(guild.Id, user1, RatWatchStatus.Pending);
+
+        // User2: 5 watches (most)
+        await CreateRatWatchAsync(guild.Id, user2, RatWatchStatus.Guilty, guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, user2, RatWatchStatus.Guilty, guiltyVotes: 3, notGuiltyVotes: 1);
+        await CreateRatWatchAsync(guild.Id, user2, RatWatchStatus.ClearedEarly);
+        await CreateRatWatchAsync(guild.Id, user2, RatWatchStatus.Pending);
+        await CreateRatWatchAsync(guild.Id, user2, RatWatchStatus.NotGuilty, guiltyVotes: 1, notGuiltyVotes: 4);
+
+        // User3: 2 watches
+        await CreateRatWatchAsync(guild.Id, user3, RatWatchStatus.Guilty, guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, user3, RatWatchStatus.ClearedEarly);
+
+        // Act
+        var result = await _repository.GetUserMetricsAsync(guild.Id, "watched", 10);
+
+        // Assert
+        var resultList = result.ToList();
+        resultList.Should().HaveCount(3);
+        resultList[0].UserId.Should().Be(user2, "user with most watches should be first");
+        resultList[0].WatchesAgainst.Should().Be(5);
+        resultList[1].UserId.Should().Be(user1);
+        resultList[1].WatchesAgainst.Should().Be(3);
+        resultList[2].UserId.Should().Be(user3);
+        resultList[2].WatchesAgainst.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetUserMetricsAsync_SortsByGuilty()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var user1 = 100000001ul;
+        var user2 = 100000002ul;
+        var user3 = 100000003ul;
+
+        // User1: 1 guilty
+        await CreateRatWatchAsync(guild.Id, user1, RatWatchStatus.Guilty, guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, user1, RatWatchStatus.ClearedEarly);
+
+        // User2: 3 guilty (most)
+        await CreateRatWatchAsync(guild.Id, user2, RatWatchStatus.Guilty, guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, user2, RatWatchStatus.Guilty, guiltyVotes: 3, notGuiltyVotes: 1);
+        await CreateRatWatchAsync(guild.Id, user2, RatWatchStatus.Guilty, guiltyVotes: 4, notGuiltyVotes: 1);
+
+        // User3: 0 guilty
+        await CreateRatWatchAsync(guild.Id, user3, RatWatchStatus.ClearedEarly);
+        await CreateRatWatchAsync(guild.Id, user3, RatWatchStatus.NotGuilty, guiltyVotes: 1, notGuiltyVotes: 4);
+
+        // Act
+        var result = await _repository.GetUserMetricsAsync(guild.Id, "guilty", 10);
+
+        // Assert
+        var resultList = result.ToList();
+        resultList.Should().HaveCount(3);
+        resultList[0].UserId.Should().Be(user2, "user with most guilty verdicts should be first");
+        resultList[0].GuiltyCount.Should().Be(3);
+        resultList[1].UserId.Should().Be(user1);
+        resultList[1].GuiltyCount.Should().Be(1);
+        resultList[2].UserId.Should().Be(user3);
+        resultList[2].GuiltyCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetUserMetricsAsync_SortsByAccountability()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var user1 = 100000001ul;
+        var user2 = 100000002ul;
+        var user3 = 100000003ul;
+
+        // User1: 2/4 = 50%
+        await CreateRatWatchAsync(guild.Id, user1, RatWatchStatus.ClearedEarly);
+        await CreateRatWatchAsync(guild.Id, user1, RatWatchStatus.ClearedEarly);
+        await CreateRatWatchAsync(guild.Id, user1, RatWatchStatus.Guilty, guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, user1, RatWatchStatus.Guilty, guiltyVotes: 3, notGuiltyVotes: 1);
+
+        // User2: 3/3 = 100% (highest)
+        await CreateRatWatchAsync(guild.Id, user2, RatWatchStatus.ClearedEarly);
+        await CreateRatWatchAsync(guild.Id, user2, RatWatchStatus.ClearedEarly);
+        await CreateRatWatchAsync(guild.Id, user2, RatWatchStatus.ClearedEarly);
+
+        // User3: 0/3 = 0%
+        await CreateRatWatchAsync(guild.Id, user3, RatWatchStatus.Guilty, guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, user3, RatWatchStatus.Guilty, guiltyVotes: 3, notGuiltyVotes: 1);
+        await CreateRatWatchAsync(guild.Id, user3, RatWatchStatus.NotGuilty, guiltyVotes: 1, notGuiltyVotes: 4);
+
+        // Act
+        var result = await _repository.GetUserMetricsAsync(guild.Id, "accountability", 10);
+
+        // Assert
+        var resultList = result.ToList();
+        resultList.Should().HaveCount(3);
+        resultList[0].UserId.Should().Be(user2, "user with highest accountability should be first");
+        resultList[0].AccountabilityScore.Should().BeApproximately(100.0, 0.01);
+        resultList[1].UserId.Should().Be(user1);
+        resultList[1].AccountabilityScore.Should().BeApproximately(50.0, 0.01);
+        resultList[2].UserId.Should().Be(user3);
+        resultList[2].AccountabilityScore.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetUserMetricsAsync_DefaultsToWatchedSort_WithInvalidSortBy()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var user1 = 100000001ul;
+        var user2 = 100000002ul;
+
+        await CreateRatWatchAsync(guild.Id, user1, RatWatchStatus.Guilty, guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, user2, RatWatchStatus.Guilty, guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, user2, RatWatchStatus.ClearedEarly);
+
+        // Act - Use invalid sort parameter
+        var result = await _repository.GetUserMetricsAsync(guild.Id, "invalid-sort", 10);
+
+        // Assert - Should default to "watched" sorting
+        var resultList = result.ToList();
+        resultList.Should().HaveCount(2);
+        resultList[0].UserId.Should().Be(user2, "user with more watches should be first (default sort)");
+        resultList[0].WatchesAgainst.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetUserMetricsAsync_RespectsLimit()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+
+        for (ulong i = 1; i <= 15; i++)
+        {
+            await CreateRatWatchAsync(guild.Id, 100000000 + i, RatWatchStatus.Guilty, guiltyVotes: 5, notGuiltyVotes: 2);
+        }
+
+        // Act
+        var result = await _repository.GetUserMetricsAsync(guild.Id, "watched", 10);
+
+        // Assert
+        result.Should().HaveCount(10, "limit should restrict results");
+    }
+
+    [Fact]
+    public async Task GetUserMetricsAsync_FiltersByGuildId()
+    {
+        // Arrange
+        var guild1 = await SeedGuildAsync(111111111);
+        var guild2 = await SeedGuildAsync(222222222);
+        var userId = 333333333ul;
+
+        await CreateRatWatchAsync(guild1.Id, userId, RatWatchStatus.Guilty, guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild1.Id, userId, RatWatchStatus.ClearedEarly);
+        await CreateRatWatchAsync(guild2.Id, userId, RatWatchStatus.Guilty, guiltyVotes: 3, notGuiltyVotes: 1);
+
+        // Act
+        var result = await _repository.GetUserMetricsAsync(guild1.Id, "watched", 10);
+
+        // Assert
+        var metrics = result.Single();
+        metrics.WatchesAgainst.Should().Be(2, "only guild1 watches should be counted");
+    }
+
+    [Fact]
+    public async Task GetUserMetricsAsync_GroupsByUser()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var user1 = 100000001ul;
+        var user2 = 100000002ul;
+
+        await CreateRatWatchAsync(guild.Id, user1, RatWatchStatus.Guilty, guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, user1, RatWatchStatus.ClearedEarly);
+        await CreateRatWatchAsync(guild.Id, user2, RatWatchStatus.Guilty, guiltyVotes: 3, notGuiltyVotes: 1);
+
+        // Act
+        var result = await _repository.GetUserMetricsAsync(guild.Id, "watched", 10);
+
+        // Assert
+        result.Should().HaveCount(2, "two distinct users");
+
+        var user1Metrics = result.First(m => m.UserId == user1);
+        user1Metrics.WatchesAgainst.Should().Be(2);
+
+        var user2Metrics = result.First(m => m.UserId == user2);
+        user2Metrics.WatchesAgainst.Should().Be(1);
+    }
+
+    #endregion
+
+    #region GetFunStatsAsync Tests
+
+    [Fact]
+    public async Task GetFunStatsAsync_WithEmptyDataset_ReturnsNullStats()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+
+        // Act
+        var result = await _repository.GetFunStatsAsync(guild.Id);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.LongestGuiltyStreak.Should().BeNull();
+        result.LongestCleanStreak.Should().BeNull();
+        result.BiggestLandslide.Should().BeNull();
+        result.ClosestCall.Should().BeNull();
+        result.FastestCheckIn.Should().BeNull();
+        result.LatestCheckIn.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetFunStatsAsync_CalculatesBiggestLandslide()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var userId = 222222222ul;
+
+        // Small margin: 3-2 = 1
+        var watch1 = await CreateRatWatchAsync(guild.Id, userId, RatWatchStatus.Guilty, guiltyVotes: 3, notGuiltyVotes: 2);
+
+        // Biggest landslide: 10-1 = 9
+        var watch2 = await CreateRatWatchAsync(guild.Id, userId, RatWatchStatus.Guilty, guiltyVotes: 10, notGuiltyVotes: 1);
+
+        // Medium margin: 5-2 = 3
+        var watch3 = await CreateRatWatchAsync(guild.Id, userId, RatWatchStatus.NotGuilty, guiltyVotes: 2, notGuiltyVotes: 5);
+
+        // Act
+        var result = await _repository.GetFunStatsAsync(guild.Id);
+
+        // Assert
+        result.BiggestLandslide.Should().NotBeNull();
+        result.BiggestLandslide!.WatchId.Should().Be(watch2.Id);
+        result.BiggestLandslide.UserId.Should().Be(userId);
+        result.BiggestLandslide.Description.Should().Contain("10-1");
+        result.BiggestLandslide.Description.Should().Contain("Guilty");
+    }
+
+    [Fact]
+    public async Task GetFunStatsAsync_CalculatesClosestCall()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var userId = 222222222ul;
+
+        // Large margin: 10-1 = 9
+        var watch1 = await CreateRatWatchAsync(guild.Id, userId, RatWatchStatus.Guilty, guiltyVotes: 10, notGuiltyVotes: 1);
+
+        // Closest guilty: 3-2 = 1
+        var watch2 = await CreateRatWatchAsync(guild.Id, userId, RatWatchStatus.Guilty, guiltyVotes: 3, notGuiltyVotes: 2);
+
+        // Medium margin: 5-2 = 3
+        var watch3 = await CreateRatWatchAsync(guild.Id, userId, RatWatchStatus.Guilty, guiltyVotes: 5, notGuiltyVotes: 2);
+
+        // Not guilty - should not count
+        var watch4 = await CreateRatWatchAsync(guild.Id, userId, RatWatchStatus.NotGuilty, guiltyVotes: 2, notGuiltyVotes: 3);
+
+        // Act
+        var result = await _repository.GetFunStatsAsync(guild.Id);
+
+        // Assert
+        result.ClosestCall.Should().NotBeNull();
+        result.ClosestCall!.WatchId.Should().Be(watch2.Id, "smallest margin among guilty verdicts");
+        result.ClosestCall.UserId.Should().Be(userId);
+        result.ClosestCall.Description.Should().Contain("3-2");
+        result.ClosestCall.Description.Should().Contain("Guilty");
+    }
+
+    [Fact]
+    public async Task GetFunStatsAsync_CalculatesFastestCheckIn()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var user1 = 100000001ul;
+        var user2 = 100000002ul;
+        var user3 = 100000003ul;
+        var now = DateTime.UtcNow;
+
+        // Create watches with different clear times
+        var watch1 = await CreateRatWatchAsync(guild.Id, user1, RatWatchStatus.ClearedEarly, createdAt: now);
+        watch1.ClearedAt = watch1.CreatedAt.AddHours(1); // 1 hour
+        _context.RatWatches.Update(watch1);
+
+        var watch2 = await CreateRatWatchAsync(guild.Id, user2, RatWatchStatus.ClearedEarly, createdAt: now);
+        watch2.ClearedAt = watch2.CreatedAt.AddMinutes(5); // 5 minutes (fastest)
+        _context.RatWatches.Update(watch2);
+
+        var watch3 = await CreateRatWatchAsync(guild.Id, user3, RatWatchStatus.ClearedEarly, createdAt: now);
+        watch3.ClearedAt = watch3.CreatedAt.AddMinutes(30); // 30 minutes
+        _context.RatWatches.Update(watch3);
+
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _repository.GetFunStatsAsync(guild.Id);
+
+        // Assert
+        result.FastestCheckIn.Should().NotBeNull();
+        result.FastestCheckIn!.WatchId.Should().Be(watch2.Id, "watch with shortest duration");
+        result.FastestCheckIn.UserId.Should().Be(user2);
+        result.FastestCheckIn.Description.Should().Contain("5 minutes");
+    }
+
+    [Fact]
+    public async Task GetFunStatsAsync_CalculatesLatestCheckIn()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var user1 = 100000001ul;
+        var user2 = 100000002ul;
+        var user3 = 100000003ul;
+        var now = DateTime.UtcNow;
+
+        // Create watches scheduled for 2 hours from creation
+        var watch1 = await CreateRatWatchAsync(guild.Id, user1, RatWatchStatus.ClearedEarly, createdAt: now);
+        watch1.ScheduledAt = watch1.CreatedAt.AddHours(2);
+        watch1.ClearedAt = watch1.ScheduledAt.AddMinutes(-30); // 30 min before deadline
+        _context.RatWatches.Update(watch1);
+
+        var watch2 = await CreateRatWatchAsync(guild.Id, user2, RatWatchStatus.ClearedEarly, createdAt: now);
+        watch2.ScheduledAt = watch2.CreatedAt.AddHours(2);
+        watch2.ClearedAt = watch2.ScheduledAt.AddMinutes(-5); // 5 min before deadline (latest)
+        _context.RatWatches.Update(watch2);
+
+        var watch3 = await CreateRatWatchAsync(guild.Id, user3, RatWatchStatus.ClearedEarly, createdAt: now);
+        watch3.ScheduledAt = watch3.CreatedAt.AddHours(2);
+        watch3.ClearedAt = watch3.ScheduledAt.AddMinutes(-60); // 60 min before deadline
+        _context.RatWatches.Update(watch3);
+
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _repository.GetFunStatsAsync(guild.Id);
+
+        // Assert
+        result.LatestCheckIn.Should().NotBeNull();
+        result.LatestCheckIn!.WatchId.Should().Be(watch2.Id, "cleared closest to deadline");
+        result.LatestCheckIn.UserId.Should().Be(user2);
+        result.LatestCheckIn.Description.Should().Contain("5 minutes");
+        result.LatestCheckIn.Description.Should().Contain("before deadline");
+    }
+
+    [Fact]
+    public async Task GetFunStatsAsync_CalculatesLongestGuiltyStreak()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var user1 = 100000001ul;
+        var user2 = 100000002ul;
+        var now = DateTime.UtcNow;
+
+        // User1: Guilty, Guilty, Not Guilty, Guilty = max streak 2
+        await CreateRatWatchAsync(guild.Id, user1, RatWatchStatus.Guilty, createdAt: now.AddDays(-10), guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, user1, RatWatchStatus.Guilty, createdAt: now.AddDays(-9), guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, user1, RatWatchStatus.NotGuilty, createdAt: now.AddDays(-8), guiltyVotes: 1, notGuiltyVotes: 4);
+        await CreateRatWatchAsync(guild.Id, user1, RatWatchStatus.Guilty, createdAt: now.AddDays(-7), guiltyVotes: 5, notGuiltyVotes: 2);
+
+        // User2: Guilty, Guilty, Guilty, Cleared = max streak 3 (longest)
+        await CreateRatWatchAsync(guild.Id, user2, RatWatchStatus.Guilty, createdAt: now.AddDays(-6), guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, user2, RatWatchStatus.Guilty, createdAt: now.AddDays(-5), guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, user2, RatWatchStatus.Guilty, createdAt: now.AddDays(-4), guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, user2, RatWatchStatus.ClearedEarly, createdAt: now.AddDays(-3));
+
+        // Act
+        var result = await _repository.GetFunStatsAsync(guild.Id);
+
+        // Assert
+        result.LongestGuiltyStreak.Should().NotBeNull();
+        result.LongestGuiltyStreak!.UserId.Should().Be(user2, "user with longest consecutive guilty verdicts");
+        result.LongestGuiltyStreak.StreakCount.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task GetFunStatsAsync_CalculatesLongestCleanStreak()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var user1 = 100000001ul;
+        var user2 = 100000002ul;
+        var now = DateTime.UtcNow;
+
+        // User1: Cleared, Cleared, Guilty, Cleared = max streak 2
+        await CreateRatWatchAsync(guild.Id, user1, RatWatchStatus.ClearedEarly, createdAt: now.AddDays(-10));
+        await CreateRatWatchAsync(guild.Id, user1, RatWatchStatus.ClearedEarly, createdAt: now.AddDays(-9));
+        await CreateRatWatchAsync(guild.Id, user1, RatWatchStatus.Guilty, createdAt: now.AddDays(-8), guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, user1, RatWatchStatus.ClearedEarly, createdAt: now.AddDays(-7));
+
+        // User2: Cleared, Cleared, Cleared, Cleared = max streak 4 (longest)
+        await CreateRatWatchAsync(guild.Id, user2, RatWatchStatus.ClearedEarly, createdAt: now.AddDays(-6));
+        await CreateRatWatchAsync(guild.Id, user2, RatWatchStatus.ClearedEarly, createdAt: now.AddDays(-5));
+        await CreateRatWatchAsync(guild.Id, user2, RatWatchStatus.ClearedEarly, createdAt: now.AddDays(-4));
+        await CreateRatWatchAsync(guild.Id, user2, RatWatchStatus.ClearedEarly, createdAt: now.AddDays(-3));
+
+        // Act
+        var result = await _repository.GetFunStatsAsync(guild.Id);
+
+        // Assert
+        result.LongestCleanStreak.Should().NotBeNull();
+        result.LongestCleanStreak!.UserId.Should().Be(user2, "user with longest consecutive early check-ins");
+        result.LongestCleanStreak.StreakCount.Should().Be(4);
+    }
+
+    [Fact]
+    public async Task GetFunStatsAsync_IgnoresClearedEarly_ForVotingStats()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var userId = 222222222ul;
+
+        // Only cleared early watches - should not have voting stats
+        await CreateRatWatchAsync(guild.Id, userId, RatWatchStatus.ClearedEarly);
+        await CreateRatWatchAsync(guild.Id, userId, RatWatchStatus.ClearedEarly);
+
+        // Act
+        var result = await _repository.GetFunStatsAsync(guild.Id);
+
+        // Assert
+        result.BiggestLandslide.Should().BeNull("no voting watches");
+        result.ClosestCall.Should().BeNull("no guilty verdicts");
+    }
+
+    [Fact]
+    public async Task GetFunStatsAsync_IgnoresVoting_ForClearedEarlyStats()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var userId = 222222222ul;
+
+        // Only voting watches - should not have cleared early stats
+        await CreateRatWatchAsync(guild.Id, userId, RatWatchStatus.Guilty, guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, userId, RatWatchStatus.NotGuilty, guiltyVotes: 1, notGuiltyVotes: 4);
+
+        // Act
+        var result = await _repository.GetFunStatsAsync(guild.Id);
+
+        // Assert
+        result.FastestCheckIn.Should().BeNull("no cleared early watches");
+        result.LatestCheckIn.Should().BeNull("no cleared early watches");
+    }
+
+    [Fact]
+    public async Task GetFunStatsAsync_HandlesNoClearedAtValue()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var userId = 222222222ul;
+
+        var watch = await CreateRatWatchAsync(guild.Id, userId, RatWatchStatus.ClearedEarly);
+        watch.ClearedAt = null; // Simulate corrupted data
+        _context.RatWatches.Update(watch);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _repository.GetFunStatsAsync(guild.Id);
+
+        // Assert - Should handle gracefully
+        result.FastestCheckIn.Should().BeNull("ClearedAt is null");
+        result.LatestCheckIn.Should().BeNull("ClearedAt is null");
+    }
+
+    [Fact]
+    public async Task GetFunStatsAsync_FiltersByGuildId()
+    {
+        // Arrange
+        var guild1 = await SeedGuildAsync(111111111);
+        var guild2 = await SeedGuildAsync(222222222);
+        var user1 = 100000001ul;
+        var user2 = 100000002ul;
+
+        // Guild1 - biggest landslide 10-1
+        var watch1 = await CreateRatWatchAsync(guild1.Id, user1, RatWatchStatus.Guilty, guiltyVotes: 10, notGuiltyVotes: 1);
+
+        // Guild2 - biggest landslide 5-1 (different)
+        var watch2 = await CreateRatWatchAsync(guild2.Id, user2, RatWatchStatus.Guilty, guiltyVotes: 5, notGuiltyVotes: 1);
+
+        // Act
+        var result = await _repository.GetFunStatsAsync(guild1.Id);
+
+        // Assert
+        result.BiggestLandslide.Should().NotBeNull();
+        result.BiggestLandslide!.WatchId.Should().Be(watch1.Id, "only guild1 watches should be counted");
+        result.BiggestLandslide.Description.Should().Contain("10-1");
+    }
+
+    [Fact]
+    public async Task GetFunStatsAsync_HandlesTieBreaking()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var user1 = 100000001ul;
+        var user2 = 100000002ul;
+        var now = DateTime.UtcNow;
+
+        // Two watches with same margin - should pick first one encountered
+        var watch1 = await CreateRatWatchAsync(guild.Id, user1, RatWatchStatus.Guilty, createdAt: now.AddDays(-2), guiltyVotes: 5, notGuiltyVotes: 2);
+        var watch2 = await CreateRatWatchAsync(guild.Id, user2, RatWatchStatus.Guilty, createdAt: now.AddDays(-1), guiltyVotes: 5, notGuiltyVotes: 2);
+
+        // Act
+        var result = await _repository.GetFunStatsAsync(guild.Id);
+
+        // Assert
+        result.BiggestLandslide.Should().NotBeNull();
+        // Either watch is acceptable for a tie
+        result.BiggestLandslide!.Description.Should().Contain("5-2");
+    }
+
+    #endregion
+}

--- a/tests/DiscordBot.Tests/Data/Repositories/RatWatchRepositoryAnalyticsTests.cs
+++ b/tests/DiscordBot.Tests/Data/Repositories/RatWatchRepositoryAnalyticsTests.cs
@@ -1,0 +1,741 @@
+using DiscordBot.Core.Entities;
+using DiscordBot.Core.Enums;
+using DiscordBot.Infrastructure.Data;
+using DiscordBot.Infrastructure.Data.Repositories;
+using DiscordBot.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace DiscordBot.Tests.Data.Repositories;
+
+/// <summary>
+/// Unit tests for RatWatchRepository analytics methods.
+/// Tests cover GetAnalyticsSummaryAsync, GetTimeSeriesAsync, and GetActivityHeatmapAsync.
+/// </summary>
+public class RatWatchRepositoryAnalyticsTests : IDisposable
+{
+    private readonly BotDbContext _context;
+    private readonly SqliteConnection _connection;
+    private readonly RatWatchRepository _repository;
+    private readonly Mock<ILogger<RatWatchRepository>> _mockLogger;
+    private readonly Mock<ILogger<Repository<RatWatch>>> _mockBaseLogger;
+
+    public RatWatchRepositoryAnalyticsTests()
+    {
+        (_context, _connection) = TestDbContextFactory.CreateContext();
+        _mockLogger = new Mock<ILogger<RatWatchRepository>>();
+        _mockBaseLogger = new Mock<ILogger<Repository<RatWatch>>>();
+        _repository = new RatWatchRepository(_context, _mockLogger.Object, _mockBaseLogger.Object);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+    }
+
+    private async Task<Guild> SeedGuildAsync(ulong id = 123456789)
+    {
+        var guild = new Guild
+        {
+            Id = id,
+            Name = $"Test Guild {id}",
+            JoinedAt = DateTime.UtcNow,
+            IsActive = true
+        };
+        await _context.Guilds.AddAsync(guild);
+        await _context.SaveChangesAsync();
+        return guild;
+    }
+
+    private async Task<RatWatch> CreateRatWatchAsync(
+        ulong guildId,
+        RatWatchStatus status,
+        DateTime? createdAt = null,
+        DateTime? scheduledAt = null,
+        int guiltyVotes = 0,
+        int notGuiltyVotes = 0)
+    {
+        var watch = new RatWatch
+        {
+            Id = Guid.NewGuid(),
+            GuildId = guildId,
+            ChannelId = 111111111,
+            AccusedUserId = 222222222,
+            InitiatorUserId = 333333333,
+            OriginalMessageId = 444444444,
+            ScheduledAt = scheduledAt ?? DateTime.UtcNow.AddHours(1),
+            CreatedAt = createdAt ?? DateTime.UtcNow,
+            Status = status
+        };
+
+        if (status == RatWatchStatus.ClearedEarly)
+        {
+            watch.ClearedAt = watch.CreatedAt.AddMinutes(30);
+        }
+
+        if (status == RatWatchStatus.Voting || status == RatWatchStatus.Guilty || status == RatWatchStatus.NotGuilty)
+        {
+            watch.VotingStartedAt = watch.ScheduledAt;
+        }
+
+        if (status == RatWatchStatus.Guilty || status == RatWatchStatus.NotGuilty)
+        {
+            watch.VotingEndedAt = watch.VotingStartedAt!.Value.AddMinutes(30);
+        }
+
+        await _context.RatWatches.AddAsync(watch);
+
+        // Add votes if specified
+        if (guiltyVotes > 0 || notGuiltyVotes > 0)
+        {
+            ulong voterIdBase = 500000000;
+            for (int i = 0; i < guiltyVotes; i++)
+            {
+                await _context.RatVotes.AddAsync(new RatVote
+                {
+                    Id = Guid.NewGuid(),
+                    RatWatchId = watch.Id,
+                    VoterUserId = voterIdBase++,
+                    IsGuiltyVote = true,
+                    VotedAt = watch.VotingStartedAt!.Value.AddMinutes(5)
+                });
+            }
+
+            for (int i = 0; i < notGuiltyVotes; i++)
+            {
+                await _context.RatVotes.AddAsync(new RatVote
+                {
+                    Id = Guid.NewGuid(),
+                    RatWatchId = watch.Id,
+                    VoterUserId = voterIdBase++,
+                    IsGuiltyVote = false,
+                    VotedAt = watch.VotingStartedAt!.Value.AddMinutes(5)
+                });
+            }
+        }
+
+        await _context.SaveChangesAsync();
+        return watch;
+    }
+
+    #region GetAnalyticsSummaryAsync Tests
+
+    [Fact]
+    public async Task GetAnalyticsSummaryAsync_WithEmptyDataset_ReturnsZeros()
+    {
+        // Arrange
+        await SeedGuildAsync();
+
+        // Act
+        var result = await _repository.GetAnalyticsSummaryAsync(null, null, null);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.TotalWatches.Should().Be(0);
+        result.ActiveWatches.Should().Be(0);
+        result.GuiltyCount.Should().Be(0);
+        result.ClearedEarlyCount.Should().Be(0);
+        result.GuiltyRate.Should().Be(0);
+        result.EarlyCheckInRate.Should().Be(0);
+        result.AvgVotingParticipation.Should().Be(0);
+        result.AvgVoteMargin.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetAnalyticsSummaryAsync_CountsTotalWatches()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Pending);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Guilty, guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.ClearedEarly);
+
+        // Act
+        var result = await _repository.GetAnalyticsSummaryAsync(null, null, null);
+
+        // Assert
+        result.TotalWatches.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task GetAnalyticsSummaryAsync_CountsActiveWatches()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Pending);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Voting, guiltyVotes: 3, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Guilty, guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.ClearedEarly);
+
+        // Act
+        var result = await _repository.GetAnalyticsSummaryAsync(null, null, null);
+
+        // Assert
+        result.ActiveWatches.Should().Be(2, "Pending and Voting are active statuses");
+    }
+
+    [Fact]
+    public async Task GetAnalyticsSummaryAsync_CountsGuiltyVerdicts()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Guilty, guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Guilty, guiltyVotes: 3, notGuiltyVotes: 1);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.NotGuilty, guiltyVotes: 1, notGuiltyVotes: 4);
+
+        // Act
+        var result = await _repository.GetAnalyticsSummaryAsync(null, null, null);
+
+        // Assert
+        result.GuiltyCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetAnalyticsSummaryAsync_CountsClearedEarly()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.ClearedEarly);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.ClearedEarly);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Guilty, guiltyVotes: 5, notGuiltyVotes: 2);
+
+        // Act
+        var result = await _repository.GetAnalyticsSummaryAsync(null, null, null);
+
+        // Assert
+        result.ClearedEarlyCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetAnalyticsSummaryAsync_CalculatesGuiltyRate()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+
+        // 3 guilty, 1 not guilty, 1 cleared early = 5 completed, 3 guilty = 60%
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Guilty, guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Guilty, guiltyVotes: 3, notGuiltyVotes: 1);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Guilty, guiltyVotes: 4, notGuiltyVotes: 1);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.NotGuilty, guiltyVotes: 1, notGuiltyVotes: 4);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.ClearedEarly);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Pending); // Not completed, should not count
+
+        // Act
+        var result = await _repository.GetAnalyticsSummaryAsync(null, null, null);
+
+        // Assert
+        result.GuiltyRate.Should().BeApproximately(60.0, 0.01, "3 guilty out of 5 completed = 60%");
+    }
+
+    [Fact]
+    public async Task GetAnalyticsSummaryAsync_CalculatesEarlyCheckInRate()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+
+        // 2 cleared early, 3 guilty verdicts = 5 completed, 2 early = 40%
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.ClearedEarly);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.ClearedEarly);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Guilty, guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Guilty, guiltyVotes: 3, notGuiltyVotes: 1);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Guilty, guiltyVotes: 4, notGuiltyVotes: 1);
+
+        // Act
+        var result = await _repository.GetAnalyticsSummaryAsync(null, null, null);
+
+        // Assert
+        result.EarlyCheckInRate.Should().BeApproximately(40.0, 0.01, "2 cleared early out of 5 completed = 40%");
+    }
+
+    [Fact]
+    public async Task GetAnalyticsSummaryAsync_CalculatesAvgVotingParticipation()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+
+        // Watch 1: 7 votes (5 guilty + 2 not guilty)
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Guilty, guiltyVotes: 5, notGuiltyVotes: 2);
+        // Watch 2: 4 votes (3 guilty + 1 not guilty)
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Guilty, guiltyVotes: 3, notGuiltyVotes: 1);
+        // Watch 3: 5 votes (1 guilty + 4 not guilty)
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.NotGuilty, guiltyVotes: 1, notGuiltyVotes: 4);
+        // Cleared early - should not count
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.ClearedEarly);
+
+        // Average = (7 + 4 + 5) / 3 = 5.33
+        // Act
+        var result = await _repository.GetAnalyticsSummaryAsync(null, null, null);
+
+        // Assert
+        result.AvgVotingParticipation.Should().BeApproximately(5.33, 0.01, "average of 7, 4, and 5 votes");
+    }
+
+    [Fact]
+    public async Task GetAnalyticsSummaryAsync_CalculatesAvgVoteMargin()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+
+        // Watch 1: 5 guilty, 2 not guilty -> margin = |5-2| = 3
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Guilty, guiltyVotes: 5, notGuiltyVotes: 2);
+        // Watch 2: 3 guilty, 1 not guilty -> margin = |3-1| = 2
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Guilty, guiltyVotes: 3, notGuiltyVotes: 1);
+        // Watch 3: 1 guilty, 4 not guilty -> margin = |1-4| = 3
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.NotGuilty, guiltyVotes: 1, notGuiltyVotes: 4);
+
+        // Average margin = (3 + 2 + 3) / 3 = 2.67
+        // Act
+        var result = await _repository.GetAnalyticsSummaryAsync(null, null, null);
+
+        // Assert
+        result.AvgVoteMargin.Should().BeApproximately(2.67, 0.01, "average margin of 3, 2, and 3");
+    }
+
+    [Fact]
+    public async Task GetAnalyticsSummaryAsync_FiltersByGuildId()
+    {
+        // Arrange
+        var guild1 = await SeedGuildAsync(111111111);
+        var guild2 = await SeedGuildAsync(222222222);
+
+        await CreateRatWatchAsync(guild1.Id, RatWatchStatus.Guilty, guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild1.Id, RatWatchStatus.ClearedEarly);
+        await CreateRatWatchAsync(guild2.Id, RatWatchStatus.Guilty, guiltyVotes: 3, notGuiltyVotes: 1);
+        await CreateRatWatchAsync(guild2.Id, RatWatchStatus.Pending);
+
+        // Act - Filter by guild1
+        var result = await _repository.GetAnalyticsSummaryAsync(guild1.Id, null, null);
+
+        // Assert
+        result.TotalWatches.Should().Be(2, "only guild1 watches should be counted");
+        result.GuiltyCount.Should().Be(1);
+        result.ClearedEarlyCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetAnalyticsSummaryAsync_FiltersByDateRange()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var now = DateTime.UtcNow;
+
+        // Old watch - outside range
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Guilty, createdAt: now.AddDays(-10), guiltyVotes: 5, notGuiltyVotes: 2);
+
+        // In range
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Guilty, createdAt: now.AddDays(-3), guiltyVotes: 3, notGuiltyVotes: 1);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.ClearedEarly, createdAt: now.AddDays(-2));
+
+        // Future watch - outside range
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Pending, createdAt: now.AddDays(1));
+
+        // Act - Filter last 7 days
+        var result = await _repository.GetAnalyticsSummaryAsync(null, now.AddDays(-7), now);
+
+        // Assert
+        result.TotalWatches.Should().Be(2, "only watches within date range should be counted");
+        result.GuiltyCount.Should().Be(1);
+        result.ClearedEarlyCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetAnalyticsSummaryAsync_WithOnlyStartDate_FiltersCorrectly()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var now = DateTime.UtcNow;
+
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Guilty, createdAt: now.AddDays(-10), guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Guilty, createdAt: now.AddDays(-3), guiltyVotes: 3, notGuiltyVotes: 1);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.ClearedEarly, createdAt: now);
+
+        // Act - Only start date, no end date
+        var result = await _repository.GetAnalyticsSummaryAsync(null, now.AddDays(-5), null);
+
+        // Assert
+        result.TotalWatches.Should().Be(2, "watches after start date should be counted");
+    }
+
+    [Fact]
+    public async Task GetAnalyticsSummaryAsync_WithOnlyEndDate_FiltersCorrectly()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var now = DateTime.UtcNow;
+
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Guilty, createdAt: now.AddDays(-10), guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Guilty, createdAt: now.AddDays(-3), guiltyVotes: 3, notGuiltyVotes: 1);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.ClearedEarly, createdAt: now);
+
+        // Act - Only end date, no start date
+        var result = await _repository.GetAnalyticsSummaryAsync(null, null, now.AddDays(-5));
+
+        // Assert
+        result.TotalWatches.Should().Be(1, "only watches before end date should be counted");
+    }
+
+    [Fact]
+    public async Task GetAnalyticsSummaryAsync_HandlesZeroDivision_WhenNoCompletedWatches()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Pending);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Voting, guiltyVotes: 3, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Cancelled);
+
+        // Act
+        var result = await _repository.GetAnalyticsSummaryAsync(null, null, null);
+
+        // Assert
+        result.GuiltyRate.Should().Be(0, "no completed watches, rate should be 0");
+        result.EarlyCheckInRate.Should().Be(0, "no completed watches, rate should be 0");
+    }
+
+    [Fact]
+    public async Task GetAnalyticsSummaryAsync_HandlesZeroDivision_WhenNoVotingWatches()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.ClearedEarly);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.ClearedEarly);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Pending);
+
+        // Act
+        var result = await _repository.GetAnalyticsSummaryAsync(null, null, null);
+
+        // Assert
+        result.AvgVotingParticipation.Should().Be(0, "no voting watches, average should be 0");
+        result.AvgVoteMargin.Should().Be(0, "no voting watches, average should be 0");
+    }
+
+    #endregion
+
+    #region GetTimeSeriesAsync Tests
+
+    [Fact]
+    public async Task GetTimeSeriesAsync_WithEmptyDataset_ReturnsEmptyList()
+    {
+        // Arrange
+        await SeedGuildAsync();
+        var now = DateTime.UtcNow;
+
+        // Act
+        var result = await _repository.GetTimeSeriesAsync(null, now.AddDays(-7), now);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetTimeSeriesAsync_GroupsByDate()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var now = DateTime.UtcNow.Date; // Use .Date to normalize to midnight
+
+        // Create watches on different dates
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Guilty, createdAt: now.AddDays(-3), guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Guilty, createdAt: now.AddDays(-3).AddHours(5), guiltyVotes: 3, notGuiltyVotes: 1);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.ClearedEarly, createdAt: now.AddDays(-2));
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Pending, createdAt: now.AddDays(-1));
+
+        // Act
+        var result = await _repository.GetTimeSeriesAsync(null, now.AddDays(-7), now);
+
+        // Assert
+        var resultList = result.ToList();
+        resultList.Should().HaveCount(3, "watches on 3 different dates");
+
+        // Day -3 should have 2 watches
+        var day3Data = resultList.FirstOrDefault(r => r.Date == now.AddDays(-3));
+        day3Data.Should().NotBeNull();
+        day3Data!.TotalCount.Should().Be(2);
+        day3Data.GuiltyCount.Should().Be(2);
+        day3Data.ClearedCount.Should().Be(0);
+
+        // Day -2 should have 1 watch
+        var day2Data = resultList.FirstOrDefault(r => r.Date == now.AddDays(-2));
+        day2Data.Should().NotBeNull();
+        day2Data!.TotalCount.Should().Be(1);
+        day2Data.ClearedCount.Should().Be(1);
+
+        // Day -1 should have 1 watch
+        var day1Data = resultList.FirstOrDefault(r => r.Date == now.AddDays(-1));
+        day1Data.Should().NotBeNull();
+        day1Data!.TotalCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetTimeSeriesAsync_CountsGuiltyAndClearedSeparately()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var targetDate = DateTime.UtcNow.Date;
+
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Guilty, createdAt: targetDate, guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Guilty, createdAt: targetDate.AddHours(2), guiltyVotes: 3, notGuiltyVotes: 1);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.ClearedEarly, createdAt: targetDate.AddHours(4));
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.NotGuilty, createdAt: targetDate.AddHours(6), guiltyVotes: 1, notGuiltyVotes: 4);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Pending, createdAt: targetDate.AddHours(8));
+
+        // Act
+        var result = await _repository.GetTimeSeriesAsync(null, targetDate, targetDate.AddDays(1));
+
+        // Assert
+        var data = result.Single();
+        data.Date.Should().Be(targetDate);
+        data.TotalCount.Should().Be(5);
+        data.GuiltyCount.Should().Be(2, "only Guilty status counts");
+        data.ClearedCount.Should().Be(1, "only ClearedEarly status counts");
+    }
+
+    [Fact]
+    public async Task GetTimeSeriesAsync_OrdersByDateAscending()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var now = DateTime.UtcNow.Date;
+
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Guilty, createdAt: now.AddDays(-5), guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Guilty, createdAt: now.AddDays(-2), guiltyVotes: 3, notGuiltyVotes: 1);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.ClearedEarly, createdAt: now.AddDays(-4));
+
+        // Act
+        var result = await _repository.GetTimeSeriesAsync(null, now.AddDays(-7), now);
+
+        // Assert
+        var resultList = result.ToList();
+        resultList.Should().BeInAscendingOrder(r => r.Date);
+        resultList[0].Date.Should().Be(now.AddDays(-5));
+        resultList[1].Date.Should().Be(now.AddDays(-4));
+        resultList[2].Date.Should().Be(now.AddDays(-2));
+    }
+
+    [Fact]
+    public async Task GetTimeSeriesAsync_FiltersByGuildId()
+    {
+        // Arrange
+        var guild1 = await SeedGuildAsync(111111111);
+        var guild2 = await SeedGuildAsync(222222222);
+        var now = DateTime.UtcNow.Date;
+
+        await CreateRatWatchAsync(guild1.Id, RatWatchStatus.Guilty, createdAt: now, guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild1.Id, RatWatchStatus.ClearedEarly, createdAt: now);
+        await CreateRatWatchAsync(guild2.Id, RatWatchStatus.Guilty, createdAt: now, guiltyVotes: 3, notGuiltyVotes: 1);
+
+        // Act - Filter by guild1
+        var result = await _repository.GetTimeSeriesAsync(guild1.Id, now, now.AddDays(1));
+
+        // Assert
+        var data = result.Single();
+        data.TotalCount.Should().Be(2, "only guild1 watches should be counted");
+        data.GuiltyCount.Should().Be(1);
+        data.ClearedCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetTimeSeriesAsync_FiltersByDateRange()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var now = DateTime.UtcNow.Date;
+
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Guilty, createdAt: now.AddDays(-10), guiltyVotes: 5, notGuiltyVotes: 2);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Guilty, createdAt: now.AddDays(-3), guiltyVotes: 3, notGuiltyVotes: 1);
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.ClearedEarly, createdAt: now.AddDays(-2));
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Pending, createdAt: now.AddDays(1));
+
+        // Act - Get last 7 days
+        var result = await _repository.GetTimeSeriesAsync(null, now.AddDays(-7), now);
+
+        // Assert
+        result.Should().HaveCount(2, "only watches within date range");
+    }
+
+    #endregion
+
+    #region GetActivityHeatmapAsync Tests
+
+    [Fact]
+    public async Task GetActivityHeatmapAsync_WithEmptyDataset_ReturnsEmptyList()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var now = DateTime.UtcNow;
+
+        // Act
+        var result = await _repository.GetActivityHeatmapAsync(guild.Id, now.AddDays(-7), now);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetActivityHeatmapAsync_GroupsByDayAndHour()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var baseDate = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc); // Monday
+
+        // Create watches at different times
+        // Monday 10:00
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Pending, scheduledAt: baseDate.AddHours(10));
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Pending, scheduledAt: baseDate.AddHours(10).AddMinutes(30));
+
+        // Tuesday 14:00
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Pending, scheduledAt: baseDate.AddDays(1).AddHours(14));
+
+        // Monday 10:00 (same as first group)
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Pending, scheduledAt: baseDate.AddDays(7).AddHours(10));
+
+        // Act
+        var result = await _repository.GetActivityHeatmapAsync(guild.Id, baseDate, baseDate.AddDays(14));
+
+        // Assert
+        var resultList = result.ToList();
+        resultList.Should().HaveCount(2, "two unique day/hour combinations");
+
+        // Monday (1) at hour 10 should have 3 watches
+        var mondayData = resultList.FirstOrDefault(r => r.DayOfWeek == 1 && r.Hour == 10);
+        mondayData.Should().NotBeNull();
+        mondayData!.Count.Should().Be(3);
+
+        // Tuesday (2) at hour 14 should have 1 watch
+        var tuesdayData = resultList.FirstOrDefault(r => r.DayOfWeek == 2 && r.Hour == 14);
+        tuesdayData.Should().NotBeNull();
+        tuesdayData!.Count.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetActivityHeatmapAsync_UsesScheduledAtNotCreatedAt()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var createdDate = new DateTime(2024, 1, 1, 8, 0, 0, DateTimeKind.Utc);
+        var scheduledDate = new DateTime(2024, 1, 1, 14, 0, 0, DateTimeKind.Utc);
+
+        await CreateRatWatchAsync(
+            guild.Id,
+            RatWatchStatus.Pending,
+            createdAt: createdDate,
+            scheduledAt: scheduledDate);
+
+        // Act
+        var result = await _repository.GetActivityHeatmapAsync(guild.Id, scheduledDate.AddDays(-1), scheduledDate.AddDays(1));
+
+        // Assert
+        var data = result.Single();
+        data.Hour.Should().Be(14, "should use ScheduledAt hour, not CreatedAt hour");
+    }
+
+    [Fact]
+    public async Task GetActivityHeatmapAsync_OrdersByDayAndHour()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var baseDate = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        // Create in non-sequential order
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Pending, scheduledAt: baseDate.AddDays(3).AddHours(15)); // Thursday 15:00
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Pending, scheduledAt: baseDate.AddHours(8)); // Monday 8:00
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Pending, scheduledAt: baseDate.AddHours(14)); // Monday 14:00
+
+        // Act
+        var result = await _repository.GetActivityHeatmapAsync(guild.Id, baseDate, baseDate.AddDays(7));
+
+        // Assert
+        var resultList = result.ToList();
+        resultList.Should().HaveCount(3);
+
+        // Should be ordered by day, then hour
+        resultList[0].DayOfWeek.Should().Be(1); // Monday
+        resultList[0].Hour.Should().Be(8);
+
+        resultList[1].DayOfWeek.Should().Be(1); // Monday
+        resultList[1].Hour.Should().Be(14);
+
+        resultList[2].DayOfWeek.Should().Be(4); // Thursday
+        resultList[2].Hour.Should().Be(15);
+    }
+
+    [Fact]
+    public async Task GetActivityHeatmapAsync_FiltersByGuildId()
+    {
+        // Arrange
+        var guild1 = await SeedGuildAsync(111111111);
+        var guild2 = await SeedGuildAsync(222222222);
+        var baseDate = new DateTime(2024, 1, 1, 10, 0, 0, DateTimeKind.Utc);
+
+        await CreateRatWatchAsync(guild1.Id, RatWatchStatus.Pending, scheduledAt: baseDate);
+        await CreateRatWatchAsync(guild1.Id, RatWatchStatus.Pending, scheduledAt: baseDate.AddMinutes(30));
+        await CreateRatWatchAsync(guild2.Id, RatWatchStatus.Pending, scheduledAt: baseDate);
+
+        // Act - Filter by guild1
+        var result = await _repository.GetActivityHeatmapAsync(guild1.Id, baseDate.AddDays(-1), baseDate.AddDays(1));
+
+        // Assert
+        var data = result.Single();
+        data.Count.Should().Be(2, "only guild1 watches should be counted");
+    }
+
+    [Fact]
+    public async Task GetActivityHeatmapAsync_FiltersByDateRange()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+        var now = DateTime.UtcNow;
+
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Pending, scheduledAt: now.AddDays(-10));
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Pending, scheduledAt: now.AddDays(-3));
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Pending, scheduledAt: now.AddDays(-2));
+        await CreateRatWatchAsync(guild.Id, RatWatchStatus.Pending, scheduledAt: now.AddDays(1));
+
+        // Act - Get last 7 days
+        var result = await _repository.GetActivityHeatmapAsync(guild.Id, now.AddDays(-7), now);
+
+        // Assert
+        result.Should().HaveCount(2, "only watches within date range");
+    }
+
+    [Fact]
+    public async Task GetActivityHeatmapAsync_HandlesDayOfWeekValues()
+    {
+        // Arrange
+        var guild = await SeedGuildAsync();
+
+        // Create watches for each day of the week
+        var sunday = new DateTime(2024, 1, 7, 10, 0, 0, DateTimeKind.Utc); // Sunday
+
+        for (int i = 0; i < 7; i++)
+        {
+            await CreateRatWatchAsync(guild.Id, RatWatchStatus.Pending, scheduledAt: sunday.AddDays(i).AddHours(10));
+        }
+
+        // Act
+        var result = await _repository.GetActivityHeatmapAsync(guild.Id, sunday, sunday.AddDays(7));
+
+        // Assert
+        var resultList = result.ToList();
+        resultList.Should().HaveCount(7, "one entry for each day of the week");
+
+        // Verify day of week values (0=Sunday through 6=Saturday)
+        resultList.Should().Contain(r => r.DayOfWeek == 0); // Sunday
+        resultList.Should().Contain(r => r.DayOfWeek == 1); // Monday
+        resultList.Should().Contain(r => r.DayOfWeek == 2); // Tuesday
+        resultList.Should().Contain(r => r.DayOfWeek == 3); // Wednesday
+        resultList.Should().Contain(r => r.DayOfWeek == 4); // Thursday
+        resultList.Should().Contain(r => r.DayOfWeek == 5); // Friday
+        resultList.Should().Contain(r => r.DayOfWeek == 6); // Saturday
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
Implements the data layer for Rat Watch Analytics by creating DTOs and repository methods for analytics queries. This is the foundation for the analytics UI pages (issues #422-426).

## Changes

### DTOs Created (`RatWatchAnalyticsDtos.cs`)
- `RatWatchAnalyticsSummaryDto` - Dashboard summary statistics (total watches, guilty count, vote counts, etc.)
- `RatWatchTimeSeriesDto` - Time series data for trend charts (watches per day, guilty verdicts over time)
- `RatWatchUserMetricsDto` - User-level metrics for leaderboards (watches, guilty/innocent counts, streaks)
- `RatWatchFunStatsDto` - Container for fun statistics (streaks, highlights, fastest trials)
- `UserStreakDto` - User streak information (current/longest innocent/guilty streaks)
- `IncidentHighlightDto` - Highlight of specific incidents (shortest/longest trials, most votes)
- `ActivityHeatmapDto` - Activity heatmap data by day/hour

### Repository Methods Added

**IRatWatchRepository / RatWatchRepository:**
- `GetAnalyticsSummaryAsync(guildId, startDate, endDate)` - Gets summary statistics for date range
- `GetTimeSeriesAsync(guildId, startDate, endDate, interval)` - Gets time series data for charts
- `GetActivityHeatmapAsync(guildId, startDate, endDate)` - Gets activity heatmap by day/hour

**IRatRecordRepository / RatRecordRepository:**
- `GetUserMetricsAsync(guildId, startDate, endDate)` - Gets user metrics for leaderboards
- `GetFunStatsAsync(guildId)` - Gets fun stats for public leaderboard

### Tests
- 54 unit tests covering all analytics methods
- Tests cover edge cases: empty data, single records, date filtering, tie breaking
- All tests pass

## Testing

```bash
# Run all analytics tests
dotnet test --filter "FullyQualifiedName~RatWatchRepositoryAnalyticsTests"
dotnet test --filter "FullyQualifiedName~RatRecordRepositoryAnalyticsTests"

# Run specific test method
dotnet test --filter "FullyQualifiedName~RatWatchRepositoryAnalyticsTests.GetAnalyticsSummaryAsync_ReturnsCorrectSummary"
```

## Next Steps
- Issue #422: Add summary stats to Rat Watch settings page
- Issue #423: Create Guild Rat Watch Analytics page
- Issue #424: Create Rat Watch Incidents browser page
- Issue #425: Create Global Rat Watch Analytics page
- Issue #426: Create Public Rat Watch Leaderboard page

## Related Issues
- Closes #420
- Closes #421
- Part of #418 (Rat Watch Enhancements epic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)