### PR TITLE
[Feature] Update navigation for Rat Watch Analytics pages

### DIFF
--- a/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml
@@ -342,9 +342,17 @@
                     </span>
                 }
             </div>
-            <a asp-page="RatWatch/Index" asp-route-guildId="@guild.Id" class="text-sm text-accent-blue hover:text-accent-blue/80 transition-colors">
-                Manage →
-            </a>
+            <div class="flex items-center gap-3">
+                <a asp-page="RatWatch/Index" asp-route-guildId="@guild.Id" class="text-sm text-text-secondary hover:text-text-primary transition-colors">
+                    Settings
+                </a>
+                <a asp-page="RatWatch/Analytics" asp-route-guildId="@guild.Id" class="text-sm text-text-secondary hover:text-text-primary transition-colors">
+                    Analytics
+                </a>
+                <a asp-page="RatWatch/Incidents" asp-route-guildId="@guild.Id" class="text-sm text-accent-blue hover:text-accent-blue/80 transition-colors">
+                    Incidents →
+                </a>
+            </div>
         </div>
 
         @if (Model.RatWatchTotal > 0)


### PR DESCRIPTION
## Summary
- Add navigation links (Settings, Analytics, Incidents) to the Rat Watch section on the Guild Details page
- Replaces single "Manage →" link with three distinct navigation options
- Users can now navigate directly to specific Rat Watch pages from the guild overview

## Implementation Notes
- **RatWatch tabs**: Already implemented in all three pages (Index, Analytics, Incidents)
- **Admin sidebar link**: Already present for Admin+ users to access Global Rat Watch Analytics  
- **CLAUDE.md routes**: Already documented with correct URL patterns
- **Guild Details page**: Updated to add navigation links to all three Rat Watch pages

## Test plan
- [ ] Verify navigation links in Guild Details page work correctly
- [ ] Test that Settings, Analytics, and Incidents links navigate to correct pages with guildId
- [ ] Confirm existing tab navigation in RatWatch pages still works
- [ ] Verify Admin sidebar link remains functional for Admin+ users

Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)