### PR TITLE
fix: Improve accessibility for moderation pages

### DIFF
--- a/src/DiscordBot.Bot/Pages/Guilds/FlaggedEvents/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/FlaggedEvents/Index.cshtml
@@ -182,7 +182,7 @@
                 <thead class="bg-bg-tertiary">
                     <tr>
                         <th scope="col" class="w-12 px-4 py-3">
-                            <input type="checkbox" id="selectAll" onclick="toggleSelectAll(this)" class="w-4 h-4 rounded border-border-primary text-accent-blue focus:ring-accent-blue" />
+                            <input type="checkbox" id="selectAll" onclick="toggleSelectAll(this)" class="w-4 h-4 rounded border-border-primary text-accent-blue focus:ring-accent-blue" aria-label="Select all events" />
                         </th>
                         <th scope="col" class="px-4 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Severity</th>
                         <th scope="col" class="px-4 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">User</th>
@@ -198,7 +198,7 @@
                     {
                         <tr class="hover:bg-bg-hover transition-colors">
                             <td class="px-4 py-4 whitespace-nowrap">
-                                <input type="checkbox" class="event-checkbox w-4 h-4 rounded border-border-primary text-accent-blue focus:ring-accent-blue" data-event-id="@evt.Id" onclick="updateBulkToolbar()" />
+                                <input type="checkbox" class="event-checkbox w-4 h-4 rounded border-border-primary text-accent-blue focus:ring-accent-blue" data-event-id="@evt.Id" onclick="updateBulkToolbar()" aria-label="Select event from @evt.Username" />
                             </td>
                             <td class="px-4 py-4 whitespace-nowrap">
                                 <partial name="Shared/Components/_SeverityBadge" model="evt.Severity" />
@@ -252,7 +252,7 @@
                 <div class="bg-bg-secondary border border-border-primary rounded-lg p-4">
                     <div class="flex items-start justify-between mb-3">
                         <div class="flex items-center gap-3">
-                            <input type="checkbox" class="event-checkbox w-4 h-4 rounded border-border-primary text-accent-blue focus:ring-accent-blue" data-event-id="@evt.Id" onclick="updateBulkToolbar()" />
+                            <input type="checkbox" class="event-checkbox w-4 h-4 rounded border-border-primary text-accent-blue focus:ring-accent-blue" data-event-id="@evt.Id" onclick="updateBulkToolbar()" aria-label="Select event from @evt.Username" />
                             <partial name="Shared/Components/_SeverityBadge" model="evt.Severity" />
                         </div>
                         <partial name="Shared/Components/_StatusBadge" model="evt.Status" />

--- a/src/DiscordBot.Bot/Pages/Guilds/Members/Moderation.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Members/Moderation.cshtml
@@ -130,23 +130,23 @@
     </div>
 
     <!-- Tab Navigation -->
-    <div class="settings-tabs mb-6">
-        <button type="button" class="settings-tab settings-tab-active" data-tab="cases" onclick="switchTab('cases')">
-            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <div class="settings-tabs mb-6" role="tablist" aria-label="User moderation sections">
+        <button type="button" class="settings-tab settings-tab-active" id="tab-btn-cases" role="tab" aria-selected="true" aria-controls="tab-cases" data-tab="cases" onclick="switchTab('cases')">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
             </svg>
             Cases
             <span class="inline-flex items-center justify-center px-2 py-0.5 rounded-full text-xs font-medium bg-error text-white">@Model.ViewModel.Cases.Count</span>
         </button>
-        <button type="button" class="settings-tab" data-tab="notes" onclick="switchTab('notes')">
-            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <button type="button" class="settings-tab" id="tab-btn-notes" role="tab" aria-selected="false" aria-controls="tab-notes" data-tab="notes" onclick="switchTab('notes')">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
             </svg>
             Notes
             <span class="inline-flex items-center justify-center px-2 py-0.5 rounded-full text-xs font-medium bg-accent-blue text-white">@Model.ViewModel.Notes.Count</span>
         </button>
-        <button type="button" class="settings-tab" data-tab="flags" onclick="switchTab('flags')">
-            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <button type="button" class="settings-tab" id="tab-btn-flags" role="tab" aria-selected="false" aria-controls="tab-flags" data-tab="flags" onclick="switchTab('flags')">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 21v-4m0 0V5a2 2 0 012-2h6.5l1 1H21l-3 6 3 6h-8.5l-1-1H5a2 2 0 00-2 2zm9-13.5V9" />
             </svg>
             Flags
@@ -157,7 +157,7 @@
     <!-- Tab Content -->
     <div class="bg-bg-secondary border border-border-primary rounded-lg">
         <!-- Cases Tab -->
-        <div id="tab-cases" class="tab-content">
+        <div id="tab-cases" class="tab-content" role="tabpanel" aria-labelledby="tab-btn-cases">
             <div class="overflow-x-auto">
                 <table class="w-full" role="table" aria-label="Moderation cases">
                     <thead class="bg-bg-tertiary">
@@ -216,7 +216,7 @@
         </div>
 
         <!-- Notes Tab -->
-        <div id="tab-notes" class="tab-content hidden p-6">
+        <div id="tab-notes" class="tab-content hidden p-6" role="tabpanel" aria-labelledby="tab-btn-notes">
             <!-- Add Note Form -->
             <div class="mb-6">
                 <h3 class="text-sm font-semibold text-text-primary mb-2">Add New Note</h3>
@@ -258,7 +258,7 @@
         </div>
 
         <!-- Flags Tab -->
-        <div id="tab-flags" class="tab-content hidden">
+        <div id="tab-flags" class="tab-content hidden" role="tabpanel" aria-labelledby="tab-btn-flags">
             <div class="overflow-x-auto">
                 <table class="w-full" role="table" aria-label="Flagged events">
                     <thead class="bg-bg-tertiary">

--- a/src/DiscordBot.Bot/Pages/Guilds/ModerationSettings/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/ModerationSettings/Index.cshtml
@@ -46,33 +46,33 @@
 </div>
 
 <!-- Tab Navigation -->
-<div class="settings-tabs mb-6">
-    <button type="button" class="settings-tab settings-tab-active" data-tab="overview" onclick="window.moderationSettings.switchTab('overview')">
-        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+<div class="settings-tabs mb-6" role="tablist" aria-label="Moderation settings sections">
+    <button type="button" class="settings-tab settings-tab-active" id="tab-btn-overview" role="tab" aria-selected="true" aria-controls="tab-overview" data-tab="overview" onclick="window.moderationSettings.switchTab('overview')">
+        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
         </svg>
         Overview
     </button>
-    <button type="button" class="settings-tab" data-tab="spam" onclick="window.moderationSettings.switchTab('spam')">
-        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <button type="button" class="settings-tab" id="tab-btn-spam" role="tab" aria-selected="false" aria-controls="tab-spam" data-tab="spam" onclick="window.moderationSettings.switchTab('spam')">
+        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
         </svg>
         Spam
     </button>
-    <button type="button" class="settings-tab" data-tab="content" onclick="window.moderationSettings.switchTab('content')">
-        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <button type="button" class="settings-tab" id="tab-btn-content" role="tab" aria-selected="false" aria-controls="tab-content" data-tab="content" onclick="window.moderationSettings.switchTab('content')">
+        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.618 5.984A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016zM12 9v2m0 4h.01" />
         </svg>
         Content
     </button>
-    <button type="button" class="settings-tab" data-tab="raid" onclick="window.moderationSettings.switchTab('raid')">
-        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <button type="button" class="settings-tab" id="tab-btn-raid" role="tab" aria-selected="false" aria-controls="tab-raid" data-tab="raid" onclick="window.moderationSettings.switchTab('raid')">
+        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
         </svg>
         Raid
     </button>
-    <button type="button" class="settings-tab" data-tab="tags" onclick="window.moderationSettings.switchTab('tags')">
-        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <button type="button" class="settings-tab" id="tab-btn-tags" role="tab" aria-selected="false" aria-controls="tab-tags" data-tab="tags" onclick="window.moderationSettings.switchTab('tags')">
+        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
         </svg>
         Tags
@@ -82,7 +82,7 @@
 <!-- Tab Content Container -->
 <div class="bg-bg-secondary border border-border-primary rounded-lg">
     <!-- Overview Tab -->
-    <div id="tab-overview" class="tab-content p-6">
+    <div id="tab-overview" class="tab-content p-6" role="tabpanel" aria-labelledby="tab-btn-overview">
         <!-- Mode Toggle -->
         <div class="mb-8">
             <h3 class="text-lg font-semibold text-text-primary mb-2">Configuration Mode</h3>
@@ -197,7 +197,7 @@
     </div>
 
     <!-- Spam Tab -->
-    <div id="tab-spam" class="tab-content hidden p-6">
+    <div id="tab-spam" class="tab-content hidden p-6" role="tabpanel" aria-labelledby="tab-btn-spam">
         <!-- Enable Toggle -->
         <div class="flex items-center justify-between mb-6 pb-6 border-b border-border-secondary">
             <div>
@@ -216,12 +216,12 @@
             <!-- Message Rate -->
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
-                    <label class="block text-sm font-medium text-text-primary mb-1">Message Rate Threshold</label>
+                    <label for="spam-max-messages" class="block text-sm font-medium text-text-primary mb-1">Message Rate Threshold</label>
                     <p class="text-xs text-text-tertiary mb-2">Flag when user sends this many messages...</p>
                     <input type="number" id="spam-max-messages" value="@Model.ViewModel.SpamConfig.MaxMessagesPerWindow" min="1" max="100" class="w-full px-3 py-2 text-sm bg-bg-primary border border-border-primary rounded-lg text-text-primary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors" />
                 </div>
                 <div>
-                    <label class="block text-sm font-medium text-text-primary mb-1">Time Window (seconds)</label>
+                    <label for="spam-window-seconds" class="block text-sm font-medium text-text-primary mb-1">Time Window (seconds)</label>
                     <p class="text-xs text-text-tertiary mb-2">...within this time period</p>
                     <input type="number" id="spam-window-seconds" value="@Model.ViewModel.SpamConfig.WindowSeconds" min="1" max="60" class="w-full px-3 py-2 text-sm bg-bg-primary border border-border-primary rounded-lg text-text-primary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors" />
                 </div>
@@ -230,12 +230,12 @@
             <!-- Duplicate Detection -->
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
-                    <label class="block text-sm font-medium text-text-primary mb-1">Max Mentions Per Message</label>
+                    <label for="spam-max-mentions" class="block text-sm font-medium text-text-primary mb-1">Max Mentions Per Message</label>
                     <p class="text-xs text-text-tertiary mb-2">Maximum mentions allowed per message</p>
                     <input type="number" id="spam-max-mentions" value="@Model.ViewModel.SpamConfig.MaxMentionsPerMessage" min="1" max="50" class="w-full px-3 py-2 text-sm bg-bg-primary border border-border-primary rounded-lg text-text-primary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors" />
                 </div>
                 <div>
-                    <label class="block text-sm font-medium text-text-primary mb-1">Similarity Threshold (%)</label>
+                    <label for="spam-duplicate-threshold" class="block text-sm font-medium text-text-primary mb-1">Similarity Threshold (%)</label>
                     <p class="text-xs text-text-tertiary mb-2">Messages this similar count as duplicates</p>
                     <input type="number" id="spam-duplicate-threshold" value="@((int)(Model.ViewModel.SpamConfig.DuplicateMessageThreshold * 100))" min="50" max="100" class="w-full px-3 py-2 text-sm bg-bg-primary border border-border-primary rounded-lg text-text-primary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors" />
                 </div>
@@ -243,7 +243,7 @@
 
             <!-- Auto Action -->
             <div>
-                <label class="block text-sm font-medium text-text-primary mb-1">Auto-Action on Detection</label>
+                <label for="spam-auto-action" class="block text-sm font-medium text-text-primary mb-1">Auto-Action on Detection</label>
                 <p class="text-xs text-text-tertiary mb-2">Automatically take action when spam is detected</p>
                 <select id="spam-auto-action" class="w-full md:w-64 px-3 py-2 text-sm bg-bg-primary border border-border-primary rounded-lg text-text-primary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors cursor-pointer">
                     <option value="0" selected="@(Model.ViewModel.SpamConfig.AutoAction == Core.DTOs.AutoAction.None)">None (Flag Only)</option>
@@ -265,7 +265,7 @@
     </div>
 
     <!-- Content Tab -->
-    <div id="tab-content" class="tab-content hidden p-6">
+    <div id="tab-content" class="tab-content hidden p-6" role="tabpanel" aria-labelledby="tab-btn-content">
         <!-- Enable Toggle -->
         <div class="flex items-center justify-between mb-6 pb-6 border-b border-border-secondary">
             <div>
@@ -283,23 +283,23 @@
         <div class="space-y-6">
             <!-- Custom Blocklist -->
             <div>
-                <label class="block text-sm font-medium text-text-primary mb-1">Custom Blocklist</label>
+                <label for="content-prohibited-words" class="block text-sm font-medium text-text-primary mb-1">Custom Blocklist</label>
                 <p class="text-xs text-text-tertiary mb-2">Words and phrases to block (comma-separated)</p>
                 <textarea id="content-prohibited-words" rows="3" placeholder="Enter words or phrases..." class="w-full px-3 py-2 text-sm bg-bg-primary border border-border-primary rounded-lg text-text-primary placeholder-text-tertiary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors resize-none">@string.Join(", ", Model.ViewModel.ContentFilterConfig.ProhibitedWords)</textarea>
             </div>
 
             <!-- Block Invite Links -->
             <div class="flex items-center gap-3">
-                <input type="checkbox" id="content-block-invites" @(Model.ViewModel.ContentFilterConfig.BlockInviteLinks ? "checked" : "") class="w-4 h-4 rounded border-border-primary" />
+                <input type="checkbox" id="content-block-invites" @(Model.ViewModel.ContentFilterConfig.BlockInviteLinks ? "checked" : "") class="w-4 h-4 rounded border-border-primary" aria-describedby="content-block-invites-desc" />
                 <div>
-                    <span class="text-sm text-text-primary font-medium">Block Discord Invite Links</span>
-                    <p class="text-xs text-text-tertiary">Prevent users from posting Discord server invites</p>
+                    <label for="content-block-invites" class="text-sm text-text-primary font-medium cursor-pointer">Block Discord Invite Links</label>
+                    <p id="content-block-invites-desc" class="text-xs text-text-tertiary">Prevent users from posting Discord server invites</p>
                 </div>
             </div>
 
             <!-- Auto Action -->
             <div>
-                <label class="block text-sm font-medium text-text-primary mb-1">Auto-Action on Detection</label>
+                <label for="content-auto-action" class="block text-sm font-medium text-text-primary mb-1">Auto-Action on Detection</label>
                 <select id="content-auto-action" class="w-full md:w-64 px-3 py-2 text-sm bg-bg-primary border border-border-primary rounded-lg text-text-primary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors cursor-pointer">
                     <option value="0" selected="@(Model.ViewModel.ContentFilterConfig.AutoAction == Core.DTOs.AutoAction.None)">None (Flag Only)</option>
                     <option value="1" selected="@(Model.ViewModel.ContentFilterConfig.AutoAction == Core.DTOs.AutoAction.Delete)">Delete Message</option>
@@ -319,7 +319,7 @@
     </div>
 
     <!-- Raid Tab -->
-    <div id="tab-raid" class="tab-content hidden p-6">
+    <div id="tab-raid" class="tab-content hidden p-6" role="tabpanel" aria-labelledby="tab-btn-raid">
         <!-- Enable Toggle -->
         <div class="flex items-center justify-between mb-6 pb-6 border-b border-border-secondary">
             <div>
@@ -338,12 +338,12 @@
             <!-- Join Rate -->
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
-                    <label class="block text-sm font-medium text-text-primary mb-1">Mass Join Threshold</label>
+                    <label for="raid-max-joins" class="block text-sm font-medium text-text-primary mb-1">Mass Join Threshold</label>
                     <p class="text-xs text-text-tertiary mb-2">Trigger when this many users join...</p>
                     <input type="number" id="raid-max-joins" value="@Model.ViewModel.RaidProtectionConfig.MaxJoinsPerWindow" min="5" max="100" class="w-full px-3 py-2 text-sm bg-bg-primary border border-border-primary rounded-lg text-text-primary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors" />
                 </div>
                 <div>
-                    <label class="block text-sm font-medium text-text-primary mb-1">Time Window (seconds)</label>
+                    <label for="raid-window-seconds" class="block text-sm font-medium text-text-primary mb-1">Time Window (seconds)</label>
                     <p class="text-xs text-text-tertiary mb-2">...within this time period</p>
                     <input type="number" id="raid-window-seconds" value="@Model.ViewModel.RaidProtectionConfig.WindowSeconds" min="10" max="300" class="w-full px-3 py-2 text-sm bg-bg-primary border border-border-primary rounded-lg text-text-primary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors" />
                 </div>
@@ -351,14 +351,14 @@
 
             <!-- Account Age -->
             <div>
-                <label class="block text-sm font-medium text-text-primary mb-1">Minimum Account Age (hours)</label>
+                <label for="raid-min-account-age" class="block text-sm font-medium text-text-primary mb-1">Minimum Account Age (hours)</label>
                 <p class="text-xs text-text-tertiary mb-2">Require accounts to be older than this (0 = no restriction)</p>
                 <input type="number" id="raid-min-account-age" value="@Model.ViewModel.RaidProtectionConfig.MinAccountAgeHours" min="0" max="720" class="w-32 px-3 py-2 text-sm bg-bg-primary border border-border-primary rounded-lg text-text-primary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors" />
             </div>
 
             <!-- Auto Action -->
             <div>
-                <label class="block text-sm font-medium text-text-primary mb-1">Auto-Action on Raid Detection</label>
+                <label for="raid-auto-action" class="block text-sm font-medium text-text-primary mb-1">Auto-Action on Raid Detection</label>
                 <p class="text-xs text-text-tertiary mb-2">Action to take when a raid is detected</p>
                 <select id="raid-auto-action" class="w-full md:w-64 px-3 py-2 text-sm bg-bg-primary border border-border-primary rounded-lg text-text-primary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors cursor-pointer">
                     <option value="0" selected="@(Model.ViewModel.RaidProtectionConfig.AutoAction == Core.DTOs.RaidAutoAction.None)">None</option>
@@ -378,7 +378,7 @@
     </div>
 
     <!-- Tags Tab -->
-    <div id="tab-tags" class="tab-content hidden p-6">
+    <div id="tab-tags" class="tab-content hidden p-6" role="tabpanel" aria-labelledby="tab-btn-tags">
         <div class="flex items-center justify-between mb-6">
             <div>
                 <h3 class="text-lg font-semibold text-text-primary">User Tags</h3>
@@ -417,11 +417,11 @@
             <h4 class="font-medium text-text-primary mb-4">Add New Tag</h4>
             <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                 <div>
-                    <label class="block text-sm font-medium text-text-primary mb-1">Tag Name</label>
+                    <label for="new-tag-name" class="block text-sm font-medium text-text-primary mb-1">Tag Name</label>
                     <input type="text" id="new-tag-name" placeholder="e.g., VIP, Trusted, etc." class="w-full px-3 py-2 text-sm bg-bg-primary border border-border-primary rounded-lg text-text-primary placeholder-text-tertiary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors" />
                 </div>
                 <div>
-                    <label class="block text-sm font-medium text-text-primary mb-1">Color</label>
+                    <label for="new-tag-color" class="block text-sm font-medium text-text-primary mb-1">Color</label>
                     <select id="new-tag-color" class="w-full px-3 py-2 text-sm bg-bg-primary border border-border-primary rounded-lg text-text-primary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors cursor-pointer">
                         <option value="0">Default (Gray)</option>
                         <option value="1">Positive (Green)</option>


### PR DESCRIPTION
## Summary
- Add proper ARIA attributes to tab navigation for screen reader accessibility
- Add `for` attributes to form labels for proper label-input associations  
- Add `aria-label` attributes to checkboxes for screen reader context

## Changes Made

### Tab Navigation ARIA Attributes (#509)
- **ModerationSettings/Index.cshtml**: Added `role="tablist"`, `role="tab"`, `aria-selected`, `aria-controls` to tab buttons; added `role="tabpanel"`, `aria-labelledby` to tab panels
- **Members/Moderation.cshtml**: Same ARIA improvements for Cases/Notes/Flags tabs

### Form Label Associations (#510)
- **ModerationSettings/Index.cshtml**: Added `for` attributes linking labels to:
  - Spam settings: `spam-max-messages`, `spam-window-seconds`, `spam-max-mentions`, `spam-duplicate-threshold`, `spam-auto-action`
  - Content settings: `content-prohibited-words`, `content-block-invites`, `content-auto-action`
  - Raid settings: `raid-max-joins`, `raid-window-seconds`, `raid-min-account-age`, `raid-auto-action`
  - Tags: `new-tag-name`, `new-tag-color`

### Checkbox Aria-Labels (#511)
- **FlaggedEvents/Index.cshtml**: Added `aria-label` to "Select all" header checkbox and individual event checkboxes in both desktop table and mobile card layouts

## Test Plan
- [ ] Navigate Moderation Settings tabs with keyboard and verify proper focus management
- [ ] Use screen reader to verify tabs announce correctly with roles and selection state
- [ ] Click on form labels and verify corresponding inputs receive focus
- [ ] Use screen reader on Flagged Events page and verify checkbox labels announce which event they select

Closes #509
Closes #510
Closes #511

🤖 Generated with [Claude Code](https://claude.com/claude-code)