### PR TITLE
[Feature] Create Guild Rat Watch Analytics page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,7 @@ Located in `src/DiscordBot.Bot/Pages/`:
 | Scheduled Message Create | `/Guilds/ScheduledMessages/Create/{guildId:long}` | New scheduled message |
 | Scheduled Message Edit | `/Guilds/ScheduledMessages/Edit/{guildId:long}/{id:guid}` | Edit scheduled message |
 | Rat Watch | `/Guilds/RatWatch/{guildId:long}` | Rat Watch management |
+| Rat Watch Analytics | `/Guilds/RatWatch/{guildId:long}/Analytics` | Rat Watch analytics and metrics |
 | Users | `/Admin/Users` | User management (SuperAdmin) |
 | User Details | `/Admin/Users/Details?id={id}` | User profile and roles |
 | User Create | `/Admin/Users/Create` | Create new user |

--- a/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Analytics.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Analytics.cshtml
@@ -1,0 +1,768 @@
+@page "{guildId:long}"
+@model DiscordBot.Bot.Pages.Guilds.RatWatch.AnalyticsModel
+@using DiscordBot.Bot.ViewModels.Components
+@{
+    ViewData["Title"] = $"Rat Watch Analytics - {Model.ViewModel.GuildName}";
+}
+
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <!-- Breadcrumb Navigation -->
+    <nav aria-label="Breadcrumb" class="mb-6">
+        <ol class="flex items-center gap-2 text-sm flex-wrap">
+            <li>
+                <a asp-page="/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Dashboard</a>
+            </li>
+            <li class="text-text-tertiary" aria-hidden="true">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                </svg>
+            </li>
+            <li>
+                <a asp-page="/Guilds/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Servers</a>
+            </li>
+            <li class="text-text-tertiary" aria-hidden="true">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                </svg>
+            </li>
+            <li>
+                <a asp-page="/Guilds/Details" asp-route-id="@Model.ViewModel.GuildId" class="text-text-secondary hover:text-accent-blue transition-colors">@Model.ViewModel.GuildName</a>
+            </li>
+            <li class="text-text-tertiary" aria-hidden="true">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                </svg>
+            </li>
+            <li>
+                <a asp-page="/Guilds/RatWatch/Index" asp-route-guildId="@Model.ViewModel.GuildId" class="text-text-secondary hover:text-accent-blue transition-colors">Rat Watch</a>
+            </li>
+            <li class="text-text-tertiary" aria-hidden="true">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                </svg>
+            </li>
+            <li>
+                <span class="text-text-primary font-medium" aria-current="page">Analytics</span>
+            </li>
+        </ol>
+    </nav>
+
+    <!-- Page Header -->
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+        <div>
+            <div class="flex items-center gap-3 mb-1">
+                <h1 class="text-2xl lg:text-3xl font-bold text-text-primary">Rat Watch Analytics</h1>
+                @{
+                    var guildBadge = new BadgeViewModel {
+                        Text = Model.ViewModel.GuildName,
+                        Variant = BadgeVariant.Orange,
+                        Size = BadgeSize.Medium
+                    };
+                }
+                <partial name="Shared/Components/_Badge" model="guildBadge" />
+            </div>
+            <p class="text-text-secondary">Accountability metrics and trends for your server</p>
+        </div>
+        <div class="flex items-center gap-3">
+            <a asp-page="/Guilds/RatWatch/Index" asp-route-guildId="@Model.ViewModel.GuildId" class="btn btn-secondary">
+                <svg class="w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                </svg>
+                Back to Settings
+            </a>
+        </div>
+    </div>
+
+    <!-- Display any errors -->
+    @if (TempData["ErrorMessage"] != null)
+    {
+        <div class="mb-6">
+            @{
+                var errorAlert = new AlertViewModel {
+                    Variant = AlertVariant.Error,
+                    Title = "Error",
+                    Message = TempData["ErrorMessage"]!.ToString()!,
+                    ShowIcon = true
+                };
+            }
+            <partial name="Shared/Components/_Alert" model="errorAlert" />
+        </div>
+    }
+
+    <!-- Filter Panel -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg mb-6">
+        <button type="button"
+                id="filterToggle"
+                class="w-full flex items-center justify-between px-5 py-4 text-left"
+                aria-expanded="true"
+                aria-controls="filterContent"
+                onclick="toggleFilterPanel()">
+            <div class="flex items-center gap-3">
+                <svg class="w-5 h-5 text-text-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
+                </svg>
+                <span class="text-lg font-semibold text-text-primary">Filters</span>
+                @if (Model.StartDate.HasValue || Model.EndDate.HasValue)
+                {
+                    <partial name="Shared/Components/_Badge" model="@(new BadgeViewModel {
+                        Text = "Active",
+                        Variant = BadgeVariant.Orange,
+                        Size = BadgeSize.Small
+                    })" />
+                }
+            </div>
+            <svg id="filterChevron" class="w-5 h-5 text-text-secondary transition-transform duration-200" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            </svg>
+        </button>
+
+        <div id="filterContent" class="overflow-hidden transition-all duration-300 max-h-[1000px]">
+            <div class="border-t border-border-primary p-5">
+                <form method="get" id="filterForm">
+                    <!-- Quick Date Presets -->
+                    <div class="mb-4">
+                        <label class="block text-sm font-medium text-text-primary mb-2">Quick Date Range</label>
+                        @{
+                            var today = DateTime.UtcNow.Date;
+                            var isToday = Model.StartDate.HasValue && Model.EndDate.HasValue &&
+                                         Model.StartDate.Value.Date == today && Model.EndDate.Value.Date == today;
+                            var is7Days = Model.StartDate.HasValue && Model.EndDate.HasValue &&
+                                         Model.StartDate.Value.Date == today.AddDays(-7) && Model.EndDate.Value.Date == today;
+                            var is30Days = Model.StartDate.HasValue && Model.EndDate.HasValue &&
+                                          Model.StartDate.Value.Date == today.AddDays(-30) && Model.EndDate.Value.Date == today;
+
+                            string GetPresetClass(bool isActive) => isActive
+                                ? "px-3 py-1.5 text-xs font-medium bg-accent-orange text-white border border-accent-orange rounded-md hover:bg-accent-orange-hover transition-colors"
+                                : "px-3 py-1.5 text-xs font-medium bg-bg-tertiary text-text-secondary border border-border-primary rounded-md hover:bg-bg-hover transition-colors";
+                        }
+                        <div class="flex flex-wrap gap-2">
+                            <button type="button" onclick="setDatePreset('today')" class="@GetPresetClass(isToday)">
+                                Today
+                            </button>
+                            <button type="button" onclick="setDatePreset('7days')" class="@GetPresetClass(is7Days)">
+                                Last 7 Days
+                            </button>
+                            <button type="button" onclick="setDatePreset('30days')" class="@GetPresetClass(is30Days)">
+                                Last 30 Days
+                            </button>
+                        </div>
+                    </div>
+
+                    <!-- Filter Grid -->
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        <!-- Start Date -->
+                        <div>
+                            <label for="StartDate" class="block text-sm font-medium text-text-primary mb-1">Start Date</label>
+                            <input type="date"
+                                   id="StartDate"
+                                   name="StartDate"
+                                   value="@Model.StartDate?.ToString("yyyy-MM-dd")"
+                                   class="w-full px-3 py-2 text-sm bg-bg-primary border border-border-primary rounded-lg text-text-primary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors" />
+                        </div>
+
+                        <!-- End Date -->
+                        <div>
+                            <label for="EndDate" class="block text-sm font-medium text-text-primary mb-1">End Date</label>
+                            <input type="date"
+                                   id="EndDate"
+                                   name="EndDate"
+                                   value="@Model.EndDate?.ToString("yyyy-MM-dd")"
+                                   class="w-full px-3 py-2 text-sm bg-bg-primary border border-border-primary rounded-lg text-text-primary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors" />
+                        </div>
+                    </div>
+
+                    <!-- Filter Actions -->
+                    <div class="flex items-center gap-3 mt-6 pt-4 border-t border-border-secondary">
+                        <button type="submit" class="btn btn-primary">
+                            <svg class="w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
+                            </svg>
+                            Apply Filters
+                        </button>
+                        @if (Model.StartDate.HasValue || Model.EndDate.HasValue)
+                        {
+                            <a asp-page="Analytics" asp-route-guildId="@Model.ViewModel.GuildId" class="btn btn-secondary">
+                                <svg class="w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                                </svg>
+                                Clear Filters
+                            </a>
+                        }
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <!-- Summary Stats Row -->
+    <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4 lg:gap-6 mb-8">
+        <!-- Total Watches -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-5">
+            <div class="flex items-center justify-between">
+                <div>
+                    <p class="text-sm font-medium text-text-secondary">Total Watches</p>
+                    <p class="mt-2 text-3xl font-bold text-text-primary">@Model.ViewModel.Summary.TotalWatches.ToString("N0")</p>
+                    <p class="mt-1 text-xs text-text-tertiary">@Model.ViewModel.Summary.ActiveWatches active</p>
+                </div>
+                <div class="p-3 bg-accent-blue/10 rounded-lg">
+                    <svg class="w-6 h-6 text-accent-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                    </svg>
+                </div>
+            </div>
+        </div>
+
+        <!-- Guilty Rate -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-5">
+            <div class="flex items-center justify-between">
+                <div>
+                    <p class="text-sm font-medium text-text-secondary">Guilty Rate</p>
+                    <p class="mt-2 text-3xl font-bold @(Model.ViewModel.Summary.GuiltyRate >= 70 ? "text-error" : Model.ViewModel.Summary.GuiltyRate >= 50 ? "text-warning" : "text-success")">
+                        @Model.ViewModel.Summary.GuiltyRate.ToString("F0")%
+                    </p>
+                    <p class="mt-1 text-xs text-text-tertiary">@Model.ViewModel.Summary.GuiltyCount guilty verdicts</p>
+                </div>
+                <div class="p-3 @(Model.ViewModel.Summary.GuiltyRate >= 70 ? "bg-error/10" : Model.ViewModel.Summary.GuiltyRate >= 50 ? "bg-warning/10" : "bg-success/10") rounded-lg">
+                    <svg class="w-6 h-6 @(Model.ViewModel.Summary.GuiltyRate >= 70 ? "text-error" : Model.ViewModel.Summary.GuiltyRate >= 50 ? "text-warning" : "text-success")" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3" />
+                    </svg>
+                </div>
+            </div>
+        </div>
+
+        <!-- Check-in Rate -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-5">
+            <div class="flex items-center justify-between">
+                <div>
+                    <p class="text-sm font-medium text-text-secondary">Check-in Rate</p>
+                    <p class="mt-2 text-3xl font-bold text-success">@Model.ViewModel.Summary.EarlyCheckInRate.ToString("F0")%</p>
+                    <p class="mt-1 text-xs text-text-tertiary">@Model.ViewModel.Summary.ClearedEarlyCount cleared early</p>
+                </div>
+                <div class="p-3 bg-success/10 rounded-lg">
+                    <svg class="w-6 h-6 text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                </div>
+            </div>
+        </div>
+
+        <!-- Avg Votes per Watch -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-5">
+            <div class="flex items-center justify-between">
+                <div>
+                    <p class="text-sm font-medium text-text-secondary">Avg Votes per Watch</p>
+                    <p class="mt-2 text-3xl font-bold text-warning">@Model.ViewModel.Summary.AvgVotingParticipation.ToString("F1")</p>
+                    <p class="mt-1 text-xs text-text-tertiary">Active community</p>
+                </div>
+                <div class="p-3 bg-warning/10 rounded-lg">
+                    <svg class="w-6 h-6 text-warning" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 11.5V14m0-2.5v-6a1.5 1.5 0 113 0m-3 6a1.5 1.5 0 00-3 0v2a7.5 7.5 0 0015 0v-5a1.5 1.5 0 00-3 0m-6-3V11m0-5.5v-1a1.5 1.5 0 013 0v1m0 0V11m0-5.5a1.5 1.5 0 013 0v3m0 0V11" />
+                    </svg>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Charts Grid -->
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 lg:gap-6 mb-8">
+        <!-- Watches Over Time Chart -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden">
+            <div class="px-5 py-4 border-b border-border-primary">
+                <div class="flex items-center gap-3">
+                    <div class="p-2 bg-accent-orange/10 rounded-lg">
+                        <svg class="w-5 h-5 text-accent-orange" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 12l3-3 3 3 4-4M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z" />
+                        </svg>
+                    </div>
+                    <h2 class="text-lg font-semibold text-text-primary">Watches Over Time</h2>
+                </div>
+            </div>
+            <div class="p-5">
+                @if (Model.ViewModel.TimeSeries.Any())
+                {
+                    <div style="position: relative; min-height: 300px; max-height: 400px;">
+                        <canvas id="watchesOverTimeChart" aria-label="Line chart showing Rat Watches over time" role="img"></canvas>
+                    </div>
+                }
+                else
+                {
+                    <div class="py-12 text-center">
+                        <svg class="w-12 h-12 mx-auto text-text-tertiary mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 12l3-3 3 3 4-4M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z" />
+                        </svg>
+                        <p class="text-text-secondary font-medium">No watch data available</p>
+                        <p class="text-sm text-text-tertiary mt-1">Data will appear here once watches are created</p>
+                    </div>
+                }
+            </div>
+        </div>
+
+        <!-- Outcome Distribution Chart -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden">
+            <div class="px-5 py-4 border-b border-border-primary">
+                <div class="flex items-center gap-3">
+                    <div class="p-2 bg-accent-blue/10 rounded-lg">
+                        <svg class="w-5 h-5 text-accent-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+                        </svg>
+                    </div>
+                    <h2 class="text-lg font-semibold text-text-primary">Outcome Distribution</h2>
+                </div>
+            </div>
+            <div class="p-5">
+                @if (Model.ViewModel.Summary.TotalWatches > 0)
+                {
+                    <div style="position: relative; min-height: 300px; max-height: 400px;">
+                        <canvas id="outcomeDistributionChart" aria-label="Doughnut chart showing outcome distribution" role="img"></canvas>
+                    </div>
+                }
+                else
+                {
+                    <div class="py-12 text-center">
+                        <svg class="w-12 h-12 mx-auto text-text-tertiary mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+                        </svg>
+                        <p class="text-text-secondary font-medium">No data available</p>
+                        <p class="text-sm text-text-tertiary mt-1">Outcomes will appear here once watches complete</p>
+                    </div>
+                }
+            </div>
+        </div>
+
+        <!-- Activity Heatmap -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden">
+            <div class="px-5 py-4 border-b border-border-primary">
+                <div class="flex items-center justify-between">
+                    <div class="flex items-center gap-3">
+                        <div class="p-2 bg-success/10 rounded-lg">
+                            <svg class="w-5 h-5 text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                            </svg>
+                        </div>
+                        <h2 class="text-lg font-semibold text-text-primary">Activity Heatmap</h2>
+                    </div>
+                    <span class="text-xs text-text-tertiary">When watches are scheduled</span>
+                </div>
+            </div>
+            <div class="p-5">
+                @if (Model.ViewModel.Heatmap.Any())
+                {
+                    <div id="activityHeatmap" class="overflow-x-auto">
+                        <!-- Heatmap will be rendered by JavaScript -->
+                    </div>
+                }
+                else
+                {
+                    <div class="py-12 text-center">
+                        <svg class="w-12 h-12 mx-auto text-text-tertiary mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        </svg>
+                        <p class="text-text-secondary font-medium">No activity data available</p>
+                        <p class="text-sm text-text-tertiary mt-1">Activity patterns will appear here</p>
+                    </div>
+                }
+            </div>
+        </div>
+
+        <!-- Top Watched Users Chart -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden">
+            <div class="px-5 py-4 border-b border-border-primary">
+                <div class="flex items-center gap-3">
+                    <div class="p-2 bg-warning/10 rounded-lg">
+                        <svg class="w-5 h-5 text-warning" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                        </svg>
+                    </div>
+                    <h2 class="text-lg font-semibold text-text-primary">Top Watched Users</h2>
+                </div>
+            </div>
+            <div class="p-5">
+                @if (Model.ViewModel.MostWatched.Any())
+                {
+                    <div style="position: relative; min-height: 300px; max-height: 400px;">
+                        <canvas id="topUsersChart" aria-label="Horizontal bar chart showing top watched users" role="img"></canvas>
+                    </div>
+                }
+                else
+                {
+                    <div class="py-12 text-center">
+                        <svg class="w-12 h-12 mx-auto text-text-tertiary mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                        </svg>
+                        <p class="text-text-secondary font-medium">No user data available</p>
+                        <p class="text-sm text-text-tertiary mt-1">User leaderboard will appear here</p>
+                    </div>
+                }
+            </div>
+        </div>
+    </div>
+
+    <!-- Behavioral Insights Section -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg mb-8">
+        <div class="px-5 py-4 border-b border-border-primary">
+            <h2 class="text-lg font-semibold text-text-primary">Behavioral Insights</h2>
+        </div>
+        <div class="p-5">
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+                <!-- Early Check-in Rate -->
+                <div class="bg-bg-primary border border-border-secondary rounded-lg p-4">
+                    <div class="flex items-center gap-3 mb-2">
+                        <div class="p-2 bg-success/10 rounded-lg">
+                            <svg class="w-5 h-5 text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                            </svg>
+                        </div>
+                        <span class="text-sm font-medium text-text-secondary">Early Check-in Rate</span>
+                    </div>
+                    <p class="text-2xl font-bold text-text-primary">@Model.ViewModel.Summary.EarlyCheckInRate.ToString("F0")%</p>
+                    <p class="text-xs text-text-tertiary mt-1">Cleared before voting starts</p>
+                </div>
+
+                <!-- Avg Voting Participation -->
+                <div class="bg-bg-primary border border-border-secondary rounded-lg p-4">
+                    <div class="flex items-center gap-3 mb-2">
+                        <div class="p-2 bg-accent-blue/10 rounded-lg">
+                            <svg class="w-5 h-5 text-accent-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+                            </svg>
+                        </div>
+                        <span class="text-sm font-medium text-text-secondary">Avg Voting Participation</span>
+                    </div>
+                    <p class="text-2xl font-bold text-text-primary">@Model.ViewModel.Summary.AvgVotingParticipation.ToString("F1")</p>
+                    <p class="text-xs text-text-tertiary mt-1">Voters per watch</p>
+                </div>
+
+                <!-- Avg Vote Margin -->
+                <div class="bg-bg-primary border border-border-secondary rounded-lg p-4">
+                    <div class="flex items-center gap-3 mb-2">
+                        <div class="p-2 bg-warning/10 rounded-lg">
+                            <svg class="w-5 h-5 text-warning" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
+                            </svg>
+                        </div>
+                        <span class="text-sm font-medium text-text-secondary">Avg Vote Margin</span>
+                    </div>
+                    <p class="text-2xl font-bold text-text-primary">@Model.ViewModel.Summary.AvgVoteMargin.ToString("F1")</p>
+                    <p class="text-xs text-text-tertiary mt-1">Votes difference</p>
+                </div>
+
+                <!-- Guilty Rate (duplicate for 4-column layout) -->
+                <div class="bg-bg-primary border border-border-secondary rounded-lg p-4">
+                    <div class="flex items-center gap-3 mb-2">
+                        <div class="p-2 bg-error/10 rounded-lg">
+                            <svg class="w-5 h-5 text-error" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                            </svg>
+                        </div>
+                        <span class="text-sm font-medium text-text-secondary">Community Accountability</span>
+                    </div>
+                    <p class="text-2xl font-bold text-text-primary">@Model.ViewModel.Summary.GuiltyRate.ToString("F0")%</p>
+                    <p class="text-xs text-text-tertiary mt-1">Watches result in action</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- User Leaderboards with Tabs -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden">
+        <div class="flex items-center gap-1 px-5 py-4 border-b border-border-primary overflow-x-auto">
+            <button onclick="switchTab('mostWatched')"
+                    class="tab-btn px-4 py-2 text-sm font-medium text-text-secondary border-b-2 border-transparent hover:text-text-primary transition-colors active"
+                    data-tab="mostWatched">
+                Most Watched
+            </button>
+            <button onclick="switchTab('topAccusers')"
+                    class="tab-btn px-4 py-2 text-sm font-medium text-text-secondary border-b-2 border-transparent hover:text-text-primary transition-colors"
+                    data-tab="topAccusers">
+                Top Accusers
+            </button>
+            <button onclick="switchTab('biggestRats')"
+                    class="tab-btn px-4 py-2 text-sm font-medium text-text-secondary border-b-2 border-transparent hover:text-text-primary transition-colors"
+                    data-tab="biggestRats">
+                Biggest Rats
+            </button>
+        </div>
+
+        <!-- Tab Content: Most Watched -->
+        <div id="tabMostWatched" class="tab-content">
+            @if (Model.ViewModel.MostWatched.Any())
+            {
+                <div class="overflow-x-auto">
+                    <table class="w-full">
+                        <thead class="bg-bg-primary/50">
+                            <tr>
+                                <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Rank</th>
+                                <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">User</th>
+                                <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Total Watches</th>
+                                <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Guilty Count</th>
+                                <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Accountability Score</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-border-primary">
+                            @for (int i = 0; i < Model.ViewModel.MostWatched.Count; i++)
+                            {
+                                var user = Model.ViewModel.MostWatched[i];
+                                var rank = i + 1;
+                                var rankBadgeClass = rank == 1 ? "bg-warning/20 text-warning" : rank <= 3 ? "bg-accent-orange/20 text-accent-orange" : "bg-bg-tertiary text-text-tertiary";
+                                <tr class="hover:bg-bg-hover transition-colors">
+                                    <td class="px-5 py-4">
+                                        <span class="inline-flex items-center justify-center w-8 h-8 rounded-full @rankBadgeClass font-bold text-sm">@rank</span>
+                                    </td>
+                                    <td class="px-5 py-4">
+                                        <p class="font-medium text-text-primary">User @user.UserId</p>
+                                        <p class="text-xs text-text-tertiary">#@user.UserId.ToString().Substring(0, 4)</p>
+                                    </td>
+                                    <td class="px-5 py-4 text-text-primary font-medium">@user.WatchesAgainst</td>
+                                    <td class="px-5 py-4">
+                                        <span class="inline-flex items-center px-2.5 py-0.5 text-xs font-semibold @(user.GuiltyCount > 0 ? "text-error bg-error/10" : "text-success bg-success/10") rounded-full">
+                                            @user.GuiltyCount
+                                        </span>
+                                    </td>
+                                    <td class="px-5 py-4">
+                                        <span class="inline-flex items-center px-2.5 py-0.5 text-xs font-semibold @(user.AccountabilityScore >= 50 ? "text-success bg-success/10" : "text-warning bg-warning/10") rounded-full">
+                                            @user.AccountabilityScore.ToString("F0")%
+                                        </span>
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            }
+            else
+            {
+                <div class="py-12 text-center">
+                    <p class="text-text-secondary font-medium">No watch data available</p>
+                    <p class="text-sm text-text-tertiary mt-1">Leaderboard will appear once watches are created</p>
+                </div>
+            }
+        </div>
+
+        <!-- Tab Content: Top Accusers -->
+        <div id="tabTopAccusers" class="tab-content hidden">
+            @if (Model.ViewModel.TopAccusers.Any())
+            {
+                <div class="overflow-x-auto">
+                    <table class="w-full">
+                        <thead class="bg-bg-primary/50">
+                            <tr>
+                                <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Rank</th>
+                                <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">User</th>
+                                <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Watches Created</th>
+                                <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Success Rate</th>
+                                <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Last Created</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-border-primary">
+                            @for (int i = 0; i < Model.ViewModel.TopAccusers.Count; i++)
+                            {
+                                var accuser = Model.ViewModel.TopAccusers[i];
+                                var rank = i + 1;
+                                var rankBadgeClass = rank == 1 ? "bg-warning/20 text-warning" : rank <= 3 ? "bg-accent-orange/20 text-accent-orange" : "bg-bg-tertiary text-text-tertiary";
+                                <tr class="hover:bg-bg-hover transition-colors">
+                                    <td class="px-5 py-4">
+                                        <span class="inline-flex items-center justify-center w-8 h-8 rounded-full @rankBadgeClass font-bold text-sm">@rank</span>
+                                    </td>
+                                    <td class="px-5 py-4">
+                                        <p class="font-medium text-text-primary">User @accuser.UserId</p>
+                                        <p class="text-xs text-text-tertiary">#@accuser.UserId.ToString().Substring(0, 4)</p>
+                                    </td>
+                                    <td class="px-5 py-4 text-text-primary font-medium">@accuser.WatchesCreated</td>
+                                    <td class="px-5 py-4">
+                                        <span class="inline-flex items-center px-2.5 py-0.5 text-xs font-semibold @(accuser.SuccessRate >= 70 ? "text-success bg-success/10" : "text-warning bg-warning/10") rounded-full">
+                                            @accuser.SuccessRate.ToString("F0")%
+                                        </span>
+                                    </td>
+                                    <td class="px-5 py-4 text-text-secondary text-sm">
+                                        @if (accuser.LastCreatedDate.HasValue)
+                                        {
+                                            @accuser.LastCreatedDate.Value.ToString("MMM d, yyyy")
+                                        }
+                                        else
+                                        {
+                                            <span class="text-text-tertiary">Never</span>
+                                        }
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            }
+            else
+            {
+                <div class="py-12 text-center">
+                    <p class="text-text-secondary font-medium">No accuser data available</p>
+                    <p class="text-sm text-text-tertiary mt-1">Leaderboard will appear once watches are created</p>
+                </div>
+            }
+        </div>
+
+        <!-- Tab Content: Biggest Rats -->
+        <div id="tabBiggestRats" class="tab-content hidden">
+            @if (Model.ViewModel.BiggestRats.Any())
+            {
+                <div class="overflow-x-auto">
+                    <table class="w-full">
+                        <thead class="bg-bg-primary/50">
+                            <tr>
+                                <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Rank</th>
+                                <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">User</th>
+                                <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Guilty Verdicts</th>
+                                <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Total Watches</th>
+                                <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Guilty Rate</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-border-primary">
+                            @for (int i = 0; i < Model.ViewModel.BiggestRats.Count; i++)
+                            {
+                                var user = Model.ViewModel.BiggestRats[i];
+                                var rank = i + 1;
+                                var rankBadgeClass = rank == 1 ? "bg-warning/20 text-warning" : rank <= 3 ? "bg-accent-orange/20 text-accent-orange" : "bg-bg-tertiary text-text-tertiary";
+                                var guiltyRate = user.WatchesAgainst > 0 ? (double)user.GuiltyCount / user.WatchesAgainst * 100 : 0;
+                                <tr class="hover:bg-bg-hover transition-colors">
+                                    <td class="px-5 py-4">
+                                        <span class="inline-flex items-center justify-center w-8 h-8 rounded-full @rankBadgeClass font-bold text-sm">@rank</span>
+                                    </td>
+                                    <td class="px-5 py-4">
+                                        <p class="font-medium text-text-primary">User @user.UserId</p>
+                                        <p class="text-xs text-text-tertiary">#@user.UserId.ToString().Substring(0, 4)</p>
+                                    </td>
+                                    <td class="px-5 py-4">
+                                        <span class="inline-flex items-center px-2.5 py-0.5 text-xs font-semibold text-error bg-error/10 rounded-full">
+                                            @user.GuiltyCount
+                                        </span>
+                                    </td>
+                                    <td class="px-5 py-4 text-text-primary font-medium">@user.WatchesAgainst</td>
+                                    <td class="px-5 py-4">
+                                        <span class="inline-flex items-center px-2.5 py-0.5 text-xs font-semibold text-error bg-error/10 rounded-full">
+                                            @guiltyRate.ToString("F0")%
+                                        </span>
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            }
+            else
+            {
+                <div class="py-12 text-center">
+                    <p class="text-text-secondary font-medium">No guilty verdicts yet</p>
+                    <p class="text-sm text-text-tertiary mt-1">Leaderboard will appear once guilty verdicts are recorded</p>
+                </div>
+            }
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <!-- Chart.js Library -->
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+
+    <!-- Embed Chart Data -->
+    @{
+        var chartData = new {
+            timeSeries = Model.ViewModel.TimeSeries.Select(t => new {
+                date = t.Date.ToString("yyyy-MM-dd"),
+                totalCount = t.TotalCount,
+                guiltyCount = t.GuiltyCount,
+                clearedCount = t.ClearedCount
+            }),
+            outcomeDistribution = new {
+                guiltyCount = Model.ViewModel.Summary.GuiltyCount,
+                clearedEarlyCount = Model.ViewModel.Summary.ClearedEarlyCount,
+                activeCount = Model.ViewModel.Summary.ActiveWatches,
+                otherCount = Math.Max(0, Model.ViewModel.Summary.TotalWatches - Model.ViewModel.Summary.GuiltyCount - Model.ViewModel.Summary.ClearedEarlyCount - Model.ViewModel.Summary.ActiveWatches)
+            },
+            heatmap = Model.ViewModel.Heatmap.Select(h => new {
+                dayOfWeek = h.DayOfWeek,
+                hour = h.Hour,
+                count = h.Count
+            }),
+            topUsers = Model.ViewModel.MostWatched.Take(5).Select(u => new {
+                userId = u.UserId,
+                watchesAgainst = u.WatchesAgainst,
+                guiltyCount = u.GuiltyCount
+            })
+        };
+        var chartDataJson = System.Text.Json.JsonSerializer.Serialize(chartData);
+    }
+
+    <script type="application/json" id="ratWatchChartData">
+@Html.Raw(chartDataJson)
+    </script>
+
+    <!-- Filter Panel Toggle Script -->
+    <script>
+        function toggleFilterPanel() {
+            const content = document.getElementById('filterContent');
+            const chevron = document.getElementById('filterChevron');
+            const toggle = document.getElementById('filterToggle');
+
+            if (content.style.maxHeight === '0px') {
+                content.style.maxHeight = '1000px';
+                chevron.style.transform = 'rotate(0deg)';
+                toggle.setAttribute('aria-expanded', 'true');
+            } else {
+                content.style.maxHeight = '0px';
+                chevron.style.transform = 'rotate(-90deg)';
+                toggle.setAttribute('aria-expanded', 'false');
+            }
+        }
+
+        function setDatePreset(preset) {
+            const today = new Date();
+            const startDateInput = document.getElementById('StartDate');
+            const endDateInput = document.getElementById('EndDate');
+
+            let startDate = new Date();
+
+            switch(preset) {
+                case 'today':
+                    startDate = today;
+                    break;
+                case '7days':
+                    startDate.setDate(today.getDate() - 7);
+                    break;
+                case '30days':
+                    startDate.setDate(today.getDate() - 30);
+                    break;
+            }
+
+            startDateInput.value = startDate.toISOString().split('T')[0];
+            endDateInput.value = today.toISOString().split('T')[0];
+
+            // Auto-submit the form after setting dates
+            document.getElementById('filterForm').submit();
+        }
+
+        function switchTab(tabName) {
+            // Update tab buttons
+            document.querySelectorAll('.tab-btn').forEach(btn => {
+                btn.classList.remove('active');
+                if (btn.dataset.tab === tabName) {
+                    btn.classList.add('active');
+                }
+            });
+
+            // Update tab content
+            document.querySelectorAll('.tab-content').forEach(content => {
+                content.classList.add('hidden');
+            });
+            document.getElementById('tab' + tabName.charAt(0).toUpperCase() + tabName.slice(1)).classList.remove('hidden');
+        }
+    </script>
+
+    <!-- Load Custom Analytics Chart Script -->
+    <script src="~/js/rat-watch-analytics.js" asp-append-version="true"></script>
+}
+
+<style>
+    /* Tab active state */
+    .tab-btn.active {
+        border-color: #cb4e1b;
+        color: #d7d3d0;
+    }
+</style>

--- a/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Analytics.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Analytics.cshtml.cs
@@ -1,0 +1,159 @@
+using DiscordBot.Bot.ViewModels.Pages;
+using DiscordBot.Core.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace DiscordBot.Bot.Pages.Guilds.RatWatch;
+
+/// <summary>
+/// Page model for the Guild Rat Watch Analytics Dashboard.
+/// Displays analytics metrics, charts, and leaderboards for a specific guild.
+/// </summary>
+[Authorize(Policy = "RequireModeratorOrAbove")]
+public class AnalyticsModel : PageModel
+{
+    private readonly IRatWatchRepository _ratWatchRepository;
+    private readonly IRatRecordRepository _ratRecordRepository;
+    private readonly IGuildService _guildService;
+    private readonly ILogger<AnalyticsModel> _logger;
+
+    public AnalyticsModel(
+        IRatWatchRepository ratWatchRepository,
+        IRatRecordRepository ratRecordRepository,
+        IGuildService guildService,
+        ILogger<AnalyticsModel> logger)
+    {
+        _ratWatchRepository = ratWatchRepository;
+        _ratRecordRepository = ratRecordRepository;
+        _guildService = guildService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// The analytics view model with all chart data and metrics.
+    /// </summary>
+    public RatWatchAnalyticsViewModel ViewModel { get; private set; } = new();
+
+    /// <summary>
+    /// Start date filter (bound from query string).
+    /// </summary>
+    [BindProperty(SupportsGet = true)]
+    public DateTime? StartDate { get; set; }
+
+    /// <summary>
+    /// End date filter (bound from query string).
+    /// </summary>
+    [BindProperty(SupportsGet = true)]
+    public DateTime? EndDate { get; set; }
+
+    /// <summary>
+    /// Handles GET requests to display the analytics dashboard.
+    /// </summary>
+    /// <param name="guildId">The guild's Discord snowflake ID from route parameter.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The page result.</returns>
+    public async Task<IActionResult> OnGetAsync(ulong guildId, CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Loading Rat Watch analytics for guild {GuildId}", guildId);
+
+        // Set defaults if not specified (normalize to midnight UTC)
+        StartDate = StartDate.HasValue ? StartDate.Value.Date : DateTime.UtcNow.AddDays(-7).Date;
+        EndDate = EndDate.HasValue ? EndDate.Value.Date : DateTime.UtcNow.Date;
+
+        // Query range: start at beginning of StartDate (00:00:00) and end at beginning of day after EndDate (00:00:00)
+        // This ensures we include all records from the entire EndDate day (up to 23:59:59.999)
+        var start = StartDate.Value;
+        var end = EndDate.Value.AddDays(1);
+
+        _logger.LogDebug("Analytics date range: {Start} to {End}", start, end);
+
+        try
+        {
+            // Get guild info
+            var guild = await _guildService.GetGuildByIdAsync(guildId, cancellationToken);
+            if (guild == null)
+            {
+                _logger.LogWarning("Guild {GuildId} not found", guildId);
+                return NotFound();
+            }
+
+            // Load analytics data from repository
+            var summary = await _ratWatchRepository.GetAnalyticsSummaryAsync(guildId, start, end, cancellationToken);
+            var timeSeries = await _ratWatchRepository.GetTimeSeriesAsync(guildId, start, end, cancellationToken);
+            var heatmap = await _ratWatchRepository.GetActivityHeatmapAsync(guildId, start, end, cancellationToken);
+
+            // Load leaderboards
+            var mostWatched = await _ratRecordRepository.GetUserMetricsAsync(guildId, "watched", 10, cancellationToken);
+            var biggestRats = await _ratRecordRepository.GetUserMetricsAsync(guildId, "guilty", 10, cancellationToken);
+
+            // Load top accusers (users who created the most watches)
+            var topAccusers = await GetTopAccusersAsync(guildId, 10, cancellationToken);
+
+            // Build view model
+            ViewModel = new RatWatchAnalyticsViewModel
+            {
+                GuildId = guildId,
+                GuildName = guild.Name,
+                GuildIconUrl = guild.IconUrl,
+                Summary = summary,
+                TimeSeries = timeSeries.ToList(),
+                Heatmap = heatmap.ToList(),
+                MostWatched = mostWatched.ToList(),
+                TopAccusers = topAccusers,
+                BiggestRats = biggestRats.ToList(),
+                StartDate = start,
+                EndDate = end.AddDays(-1) // Show the actual end date (not +1)
+            };
+
+            _logger.LogInformation(
+                "Analytics loaded successfully for guild {GuildId}. Total watches: {TotalWatches}, Guilty rate: {GuiltyRate:F2}%",
+                guildId, summary.TotalWatches, summary.GuiltyRate);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load analytics data for guild {GuildId}", guildId);
+            TempData["ErrorMessage"] = "Failed to load analytics data. Please try again.";
+            // Return page with empty data
+        }
+
+        return Page();
+    }
+
+    /// <summary>
+    /// Gets the top accusers (users who created the most watches).
+    /// </summary>
+    /// <param name="guildId">Guild ID.</param>
+    /// <param name="limit">Maximum number of entries to return.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of accuser metrics.</returns>
+    private async Task<List<AccuserMetricsDto>> GetTopAccusersAsync(
+        ulong guildId,
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("Retrieving top {Limit} accusers for guild {GuildId}", limit, guildId);
+
+        // Get all watches for the guild and group by initiator
+        var accuserMetrics = await _ratWatchRepository.GetAllAsync(cancellationToken);
+
+        var topAccusers = accuserMetrics
+            .Where(w => w.GuildId == guildId)
+            .GroupBy(w => w.InitiatorUserId)
+            .Select(g => new AccuserMetricsDto
+            {
+                UserId = g.Key,
+                Username = string.Empty, // Will be populated by view if needed
+                WatchesCreated = g.Count(),
+                GuiltyCount = g.Count(w => w.Status == Core.Enums.RatWatchStatus.Guilty),
+                SuccessRate = g.Any() ? (double)g.Count(w => w.Status == Core.Enums.RatWatchStatus.Guilty) / g.Count() * 100 : 0,
+                LastCreatedDate = g.Max(w => w.CreatedAt)
+            })
+            .OrderByDescending(a => a.WatchesCreated)
+            .Take(limit)
+            .ToList();
+
+        _logger.LogDebug("Retrieved {Count} top accusers", topAccusers.Count);
+        return topAccusers;
+    }
+}

--- a/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Index.cshtml
@@ -46,7 +46,13 @@
             <h1 class="text-2xl font-bold text-text-primary">Rat Watch</h1>
             <p class="mt-1 text-sm text-text-secondary">Manage accountability trackers and view the hall of shame</p>
         </div>
-        <div class="flex items-center gap-2">
+        <div class="flex items-center gap-3">
+            <a asp-page="/Guilds/RatWatch/Analytics" asp-route-guildId="@Model.ViewModel.GuildId" class="inline-flex items-center gap-2 px-4 py-2 bg-bg-tertiary border border-border-primary text-text-primary hover:bg-bg-hover font-medium text-sm rounded-lg transition-colors">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+                </svg>
+                View Analytics
+            </a>
             @if (Model.ViewModel.IsEnabled)
             {
                 <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold bg-success/20 text-success">

--- a/src/DiscordBot.Bot/ViewModels/Pages/RatWatchAnalyticsViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Pages/RatWatchAnalyticsViewModel.cs
@@ -1,0 +1,100 @@
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Bot.ViewModels.Pages;
+
+/// <summary>
+/// View model for the Guild Rat Watch Analytics page.
+/// </summary>
+public record RatWatchAnalyticsViewModel
+{
+    /// <summary>
+    /// The guild's Discord snowflake ID.
+    /// </summary>
+    public ulong GuildId { get; init; }
+
+    /// <summary>
+    /// The guild's name.
+    /// </summary>
+    public string GuildName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Optional guild icon URL.
+    /// </summary>
+    public string? GuildIconUrl { get; init; }
+
+    /// <summary>
+    /// Analytics summary with counts, rates, and averages.
+    /// </summary>
+    public RatWatchAnalyticsSummaryDto Summary { get; init; } = new();
+
+    /// <summary>
+    /// Time series data for watches over time chart.
+    /// </summary>
+    public IReadOnlyList<RatWatchTimeSeriesDto> TimeSeries { get; init; } = Array.Empty<RatWatchTimeSeriesDto>();
+
+    /// <summary>
+    /// Activity heatmap data (day of week + hour).
+    /// </summary>
+    public IReadOnlyList<ActivityHeatmapDto> Heatmap { get; init; } = Array.Empty<ActivityHeatmapDto>();
+
+    /// <summary>
+    /// Top 10 most watched users leaderboard.
+    /// </summary>
+    public IReadOnlyList<RatWatchUserMetricsDto> MostWatched { get; init; } = Array.Empty<RatWatchUserMetricsDto>();
+
+    /// <summary>
+    /// Top 10 accusers (users who created the most watches).
+    /// </summary>
+    public IReadOnlyList<AccuserMetricsDto> TopAccusers { get; init; } = Array.Empty<AccuserMetricsDto>();
+
+    /// <summary>
+    /// Top 10 users with the most guilty verdicts.
+    /// </summary>
+    public IReadOnlyList<RatWatchUserMetricsDto> BiggestRats { get; init; } = Array.Empty<RatWatchUserMetricsDto>();
+
+    /// <summary>
+    /// Start date for filtering (UTC).
+    /// </summary>
+    public DateTime StartDate { get; init; }
+
+    /// <summary>
+    /// End date for filtering (UTC).
+    /// </summary>
+    public DateTime EndDate { get; init; }
+}
+
+/// <summary>
+/// Metrics for users who create watches (accusers).
+/// </summary>
+public record AccuserMetricsDto
+{
+    /// <summary>
+    /// Discord user snowflake ID.
+    /// </summary>
+    public ulong UserId { get; init; }
+
+    /// <summary>
+    /// Username (populated by service layer).
+    /// </summary>
+    public string Username { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Total number of watches created by this user.
+    /// </summary>
+    public int WatchesCreated { get; init; }
+
+    /// <summary>
+    /// Number of watches that resulted in guilty verdicts.
+    /// </summary>
+    public int GuiltyCount { get; init; }
+
+    /// <summary>
+    /// Success rate: percentage of created watches that resulted in guilty verdicts.
+    /// </summary>
+    public double SuccessRate { get; init; }
+
+    /// <summary>
+    /// Date of the most recently created watch.
+    /// </summary>
+    public DateTime? LastCreatedDate { get; init; }
+}

--- a/src/DiscordBot.Bot/wwwroot/js/rat-watch-analytics.js
+++ b/src/DiscordBot.Bot/wwwroot/js/rat-watch-analytics.js
@@ -1,0 +1,532 @@
+// rat-watch-analytics.js
+// Rat Watch analytics dashboard with Chart.js visualizations and activity heatmap
+
+(function () {
+    'use strict';
+
+    // Design system chart colors
+    const CHART_COLORS = [
+        '#cb4e1b',  // accent-orange
+        '#098ecf',  // accent-blue
+        '#10b981',  // success
+        '#f59e0b',  // warning
+        '#06b6d4',  // info
+        '#ef4444',  // error
+        '#8b5cf6',  // purple
+        '#ec4899',  // pink
+        '#14b8a6',  // teal
+        '#6366f1',  // indigo
+    ];
+
+    const BG_COLORS = {
+        primary: '#1d2022',
+        secondary: '#262a2d',
+        tertiary: '#2f3336',
+    };
+
+    const TEXT_COLORS = {
+        primary: '#d7d3d0',
+        secondary: '#a8a5a3',
+        tertiary: '#7a7876',
+    };
+
+    const BORDER_COLOR = '#3f4447';
+
+    // Chart instance references
+    let watchesOverTimeChart = null;
+    let outcomeDistributionChart = null;
+    let topUsersChart = null;
+
+    /**
+     * Common Chart.js options for all charts.
+     */
+    const commonOptions = {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+            legend: {
+                display: false,
+            },
+            tooltip: {
+                backgroundColor: BG_COLORS.tertiary,
+                titleColor: TEXT_COLORS.primary,
+                bodyColor: TEXT_COLORS.secondary,
+                borderColor: BORDER_COLOR,
+                borderWidth: 1,
+                padding: 12,
+                cornerRadius: 6,
+            },
+        },
+    };
+
+    /**
+     * Common grid styling for chart axes.
+     */
+    const gridConfig = {
+        color: 'rgba(63, 68, 71, 0.5)',
+        drawBorder: false,
+    };
+
+    const ticksConfig = {
+        color: TEXT_COLORS.tertiary,
+        font: {
+            size: 12,
+        },
+    };
+
+    /**
+     * Formats a number with thousands separator.
+     * @param {number} num - The number to format
+     * @returns {string} Formatted number (e.g., "1,234")
+     */
+    function formatNumber(num) {
+        return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+    }
+
+    /**
+     * Formats a date string to short format (e.g., "Jan 15").
+     * @param {string} dateStr - ISO date string
+     * @returns {string} Formatted date
+     */
+    function formatDate(dateStr) {
+        const date = new Date(dateStr);
+        const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+            'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+        return `${monthNames[date.getMonth()]} ${date.getDate()}`;
+    }
+
+    /**
+     * Plugin to display center text in doughnut chart.
+     */
+    const centerTextPlugin = {
+        id: 'centerText',
+        afterDatasetsDraw: function (chart) {
+            if (!chart.config.options.plugins.centerText) {
+                return;
+            }
+
+            const { ctx, chartArea: { width, height } } = chart;
+            const centerX = width / 2;
+            const centerY = height / 2;
+            const text = chart.config.options.plugins.centerText.text;
+
+            ctx.save();
+            ctx.font = 'bold 32px ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto';
+            ctx.fillStyle = TEXT_COLORS.primary;
+            ctx.textAlign = 'center';
+            ctx.textBaseline = 'middle';
+            ctx.fillText(text, centerX, centerY);
+            ctx.restore();
+        }
+    };
+
+    /**
+     * Initializes the Watches Over Time line chart.
+     * @param {Array} timeSeriesData - Array of {date, totalCount, guiltyCount, clearedCount} objects
+     */
+    function initWatchesOverTimeChart(timeSeriesData) {
+        const canvas = document.getElementById('watchesOverTimeChart');
+        if (!canvas || !timeSeriesData || timeSeriesData.length === 0) {
+            return;
+        }
+
+        const ctx = canvas.getContext('2d');
+        const labels = timeSeriesData.map(item => formatDate(item.date));
+        const totalData = timeSeriesData.map(item => item.totalCount);
+        const guiltyData = timeSeriesData.map(item => item.guiltyCount);
+        const clearedData = timeSeriesData.map(item => item.clearedCount);
+
+        // Create gradients
+        const totalGradient = ctx.createLinearGradient(0, 0, 0, 300);
+        totalGradient.addColorStop(0, 'rgba(203, 78, 27, 0.3)');
+        totalGradient.addColorStop(1, 'rgba(203, 78, 27, 0.0)');
+
+        watchesOverTimeChart = new Chart(ctx, {
+            type: 'line',
+            data: {
+                labels: labels,
+                datasets: [
+                    {
+                        label: 'Total Watches',
+                        data: totalData,
+                        borderColor: CHART_COLORS[0],
+                        backgroundColor: totalGradient,
+                        borderWidth: 2,
+                        fill: true,
+                        tension: 0.3,
+                        pointRadius: 4,
+                        pointBackgroundColor: CHART_COLORS[0],
+                        pointBorderColor: BG_COLORS.primary,
+                        pointBorderWidth: 2,
+                        pointHoverRadius: 6,
+                    },
+                    {
+                        label: 'Guilty',
+                        data: guiltyData,
+                        borderColor: CHART_COLORS[5],
+                        backgroundColor: 'transparent',
+                        borderWidth: 2,
+                        fill: false,
+                        tension: 0.3,
+                        pointRadius: 3,
+                        pointBackgroundColor: CHART_COLORS[5],
+                        pointBorderColor: BG_COLORS.primary,
+                        pointBorderWidth: 2,
+                        pointHoverRadius: 5,
+                        borderDash: [5, 5],
+                    },
+                    {
+                        label: 'Cleared Early',
+                        data: clearedData,
+                        borderColor: CHART_COLORS[2],
+                        backgroundColor: 'transparent',
+                        borderWidth: 2,
+                        fill: false,
+                        tension: 0.3,
+                        pointRadius: 3,
+                        pointBackgroundColor: CHART_COLORS[2],
+                        pointBorderColor: BG_COLORS.primary,
+                        pointBorderWidth: 2,
+                        pointHoverRadius: 5,
+                        borderDash: [2, 2],
+                    }
+                ]
+            },
+            options: {
+                ...commonOptions,
+                plugins: {
+                    ...commonOptions.plugins,
+                    legend: {
+                        display: true,
+                        position: 'bottom',
+                        labels: {
+                            color: TEXT_COLORS.primary,
+                            padding: 16,
+                            font: {
+                                size: 12,
+                            },
+                            usePointStyle: true,
+                        }
+                    },
+                    tooltip: {
+                        ...commonOptions.plugins.tooltip,
+                        callbacks: {
+                            title: function (context) {
+                                return timeSeriesData[context[0].dataIndex].date;
+                            },
+                            label: function (context) {
+                                return `${context.dataset.label}: ${formatNumber(context.parsed.y)}`;
+                            }
+                        }
+                    }
+                },
+                scales: {
+                    x: {
+                        grid: gridConfig,
+                        ticks: ticksConfig,
+                    },
+                    y: {
+                        beginAtZero: true,
+                        grid: gridConfig,
+                        ticks: {
+                            ...ticksConfig,
+                            callback: function (value) {
+                                if (value >= 1000) {
+                                    return (value / 1000).toFixed(1) + 'k';
+                                }
+                                return value;
+                            }
+                        },
+                    }
+                },
+                interaction: {
+                    intersect: false,
+                    mode: 'index',
+                }
+            }
+        });
+
+        console.log('Watches over time chart initialized');
+    }
+
+    /**
+     * Initializes the Outcome Distribution doughnut chart.
+     * @param {Object} outcomeData - Object with {guiltyCount, clearedEarlyCount, activeCount, otherCount}
+     */
+    function initOutcomeDistributionChart(outcomeData) {
+        const canvas = document.getElementById('outcomeDistributionChart');
+        if (!canvas || !outcomeData) {
+            return;
+        }
+
+        const ctx = canvas.getContext('2d');
+        const total = outcomeData.guiltyCount + outcomeData.clearedEarlyCount +
+                     outcomeData.activeCount + outcomeData.otherCount;
+        const guiltyPercentage = total > 0 ? ((outcomeData.guiltyCount / total) * 100).toFixed(1) : '0.0';
+
+        outcomeDistributionChart = new Chart(ctx, {
+            type: 'doughnut',
+            data: {
+                labels: ['Guilty', 'Cleared Early', 'Active', 'Other'],
+                datasets: [{
+                    data: [
+                        outcomeData.guiltyCount,
+                        outcomeData.clearedEarlyCount,
+                        outcomeData.activeCount,
+                        outcomeData.otherCount
+                    ],
+                    backgroundColor: [
+                        CHART_COLORS[5], // error red for guilty
+                        CHART_COLORS[2], // success green for cleared
+                        CHART_COLORS[1], // blue for active
+                        CHART_COLORS[3]  // warning orange for other
+                    ],
+                    borderColor: BG_COLORS.primary,
+                    borderWidth: 3,
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                cutout: '70%',
+                plugins: {
+                    legend: {
+                        display: true,
+                        position: 'bottom',
+                        labels: {
+                            color: TEXT_COLORS.primary,
+                            padding: 16,
+                            font: {
+                                size: 13,
+                            },
+                            usePointStyle: true,
+                            pointStyle: 'circle',
+                        }
+                    },
+                    tooltip: {
+                        ...commonOptions.plugins.tooltip,
+                        callbacks: {
+                            label: function (context) {
+                                const label = context.label || '';
+                                const value = context.parsed;
+                                const percentage = total > 0 ? ((value / total) * 100).toFixed(1) : '0.0';
+                                return `${label}: ${formatNumber(value)} (${percentage}%)`;
+                            }
+                        }
+                    },
+                    centerText: {
+                        text: `${guiltyPercentage}%`
+                    }
+                }
+            },
+            plugins: [centerTextPlugin]
+        });
+
+        console.log('Outcome distribution chart initialized');
+    }
+
+    /**
+     * Initializes the Top Watched Users horizontal bar chart.
+     * @param {Array} topUsersData - Array of {userId, watchesAgainst, guiltyCount} objects
+     */
+    function initTopUsersChart(topUsersData) {
+        const canvas = document.getElementById('topUsersChart');
+        if (!canvas || !topUsersData || topUsersData.length === 0) {
+            return;
+        }
+
+        const ctx = canvas.getContext('2d');
+        const labels = topUsersData.map(item => `User ${item.userId.toString().substring(0, 8)}`);
+        const data = topUsersData.map(item => item.watchesAgainst);
+        const guiltyData = topUsersData.map(item => item.guiltyCount);
+
+        // Assign colors cycling through CHART_COLORS
+        const colors = labels.map((_, index) => CHART_COLORS[index % CHART_COLORS.length]);
+
+        topUsersChart = new Chart(ctx, {
+            type: 'bar',
+            data: {
+                labels: labels,
+                datasets: [{
+                    label: 'Total Watches',
+                    data: data,
+                    backgroundColor: colors,
+                    borderColor: colors,
+                    borderWidth: 1,
+                    borderRadius: 4,
+                    barThickness: 24,
+                }]
+            },
+            options: {
+                indexAxis: 'y',
+                ...commonOptions,
+                plugins: {
+                    ...commonOptions.plugins,
+                    tooltip: {
+                        ...commonOptions.plugins.tooltip,
+                        displayColors: true,
+                        callbacks: {
+                            label: function (context) {
+                                const value = context.parsed.x;
+                                const guilty = guiltyData[context.dataIndex];
+                                return `Watches: ${formatNumber(value)} (${guilty} guilty)`;
+                            }
+                        }
+                    }
+                },
+                scales: {
+                    x: {
+                        beginAtZero: true,
+                        grid: gridConfig,
+                        ticks: {
+                            ...ticksConfig,
+                            callback: function (value) {
+                                return Math.floor(value);
+                            }
+                        },
+                    },
+                    y: {
+                        grid: {
+                            display: false,
+                        },
+                        ticks: {
+                            color: TEXT_COLORS.primary,
+                            font: {
+                                size: 12,
+                                family: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+                            },
+                            padding: 8,
+                        }
+                    }
+                },
+                animation: {
+                    duration: 500,
+                    easing: 'easeOutQuart',
+                }
+            }
+        });
+
+        console.log('Top users chart initialized');
+    }
+
+    /**
+     * Renders the activity heatmap.
+     * @param {Array} heatmapData - Array of {dayOfWeek, hour, count} objects
+     */
+    function renderActivityHeatmap(heatmapData) {
+        const container = document.getElementById('activityHeatmap');
+        if (!container || !heatmapData || heatmapData.length === 0) {
+            return;
+        }
+
+        const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+        const hours = Array.from({ length: 24 }, (_, i) => i);
+
+        // Create a map for quick lookup
+        const dataMap = new Map();
+        let maxCount = 0;
+        heatmapData.forEach(item => {
+            const key = `${item.dayOfWeek}-${item.hour}`;
+            dataMap.set(key, item.count);
+            maxCount = Math.max(maxCount, item.count);
+        });
+
+        // Build heatmap HTML
+        let html = '<div class="text-xs text-text-tertiary mb-2">Activity by day and hour (UTC)</div>';
+        html += '<div class="grid grid-cols-[auto_repeat(24,minmax(0,1fr))] gap-1 text-xs">';
+
+        // Header row (hours)
+        html += '<div></div>'; // Empty corner
+        hours.forEach(hour => {
+            html += `<div class="text-center text-text-tertiary">${hour % 6 === 0 ? hour : ''}</div>`;
+        });
+
+        // Data rows
+        days.forEach((day, dayIndex) => {
+            html += `<div class="text-text-secondary font-medium pr-2">${day}</div>`;
+            hours.forEach(hour => {
+                const key = `${dayIndex}-${hour}`;
+                const count = dataMap.get(key) || 0;
+                const intensity = maxCount > 0 ? count / maxCount : 0;
+                const bgColor = getHeatmapColor(intensity);
+                const title = `${day} ${hour}:00 - ${count} watches`;
+                html += `<div class="aspect-square rounded-sm" style="background-color: ${bgColor};" title="${title}"></div>`;
+            });
+        });
+
+        html += '</div>';
+
+        // Add legend
+        html += '<div class="flex items-center gap-2 mt-4 text-xs text-text-tertiary">';
+        html += '<span>Less</span>';
+        for (let i = 0; i <= 4; i++) {
+            const intensity = i / 4;
+            const bgColor = getHeatmapColor(intensity);
+            html += `<div class="w-4 h-4 rounded-sm" style="background-color: ${bgColor};"></div>`;
+        }
+        html += '<span>More</span>';
+        html += '</div>';
+
+        container.innerHTML = html;
+        console.log('Activity heatmap rendered');
+    }
+
+    /**
+     * Gets a color based on heatmap intensity.
+     * @param {number} intensity - Value between 0 and 1
+     * @returns {string} Hex color
+     */
+    function getHeatmapColor(intensity) {
+        if (intensity === 0) return '#2f3336'; // bg-tertiary
+        if (intensity < 0.25) return 'rgba(203, 78, 27, 0.2)'; // light orange
+        if (intensity < 0.5) return 'rgba(203, 78, 27, 0.4)';
+        if (intensity < 0.75) return 'rgba(203, 78, 27, 0.6)';
+        return 'rgba(203, 78, 27, 0.8)'; // full orange
+    }
+
+    /**
+     * Initialize all Rat Watch analytics charts.
+     */
+    function init() {
+        // Load chart data from embedded JSON
+        const dataElement = document.getElementById('ratWatchChartData');
+        if (!dataElement) {
+            console.log('Rat Watch chart data not found on this page');
+            return;
+        }
+
+        try {
+            const chartData = JSON.parse(dataElement.textContent);
+
+            // Initialize each chart if data is available
+            if (chartData.timeSeries && chartData.timeSeries.length > 0) {
+                initWatchesOverTimeChart(chartData.timeSeries);
+            }
+
+            if (chartData.outcomeDistribution) {
+                initOutcomeDistributionChart(chartData.outcomeDistribution);
+            }
+
+            if (chartData.heatmap && chartData.heatmap.length > 0) {
+                renderActivityHeatmap(chartData.heatmap);
+            }
+
+            if (chartData.topUsers && chartData.topUsers.length > 0) {
+                initTopUsersChart(chartData.topUsers);
+            }
+
+            console.log('Rat Watch analytics charts initialized');
+
+        } catch (error) {
+            console.error('Failed to initialize Rat Watch analytics charts:', error);
+        }
+    }
+
+    // Initialize when DOM is ready
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+
+})();


### PR DESCRIPTION
## Summary

- Implements comprehensive analytics dashboard for guild-specific Rat Watch data at `/Guilds/RatWatch/{guildId}/Analytics`
- Adds summary stats cards displaying total watches, guilty rate, check-in rate, and average votes per watch
- Includes collapsible filter panel with date range picker and quick presets (Today, Last 7 Days, Last 30 Days)
- Creates four charts using Chart.js: Watches Over Time (line), Outcome Distribution (doughnut), Activity Heatmap (custom grid), Top Watched Users (horizontal bar)
- Displays behavioral insights metrics (early check-in rate, avg voting participation, avg vote margin)
- Implements three leaderboard tabs: Most Watched, Top Accusers, and Biggest Rats
- Adds navigation link from RatWatch settings page to Analytics

## Files Changed

| File | Description |
|------|-------------|
| `RatWatchAnalyticsViewModel.cs` | View model containing analytics data structures |
| `Analytics.cshtml` | Razor page with charts, stats cards, and leaderboards |
| `Analytics.cshtml.cs` | PageModel with repository queries and data loading |
| `rat-watch-analytics.js` | Chart.js initialization and activity heatmap rendering |
| `Index.cshtml` | Added "View Analytics" navigation button |
| `CLAUDE.md` | Updated route documentation |

## Test plan

- [ ] Build project successfully
- [ ] Navigate to `/Guilds/RatWatch/{guildId}/Analytics`
- [ ] Verify page loads with no errors (even with no data)
- [ ] Test date filter presets update the view
- [ ] Verify charts render correctly with data
- [ ] Test leaderboard tab switching
- [ ] Confirm "Back to Settings" link works
- [ ] Test authorization (Moderator or above required)

Closes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)