### PR TITLE
[Feature] Add summary stats to Rat Watch settings page

### DIFF
--- a/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Index.cshtml
@@ -162,6 +162,121 @@
         </form>
     </div>
 
+    <!-- Navigation Tabs -->
+    <div class="flex items-center gap-1 mb-6 border-b border-border-primary">
+        <a asp-page="Index" asp-route-guildId="@Model.ViewModel.GuildId"
+           class="px-4 py-3 text-sm font-medium border-b-2 border-accent-orange text-text-primary">
+            Settings
+        </a>
+        <a asp-page="Analytics" asp-route-guildId="@Model.ViewModel.GuildId"
+           class="px-4 py-3 text-sm font-medium border-b-2 border-transparent text-text-secondary hover:text-text-primary transition-colors">
+            Analytics
+        </a>
+        <a asp-page="Incidents" asp-route-guildId="@Model.ViewModel.GuildId"
+           class="px-4 py-3 text-sm font-medium border-b-2 border-transparent text-text-secondary hover:text-text-primary transition-colors">
+            Incidents
+        </a>
+    </div>
+
+    <!-- Summary Stats Cards -->
+    @if (Model.ViewModel.AnalyticsSummary != null)
+    {
+        <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4 mb-6">
+            <!-- Total Watches -->
+            <div class="bg-bg-secondary border border-border-primary rounded-lg p-5">
+                <div class="flex items-center justify-between">
+                    <div>
+                        <p class="text-sm font-medium text-text-secondary">Total Watches</p>
+                        <p class="mt-2 text-3xl font-bold text-text-primary">@Model.ViewModel.AnalyticsSummary.TotalWatches.ToString("N0")</p>
+                        <p class="mt-1 text-xs text-text-tertiary">All-time</p>
+                    </div>
+                    <div class="p-3 bg-accent-blue/10 rounded-lg">
+                        <!-- Eye Icon -->
+                        <svg class="w-6 h-6 text-accent-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                        </svg>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Active Watches -->
+            <div class="bg-bg-secondary border border-border-primary rounded-lg p-5">
+                <div class="flex items-center justify-between">
+                    <div>
+                        <p class="text-sm font-medium text-text-secondary">Active Watches</p>
+                        <p class="mt-2 text-3xl font-bold text-warning">@Model.ViewModel.AnalyticsSummary.ActiveWatches.ToString("N0")</p>
+                        <p class="mt-1 text-xs text-text-tertiary">Pending + Voting</p>
+                    </div>
+                    <div class="p-3 bg-warning/10 rounded-lg">
+                        <!-- Clock Icon -->
+                        <svg class="w-6 h-6 text-warning" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        </svg>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Guilty Rate -->
+            <div class="bg-bg-secondary border border-border-primary rounded-lg p-5">
+                <div class="flex items-center justify-between">
+                    <div>
+                        <p class="text-sm font-medium text-text-secondary">Guilty Rate</p>
+                        @{
+                            var guiltyRate = Model.ViewModel.AnalyticsSummary.GuiltyRate;
+                            var guiltyRateColor = guiltyRate < 50 ? "text-success" : guiltyRate <= 80 ? "text-warning" : "text-error";
+                            var guiltyRateIconBg = guiltyRate < 50 ? "bg-success/10" : guiltyRate <= 80 ? "bg-warning/10" : "bg-error/10";
+                            var guiltyRateIconColor = guiltyRate < 50 ? "text-success" : guiltyRate <= 80 ? "text-warning" : "text-error";
+                        }
+                        <p class="mt-2 text-3xl font-bold @guiltyRateColor">@guiltyRate.ToString("F0")%</p>
+                        <p class="mt-1 text-xs text-text-tertiary">@Model.ViewModel.AnalyticsSummary.GuiltyCount guilty verdicts</p>
+                    </div>
+                    <div class="p-3 @guiltyRateIconBg rounded-lg">
+                        <!-- Scale Icon -->
+                        <svg class="w-6 h-6 @guiltyRateIconColor" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3" />
+                        </svg>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Early Check-in Rate -->
+            <div class="bg-bg-secondary border border-border-primary rounded-lg p-5">
+                <div class="flex items-center justify-between">
+                    <div>
+                        <p class="text-sm font-medium text-text-secondary">Early Check-in Rate</p>
+                        @{
+                            var checkInRate = Model.ViewModel.AnalyticsSummary.EarlyCheckInRate;
+                            var checkInRateColor = checkInRate > 80 ? "text-success" : checkInRate >= 50 ? "text-warning" : "text-error";
+                            var checkInRateIconBg = checkInRate > 80 ? "bg-success/10" : checkInRate >= 50 ? "bg-warning/10" : "bg-error/10";
+                            var checkInRateIconColor = checkInRate > 80 ? "text-success" : checkInRate >= 50 ? "text-warning" : "text-error";
+                        }
+                        <p class="mt-2 text-3xl font-bold @checkInRateColor">@checkInRate.ToString("F0")%</p>
+                        <p class="mt-1 text-xs text-text-tertiary">@Model.ViewModel.AnalyticsSummary.ClearedEarlyCount cleared early</p>
+                    </div>
+                    <div class="p-3 @checkInRateIconBg rounded-lg">
+                        <!-- Check Circle Icon -->
+                        <svg class="w-6 h-6 @checkInRateIconColor" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        </svg>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- View Full Analytics Button -->
+        <div class="mb-6 text-center">
+            <a asp-page="Analytics" asp-route-guildId="@Model.ViewModel.GuildId"
+               class="inline-flex items-center gap-2 px-4 py-2 bg-accent-orange hover:bg-accent-orange-hover text-white font-medium text-sm rounded-lg transition-colors">
+                <!-- Chart Bar Icon -->
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+                </svg>
+                View Full Analytics
+            </a>
+        </div>
+    }
+
     <!-- Stats and Leaderboard Row -->
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
         <!-- Stats Card -->

--- a/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Index.cshtml.cs
@@ -15,15 +15,18 @@ public class IndexModel : PageModel
 {
     private readonly IRatWatchService _ratWatchService;
     private readonly IGuildService _guildService;
+    private readonly IRatWatchRepository _ratWatchRepository;
     private readonly ILogger<IndexModel> _logger;
 
     public IndexModel(
         IRatWatchService ratWatchService,
         IGuildService guildService,
+        IRatWatchRepository ratWatchRepository,
         ILogger<IndexModel> logger)
     {
         _ratWatchService = ratWatchService;
         _guildService = guildService;
+        _ratWatchRepository = ratWatchRepository;
         _logger = logger;
     }
 
@@ -86,6 +89,13 @@ public class IndexModel : PageModel
         // Get leaderboard
         var leaderboard = await _ratWatchService.GetLeaderboardAsync(guildId, 10, cancellationToken);
 
+        // Get analytics summary (all-time stats for the guild)
+        var analyticsSummary = await _ratWatchRepository.GetAnalyticsSummaryAsync(
+            guildId,
+            null,
+            null,
+            cancellationToken);
+
         _logger.LogDebug("Retrieved {Count} watches for guild {GuildId} (page {Page} of {TotalPages})",
             watches.Count(), guildId, page, (int)Math.Ceiling((double)totalCount / pageSize));
 
@@ -99,7 +109,8 @@ public class IndexModel : PageModel
             totalCount,
             leaderboard,
             page,
-            pageSize);
+            pageSize,
+            analyticsSummary);
 
         return Page();
     }

--- a/src/DiscordBot.Bot/ViewModels/Pages/RatWatchIndexViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Pages/RatWatchIndexViewModel.cs
@@ -100,6 +100,11 @@ public record RatWatchIndexViewModel
     public int CompletedCount => Watches.Count(w => w.Status == RatWatchStatus.Guilty || w.Status == RatWatchStatus.NotGuilty);
 
     /// <summary>
+    /// Gets the analytics summary for the guild.
+    /// </summary>
+    public RatWatchAnalyticsSummaryDto? AnalyticsSummary { get; init; }
+
+    /// <summary>
     /// Creates a RatWatchIndexViewModel from service data.
     /// </summary>
     public static RatWatchIndexViewModel Create(
@@ -111,7 +116,8 @@ public record RatWatchIndexViewModel
         int totalWatches,
         IEnumerable<RatLeaderboardEntryDto> leaderboard,
         int page,
-        int pageSize)
+        int pageSize,
+        RatWatchAnalyticsSummaryDto? analyticsSummary = null)
     {
         var votingDurationMinutes = settings.VotingDurationMinutes;
         return new RatWatchIndexViewModel
@@ -127,7 +133,8 @@ public record RatWatchIndexViewModel
             TotalWatches = totalWatches,
             Leaderboard = leaderboard.Select(RatLeaderboardEntryViewModel.FromDto).ToList(),
             CurrentPage = page,
-            PageSize = pageSize
+            PageSize = pageSize,
+            AnalyticsSummary = analyticsSummary
         };
     }
 }


### PR DESCRIPTION
## Summary
- Adds 4-column summary stats grid to Rat Watch settings page showing Total Watches, Active Watches, Guilty Rate, and Early Check-in Rate
- Adds navigation tabs for Settings (current), Analytics, and Incidents pages
- Implements color-coded rate indicators (green/yellow/red thresholds)
- Adds "View Full Analytics" button linking to analytics page

## Changes
- **RatWatchIndexViewModel.cs**: Added `AnalyticsSummary` property to hold analytics data
- **Index.cshtml.cs**: Inject `IRatWatchRepository` and call `GetAnalyticsSummaryAsync()` in `OnGetAsync()`
- **Index.cshtml**: Added navigation tabs and summary stats cards with responsive grid layout

## Test plan
- [ ] Navigate to `/Guilds/RatWatch/{guildId}` and verify stats cards display correctly
- [ ] Verify Total Watches shows all-time count
- [ ] Verify Active Watches shows Pending + Voting count
- [ ] Verify Guilty Rate shows percentage with correct color coding (red > 80%, yellow 50-80%, green < 50%)
- [ ] Verify Early Check-in Rate shows percentage with correct color coding (green > 80%, yellow 50-80%, red < 50%)
- [ ] Verify "View Full Analytics" button links correctly
- [ ] Verify navigation tabs are present (Analytics/Incidents links will 404 until those pages are created)
- [ ] Verify responsive layout works on mobile (1 column) and desktop (4 columns)

Closes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)