### PR TITLE
feat(ratwatch): Standardize UI patterns across Rat Watch pages (#443)

### DIFF
--- a/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Analytics.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Analytics.cshtml
@@ -10,7 +10,7 @@
     <nav aria-label="Breadcrumb" class="mb-6">
         <ol class="flex items-center gap-2 text-sm flex-wrap">
             <li>
-                <a asp-page="/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Dashboard</a>
+                <a asp-page="/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Home</a>
             </li>
             <li class="text-text-tertiary" aria-hidden="true">
                 <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -285,13 +285,13 @@
                 }
                 else
                 {
-                    <div class="py-12 text-center">
-                        <svg class="w-12 h-12 mx-auto text-text-tertiary mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 12l3-3 3 3 4-4M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z" />
-                        </svg>
-                        <p class="text-text-secondary font-medium">No watch data available</p>
-                        <p class="text-sm text-text-tertiary mt-1">Data will appear here once watches are created</p>
-                    </div>
+                    <partial name="Shared/Components/_EmptyState" model='new EmptyStateViewModel {
+                        Type = EmptyStateType.NoData,
+                        Title = "No watch data available",
+                        Description = "Data will appear here once watches are created",
+                        Size = EmptyStateSize.Compact,
+                        IconSvgPath = "M7 12l3-3 3 3 4-4M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z"
+                    }' />
                 }
             </div>
         </div>
@@ -317,13 +317,13 @@
                 }
                 else
                 {
-                    <div class="py-12 text-center">
-                        <svg class="w-12 h-12 mx-auto text-text-tertiary mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-                        </svg>
-                        <p class="text-text-secondary font-medium">No data available</p>
-                        <p class="text-sm text-text-tertiary mt-1">Outcomes will appear here once watches complete</p>
-                    </div>
+                    <partial name="Shared/Components/_EmptyState" model='new EmptyStateViewModel {
+                        Type = EmptyStateType.NoData,
+                        Title = "No data available",
+                        Description = "Outcomes will appear here once watches complete",
+                        Size = EmptyStateSize.Compact,
+                        IconSvgPath = "M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+                    }' />
                 }
             </div>
         </div>
@@ -352,13 +352,13 @@
                 }
                 else
                 {
-                    <div class="py-12 text-center">
-                        <svg class="w-12 h-12 mx-auto text-text-tertiary mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-                        </svg>
-                        <p class="text-text-secondary font-medium">No activity data available</p>
-                        <p class="text-sm text-text-tertiary mt-1">Activity patterns will appear here</p>
-                    </div>
+                    <partial name="Shared/Components/_EmptyState" model='new EmptyStateViewModel {
+                        Type = EmptyStateType.NoData,
+                        Title = "No activity data available",
+                        Description = "Activity patterns will appear here",
+                        Size = EmptyStateSize.Compact,
+                        IconSvgPath = "M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+                    }' />
                 }
             </div>
         </div>
@@ -384,13 +384,13 @@
                 }
                 else
                 {
-                    <div class="py-12 text-center">
-                        <svg class="w-12 h-12 mx-auto text-text-tertiary mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-                        </svg>
-                        <p class="text-text-secondary font-medium">No user data available</p>
-                        <p class="text-sm text-text-tertiary mt-1">User leaderboard will appear here</p>
-                    </div>
+                    <partial name="Shared/Components/_EmptyState" model='new EmptyStateViewModel {
+                        Type = EmptyStateType.NoData,
+                        Title = "No user data available",
+                        Description = "User leaderboard will appear here",
+                        Size = EmptyStateSize.Compact,
+                        IconSvgPath = "M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+                    }' />
                 }
             </div>
         </div>
@@ -617,6 +617,8 @@
                                 var rank = i + 1;
                                 var rankBadgeClass = rank == 1 ? "bg-warning/20 text-warning" : rank <= 3 ? "bg-accent-orange/20 text-accent-orange" : "bg-bg-tertiary text-text-tertiary";
                                 var guiltyRate = user.WatchesAgainst > 0 ? (double)user.GuiltyCount / user.WatchesAgainst * 100 : 0;
+                                // Standardized color thresholds: <50% success, 50-80% warning, >80% error
+                                var guiltyRateColorClass = guiltyRate < 50 ? "text-success bg-success/10" : guiltyRate <= 80 ? "text-warning bg-warning/10" : "text-error bg-error/10";
                                 <tr class="hover:bg-bg-hover transition-colors">
                                     <td class="px-5 py-4">
                                         <span class="inline-flex items-center justify-center w-8 h-8 rounded-full @rankBadgeClass font-bold text-sm">@rank</span>
@@ -631,7 +633,7 @@
                                     </td>
                                     <td class="px-5 py-4 text-text-primary font-medium">@user.WatchesAgainst</td>
                                     <td class="px-5 py-4">
-                                        <span class="inline-flex items-center px-2.5 py-0.5 text-xs font-semibold text-error bg-error/10 rounded-full">
+                                        <span class="inline-flex items-center px-2.5 py-0.5 text-xs font-semibold @guiltyRateColorClass rounded-full">
                                             @guiltyRate.ToString("F0")%
                                         </span>
                                     </td>
@@ -643,10 +645,12 @@
             }
             else
             {
-                <div class="py-12 text-center">
-                    <p class="text-text-secondary font-medium">No guilty verdicts yet</p>
-                    <p class="text-sm text-text-tertiary mt-1">Leaderboard will appear once guilty verdicts are recorded</p>
-                </div>
+                <partial name="Shared/Components/_EmptyState" model='new EmptyStateViewModel {
+                    Type = EmptyStateType.NoData,
+                    Title = "No guilty verdicts yet",
+                    Description = "Leaderboard will appear once guilty verdicts are recorded",
+                    Size = EmptyStateSize.Compact
+                }' />
             }
         </div>
     </div>
@@ -756,9 +760,9 @@
 }
 
 <style>
-    /* Tab active state */
+    /* Tab active state - using Tailwind CSS custom properties */
     .tab-btn.active {
-        border-color: #cb4e1b;
-        color: #d7d3d0;
+        border-color: rgb(var(--color-accent-orange) / 1);
+        color: rgb(var(--color-text-primary) / 1);
     }
 </style>

--- a/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Incidents.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Incidents.cshtml
@@ -73,24 +73,35 @@
         </a>
     </div>
 
-    <!-- Filters Section -->
+    <!-- Filter Panel -->
     <div class="bg-bg-secondary border border-border-primary rounded-lg mb-6">
-        <div class="flex items-center justify-between p-4 border-b border-border-primary">
-            <h2 class="text-sm font-semibold text-text-primary flex items-center gap-2">
-                <svg class="w-4 h-4 text-text-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <button type="button"
+                id="filterToggle"
+                class="w-full flex items-center justify-between px-5 py-4 text-left"
+                aria-expanded="true"
+                aria-controls="filterContent"
+                onclick="toggleFilterPanel()">
+            <div class="flex items-center gap-3">
+                <svg class="w-5 h-5 text-text-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
                 </svg>
-                Advanced Filters
-            </h2>
-            <button id="toggleFiltersBtn" type="button" class="text-sm text-accent-blue hover:text-accent-blue-hover transition-colors flex items-center gap-1">
-                <span id="toggleFiltersText">Hide Filters</span>
-                <svg id="toggleFiltersIcon" class="w-4 h-4 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7" />
-                </svg>
-            </button>
-        </div>
+                <span class="text-lg font-semibold text-text-primary">Filters</span>
+                @if (Model.ViewModel.ActiveFilterCount > 0)
+                {
+                    <partial name="Shared/Components/_Badge" model="@(new BadgeViewModel {
+                        Text = "Active",
+                        Variant = BadgeVariant.Orange,
+                        Size = BadgeSize.Small
+                    })" />
+                }
+            </div>
+            <svg id="filterChevron" class="w-5 h-5 text-text-secondary transition-transform duration-200" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            </svg>
+        </button>
 
-        <div id="filtersPanel" class="p-4">
+        <div id="filterContent" class="overflow-hidden transition-all duration-300 max-h-[1000px]">
+            <div class="border-t border-border-primary p-5">
             <form method="get" asp-page="Incidents" asp-route-guildId="@Model.ViewModel.GuildId" class="space-y-4">
                 <!-- Row 1: Status Multi-select -->
                 <div>
@@ -185,22 +196,25 @@
                 <input type="hidden" name="PageSize" value="@Model.ViewModel.PageSize" />
 
                 <!-- Filter Actions -->
-                <div class="flex flex-col sm:flex-row justify-end gap-2 pt-2">
-                    <a asp-page="Incidents" asp-route-guildId="@Model.ViewModel.GuildId"
-                       class="px-4 py-2 text-sm font-medium text-text-secondary bg-transparent border border-border-primary rounded-md hover:bg-bg-hover transition-colors text-center">
-                        Clear Filters
-                    </a>
-                    <button type="submit"
-                            class="px-4 py-2 text-sm font-medium text-white bg-accent-orange border border-accent-orange rounded-md hover:bg-accent-orange-hover transition-colors">
-                        <span class="flex items-center justify-center gap-2">
-                            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-                            </svg>
-                            Apply Filters
-                        </span>
+                <div class="flex items-center gap-3 mt-6 pt-4 border-t border-border-secondary">
+                    <button type="submit" class="btn btn-primary">
+                        <svg class="w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
+                        </svg>
+                        Apply Filters
                     </button>
+                    @if (Model.ViewModel.ActiveFilterCount > 0)
+                    {
+                        <a asp-page="Incidents" asp-route-guildId="@Model.ViewModel.GuildId" class="btn btn-secondary">
+                            <svg class="w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                            Clear Filters
+                        </a>
+                    }
                 </div>
             </form>
+            </div>
         </div>
     </div>
 
@@ -357,23 +371,27 @@
     else
     {
         <!-- Empty State -->
-        <div class="bg-bg-secondary border border-border-primary rounded-lg p-12 text-center">
-            <div class="w-16 h-16 mx-auto mb-4 rounded-full bg-bg-tertiary flex items-center justify-center">
-                <svg class="w-8 h-8 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-                </svg>
-            </div>
-            <h3 class="text-lg font-semibold text-text-primary mb-2">No Incidents Found</h3>
-            <p class="text-sm text-text-secondary max-w-sm mx-auto">
-                @if (Model.ViewModel.ActiveFilterCount > 0)
-                {
-                    <text>No incidents match your current filters. Try adjusting or clearing the filters.</text>
-                }
-                else
-                {
-                    <text>No Rat Watch incidents have been created in this server yet.</text>
-                }
-            </p>
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-8">
+            @if (Model.ViewModel.ActiveFilterCount > 0)
+            {
+                <partial name="Shared/Components/_EmptyState" model='new EmptyStateViewModel {
+                    Type = EmptyStateType.NoResults,
+                    Title = "No Incidents Found",
+                    Description = "No incidents match your current filters. Try adjusting or clearing the filters.",
+                    Size = EmptyStateSize.Default,
+                    SecondaryActionText = "Clear Filters",
+                    SecondaryActionUrl = "/Guilds/RatWatch/Incidents/" + Model.ViewModel.GuildId
+                }' />
+            }
+            else
+            {
+                <partial name="Shared/Components/_EmptyState" model='new EmptyStateViewModel {
+                    Type = EmptyStateType.NoData,
+                    Title = "No Incidents Found",
+                    Description = "No Rat Watch incidents have been created in this server yet.",
+                    Size = EmptyStateSize.Default
+                }' />
+            }
         </div>
     }
 </div>
@@ -417,19 +435,24 @@
 
 @section Scripts {
     <script>
-        // Filter panel toggle
-        document.getElementById('toggleFiltersBtn').addEventListener('click', function() {
-            const panel = document.getElementById('filtersPanel');
-            const text = document.getElementById('toggleFiltersText');
-            const icon = document.getElementById('toggleFiltersIcon');
-            const isHidden = panel.classList.contains('hidden');
+        // Filter panel toggle - matches Analytics page pattern
+        function toggleFilterPanel() {
+            const content = document.getElementById('filterContent');
+            const chevron = document.getElementById('filterChevron');
+            const toggle = document.getElementById('filterToggle');
 
-            panel.classList.toggle('hidden');
-            text.textContent = isHidden ? 'Hide Filters' : 'Show Filters';
-            icon.style.transform = isHidden ? 'rotate(0deg)' : 'rotate(180deg)';
-        });
+            if (content.style.maxHeight === '0px') {
+                content.style.maxHeight = '1000px';
+                chevron.style.transform = 'rotate(0deg)';
+                toggle.setAttribute('aria-expanded', 'true');
+            } else {
+                content.style.maxHeight = '0px';
+                chevron.style.transform = 'rotate(-90deg)';
+                toggle.setAttribute('aria-expanded', 'false');
+            }
+        }
 
-        // Quick date preset buttons
+        // Quick date preset buttons - auto-submit after setting dates
         document.querySelectorAll('.quick-date-btn').forEach(btn => {
             btn.addEventListener('click', function() {
                 const range = this.dataset.range;
@@ -451,6 +474,10 @@
 
                 document.getElementById('StartDate').value = startDate;
                 document.getElementById('EndDate').value = endDate;
+
+                // Auto-submit the form after setting dates
+                const form = document.querySelector('#filterContent form');
+                if (form) form.submit();
             });
         });
 

--- a/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Index.cshtml
@@ -181,7 +181,7 @@
     <!-- Summary Stats Cards -->
     @if (Model.ViewModel.AnalyticsSummary != null)
     {
-        <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4 mb-6">
+        <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4 lg:gap-6 mb-6">
             <!-- Total Watches -->
             <div class="bg-bg-secondary border border-border-primary rounded-lg p-5">
                 <div class="flex items-center justify-between">
@@ -510,28 +510,30 @@
     else
     {
         <!-- Empty State -->
-        <div class="bg-bg-secondary border border-border-primary rounded-lg p-12 text-center">
-            <div class="w-16 h-16 mx-auto mb-4 rounded-full bg-bg-tertiary flex items-center justify-center">
-                <svg class="w-8 h-8 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-                </svg>
-            </div>
-            <h3 class="text-lg font-semibold text-text-primary mb-2">No Rat Watches Yet</h3>
-            <p class="text-sm text-text-secondary max-w-sm mx-auto">
-                No accountability watches have been created in this server. Use the "Rat Watch" context menu on a message in Discord to start one.
-            </p>
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-8">
+            @{
+                var emptyStateDescription = "No accountability watches have been created in this server. Use the \"Rat Watch\" context menu on a message in Discord to start one.";
+            }
+            <partial name="Shared/Components/_EmptyState" model='new EmptyStateViewModel {
+                Type = EmptyStateType.FirstTime,
+                Title = "No Rat Watches Yet",
+                Description = emptyStateDescription,
+                Size = EmptyStateSize.Default,
+                IconSvgPath = "M15 12a3 3 0 11-6 0 3 3 0 016 0zM2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+            }' />
         </div>
     }
 </div>
 
 <!-- Cancel Confirmation Modal -->
-<div id="cancel-modal" class="hidden fixed inset-0 z-50 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
-    <div class="flex items-center justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:block sm:p-0">
-        <div class="modal-overlay fixed inset-0 transition-opacity" aria-hidden="true" onclick="hideCancelModal()"></div>
-        <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
-        <div class="inline-block align-bottom bg-bg-secondary rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full border border-border-primary">
-            <div class="px-6 py-5">
+<div id="cancel-modal" class="hidden fixed inset-0 z-50" role="alertdialog" aria-modal="true" aria-labelledby="modal-title">
+    <!-- Backdrop - standardized with Incidents modal -->
+    <div class="fixed inset-0 bg-black/70 backdrop-blur-sm" onclick="hideCancelModal()" aria-hidden="true"></div>
+    <!-- Modal Dialog - centered with flexbox -->
+    <div class="fixed inset-0 flex items-center justify-center p-4">
+        <div class="bg-bg-tertiary border border-border-primary rounded-lg shadow-xl max-w-md w-full" role="document">
+            <!-- Modal Content -->
+            <div class="p-6">
                 <div class="flex items-start gap-4">
                     <div class="flex-shrink-0 w-10 h-10 rounded-full bg-warning/20 flex items-center justify-center">
                         <svg class="w-5 h-5 text-warning" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -546,15 +548,16 @@
                     </div>
                 </div>
             </div>
-            <div class="px-6 py-4 bg-bg-primary flex flex-col-reverse sm:flex-row sm:justify-end gap-3">
+            <!-- Modal Footer - standardized -->
+            <div class="flex justify-end gap-3 px-6 py-4 bg-bg-secondary border-t border-border-primary rounded-b-lg">
                 <button type="button" onclick="hideCancelModal()"
-                        class="inline-flex justify-center px-4 py-2 text-sm font-medium text-text-primary bg-transparent border border-border-primary rounded-md hover:bg-bg-hover transition-colors">
+                        class="px-4 py-2 bg-bg-tertiary hover:bg-bg-hover border border-border-primary text-text-primary font-medium text-sm rounded-md transition-colors">
                     Keep Watch
                 </button>
-                <form id="cancel-form" method="post" asp-page="Index" asp-page-handler="Cancel" asp-route-guildId="@Model.ViewModel.GuildId">
+                <form id="cancel-form" method="post" asp-page="Index" asp-page-handler="Cancel" asp-route-guildId="@Model.ViewModel.GuildId" class="inline-block">
                     <input type="hidden" id="cancel-watch-id" name="watchId" value="" />
                     <button type="submit"
-                            class="inline-flex justify-center px-4 py-2 text-sm font-medium text-white bg-error border border-error rounded-md hover:bg-red-600 transition-colors">
+                            class="px-4 py-2 bg-error hover:bg-red-600 active:bg-red-700 text-white font-medium text-sm rounded-md transition-colors">
                         Cancel Watch
                     </button>
                 </form>
@@ -564,12 +567,14 @@
 </div>
 
 <!-- End Vote Confirmation Modal -->
-<div id="end-vote-modal" class="hidden fixed inset-0 z-50 overflow-y-auto" aria-labelledby="end-vote-modal-title" role="dialog" aria-modal="true">
-    <div class="flex items-center justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:block sm:p-0">
-        <div class="modal-overlay fixed inset-0 transition-opacity" aria-hidden="true" onclick="hideEndVoteModal()"></div>
-        <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
-        <div class="inline-block align-bottom bg-bg-secondary rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full border border-border-primary">
-            <div class="px-6 py-5">
+<div id="end-vote-modal" class="hidden fixed inset-0 z-50" role="alertdialog" aria-modal="true" aria-labelledby="end-vote-modal-title">
+    <!-- Backdrop - standardized with Incidents modal -->
+    <div class="fixed inset-0 bg-black/70 backdrop-blur-sm" onclick="hideEndVoteModal()" aria-hidden="true"></div>
+    <!-- Modal Dialog - centered with flexbox -->
+    <div class="fixed inset-0 flex items-center justify-center p-4">
+        <div class="bg-bg-tertiary border border-border-primary rounded-lg shadow-xl max-w-md w-full" role="document">
+            <!-- Modal Content -->
+            <div class="p-6">
                 <div class="flex items-start gap-4">
                     <div class="flex-shrink-0 w-10 h-10 rounded-full bg-accent-blue/20 flex items-center justify-center">
                         <svg class="w-5 h-5 text-accent-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -590,15 +595,16 @@
                     </div>
                 </div>
             </div>
-            <div class="px-6 py-4 bg-bg-primary flex flex-col-reverse sm:flex-row sm:justify-end gap-3">
+            <!-- Modal Footer - standardized -->
+            <div class="flex justify-end gap-3 px-6 py-4 bg-bg-secondary border-t border-border-primary rounded-b-lg">
                 <button type="button" onclick="hideEndVoteModal()"
-                        class="inline-flex justify-center px-4 py-2 text-sm font-medium text-text-primary bg-transparent border border-border-primary rounded-md hover:bg-bg-hover transition-colors">
+                        class="px-4 py-2 bg-bg-tertiary hover:bg-bg-hover border border-border-primary text-text-primary font-medium text-sm rounded-md transition-colors">
                     Continue Voting
                 </button>
-                <form id="end-vote-form" method="post" asp-page="Index" asp-page-handler="EndVote" asp-route-guildId="@Model.ViewModel.GuildId">
+                <form id="end-vote-form" method="post" asp-page="Index" asp-page-handler="EndVote" asp-route-guildId="@Model.ViewModel.GuildId" class="inline-block">
                     <input type="hidden" id="end-vote-watch-id" name="watchId" value="" />
                     <button type="submit"
-                            class="inline-flex justify-center px-4 py-2 text-sm font-medium text-white bg-accent-blue border border-accent-blue rounded-md hover:bg-blue-600 transition-colors">
+                            class="px-4 py-2 bg-accent-blue hover:bg-accent-blue-hover active:bg-accent-blue-active text-white font-medium text-sm rounded-md transition-colors">
                         End Vote Now
                     </button>
                 </form>
@@ -609,10 +615,6 @@
 
 @section Scripts {
     <style>
-        .modal-overlay {
-            background-color: rgba(0, 0, 0, 0.6);
-            backdrop-filter: blur(2px);
-        }
         .table-row .row-actions {
             opacity: 0;
             transition: opacity 0.15s ease-in-out;

--- a/src/DiscordBot.Bot/Pages/Shared/Components/_Badge.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/Components/_Badge.cshtml
@@ -28,6 +28,20 @@
             _ => "border border-bg-tertiary text-text-secondary bg-transparent"
         };
     }
+    else if (Model.Style == DiscordBot.Bot.ViewModels.Components.BadgeStyle.Subtle)
+    {
+        // Subtle style: muted background with colored text (commonly used for status badges)
+        variantClasses = Model.Variant switch
+        {
+            DiscordBot.Bot.ViewModels.Components.BadgeVariant.Orange => "bg-accent-orange/10 text-accent-orange",
+            DiscordBot.Bot.ViewModels.Components.BadgeVariant.Blue => "bg-accent-blue/10 text-accent-blue",
+            DiscordBot.Bot.ViewModels.Components.BadgeVariant.Success => "bg-success/10 text-success",
+            DiscordBot.Bot.ViewModels.Components.BadgeVariant.Warning => "bg-warning/10 text-warning",
+            DiscordBot.Bot.ViewModels.Components.BadgeVariant.Error => "bg-error/10 text-error",
+            DiscordBot.Bot.ViewModels.Components.BadgeVariant.Info => "bg-info/10 text-info",
+            _ => "bg-bg-tertiary/50 text-text-secondary"
+        };
+    }
     else
     {
         variantClasses = Model.Variant switch

--- a/src/DiscordBot.Bot/ViewModels/Components/BadgeViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Components/BadgeViewModel.cs
@@ -33,5 +33,6 @@ public enum BadgeSize
 public enum BadgeStyle
 {
     Filled,     // Solid background
-    Outline     // Border only
+    Outline,    // Border only
+    Subtle      // Muted background with colored text (e.g., bg-success/10 text-success)
 }

--- a/src/DiscordBot.Bot/wwwroot/js/rat-watch-analytics.js
+++ b/src/DiscordBot.Bot/wwwroot/js/rat-watch-analytics.js
@@ -4,33 +4,68 @@
 (function () {
     'use strict';
 
-    // Design system chart colors
+    /**
+     * Gets a CSS custom property value from the :root element
+     * @param {string} name - The property name (without --color- prefix)
+     * @returns {string} The computed color value
+     */
+    function getDesignToken(name) {
+        return getComputedStyle(document.documentElement)
+            .getPropertyValue(`--color-${name}`).trim();
+    }
+
+    /**
+     * Initialize design system colors from CSS custom properties
+     * This ensures chart colors stay in sync with the design system
+     */
+    function initColors() {
+        return {
+            accentOrange: getDesignToken('accent-orange') || '#cb4e1b',
+            accentBlue: getDesignToken('accent-blue') || '#098ecf',
+            success: getDesignToken('success') || '#10b981',
+            warning: getDesignToken('warning') || '#f59e0b',
+            info: getDesignToken('info') || '#06b6d4',
+            error: getDesignToken('error') || '#ef4444',
+            bgPrimary: getDesignToken('bg-primary') || '#1d2022',
+            bgSecondary: getDesignToken('bg-secondary') || '#262a2d',
+            bgTertiary: getDesignToken('bg-tertiary') || '#2f3336',
+            textPrimary: getDesignToken('text-primary') || '#d7d3d0',
+            textSecondary: getDesignToken('text-secondary') || '#a8a5a3',
+            textTertiary: getDesignToken('text-tertiary') || '#7a7876',
+            borderPrimary: getDesignToken('border-primary') || '#3f4447',
+        };
+    }
+
+    // Initialize colors from design tokens (with fallbacks for SSR/testing)
+    let colors = initColors();
+
+    // Chart colors array (derived from design tokens)
     const CHART_COLORS = [
-        '#cb4e1b',  // accent-orange
-        '#098ecf',  // accent-blue
-        '#10b981',  // success
-        '#f59e0b',  // warning
-        '#06b6d4',  // info
-        '#ef4444',  // error
-        '#8b5cf6',  // purple
-        '#ec4899',  // pink
-        '#14b8a6',  // teal
-        '#6366f1',  // indigo
+        colors.accentOrange,  // accent-orange
+        colors.accentBlue,    // accent-blue
+        colors.success,       // success
+        colors.warning,       // warning
+        colors.info,          // info
+        colors.error,         // error
+        '#8b5cf6',            // purple (extended palette)
+        '#ec4899',            // pink (extended palette)
+        '#14b8a6',            // teal (extended palette)
+        '#6366f1',            // indigo (extended palette)
     ];
 
     const BG_COLORS = {
-        primary: '#1d2022',
-        secondary: '#262a2d',
-        tertiary: '#2f3336',
+        primary: colors.bgPrimary,
+        secondary: colors.bgSecondary,
+        tertiary: colors.bgTertiary,
     };
 
     const TEXT_COLORS = {
-        primary: '#d7d3d0',
-        secondary: '#a8a5a3',
-        tertiary: '#7a7876',
+        primary: colors.textPrimary,
+        secondary: colors.textSecondary,
+        tertiary: colors.textTertiary,
     };
 
-    const BORDER_COLOR = '#3f4447';
+    const BORDER_COLOR = colors.borderPrimary;
 
     // Chart instance references
     let watchesOverTimeChart = null;


### PR DESCRIPTION
## Summary
- **Breadcrumb navigation**: Uses consistent "Home" label across all Rat Watch pages
- **Design tokens**: Chart.js colors now read from CSS custom properties instead of hardcoded values
- **Filter panel UX**: Standardized collapsible panel with chevron animation and "Active" badge
- **Date presets**: Quick date buttons now auto-submit the form after setting dates
- **Empty states**: Refactored to use shared `_EmptyState` component for consistency
- **Modal styling**: Standardized backdrop, centering, and button styling across all modals
- **Guilty rate colors**: Consistent thresholds (<50% success, 50-80% warning, >80% error)
- **Badge component**: Added `Subtle` style variant for muted background status badges
- **Grid spacing**: Standardized stat card grids with responsive gap (gap-4 lg:gap-6)

## Test plan
- [ ] Verify breadcrumb shows "Home" on Analytics, Incidents, and Index pages
- [ ] Check that chart colors match design system tokens
- [ ] Test filter panel expand/collapse animation on Incidents page
- [ ] Verify date preset buttons auto-submit the filter form
- [ ] Confirm empty states display correctly when no data
- [ ] Test modal open/close on Index (cancel/end vote) and Incidents (detail) pages
- [ ] Verify guilty rate colors change at 50% and 80% thresholds
- [ ] Check stat card grid spacing on mobile and desktop

Closes #443
Closes #444
Closes #445
Closes #446
Closes #447
Closes #448
Closes #449
Closes #450
Closes #451
Closes #452
Closes #453
Closes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)