### PR TITLE
feat: Add analytics dashboards for server, moderation, and engagement metrics

### DIFF
--- a/docs/prototypes/features/analytics-dashboard/analytics-shared.css
+++ b/docs/prototypes/features/analytics-dashboard/analytics-shared.css
@@ -1,0 +1,632 @@
+/**
+ * Analytics Dashboard Shared Styles
+ * Discord Bot Admin UI
+ *
+ * Common styles for analytics pages including:
+ * - Chart containers and styling
+ * - Navigation tabs
+ * - Date range picker
+ * - Card grid layouts
+ * - Heatmap grid
+ * - Skeleton loading states
+ */
+
+/* ========================================
+   Navigation Tabs
+   ======================================== */
+
+.analytics-tabs {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem;
+  background-color: var(--color-bg-primary, #1d2022);
+  border-radius: 0.5rem;
+  overflow-x: auto;
+}
+
+.analytics-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text-secondary, #a8a5a3);
+  background-color: transparent;
+  border: none;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  transition: all 0.15s ease-out;
+  white-space: nowrap;
+}
+
+.analytics-tab:hover {
+  color: var(--color-text-primary, #d7d3d0);
+  background-color: var(--color-bg-hover, #363a3e);
+}
+
+.analytics-tab.active {
+  color: var(--color-text-primary, #d7d3d0);
+  background-color: var(--color-bg-tertiary, #2f3336);
+}
+
+.analytics-tab .tab-icon {
+  width: 1rem;
+  height: 1rem;
+  opacity: 0.75;
+}
+
+.analytics-tab.active .tab-icon {
+  opacity: 1;
+}
+
+/* ========================================
+   Date Range Picker
+   ======================================== */
+
+.date-range-picker {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.date-preset-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+.date-preset-btn {
+  padding: 0.375rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--color-text-secondary, #a8a5a3);
+  background-color: var(--color-bg-tertiary, #2f3336);
+  border: 1px solid var(--color-border-primary, #3f4447);
+  border-radius: 0.375rem;
+  cursor: pointer;
+  transition: all 0.15s ease-out;
+}
+
+.date-preset-btn:hover {
+  color: var(--color-text-primary, #d7d3d0);
+  background-color: var(--color-bg-hover, #363a3e);
+}
+
+.date-preset-btn.active {
+  color: #098ecf;
+  background-color: rgba(9, 142, 207, 0.2);
+  border-color: rgba(9, 142, 207, 0.3);
+}
+
+.date-input-group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.date-input-separator {
+  color: var(--color-text-tertiary, #7a7876);
+  font-size: 0.75rem;
+}
+
+/* ========================================
+   Chart Containers
+   ======================================== */
+
+.chart-card {
+  background-color: var(--color-bg-secondary, #262a2d);
+  border: 1px solid var(--color-border-primary, #3f4447);
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+
+.chart-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--color-border-primary, #3f4447);
+}
+
+.chart-card-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text-primary, #d7d3d0);
+}
+
+.chart-card-subtitle {
+  font-size: 0.75rem;
+  color: var(--color-text-tertiary, #7a7876);
+  margin-top: 0.125rem;
+}
+
+.chart-card-body {
+  padding: 1.25rem;
+}
+
+.chart-container {
+  position: relative;
+  height: 250px;
+  width: 100%;
+}
+
+.chart-container-lg {
+  height: 300px;
+}
+
+.chart-container-xl {
+  height: 350px;
+}
+
+/* ========================================
+   Stats Cards Grid
+   ======================================== */
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(1, 1fr);
+  gap: 1rem;
+}
+
+@media (min-width: 640px) {
+  .stats-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1280px) {
+  .stats-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+.stat-card {
+  background-color: var(--color-bg-secondary, #262a2d);
+  border: 1px solid var(--color-border-primary, #3f4447);
+  border-radius: 0.5rem;
+  padding: 1.25rem;
+  transition: border-color 0.15s ease-out;
+}
+
+.stat-card:hover {
+  border-color: rgba(9, 142, 207, 0.5);
+}
+
+.stat-card-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.5rem;
+}
+
+.stat-card-value {
+  font-size: 1.875rem;
+  font-weight: 700;
+  line-height: 1.2;
+  color: var(--color-text-primary, #d7d3d0);
+  margin-top: 0.5rem;
+}
+
+.stat-card-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text-secondary, #a8a5a3);
+}
+
+.stat-card-change {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  margin-top: 0.25rem;
+}
+
+.stat-card-change.positive {
+  color: #10b981;
+}
+
+.stat-card-change.negative {
+  color: #ef4444;
+}
+
+.stat-card-change.neutral {
+  color: var(--color-text-tertiary, #7a7876);
+}
+
+/* ========================================
+   Heatmap Grid
+   ======================================== */
+
+.heatmap-container {
+  overflow-x: auto;
+  padding-bottom: 0.5rem;
+}
+
+.heatmap-grid {
+  min-width: 600px;
+}
+
+.heatmap-row {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin-bottom: 2px;
+}
+
+.heatmap-label {
+  width: 2.5rem;
+  flex-shrink: 0;
+  font-size: 0.75rem;
+  color: var(--color-text-tertiary, #7a7876);
+}
+
+.heatmap-cell {
+  flex: 1;
+  aspect-ratio: 1;
+  border-radius: 2px;
+  transition: transform 0.1s ease-out;
+}
+
+.heatmap-cell:hover {
+  transform: scale(1.2);
+  z-index: 1;
+}
+
+.heatmap-legend {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.heatmap-legend-label {
+  font-size: 0.75rem;
+  color: var(--color-text-tertiary, #7a7876);
+}
+
+.heatmap-legend-scale {
+  display: flex;
+  gap: 2px;
+}
+
+.heatmap-legend-cell {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 2px;
+}
+
+/* Heatmap intensity colors */
+.heatmap-intensity-0 { background-color: #2f3336; }
+.heatmap-intensity-1 { background-color: rgba(203, 78, 27, 0.2); }
+.heatmap-intensity-2 { background-color: rgba(203, 78, 27, 0.4); }
+.heatmap-intensity-3 { background-color: rgba(203, 78, 27, 0.6); }
+.heatmap-intensity-4 { background-color: rgba(203, 78, 27, 0.9); }
+
+/* Alternative blue intensity for engagement */
+.heatmap-intensity-blue-0 { background-color: #2f3336; }
+.heatmap-intensity-blue-1 { background-color: rgba(9, 142, 207, 0.2); }
+.heatmap-intensity-blue-2 { background-color: rgba(9, 142, 207, 0.4); }
+.heatmap-intensity-blue-3 { background-color: rgba(9, 142, 207, 0.6); }
+.heatmap-intensity-blue-4 { background-color: rgba(9, 142, 207, 0.9); }
+
+/* ========================================
+   Skeleton Loading States
+   ======================================== */
+
+.skeleton {
+  background: linear-gradient(
+    90deg,
+    var(--color-bg-tertiary, #2f3336) 25%,
+    var(--color-bg-hover, #363a3e) 50%,
+    var(--color-bg-tertiary, #2f3336) 75%
+  );
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.5s infinite;
+  border-radius: 0.25rem;
+}
+
+@keyframes skeleton-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+.skeleton-stat-value {
+  height: 2.25rem;
+  width: 60%;
+  margin-top: 0.5rem;
+}
+
+.skeleton-stat-change {
+  height: 0.875rem;
+  width: 40%;
+  margin-top: 0.5rem;
+}
+
+.skeleton-chart {
+  height: 200px;
+  width: 100%;
+}
+
+.skeleton-text-sm {
+  height: 0.875rem;
+  width: 80%;
+}
+
+.skeleton-text-md {
+  height: 1rem;
+  width: 60%;
+}
+
+.skeleton-text-lg {
+  height: 1.25rem;
+  width: 50%;
+}
+
+/* ========================================
+   Empty States
+   ======================================== */
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 1.5rem;
+  text-align: center;
+}
+
+.empty-state-icon {
+  width: 4rem;
+  height: 4rem;
+  color: var(--color-text-tertiary, #7a7876);
+  margin-bottom: 1rem;
+}
+
+.empty-state-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--color-text-primary, #d7d3d0);
+  margin-bottom: 0.5rem;
+}
+
+.empty-state-description {
+  font-size: 0.875rem;
+  color: var(--color-text-secondary, #a8a5a3);
+  max-width: 24rem;
+}
+
+/* ========================================
+   Info Banners
+   ======================================== */
+
+.info-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  background-color: rgba(6, 182, 212, 0.1);
+  border: 1px solid rgba(6, 182, 212, 0.3);
+  border-radius: 0.5rem;
+}
+
+.info-banner-icon {
+  flex-shrink: 0;
+  width: 1.25rem;
+  height: 1.25rem;
+  color: #06b6d4;
+}
+
+.info-banner-content {
+  flex: 1;
+}
+
+.info-banner-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #06b6d4;
+}
+
+.info-banner-text {
+  font-size: 0.875rem;
+  color: var(--color-text-secondary, #a8a5a3);
+  margin-top: 0.25rem;
+}
+
+/* Coming soon variant */
+.info-banner.coming-soon {
+  background-color: rgba(122, 120, 118, 0.1);
+  border-color: rgba(122, 120, 118, 0.3);
+}
+
+.info-banner.coming-soon .info-banner-icon,
+.info-banner.coming-soon .info-banner-title {
+  color: var(--color-text-tertiary, #7a7876);
+}
+
+/* ========================================
+   Placeholder Cards (Coming Soon)
+   ======================================== */
+
+.placeholder-card {
+  background-color: var(--color-bg-secondary, #262a2d);
+  border: 1px dashed var(--color-border-primary, #3f4447);
+  border-radius: 0.5rem;
+  padding: 2rem;
+  text-align: center;
+  opacity: 0.6;
+}
+
+.placeholder-card-icon {
+  width: 3rem;
+  height: 3rem;
+  color: var(--color-text-tertiary, #7a7876);
+  margin: 0 auto 1rem;
+}
+
+.placeholder-card-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text-secondary, #a8a5a3);
+  margin-bottom: 0.25rem;
+}
+
+.placeholder-card-text {
+  font-size: 0.875rem;
+  color: var(--color-text-tertiary, #7a7876);
+}
+
+/* ========================================
+   Data Tables for Analytics
+   ======================================== */
+
+.analytics-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.analytics-table thead {
+  background-color: rgba(29, 32, 34, 0.5);
+}
+
+.analytics-table th {
+  padding: 0.75rem 1.25rem;
+  text-align: left;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-secondary, #a8a5a3);
+}
+
+.analytics-table td {
+  padding: 1rem 1.25rem;
+  border-top: 1px solid var(--color-border-primary, #3f4447);
+  font-size: 0.875rem;
+  color: var(--color-text-primary, #d7d3d0);
+}
+
+.analytics-table tbody tr {
+  transition: background-color 0.15s ease-out;
+}
+
+.analytics-table tbody tr:hover {
+  background-color: var(--color-bg-hover, #363a3e);
+}
+
+/* ========================================
+   Funnel Chart Styles
+   ======================================== */
+
+.funnel-chart {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.funnel-step {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.funnel-bar {
+  height: 2.5rem;
+  background-color: #098ecf;
+  border-radius: 0 0.25rem 0.25rem 0;
+  transition: width 0.5s ease-out;
+  display: flex;
+  align-items: center;
+  padding-left: 0.75rem;
+}
+
+.funnel-bar-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: white;
+  white-space: nowrap;
+}
+
+.funnel-value {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-text-primary, #d7d3d0);
+  min-width: 4rem;
+}
+
+.funnel-step-name {
+  font-size: 0.75rem;
+  color: var(--color-text-secondary, #a8a5a3);
+  width: 8rem;
+  text-align: right;
+}
+
+/* ========================================
+   Chart Legend
+   ======================================== */
+
+.chart-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding-top: 1rem;
+  justify-content: center;
+}
+
+.chart-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--color-text-secondary, #a8a5a3);
+}
+
+.chart-legend-color {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 2px;
+}
+
+/* ========================================
+   Responsive Grid Layouts
+   ======================================== */
+
+.analytics-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.analytics-grid-2 {
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 1024px) {
+  .analytics-grid-2 {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.analytics-grid-3 {
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 768px) {
+  .analytics-grid-3 {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1280px) {
+  .analytics-grid-3 {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}

--- a/docs/prototypes/features/analytics-dashboard/engagement-metrics.html
+++ b/docs/prototypes/features/analytics-dashboard/engagement-metrics.html
@@ -1,0 +1,569 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Engagement Metrics - Discord Bot Admin</title>
+
+  <!-- Shared Styles -->
+  <link rel="stylesheet" href="../../css/main.css">
+  <link rel="stylesheet" href="analytics-shared.css">
+
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="../../css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
+
+  <!-- Chart.js for charts -->
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+</head>
+<body class="bg-bg-primary text-text-primary font-sans antialiased">
+
+  <!-- Main Content Area -->
+  <main class="min-h-screen">
+    <div class="p-4 lg:p-8 max-w-7xl mx-auto">
+
+      <!-- Breadcrumb Navigation -->
+      <nav aria-label="Breadcrumb" class="mb-6">
+        <ol class="flex items-center gap-2 text-sm flex-wrap">
+          <li>
+            <a href="../../dashboard.html" class="text-text-secondary hover:text-accent-blue transition-colors">Dashboard</a>
+          </li>
+          <li class="text-text-tertiary" aria-hidden="true">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+          </li>
+          <li>
+            <a href="../../pages/servers-list.html" class="text-text-secondary hover:text-accent-blue transition-colors">Guilds</a>
+          </li>
+          <li class="text-text-tertiary" aria-hidden="true">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+          </li>
+          <li>
+            <a href="#" class="text-text-secondary hover:text-accent-blue transition-colors">Gaming Community</a>
+          </li>
+          <li class="text-text-tertiary" aria-hidden="true">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+          </li>
+          <li>
+            <span class="text-text-primary font-medium" aria-current="page">Engagement Metrics</span>
+          </li>
+        </ol>
+      </nav>
+
+      <!-- Page Header -->
+      <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 mb-6">
+        <div class="flex items-center gap-4">
+          <div class="w-12 h-12 rounded-full bg-gradient-to-br from-purple-500 to-pink-500 flex items-center justify-center text-white font-bold text-lg">GC</div>
+          <div>
+            <h1 class="text-2xl lg:text-3xl font-bold text-text-primary">Engagement Metrics</h1>
+            <p class="text-text-secondary">Gaming Community</p>
+          </div>
+        </div>
+
+        <!-- Date Range Picker -->
+        <div class="date-range-picker">
+          <div class="date-preset-group">
+            <button class="date-preset-btn" onclick="setDatePreset('today')">Today</button>
+            <button class="date-preset-btn active" onclick="setDatePreset('7days')">7 Days</button>
+            <button class="date-preset-btn" onclick="setDatePreset('30days')">30 Days</button>
+            <button class="date-preset-btn" onclick="setDatePreset('custom')">Custom</button>
+          </div>
+          <div class="date-input-group hidden" id="customDateInputs">
+            <input
+              type="date"
+              id="dateFrom"
+              class="px-3 py-1.5 text-sm bg-bg-primary border border-border-primary rounded-md text-text-primary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors"
+            />
+            <span class="date-input-separator">to</span>
+            <input
+              type="date"
+              id="dateTo"
+              class="px-3 py-1.5 text-sm bg-bg-primary border border-border-primary rounded-md text-text-primary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors"
+            />
+          </div>
+        </div>
+      </div>
+
+      <!-- Navigation Tabs -->
+      <div class="analytics-tabs mb-6">
+        <a href="server-analytics.html" class="analytics-tab">
+          <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+          </svg>
+          Overview
+        </a>
+        <a href="moderation-analytics.html" class="analytics-tab">
+          <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+          </svg>
+          Moderation
+        </a>
+        <button class="analytics-tab active" onclick="switchTab('engagement')">
+          <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+          </svg>
+          Engagement
+        </button>
+      </div>
+
+      <!-- Summary Stats Cards -->
+      <div class="stats-grid mb-8">
+        <!-- Total Messages -->
+        <div class="stat-card">
+          <div class="flex items-center justify-between">
+            <div>
+              <p class="stat-card-label">Total Messages</p>
+              <p class="stat-card-value">8,492</p>
+              <p class="stat-card-change positive">
+                <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18" />
+                </svg>
+                +12.4% vs last week
+              </p>
+            </div>
+            <div class="stat-card-icon bg-accent-blue/10">
+              <svg class="w-6 h-6 text-accent-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+              </svg>
+            </div>
+          </div>
+        </div>
+
+        <!-- Messages/Day -->
+        <div class="stat-card">
+          <div class="flex items-center justify-between">
+            <div>
+              <p class="stat-card-label">Messages/Day</p>
+              <p class="stat-card-value">1,213</p>
+              <p class="stat-card-change positive">
+                <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18" />
+                </svg>
+                +8.2% vs last week
+              </p>
+            </div>
+            <div class="stat-card-icon bg-success/10">
+              <svg class="w-6 h-6 text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
+              </svg>
+            </div>
+          </div>
+        </div>
+
+        <!-- Active Members -->
+        <div class="stat-card">
+          <div class="flex items-center justify-between">
+            <div>
+              <p class="stat-card-label">Active Members</p>
+              <p class="stat-card-value">342</p>
+              <p class="stat-card-change neutral">27.7% of total</p>
+            </div>
+            <div class="stat-card-icon bg-accent-orange/10">
+              <svg class="w-6 h-6 text-accent-orange" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+              </svg>
+            </div>
+          </div>
+        </div>
+
+        <!-- New Member Retention -->
+        <div class="stat-card">
+          <div class="flex items-center justify-between">
+            <div>
+              <p class="stat-card-label">New Member Retention</p>
+              <p class="stat-card-value">68%</p>
+              <p class="stat-card-change positive">
+                <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18" />
+                </svg>
+                +5% vs last month
+              </p>
+            </div>
+            <div class="stat-card-icon bg-info/10">
+              <svg class="w-6 h-6 text-info" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Message Trends Chart (Full Width) -->
+      <div class="chart-card mb-6">
+        <div class="chart-card-header">
+          <div>
+            <h2 class="chart-card-title">Message Trends</h2>
+            <p class="chart-card-subtitle">Messages and unique authors over time</p>
+          </div>
+        </div>
+        <div class="chart-card-body">
+          <div class="chart-container chart-container-lg">
+            <canvas id="messageTrendsChart"></canvas>
+          </div>
+        </div>
+      </div>
+
+      <!-- Channel Engagement Chart (Full Width) -->
+      <div class="chart-card mb-6">
+        <div class="chart-card-header">
+          <div>
+            <h2 class="chart-card-title">Channel Engagement</h2>
+            <p class="chart-card-subtitle">Messages per channel with engagement rate</p>
+          </div>
+        </div>
+        <div class="chart-card-body">
+          <div class="chart-container chart-container-lg">
+            <canvas id="channelEngagementChart"></canvas>
+          </div>
+        </div>
+      </div>
+
+      <!-- New Member Retention Funnel -->
+      <div class="chart-card mb-6">
+        <div class="chart-card-header">
+          <div>
+            <h2 class="chart-card-title">New Member Retention Funnel</h2>
+            <p class="chart-card-subtitle">Tracking member engagement from join to active participation</p>
+          </div>
+          <span class="text-xs text-text-tertiary">Last 30 days</span>
+        </div>
+        <div class="chart-card-body">
+          <div class="funnel-chart">
+            <div class="funnel-step">
+              <span class="funnel-step-name">Joined</span>
+              <div class="funnel-bar" style="width: 100%;">
+                <span class="funnel-bar-label">100%</span>
+              </div>
+              <span class="funnel-value">48 members</span>
+            </div>
+            <div class="funnel-step">
+              <span class="funnel-step-name">Verified</span>
+              <div class="funnel-bar" style="width: 87.5%; background-color: #0ba3ea;">
+                <span class="funnel-bar-label">87.5%</span>
+              </div>
+              <span class="funnel-value">42 members</span>
+            </div>
+            <div class="funnel-step">
+              <span class="funnel-step-name">First Message</span>
+              <div class="funnel-bar" style="width: 75%; background-color: #10b981;">
+                <span class="funnel-bar-label">75%</span>
+              </div>
+              <span class="funnel-value">36 members</span>
+            </div>
+            <div class="funnel-step">
+              <span class="funnel-step-name">Week 1 Active</span>
+              <div class="funnel-bar" style="width: 68.75%; background-color: #f59e0b;">
+                <span class="funnel-bar-label">68.75%</span>
+              </div>
+              <span class="funnel-value">33 members</span>
+            </div>
+            <div class="funnel-step">
+              <span class="funnel-step-name">Month 1 Active</span>
+              <div class="funnel-bar" style="width: 56.25%; background-color: #cb4e1b;">
+                <span class="funnel-bar-label">56.25%</span>
+              </div>
+              <span class="funnel-value">27 members</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Coming Soon Banner -->
+      <div class="info-banner coming-soon mb-6">
+        <svg class="info-banner-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        <div class="info-banner-content">
+          <p class="info-banner-title">Voice and Reaction Analytics Coming Soon</p>
+          <p class="info-banner-text">We are working on bringing you detailed analytics for voice channel usage and message reactions. Stay tuned for updates!</p>
+        </div>
+      </div>
+
+      <!-- Placeholder Cards for Coming Soon Features -->
+      <div class="analytics-grid-2 mb-6">
+        <!-- Voice Analytics Placeholder -->
+        <div class="placeholder-card">
+          <svg class="placeholder-card-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z" />
+          </svg>
+          <p class="placeholder-card-title">Voice Channel Analytics</p>
+          <p class="placeholder-card-text">Track voice activity, average session duration, and peak usage times</p>
+        </div>
+
+        <!-- Reaction Analytics Placeholder -->
+        <div class="placeholder-card">
+          <svg class="placeholder-card-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.828 14.828a4 4 0 01-5.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <p class="placeholder-card-title">Reaction Analytics</p>
+          <p class="placeholder-card-text">Most used emojis, reaction rates, and sentiment analysis</p>
+        </div>
+      </div>
+
+      <!-- Loading State Example Section -->
+      <div class="chart-card mb-6">
+        <div class="chart-card-header">
+          <div>
+            <h2 class="chart-card-title">Loading State Example</h2>
+            <p class="chart-card-subtitle">Skeleton loading placeholders</p>
+          </div>
+        </div>
+        <div class="chart-card-body">
+          <!-- Skeleton Stats Grid -->
+          <div class="stats-grid mb-6">
+            <div class="stat-card">
+              <div class="skeleton skeleton-text-sm mb-2" style="width: 60%;"></div>
+              <div class="skeleton skeleton-stat-value"></div>
+              <div class="skeleton skeleton-stat-change"></div>
+            </div>
+            <div class="stat-card">
+              <div class="skeleton skeleton-text-sm mb-2" style="width: 50%;"></div>
+              <div class="skeleton skeleton-stat-value"></div>
+              <div class="skeleton skeleton-stat-change"></div>
+            </div>
+            <div class="stat-card">
+              <div class="skeleton skeleton-text-sm mb-2" style="width: 70%;"></div>
+              <div class="skeleton skeleton-stat-value"></div>
+              <div class="skeleton skeleton-stat-change"></div>
+            </div>
+            <div class="stat-card">
+              <div class="skeleton skeleton-text-sm mb-2" style="width: 55%;"></div>
+              <div class="skeleton skeleton-stat-value"></div>
+              <div class="skeleton skeleton-stat-change"></div>
+            </div>
+          </div>
+
+          <!-- Skeleton Chart -->
+          <div class="skeleton skeleton-chart"></div>
+        </div>
+      </div>
+
+      <!-- Empty State Example Section -->
+      <div class="chart-card">
+        <div class="chart-card-header">
+          <div>
+            <h2 class="chart-card-title">Empty State Example</h2>
+            <p class="chart-card-subtitle">When no data is available</p>
+          </div>
+        </div>
+        <div class="chart-card-body">
+          <div class="empty-state">
+            <svg class="empty-state-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+            </svg>
+            <h3 class="empty-state-title">No Engagement Data Available</h3>
+            <p class="empty-state-description">
+              There is no engagement data for the selected time period. Try selecting a different date range or wait for more activity.
+            </p>
+            <button class="mt-4 px-4 py-2 bg-accent-blue hover:bg-accent-blue-hover text-white font-medium text-sm rounded-lg transition-colors">
+              Select Different Range
+            </button>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </main>
+
+  <!-- JavaScript -->
+  <script>
+    // Date Preset Handler
+    function setDatePreset(preset) {
+      document.querySelectorAll('.date-preset-btn').forEach(btn => {
+        btn.classList.remove('active');
+      });
+      event.target.classList.add('active');
+
+      const customInputs = document.getElementById('customDateInputs');
+      if (preset === 'custom') {
+        customInputs.classList.remove('hidden');
+      } else {
+        customInputs.classList.add('hidden');
+      }
+    }
+
+    // Tab Switching
+    function switchTab(tabName) {
+      document.querySelectorAll('.analytics-tab').forEach(tab => {
+        tab.classList.remove('active');
+      });
+      event.target.closest('.analytics-tab').classList.add('active');
+    }
+
+    // Initialize Charts
+    document.addEventListener('DOMContentLoaded', function() {
+      // Chart.js default dark theme settings
+      Chart.defaults.color = '#a8a5a3';
+      Chart.defaults.borderColor = '#3f4447';
+
+      // Message Trends Chart (Line with dual Y-axes)
+      const trendsCtx = document.getElementById('messageTrendsChart').getContext('2d');
+      new Chart(trendsCtx, {
+        type: 'line',
+        data: {
+          labels: ['Dec 25', 'Dec 26', 'Dec 27', 'Dec 28', 'Dec 29', 'Dec 30', 'Dec 31'],
+          datasets: [
+            {
+              label: 'Messages',
+              data: [1089, 1247, 1156, 1423, 1312, 1089, 1176],
+              borderColor: '#098ecf',
+              backgroundColor: 'rgba(9, 142, 207, 0.1)',
+              fill: true,
+              tension: 0.4,
+              yAxisID: 'y'
+            },
+            {
+              label: 'Unique Authors',
+              data: [156, 178, 167, 198, 185, 152, 168],
+              borderColor: '#10b981',
+              backgroundColor: 'transparent',
+              borderDash: [5, 5],
+              tension: 0.4,
+              yAxisID: 'y1'
+            }
+          ]
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          interaction: {
+            mode: 'index',
+            intersect: false
+          },
+          plugins: {
+            legend: {
+              position: 'bottom',
+              labels: {
+                boxWidth: 12,
+                padding: 20
+              }
+            },
+            tooltip: {
+              backgroundColor: '#2f3336',
+              titleColor: '#d7d3d0',
+              bodyColor: '#a8a5a3',
+              borderColor: '#3f4447',
+              borderWidth: 1,
+              padding: 12
+            }
+          },
+          scales: {
+            y: {
+              type: 'linear',
+              display: true,
+              position: 'left',
+              beginAtZero: false,
+              grid: {
+                color: '#2f3336'
+              },
+              title: {
+                display: true,
+                text: 'Messages',
+                color: '#098ecf'
+              }
+            },
+            y1: {
+              type: 'linear',
+              display: true,
+              position: 'right',
+              beginAtZero: false,
+              grid: {
+                drawOnChartArea: false
+              },
+              title: {
+                display: true,
+                text: 'Unique Authors',
+                color: '#10b981'
+              }
+            },
+            x: {
+              grid: {
+                display: false
+              }
+            }
+          }
+        }
+      });
+
+      // Channel Engagement Chart (Horizontal Bar)
+      const channelCtx = document.getElementById('channelEngagementChart').getContext('2d');
+      new Chart(channelCtx, {
+        type: 'bar',
+        data: {
+          labels: ['#general', '#gaming', '#off-topic', '#memes', '#help', '#music', '#art', '#tech'],
+          datasets: [
+            {
+              label: 'Messages',
+              data: [2847, 2156, 1423, 1089, 756, 542, 389, 290],
+              backgroundColor: '#098ecf',
+              borderRadius: 4
+            },
+            {
+              label: 'Avg Engagement Rate',
+              data: [85, 78, 72, 95, 45, 62, 88, 52],
+              backgroundColor: '#cb4e1b',
+              borderRadius: 4
+            }
+          ]
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          indexAxis: 'y',
+          plugins: {
+            legend: {
+              position: 'bottom',
+              labels: {
+                boxWidth: 12,
+                padding: 20
+              }
+            },
+            tooltip: {
+              backgroundColor: '#2f3336',
+              titleColor: '#d7d3d0',
+              bodyColor: '#a8a5a3',
+              borderColor: '#3f4447',
+              borderWidth: 1,
+              padding: 12,
+              callbacks: {
+                label: function(context) {
+                  if (context.datasetIndex === 0) {
+                    return context.parsed.x.toLocaleString() + ' messages';
+                  } else {
+                    return context.parsed.x + '% engagement';
+                  }
+                }
+              }
+            }
+          },
+          scales: {
+            x: {
+              beginAtZero: true,
+              grid: {
+                color: '#2f3336'
+              },
+              ticks: {
+                callback: function(value) {
+                  return value.toLocaleString();
+                }
+              }
+            },
+            y: {
+              grid: {
+                display: false
+              }
+            }
+          }
+        }
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/docs/prototypes/features/analytics-dashboard/moderation-analytics.html
+++ b/docs/prototypes/features/analytics-dashboard/moderation-analytics.html
@@ -1,0 +1,675 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Moderation Analytics - Discord Bot Admin</title>
+
+  <!-- Shared Styles -->
+  <link rel="stylesheet" href="../../css/main.css">
+  <link rel="stylesheet" href="analytics-shared.css">
+
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="../../css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
+
+  <!-- Chart.js for charts -->
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+
+  <style>
+    /* Escalation path icons */
+    .escalation-path {
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+    }
+    .escalation-step {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 1.5rem;
+      height: 1.5rem;
+      border-radius: 0.25rem;
+      font-size: 0.625rem;
+      font-weight: 600;
+    }
+    .escalation-arrow {
+      width: 0.75rem;
+      height: 0.75rem;
+      color: var(--color-text-tertiary, #7a7876);
+    }
+  </style>
+</head>
+<body class="bg-bg-primary text-text-primary font-sans antialiased">
+
+  <!-- Main Content Area -->
+  <main class="min-h-screen">
+    <div class="p-4 lg:p-8 max-w-7xl mx-auto">
+
+      <!-- Breadcrumb Navigation -->
+      <nav aria-label="Breadcrumb" class="mb-6">
+        <ol class="flex items-center gap-2 text-sm flex-wrap">
+          <li>
+            <a href="../../dashboard.html" class="text-text-secondary hover:text-accent-blue transition-colors">Dashboard</a>
+          </li>
+          <li class="text-text-tertiary" aria-hidden="true">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+          </li>
+          <li>
+            <a href="../../pages/servers-list.html" class="text-text-secondary hover:text-accent-blue transition-colors">Guilds</a>
+          </li>
+          <li class="text-text-tertiary" aria-hidden="true">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+          </li>
+          <li>
+            <a href="#" class="text-text-secondary hover:text-accent-blue transition-colors">Gaming Community</a>
+          </li>
+          <li class="text-text-tertiary" aria-hidden="true">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+          </li>
+          <li>
+            <span class="text-text-primary font-medium" aria-current="page">Moderation Analytics</span>
+          </li>
+        </ol>
+      </nav>
+
+      <!-- Page Header -->
+      <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 mb-6">
+        <div class="flex items-center gap-4">
+          <div class="w-12 h-12 rounded-full bg-gradient-to-br from-purple-500 to-pink-500 flex items-center justify-center text-white font-bold text-lg">GC</div>
+          <div>
+            <h1 class="text-2xl lg:text-3xl font-bold text-text-primary">Moderation Analytics</h1>
+            <p class="text-text-secondary">Gaming Community</p>
+          </div>
+        </div>
+
+        <!-- Date Range Picker -->
+        <div class="date-range-picker">
+          <div class="date-preset-group">
+            <button class="date-preset-btn" onclick="setDatePreset('today')">Today</button>
+            <button class="date-preset-btn active" onclick="setDatePreset('7days')">7 Days</button>
+            <button class="date-preset-btn" onclick="setDatePreset('30days')">30 Days</button>
+            <button class="date-preset-btn" onclick="setDatePreset('custom')">Custom</button>
+          </div>
+          <div class="date-input-group hidden" id="customDateInputs">
+            <input
+              type="date"
+              id="dateFrom"
+              class="px-3 py-1.5 text-sm bg-bg-primary border border-border-primary rounded-md text-text-primary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors"
+            />
+            <span class="date-input-separator">to</span>
+            <input
+              type="date"
+              id="dateTo"
+              class="px-3 py-1.5 text-sm bg-bg-primary border border-border-primary rounded-md text-text-primary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors"
+            />
+          </div>
+        </div>
+      </div>
+
+      <!-- Navigation Tabs -->
+      <div class="analytics-tabs mb-6">
+        <a href="server-analytics.html" class="analytics-tab">
+          <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+          </svg>
+          Overview
+        </a>
+        <button class="analytics-tab active" onclick="switchTab('moderation')">
+          <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+          </svg>
+          Moderation
+        </button>
+        <a href="engagement-metrics.html" class="analytics-tab">
+          <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+          </svg>
+          Engagement
+        </a>
+      </div>
+
+      <!-- Summary Stats Cards -->
+      <div class="grid grid-cols-2 sm:grid-cols-3 xl:grid-cols-6 gap-4 mb-8">
+        <!-- Total Cases -->
+        <div class="stat-card">
+          <div class="flex flex-col">
+            <p class="stat-card-label">Total Cases</p>
+            <p class="stat-card-value">127</p>
+            <p class="stat-card-change positive">
+              <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18" />
+              </svg>
+              +12 this week
+            </p>
+          </div>
+        </div>
+
+        <!-- Warns -->
+        <div class="stat-card hover:border-warning/50">
+          <div class="flex flex-col">
+            <p class="stat-card-label">Warns</p>
+            <p class="stat-card-value text-warning">68</p>
+            <p class="stat-card-change neutral">53.5%</p>
+          </div>
+        </div>
+
+        <!-- Mutes -->
+        <div class="stat-card hover:border-info/50">
+          <div class="flex flex-col">
+            <p class="stat-card-label">Mutes</p>
+            <p class="stat-card-value text-info">32</p>
+            <p class="stat-card-change neutral">25.2%</p>
+          </div>
+        </div>
+
+        <!-- Kicks -->
+        <div class="stat-card hover:border-accent-orange/50">
+          <div class="flex flex-col">
+            <p class="stat-card-label">Kicks</p>
+            <p class="stat-card-value text-accent-orange">18</p>
+            <p class="stat-card-change neutral">14.2%</p>
+          </div>
+        </div>
+
+        <!-- Bans -->
+        <div class="stat-card hover:border-error/50">
+          <div class="flex flex-col">
+            <p class="stat-card-label">Bans</p>
+            <p class="stat-card-value text-error">9</p>
+            <p class="stat-card-change neutral">7.1%</p>
+          </div>
+        </div>
+
+        <!-- Avg Cases/Day -->
+        <div class="stat-card hover:border-success/50">
+          <div class="flex flex-col">
+            <p class="stat-card-label">Avg Cases/Day</p>
+            <p class="stat-card-value text-success">18.1</p>
+            <p class="stat-card-change negative">
+              <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 14l-7 7m0 0l-7-7m7 7V3" />
+              </svg>
+              -2.3 vs last week
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Action Trends Chart (Full Width) -->
+      <div class="chart-card mb-6">
+        <div class="chart-card-header">
+          <div>
+            <h2 class="chart-card-title">Action Trends Over Time</h2>
+            <p class="chart-card-subtitle">Moderation actions by type</p>
+          </div>
+        </div>
+        <div class="chart-card-body">
+          <div class="chart-container chart-container-lg">
+            <canvas id="actionTrendsChart"></canvas>
+          </div>
+        </div>
+      </div>
+
+      <!-- Two Column Row: Case Distribution & Moderator Workload -->
+      <div class="analytics-grid-2 mb-6">
+        <!-- Case Type Distribution -->
+        <div class="chart-card">
+          <div class="chart-card-header">
+            <div>
+              <h2 class="chart-card-title">Case Type Distribution</h2>
+              <p class="chart-card-subtitle">Breakdown by action type</p>
+            </div>
+          </div>
+          <div class="chart-card-body">
+            <div class="chart-container">
+              <canvas id="caseDistributionChart"></canvas>
+            </div>
+          </div>
+        </div>
+
+        <!-- Moderator Workload -->
+        <div class="chart-card">
+          <div class="chart-card-header">
+            <div>
+              <h2 class="chart-card-title">Moderator Workload</h2>
+              <p class="chart-card-subtitle">Cases handled per moderator</p>
+            </div>
+          </div>
+          <div class="chart-card-body">
+            <div class="chart-container">
+              <canvas id="moderatorWorkloadChart"></canvas>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Repeat Offenders Section -->
+      <div class="chart-card">
+        <div class="chart-card-header">
+          <div>
+            <h2 class="chart-card-title">Repeat Offenders</h2>
+            <p class="chart-card-subtitle">Users with multiple moderation cases</p>
+          </div>
+          <div class="flex items-center gap-2">
+            <span class="text-xs text-text-tertiary">Show escalation path</span>
+            <button class="px-3 py-1.5 text-sm font-medium text-accent-blue hover:text-accent-blue-hover transition-colors">
+              View All
+            </button>
+          </div>
+        </div>
+        <div class="overflow-x-auto">
+          <table class="analytics-table">
+            <thead>
+              <tr>
+                <th>User</th>
+                <th>Total Cases</th>
+                <th>Warns</th>
+                <th>Mutes</th>
+                <th>Kicks</th>
+                <th>Bans</th>
+                <th>Escalation Path</th>
+                <th>Last Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <div class="flex items-center gap-3">
+                    <div class="w-10 h-10 rounded-full bg-gradient-to-br from-red-500 to-rose-500 flex items-center justify-center text-white font-bold text-sm">TR</div>
+                    <div>
+                      <p class="font-medium text-text-primary">ToxicRaider</p>
+                      <p class="text-xs text-text-tertiary">#6789</p>
+                    </div>
+                  </div>
+                </td>
+                <td class="font-semibold text-error">8</td>
+                <td>3</td>
+                <td>2</td>
+                <td>2</td>
+                <td>
+                  <span class="inline-flex items-center px-2.5 py-0.5 text-xs font-semibold text-error bg-error/10 rounded-full">1</span>
+                </td>
+                <td>
+                  <div class="escalation-path">
+                    <span class="escalation-step bg-warning/20 text-warning">W</span>
+                    <svg class="escalation-arrow" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
+                    <span class="escalation-step bg-warning/20 text-warning">W</span>
+                    <svg class="escalation-arrow" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
+                    <span class="escalation-step bg-info/20 text-info">M</span>
+                    <svg class="escalation-arrow" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
+                    <span class="escalation-step bg-accent-orange/20 text-accent-orange">K</span>
+                    <svg class="escalation-arrow" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
+                    <span class="escalation-step bg-error/20 text-error">B</span>
+                  </div>
+                </td>
+                <td class="text-text-secondary text-sm">2 days ago</td>
+              </tr>
+              <tr>
+                <td>
+                  <div class="flex items-center gap-3">
+                    <div class="w-10 h-10 rounded-full bg-gradient-to-br from-purple-500 to-pink-500 flex items-center justify-center text-white font-bold text-sm">SS</div>
+                    <div>
+                      <p class="font-medium text-text-primary">SpamSlinger</p>
+                      <p class="text-xs text-text-tertiary">#4321</p>
+                    </div>
+                  </div>
+                </td>
+                <td class="font-semibold text-warning">5</td>
+                <td>3</td>
+                <td>1</td>
+                <td>1</td>
+                <td>0</td>
+                <td>
+                  <div class="escalation-path">
+                    <span class="escalation-step bg-warning/20 text-warning">W</span>
+                    <svg class="escalation-arrow" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
+                    <span class="escalation-step bg-warning/20 text-warning">W</span>
+                    <svg class="escalation-arrow" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
+                    <span class="escalation-step bg-info/20 text-info">M</span>
+                    <svg class="escalation-arrow" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
+                    <span class="escalation-step bg-accent-orange/20 text-accent-orange">K</span>
+                  </div>
+                </td>
+                <td class="text-text-secondary text-sm">5 days ago</td>
+              </tr>
+              <tr>
+                <td>
+                  <div class="flex items-center gap-3">
+                    <div class="w-10 h-10 rounded-full bg-gradient-to-br from-orange-500 to-yellow-500 flex items-center justify-center text-white font-bold text-sm">AT</div>
+                    <div>
+                      <p class="font-medium text-text-primary">AngryTroll</p>
+                      <p class="text-xs text-text-tertiary">#8765</p>
+                    </div>
+                  </div>
+                </td>
+                <td class="font-semibold text-warning">4</td>
+                <td>2</td>
+                <td>2</td>
+                <td>0</td>
+                <td>0</td>
+                <td>
+                  <div class="escalation-path">
+                    <span class="escalation-step bg-warning/20 text-warning">W</span>
+                    <svg class="escalation-arrow" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
+                    <span class="escalation-step bg-info/20 text-info">M</span>
+                    <svg class="escalation-arrow" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
+                    <span class="escalation-step bg-warning/20 text-warning">W</span>
+                    <svg class="escalation-arrow" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
+                    <span class="escalation-step bg-info/20 text-info">M</span>
+                  </div>
+                </td>
+                <td class="text-text-secondary text-sm">1 week ago</td>
+              </tr>
+              <tr>
+                <td>
+                  <div class="flex items-center gap-3">
+                    <div class="w-10 h-10 rounded-full bg-gradient-to-br from-blue-500 to-cyan-500 flex items-center justify-center text-white font-bold text-sm">NR</div>
+                    <div>
+                      <p class="font-medium text-text-primary">NoisyRanter</p>
+                      <p class="text-xs text-text-tertiary">#2345</p>
+                    </div>
+                  </div>
+                </td>
+                <td class="font-semibold">3</td>
+                <td>2</td>
+                <td>1</td>
+                <td>0</td>
+                <td>0</td>
+                <td>
+                  <div class="escalation-path">
+                    <span class="escalation-step bg-warning/20 text-warning">W</span>
+                    <svg class="escalation-arrow" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
+                    <span class="escalation-step bg-warning/20 text-warning">W</span>
+                    <svg class="escalation-arrow" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
+                    <span class="escalation-step bg-info/20 text-info">M</span>
+                  </div>
+                </td>
+                <td class="text-text-secondary text-sm">Yesterday</td>
+              </tr>
+              <tr>
+                <td>
+                  <div class="flex items-center gap-3">
+                    <div class="w-10 h-10 rounded-full bg-gradient-to-br from-green-500 to-emerald-500 flex items-center justify-center text-white font-bold text-sm">RB</div>
+                    <div>
+                      <p class="font-medium text-text-primary">RuleBreaker</p>
+                      <p class="text-xs text-text-tertiary">#9876</p>
+                    </div>
+                  </div>
+                </td>
+                <td class="font-semibold">3</td>
+                <td>3</td>
+                <td>0</td>
+                <td>0</td>
+                <td>0</td>
+                <td>
+                  <div class="escalation-path">
+                    <span class="escalation-step bg-warning/20 text-warning">W</span>
+                    <svg class="escalation-arrow" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
+                    <span class="escalation-step bg-warning/20 text-warning">W</span>
+                    <svg class="escalation-arrow" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
+                    <span class="escalation-step bg-warning/20 text-warning">W</span>
+                  </div>
+                </td>
+                <td class="text-text-secondary text-sm">3 days ago</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Legend -->
+        <div class="px-5 py-4 border-t border-border-primary bg-bg-primary/30">
+          <div class="flex flex-wrap items-center gap-4 text-xs text-text-tertiary">
+            <span class="font-medium text-text-secondary">Legend:</span>
+            <span class="flex items-center gap-1.5">
+              <span class="w-5 h-5 rounded bg-warning/20 text-warning flex items-center justify-center text-[10px] font-semibold">W</span>
+              Warn
+            </span>
+            <span class="flex items-center gap-1.5">
+              <span class="w-5 h-5 rounded bg-info/20 text-info flex items-center justify-center text-[10px] font-semibold">M</span>
+              Mute
+            </span>
+            <span class="flex items-center gap-1.5">
+              <span class="w-5 h-5 rounded bg-accent-orange/20 text-accent-orange flex items-center justify-center text-[10px] font-semibold">K</span>
+              Kick
+            </span>
+            <span class="flex items-center gap-1.5">
+              <span class="w-5 h-5 rounded bg-error/20 text-error flex items-center justify-center text-[10px] font-semibold">B</span>
+              Ban
+            </span>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </main>
+
+  <!-- JavaScript -->
+  <script>
+    // Date Preset Handler
+    function setDatePreset(preset) {
+      document.querySelectorAll('.date-preset-btn').forEach(btn => {
+        btn.classList.remove('active');
+      });
+      event.target.classList.add('active');
+
+      const customInputs = document.getElementById('customDateInputs');
+      if (preset === 'custom') {
+        customInputs.classList.remove('hidden');
+      } else {
+        customInputs.classList.add('hidden');
+      }
+    }
+
+    // Tab Switching
+    function switchTab(tabName) {
+      document.querySelectorAll('.analytics-tab').forEach(tab => {
+        tab.classList.remove('active');
+      });
+      event.target.closest('.analytics-tab').classList.add('active');
+    }
+
+    // Initialize Charts
+    document.addEventListener('DOMContentLoaded', function() {
+      // Chart.js default dark theme settings
+      Chart.defaults.color = '#a8a5a3';
+      Chart.defaults.borderColor = '#3f4447';
+
+      // Action Trends Chart (Stacked Area)
+      const trendsCtx = document.getElementById('actionTrendsChart').getContext('2d');
+      new Chart(trendsCtx, {
+        type: 'line',
+        data: {
+          labels: ['Dec 25', 'Dec 26', 'Dec 27', 'Dec 28', 'Dec 29', 'Dec 30', 'Dec 31'],
+          datasets: [
+            {
+              label: 'Warns',
+              data: [8, 12, 10, 15, 9, 8, 6],
+              borderColor: '#f59e0b',
+              backgroundColor: 'rgba(245, 158, 11, 0.3)',
+              fill: true,
+              tension: 0.4
+            },
+            {
+              label: 'Mutes',
+              data: [4, 6, 5, 7, 4, 3, 3],
+              borderColor: '#06b6d4',
+              backgroundColor: 'rgba(6, 182, 212, 0.3)',
+              fill: true,
+              tension: 0.4
+            },
+            {
+              label: 'Kicks',
+              data: [2, 3, 2, 4, 3, 2, 2],
+              borderColor: '#cb4e1b',
+              backgroundColor: 'rgba(203, 78, 27, 0.3)',
+              fill: true,
+              tension: 0.4
+            },
+            {
+              label: 'Bans',
+              data: [1, 2, 1, 2, 1, 1, 1],
+              borderColor: '#ef4444',
+              backgroundColor: 'rgba(239, 68, 68, 0.3)',
+              fill: true,
+              tension: 0.4
+            }
+          ]
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+            legend: {
+              position: 'bottom',
+              labels: {
+                boxWidth: 12,
+                padding: 20
+              }
+            },
+            tooltip: {
+              backgroundColor: '#2f3336',
+              titleColor: '#d7d3d0',
+              bodyColor: '#a8a5a3',
+              borderColor: '#3f4447',
+              borderWidth: 1,
+              padding: 12
+            }
+          },
+          scales: {
+            y: {
+              beginAtZero: true,
+              stacked: true,
+              grid: {
+                color: '#2f3336'
+              }
+            },
+            x: {
+              grid: {
+                display: false
+              }
+            }
+          }
+        }
+      });
+
+      // Case Distribution Chart (Doughnut)
+      const distCtx = document.getElementById('caseDistributionChart').getContext('2d');
+      new Chart(distCtx, {
+        type: 'doughnut',
+        data: {
+          labels: ['Warns', 'Mutes', 'Kicks', 'Bans'],
+          datasets: [{
+            data: [68, 32, 18, 9],
+            backgroundColor: [
+              '#f59e0b',
+              '#06b6d4',
+              '#cb4e1b',
+              '#ef4444'
+            ],
+            borderWidth: 0
+          }]
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          cutout: '65%',
+          plugins: {
+            legend: {
+              position: 'right',
+              labels: {
+                boxWidth: 12,
+                padding: 15,
+                generateLabels: function(chart) {
+                  const data = chart.data;
+                  return data.labels.map((label, i) => ({
+                    text: `${label} (${data.datasets[0].data[i]})`,
+                    fillStyle: data.datasets[0].backgroundColor[i],
+                    index: i
+                  }));
+                }
+              }
+            },
+            tooltip: {
+              backgroundColor: '#2f3336',
+              titleColor: '#d7d3d0',
+              bodyColor: '#a8a5a3',
+              borderColor: '#3f4447',
+              borderWidth: 1,
+              padding: 12,
+              callbacks: {
+                label: function(context) {
+                  const total = context.dataset.data.reduce((a, b) => a + b, 0);
+                  const percentage = ((context.parsed / total) * 100).toFixed(1);
+                  return `${context.label}: ${context.parsed} (${percentage}%)`;
+                }
+              }
+            }
+          }
+        }
+      });
+
+      // Moderator Workload Chart (Horizontal Bar)
+      const workloadCtx = document.getElementById('moderatorWorkloadChart').getContext('2d');
+      new Chart(workloadCtx, {
+        type: 'bar',
+        data: {
+          labels: ['ModMaster', 'AdminAce', 'WatchfulEye', 'PeaceKeeper', 'RuleEnforcer'],
+          datasets: [{
+            label: 'Cases Handled',
+            data: [42, 35, 28, 15, 7],
+            backgroundColor: '#098ecf',
+            borderRadius: 4
+          }]
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          indexAxis: 'y',
+          plugins: {
+            legend: {
+              display: false
+            },
+            tooltip: {
+              backgroundColor: '#2f3336',
+              titleColor: '#d7d3d0',
+              bodyColor: '#a8a5a3',
+              borderColor: '#3f4447',
+              borderWidth: 1,
+              padding: 12,
+              callbacks: {
+                label: function(context) {
+                  const total = context.dataset.data.reduce((a, b) => a + b, 0);
+                  const percentage = ((context.parsed.x / total) * 100).toFixed(1);
+                  return `${context.parsed.x} cases (${percentage}%)`;
+                }
+              }
+            }
+          },
+          scales: {
+            x: {
+              beginAtZero: true,
+              grid: {
+                color: '#2f3336'
+              }
+            },
+            y: {
+              grid: {
+                display: false
+              }
+            }
+          }
+        }
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/docs/prototypes/features/analytics-dashboard/server-analytics.html
+++ b/docs/prototypes/features/analytics-dashboard/server-analytics.html
@@ -1,0 +1,695 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Server Analytics - Discord Bot Admin</title>
+
+  <!-- Shared Styles -->
+  <link rel="stylesheet" href="../../css/main.css">
+  <link rel="stylesheet" href="analytics-shared.css">
+
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="../../css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
+
+  <!-- Chart.js for charts -->
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+</head>
+<body class="bg-bg-primary text-text-primary font-sans antialiased">
+
+  <!-- Main Content Area -->
+  <main class="min-h-screen">
+    <div class="p-4 lg:p-8 max-w-7xl mx-auto">
+
+      <!-- Breadcrumb Navigation -->
+      <nav aria-label="Breadcrumb" class="mb-6">
+        <ol class="flex items-center gap-2 text-sm flex-wrap">
+          <li>
+            <a href="../../dashboard.html" class="text-text-secondary hover:text-accent-blue transition-colors">Dashboard</a>
+          </li>
+          <li class="text-text-tertiary" aria-hidden="true">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+          </li>
+          <li>
+            <a href="../../pages/servers-list.html" class="text-text-secondary hover:text-accent-blue transition-colors">Guilds</a>
+          </li>
+          <li class="text-text-tertiary" aria-hidden="true">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+          </li>
+          <li>
+            <a href="#" class="text-text-secondary hover:text-accent-blue transition-colors">Gaming Community</a>
+          </li>
+          <li class="text-text-tertiary" aria-hidden="true">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+          </li>
+          <li>
+            <span class="text-text-primary font-medium" aria-current="page">Analytics</span>
+          </li>
+        </ol>
+      </nav>
+
+      <!-- Page Header -->
+      <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 mb-6">
+        <div class="flex items-center gap-4">
+          <div class="w-12 h-12 rounded-full bg-gradient-to-br from-purple-500 to-pink-500 flex items-center justify-center text-white font-bold text-lg">GC</div>
+          <div>
+            <h1 class="text-2xl lg:text-3xl font-bold text-text-primary">Server Analytics</h1>
+            <p class="text-text-secondary">Gaming Community</p>
+          </div>
+        </div>
+
+        <!-- Date Range Picker -->
+        <div class="date-range-picker">
+          <div class="date-preset-group">
+            <button class="date-preset-btn" onclick="setDatePreset('today')">Today</button>
+            <button class="date-preset-btn active" onclick="setDatePreset('7days')">7 Days</button>
+            <button class="date-preset-btn" onclick="setDatePreset('30days')">30 Days</button>
+            <button class="date-preset-btn" onclick="setDatePreset('custom')">Custom</button>
+          </div>
+          <div class="date-input-group hidden" id="customDateInputs">
+            <input
+              type="date"
+              id="dateFrom"
+              class="px-3 py-1.5 text-sm bg-bg-primary border border-border-primary rounded-md text-text-primary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors"
+            />
+            <span class="date-input-separator">to</span>
+            <input
+              type="date"
+              id="dateTo"
+              class="px-3 py-1.5 text-sm bg-bg-primary border border-border-primary rounded-md text-text-primary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors"
+            />
+          </div>
+        </div>
+      </div>
+
+      <!-- Navigation Tabs -->
+      <div class="analytics-tabs mb-6">
+        <button class="analytics-tab active" onclick="switchTab('overview')">
+          <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+          </svg>
+          Overview
+        </button>
+        <a href="moderation-analytics.html" class="analytics-tab">
+          <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+          </svg>
+          Moderation
+        </a>
+        <a href="engagement-metrics.html" class="analytics-tab">
+          <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+          </svg>
+          Engagement
+        </a>
+      </div>
+
+      <!-- Summary Stats Cards -->
+      <div class="stats-grid mb-8">
+        <!-- Total Members -->
+        <div class="stat-card">
+          <div class="flex items-center justify-between">
+            <div>
+              <p class="stat-card-label">Total Members</p>
+              <p class="stat-card-value">1,234</p>
+              <p class="stat-card-change positive">
+                <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18" />
+                </svg>
+                +48 this week
+              </p>
+            </div>
+            <div class="stat-card-icon bg-accent-blue/10">
+              <svg class="w-6 h-6 text-accent-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+              </svg>
+            </div>
+          </div>
+        </div>
+
+        <!-- Active Members -->
+        <div class="stat-card">
+          <div class="flex items-center justify-between">
+            <div>
+              <p class="stat-card-label">Active Members</p>
+              <p class="stat-card-value">342</p>
+              <p class="stat-card-change neutral">DAU: 89 / WAU: 245 / MAU: 342</p>
+            </div>
+            <div class="stat-card-icon bg-success/10">
+              <svg class="w-6 h-6 text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
+              </svg>
+            </div>
+          </div>
+        </div>
+
+        <!-- Messages -->
+        <div class="stat-card">
+          <div class="flex items-center justify-between">
+            <div>
+              <p class="stat-card-label">Messages</p>
+              <p class="stat-card-value">8,492</p>
+              <p class="stat-card-change positive">
+                <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18" />
+                </svg>
+                24h: 1,247 / 7d: 8,492
+              </p>
+            </div>
+            <div class="stat-card-icon bg-accent-orange/10">
+              <svg class="w-6 h-6 text-accent-orange" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+              </svg>
+            </div>
+          </div>
+        </div>
+
+        <!-- Growth Rate -->
+        <div class="stat-card">
+          <div class="flex items-center justify-between">
+            <div>
+              <p class="stat-card-label">Growth Rate</p>
+              <p class="stat-card-value">+4.2%</p>
+              <p class="stat-card-change positive">
+                <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18" />
+                </svg>
+                Above average
+              </p>
+            </div>
+            <div class="stat-card-icon bg-info/10">
+              <svg class="w-6 h-6 text-info" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 12l3-3 3 3 4-4M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z" />
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Activity Over Time Chart (Full Width) -->
+      <div class="chart-card mb-6">
+        <div class="chart-card-header">
+          <div>
+            <h2 class="chart-card-title">Activity Over Time</h2>
+            <p class="chart-card-subtitle">Messages per day</p>
+          </div>
+          <select class="px-3 py-1.5 text-sm bg-bg-primary border border-border-primary rounded-md text-text-primary focus:border-border-focus transition-colors">
+            <option>Messages</option>
+            <option>Reactions</option>
+            <option>Commands</option>
+          </select>
+        </div>
+        <div class="chart-card-body">
+          <div class="chart-container chart-container-lg">
+            <canvas id="activityOverTimeChart"></canvas>
+          </div>
+        </div>
+      </div>
+
+      <!-- Member Growth Chart (Full Width) -->
+      <div class="chart-card mb-6">
+        <div class="chart-card-header">
+          <div>
+            <h2 class="chart-card-title">Member Growth</h2>
+            <p class="chart-card-subtitle">Joins vs leaves over time</p>
+          </div>
+        </div>
+        <div class="chart-card-body">
+          <div class="chart-container chart-container-lg">
+            <canvas id="memberGrowthChart"></canvas>
+          </div>
+        </div>
+      </div>
+
+      <!-- Two Column Row: Heatmap & Top Channels -->
+      <div class="analytics-grid-2 mb-6">
+        <!-- Activity Heatmap -->
+        <div class="chart-card">
+          <div class="chart-card-header">
+            <div>
+              <h2 class="chart-card-title">Activity Heatmap</h2>
+              <p class="chart-card-subtitle">Day of week vs hour of day</p>
+            </div>
+          </div>
+          <div class="chart-card-body">
+            <div class="heatmap-container" id="activityHeatmap">
+              <!-- Heatmap will be rendered by JavaScript -->
+            </div>
+          </div>
+        </div>
+
+        <!-- Top Channels -->
+        <div class="chart-card">
+          <div class="chart-card-header">
+            <div>
+              <h2 class="chart-card-title">Top Channels</h2>
+              <p class="chart-card-subtitle">By message count</p>
+            </div>
+          </div>
+          <div class="chart-card-body">
+            <div class="chart-container">
+              <canvas id="topChannelsChart"></canvas>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Top Contributors Section -->
+      <div class="chart-card">
+        <div class="chart-card-header">
+          <div>
+            <h2 class="chart-card-title">Top Contributors</h2>
+            <p class="chart-card-subtitle">Most active members this period</p>
+          </div>
+          <button class="px-3 py-1.5 text-sm font-medium text-accent-blue hover:text-accent-blue-hover transition-colors">
+            View All
+          </button>
+        </div>
+        <div class="overflow-x-auto">
+          <table class="analytics-table">
+            <thead>
+              <tr>
+                <th>Rank</th>
+                <th>Member</th>
+                <th>Messages</th>
+                <th>Reactions</th>
+                <th>Commands</th>
+                <th>Active Days</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <span class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-warning/20 text-warning font-bold text-sm">1</span>
+                </td>
+                <td>
+                  <div class="flex items-center gap-3">
+                    <div class="w-10 h-10 rounded-full bg-gradient-to-br from-yellow-500 to-orange-500 flex items-center justify-center text-white font-bold text-sm">GK</div>
+                    <div>
+                      <p class="font-medium text-text-primary">GameKing</p>
+                      <p class="text-xs text-text-tertiary">#1234</p>
+                    </div>
+                  </div>
+                </td>
+                <td class="font-medium">1,247</td>
+                <td>342</td>
+                <td>89</td>
+                <td>
+                  <span class="inline-flex items-center px-2.5 py-0.5 text-xs font-semibold text-success bg-success/10 rounded-full">7/7</span>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <span class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-text-tertiary/20 text-text-secondary font-bold text-sm">2</span>
+                </td>
+                <td>
+                  <div class="flex items-center gap-3">
+                    <div class="w-10 h-10 rounded-full bg-gradient-to-br from-purple-500 to-pink-500 flex items-center justify-center text-white font-bold text-sm">NP</div>
+                    <div>
+                      <p class="font-medium text-text-primary">NightPlayer</p>
+                      <p class="text-xs text-text-tertiary">#5678</p>
+                    </div>
+                  </div>
+                </td>
+                <td class="font-medium">892</td>
+                <td>256</td>
+                <td>67</td>
+                <td>
+                  <span class="inline-flex items-center px-2.5 py-0.5 text-xs font-semibold text-success bg-success/10 rounded-full">7/7</span>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <span class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-accent-orange/20 text-accent-orange font-bold text-sm">3</span>
+                </td>
+                <td>
+                  <div class="flex items-center gap-3">
+                    <div class="w-10 h-10 rounded-full bg-gradient-to-br from-blue-500 to-cyan-500 flex items-center justify-center text-white font-bold text-sm">SM</div>
+                    <div>
+                      <p class="font-medium text-text-primary">StreamMaster</p>
+                      <p class="text-xs text-text-tertiary">#9012</p>
+                    </div>
+                  </div>
+                </td>
+                <td class="font-medium">654</td>
+                <td>189</td>
+                <td>45</td>
+                <td>
+                  <span class="inline-flex items-center px-2.5 py-0.5 text-xs font-semibold text-warning bg-warning/10 rounded-full">6/7</span>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <span class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-bg-tertiary text-text-tertiary font-bold text-sm">4</span>
+                </td>
+                <td>
+                  <div class="flex items-center gap-3">
+                    <div class="w-10 h-10 rounded-full bg-gradient-to-br from-green-500 to-emerald-500 flex items-center justify-center text-white font-bold text-sm">CF</div>
+                    <div>
+                      <p class="font-medium text-text-primary">ChatFan</p>
+                      <p class="text-xs text-text-tertiary">#3456</p>
+                    </div>
+                  </div>
+                </td>
+                <td class="font-medium">521</td>
+                <td>145</td>
+                <td>32</td>
+                <td>
+                  <span class="inline-flex items-center px-2.5 py-0.5 text-xs font-semibold text-warning bg-warning/10 rounded-full">5/7</span>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <span class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-bg-tertiary text-text-tertiary font-bold text-sm">5</span>
+                </td>
+                <td>
+                  <div class="flex items-center gap-3">
+                    <div class="w-10 h-10 rounded-full bg-gradient-to-br from-red-500 to-rose-500 flex items-center justify-center text-white font-bold text-sm">QP</div>
+                    <div>
+                      <p class="font-medium text-text-primary">QuickPro</p>
+                      <p class="text-xs text-text-tertiary">#7890</p>
+                    </div>
+                  </div>
+                </td>
+                <td class="font-medium">487</td>
+                <td>98</td>
+                <td>28</td>
+                <td>
+                  <span class="inline-flex items-center px-2.5 py-0.5 text-xs font-semibold text-text-tertiary bg-bg-tertiary rounded-full">4/7</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+    </div>
+  </main>
+
+  <!-- JavaScript -->
+  <script>
+    // Date Preset Handler
+    function setDatePreset(preset) {
+      // Update button active states
+      document.querySelectorAll('.date-preset-btn').forEach(btn => {
+        btn.classList.remove('active');
+      });
+      event.target.classList.add('active');
+
+      const customInputs = document.getElementById('customDateInputs');
+      if (preset === 'custom') {
+        customInputs.classList.remove('hidden');
+      } else {
+        customInputs.classList.add('hidden');
+      }
+
+      // In a real app, this would trigger data refresh
+      console.log('Date preset changed to:', preset);
+    }
+
+    // Tab Switching
+    function switchTab(tabName) {
+      document.querySelectorAll('.analytics-tab').forEach(tab => {
+        tab.classList.remove('active');
+      });
+      event.target.closest('.analytics-tab').classList.add('active');
+    }
+
+    // Initialize Charts
+    document.addEventListener('DOMContentLoaded', function() {
+      // Chart.js default dark theme settings
+      Chart.defaults.color = '#a8a5a3';
+      Chart.defaults.borderColor = '#3f4447';
+
+      // Activity Over Time Chart (Line)
+      const activityCtx = document.getElementById('activityOverTimeChart').getContext('2d');
+      new Chart(activityCtx, {
+        type: 'line',
+        data: {
+          labels: ['Dec 25', 'Dec 26', 'Dec 27', 'Dec 28', 'Dec 29', 'Dec 30', 'Dec 31'],
+          datasets: [{
+            label: 'Messages',
+            data: [1089, 1247, 1156, 1423, 1312, 1089, 1176],
+            borderColor: '#098ecf',
+            backgroundColor: 'rgba(9, 142, 207, 0.1)',
+            fill: true,
+            tension: 0.4,
+            pointBackgroundColor: '#098ecf',
+            pointBorderColor: '#098ecf',
+            pointRadius: 4,
+            pointHoverRadius: 6
+          }]
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+            legend: {
+              display: false
+            },
+            tooltip: {
+              backgroundColor: '#2f3336',
+              titleColor: '#d7d3d0',
+              bodyColor: '#a8a5a3',
+              borderColor: '#3f4447',
+              borderWidth: 1,
+              padding: 12,
+              displayColors: false
+            }
+          },
+          scales: {
+            y: {
+              beginAtZero: false,
+              grid: {
+                color: '#2f3336'
+              },
+              ticks: {
+                callback: function(value) {
+                  return value.toLocaleString();
+                }
+              }
+            },
+            x: {
+              grid: {
+                display: false
+              }
+            }
+          }
+        }
+      });
+
+      // Member Growth Chart (Area)
+      const growthCtx = document.getElementById('memberGrowthChart').getContext('2d');
+      new Chart(growthCtx, {
+        type: 'line',
+        data: {
+          labels: ['Dec 25', 'Dec 26', 'Dec 27', 'Dec 28', 'Dec 29', 'Dec 30', 'Dec 31'],
+          datasets: [
+            {
+              label: 'Joins',
+              data: [12, 8, 15, 22, 18, 10, 14],
+              borderColor: '#10b981',
+              backgroundColor: 'rgba(16, 185, 129, 0.2)',
+              fill: true,
+              tension: 0.4
+            },
+            {
+              label: 'Leaves',
+              data: [3, 5, 2, 4, 3, 2, 3],
+              borderColor: '#ef4444',
+              backgroundColor: 'rgba(239, 68, 68, 0.2)',
+              fill: true,
+              tension: 0.4
+            }
+          ]
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+            legend: {
+              position: 'bottom',
+              labels: {
+                boxWidth: 12,
+                padding: 20
+              }
+            },
+            tooltip: {
+              backgroundColor: '#2f3336',
+              titleColor: '#d7d3d0',
+              bodyColor: '#a8a5a3',
+              borderColor: '#3f4447',
+              borderWidth: 1,
+              padding: 12
+            }
+          },
+          scales: {
+            y: {
+              beginAtZero: true,
+              grid: {
+                color: '#2f3336'
+              }
+            },
+            x: {
+              grid: {
+                display: false
+              }
+            }
+          }
+        }
+      });
+
+      // Top Channels Chart (Horizontal Bar)
+      const channelsCtx = document.getElementById('topChannelsChart').getContext('2d');
+      new Chart(channelsCtx, {
+        type: 'bar',
+        data: {
+          labels: ['#general', '#gaming', '#off-topic', '#memes', '#help'],
+          datasets: [{
+            label: 'Messages',
+            data: [2847, 2156, 1423, 1089, 756],
+            backgroundColor: [
+              '#cb4e1b',
+              '#098ecf',
+              '#10b981',
+              '#f59e0b',
+              '#06b6d4'
+            ],
+            borderRadius: 4
+          }]
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          indexAxis: 'y',
+          plugins: {
+            legend: {
+              display: false
+            },
+            tooltip: {
+              backgroundColor: '#2f3336',
+              titleColor: '#d7d3d0',
+              bodyColor: '#a8a5a3',
+              borderColor: '#3f4447',
+              borderWidth: 1,
+              padding: 12,
+              callbacks: {
+                label: function(context) {
+                  return context.parsed.x.toLocaleString() + ' messages';
+                }
+              }
+            }
+          },
+          scales: {
+            x: {
+              beginAtZero: true,
+              grid: {
+                color: '#2f3336'
+              },
+              ticks: {
+                callback: function(value) {
+                  return value.toLocaleString();
+                }
+              }
+            },
+            y: {
+              grid: {
+                display: false
+              }
+            }
+          }
+        }
+      });
+
+      // Render Activity Heatmap
+      renderActivityHeatmap();
+    });
+
+    // Render Activity Heatmap
+    function renderActivityHeatmap() {
+      const container = document.getElementById('activityHeatmap');
+      const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+      const hours = Array.from({ length: 24 }, (_, i) => i);
+
+      // Sample heatmap data (day x hour) - message activity
+      const heatmapData = [
+        [2, 1, 0, 0, 1, 2, 4, 8, 12, 15, 18, 20, 22, 25, 28, 32, 35, 40, 45, 42, 38, 30, 18, 8], // Sun
+        [1, 0, 0, 0, 0, 2, 5, 12, 20, 28, 32, 35, 38, 40, 42, 45, 50, 55, 60, 58, 52, 42, 28, 12], // Mon
+        [2, 1, 0, 0, 0, 2, 6, 15, 25, 32, 38, 42, 45, 48, 50, 55, 60, 65, 70, 65, 58, 48, 32, 15], // Tue
+        [1, 1, 0, 0, 0, 2, 5, 14, 22, 30, 35, 40, 42, 45, 48, 52, 58, 62, 68, 62, 55, 45, 30, 14], // Wed
+        [2, 1, 0, 0, 0, 2, 6, 16, 26, 34, 40, 45, 48, 52, 55, 60, 65, 72, 78, 72, 62, 50, 35, 16], // Thu
+        [3, 2, 1, 0, 0, 2, 5, 12, 20, 28, 35, 42, 48, 55, 60, 65, 72, 80, 85, 80, 70, 55, 38, 18], // Fri
+        [5, 3, 2, 1, 1, 2, 5, 10, 18, 25, 30, 35, 38, 42, 45, 50, 55, 60, 58, 52, 45, 35, 22, 10]  // Sat
+      ];
+
+      const maxValue = Math.max(...heatmapData.flat());
+
+      let html = '<div class="heatmap-grid">';
+
+      // Header row with hours
+      html += '<div class="heatmap-row">';
+      html += '<div class="heatmap-label"></div>';
+      hours.forEach((hour, i) => {
+        if (i % 3 === 0) {
+          html += `<div class="flex-1 text-center text-xs text-text-tertiary">${hour}</div>`;
+        } else {
+          html += '<div class="flex-1"></div>';
+        }
+      });
+      html += '</div>';
+
+      // Rows for each day
+      days.forEach((day, dayIndex) => {
+        html += '<div class="heatmap-row">';
+        html += `<div class="heatmap-label">${day}</div>`;
+
+        hours.forEach((hour) => {
+          const value = heatmapData[dayIndex][hour];
+          const intensity = value / maxValue;
+          let intensityClass;
+
+          if (intensity === 0) {
+            intensityClass = 'heatmap-intensity-blue-0';
+          } else if (intensity < 0.25) {
+            intensityClass = 'heatmap-intensity-blue-1';
+          } else if (intensity < 0.5) {
+            intensityClass = 'heatmap-intensity-blue-2';
+          } else if (intensity < 0.75) {
+            intensityClass = 'heatmap-intensity-blue-3';
+          } else {
+            intensityClass = 'heatmap-intensity-blue-4';
+          }
+
+          html += `<div class="heatmap-cell ${intensityClass}" title="${day} ${hour}:00 - ${value} messages"></div>`;
+        });
+
+        html += '</div>';
+      });
+
+      // Legend
+      html += '<div class="heatmap-legend">';
+      html += '<span class="heatmap-legend-label">Less</span>';
+      html += '<div class="heatmap-legend-scale">';
+      ['heatmap-intensity-blue-0', 'heatmap-intensity-blue-1', 'heatmap-intensity-blue-2', 'heatmap-intensity-blue-3', 'heatmap-intensity-blue-4'].forEach(cls => {
+        html += `<div class="heatmap-legend-cell ${cls}"></div>`;
+      });
+      html += '</div>';
+      html += '<span class="heatmap-legend-label">More</span>';
+      html += '</div>';
+
+      html += '</div>';
+
+      container.innerHTML = html;
+    }
+  </script>
+
+</body>
+</html>

--- a/src/DiscordBot.Bot/Extensions/DiscordServiceExtensions.cs
+++ b/src/DiscordBot.Bot/Extensions/DiscordServiceExtensions.cs
@@ -79,6 +79,11 @@ public static class DiscordServiceExtensions
         // Register InteractionStateCleanupService as hosted service
         services.AddHostedService<InteractionStateCleanupService>();
 
+        // Register analytics services
+        services.AddScoped<IServerAnalyticsService, ServerAnalyticsService>();
+        services.AddScoped<IModerationAnalyticsService, ModerationAnalyticsService>();
+        services.AddScoped<IEngagementAnalyticsService, EngagementAnalyticsService>();
+
         return services;
     }
 }

--- a/src/DiscordBot.Bot/Pages/Guilds/Analytics/Engagement.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Analytics/Engagement.cshtml
@@ -1,0 +1,689 @@
+@page "{guildId:long}"
+@model DiscordBot.Bot.Pages.Guilds.Analytics.EngagementModel
+@using DiscordBot.Bot.ViewModels.Components
+@{
+    ViewData["Title"] = $"Engagement Metrics - {Model.ViewModel.GuildName}";
+}
+
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <!-- Breadcrumb Navigation -->
+    <nav aria-label="Breadcrumb" class="mb-6">
+        <ol class="flex items-center gap-2 text-sm flex-wrap">
+            <li>
+                <a asp-page="/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Home</a>
+            </li>
+            <li class="text-text-tertiary" aria-hidden="true">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                </svg>
+            </li>
+            <li>
+                <a asp-page="/Guilds/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Servers</a>
+            </li>
+            <li class="text-text-tertiary" aria-hidden="true">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                </svg>
+            </li>
+            <li>
+                <a asp-page="/Guilds/Details" asp-route-id="@Model.ViewModel.GuildId" class="text-text-secondary hover:text-accent-blue transition-colors">@Model.ViewModel.GuildName</a>
+            </li>
+            <li class="text-text-tertiary" aria-hidden="true">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                </svg>
+            </li>
+            <li>
+                <span class="text-text-primary font-medium" aria-current="page">Engagement Metrics</span>
+            </li>
+        </ol>
+    </nav>
+
+    <!-- Page Header -->
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+        <div>
+            <h1 class="text-2xl font-bold text-text-primary">Engagement Metrics</h1>
+            <p class="mt-1 text-sm text-text-secondary">Message trends and member retention for @Model.ViewModel.GuildName</p>
+        </div>
+    </div>
+
+    <!-- Navigation Tabs -->
+    <div class="flex items-center gap-1 mb-6 border-b border-border-primary">
+        <a asp-page="Index" asp-route-guildId="@Model.ViewModel.GuildId"
+           class="px-4 py-3 text-sm font-medium border-b-2 border-transparent text-text-secondary hover:text-text-primary transition-colors">
+            Overview
+        </a>
+        <a asp-page="Moderation" asp-route-guildId="@Model.ViewModel.GuildId"
+           class="px-4 py-3 text-sm font-medium border-b-2 border-transparent text-text-secondary hover:text-text-primary transition-colors">
+            Moderation
+        </a>
+        <a asp-page="Engagement" asp-route-guildId="@Model.ViewModel.GuildId"
+           class="px-4 py-3 text-sm font-medium border-b-2 border-accent-blue text-text-primary">
+            Engagement
+        </a>
+    </div>
+
+    <!-- Display any errors -->
+    @if (TempData["ErrorMessage"] != null)
+    {
+        <div class="mb-6">
+            @{
+                var errorAlert = new AlertViewModel {
+                    Variant = AlertVariant.Error,
+                    Title = "Error",
+                    Message = TempData["ErrorMessage"]!.ToString()!,
+                    ShowIcon = true
+                };
+            }
+            <partial name="Shared/Components/_Alert" model="errorAlert" />
+        </div>
+    }
+
+    <!-- Filter Panel -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg mb-6">
+        <button type="button"
+                id="filterToggle"
+                class="w-full flex items-center justify-between px-5 py-4 text-left"
+                aria-expanded="true"
+                aria-controls="filterContent"
+                onclick="toggleFilterPanel()">
+            <div class="flex items-center gap-3">
+                <svg class="w-5 h-5 text-text-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
+                </svg>
+                <span class="text-lg font-semibold text-text-primary">Filters</span>
+                @if (Model.StartDate.HasValue || Model.EndDate.HasValue)
+                {
+                    <partial name="Shared/Components/_Badge" model="@(new BadgeViewModel {
+                        Text = "Active",
+                        Variant = BadgeVariant.Orange,
+                        Size = BadgeSize.Small
+                    })" />
+                }
+            </div>
+            <svg id="filterChevron" class="w-5 h-5 text-text-secondary transition-transform duration-200" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            </svg>
+        </button>
+
+        <div id="filterContent" class="overflow-hidden transition-all duration-300 max-h-[1000px]">
+            <div class="border-t border-border-primary p-5">
+                <form method="get" id="filterForm">
+                    <!-- Quick Date Presets -->
+                    <div class="mb-4">
+                        <label class="block text-sm font-medium text-text-primary mb-2">Quick Date Range</label>
+                        @{
+                            var today = DateTime.UtcNow.Date;
+                            var isToday = Model.StartDate.HasValue && Model.EndDate.HasValue &&
+                                         Model.StartDate.Value.Date == today && Model.EndDate.Value.Date == today;
+                            var is7Days = Model.StartDate.HasValue && Model.EndDate.HasValue &&
+                                         Model.StartDate.Value.Date == today.AddDays(-7) && Model.EndDate.Value.Date == today;
+                            var is30Days = Model.StartDate.HasValue && Model.EndDate.HasValue &&
+                                          Model.StartDate.Value.Date == today.AddDays(-30) && Model.EndDate.Value.Date == today;
+
+                            string GetPresetClass(bool isActive) => isActive
+                                ? "px-3 py-1.5 text-xs font-medium bg-accent-orange text-white border border-accent-orange rounded-md hover:bg-accent-orange-hover transition-colors"
+                                : "px-3 py-1.5 text-xs font-medium bg-bg-tertiary text-text-secondary border border-border-primary rounded-md hover:bg-bg-hover transition-colors";
+                        }
+                        <div class="flex flex-wrap gap-2">
+                            <button type="button" onclick="setDatePreset('today')" class="@GetPresetClass(isToday)">
+                                Today
+                            </button>
+                            <button type="button" onclick="setDatePreset('7days')" class="@GetPresetClass(is7Days)">
+                                Last 7 Days
+                            </button>
+                            <button type="button" onclick="setDatePreset('30days')" class="@GetPresetClass(is30Days)">
+                                Last 30 Days
+                            </button>
+                        </div>
+                    </div>
+
+                    <!-- Filter Grid -->
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        <!-- Start Date -->
+                        <div>
+                            <label for="StartDate" class="block text-sm font-medium text-text-primary mb-1">Start Date</label>
+                            <input type="date"
+                                   id="StartDate"
+                                   name="StartDate"
+                                   value="@Model.StartDate?.ToString("yyyy-MM-dd")"
+                                   class="w-full px-3 py-2 text-sm bg-bg-primary border border-border-primary rounded-lg text-text-primary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors" />
+                        </div>
+
+                        <!-- End Date -->
+                        <div>
+                            <label for="EndDate" class="block text-sm font-medium text-text-primary mb-1">End Date</label>
+                            <input type="date"
+                                   id="EndDate"
+                                   name="EndDate"
+                                   value="@Model.EndDate?.ToString("yyyy-MM-dd")"
+                                   class="w-full px-3 py-2 text-sm bg-bg-primary border border-border-primary rounded-lg text-text-primary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors" />
+                        </div>
+                    </div>
+
+                    <!-- Filter Actions -->
+                    <div class="flex items-center gap-3 mt-6 pt-4 border-t border-border-secondary">
+                        <button type="submit" class="btn btn-primary">
+                            <svg class="w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
+                            </svg>
+                            Apply Filters
+                        </button>
+                        @if (Model.StartDate.HasValue || Model.EndDate.HasValue)
+                        {
+                            <a asp-page="Engagement" asp-route-guildId="@Model.ViewModel.GuildId" class="btn btn-secondary">
+                                <svg class="w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                                </svg>
+                                Clear Filters
+                            </a>
+                        }
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <!-- Summary Stats Row -->
+    <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4 lg:gap-6 mb-8">
+        <!-- Total Messages -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-5">
+            <div class="flex items-center justify-between">
+                <div>
+                    <p class="text-sm font-medium text-text-secondary">Total Messages</p>
+                    <p class="mt-2 text-3xl font-bold text-text-primary">@Model.ViewModel.Summary.TotalMessages.ToString("N0")</p>
+                    <p class="mt-1 text-xs text-text-tertiary">@Model.ViewModel.Summary.Messages7d.ToString("N0") in last 7 days</p>
+                </div>
+                <div class="p-3 bg-accent-blue/10 rounded-lg">
+                    <svg class="w-6 h-6 text-accent-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+                    </svg>
+                </div>
+            </div>
+        </div>
+
+        <!-- Unique Authors -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-5">
+            <div class="flex items-center justify-between">
+                <div>
+                    <p class="text-sm font-medium text-text-secondary">Unique Authors</p>
+                    <p class="mt-2 text-3xl font-bold text-text-primary">@Model.ViewModel.Summary.ActiveMembers.ToString("N0")</p>
+                    <p class="mt-1 text-xs text-text-tertiary">Active in this period</p>
+                </div>
+                <div class="p-3 bg-accent-orange/10 rounded-lg">
+                    <svg class="w-6 h-6 text-accent-orange" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+                    </svg>
+                </div>
+            </div>
+        </div>
+
+        <!-- Retention Rate -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-5">
+            <div class="flex items-center justify-between">
+                <div>
+                    <p class="text-sm font-medium text-text-secondary">Retention Rate</p>
+                    <p class="mt-2 text-3xl font-bold text-success">@Model.ViewModel.Summary.NewMemberRetentionRate.ToString("F0")%</p>
+                    <p class="mt-1 text-xs text-text-tertiary">New members retained</p>
+                </div>
+                <div class="p-3 bg-success/10 rounded-lg">
+                    <svg class="w-6 h-6 text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+                    </svg>
+                </div>
+            </div>
+        </div>
+
+        <!-- Avg Message Length -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-5">
+            <div class="flex items-center justify-between">
+                <div>
+                    <p class="text-sm font-medium text-text-secondary">Avg Message Length</p>
+                    @{
+                        var avgLength = Model.ViewModel.MessageTrends.Any()
+                            ? Model.ViewModel.MessageTrends.Average(t => t.AvgMessageLength)
+                            : 0;
+                    }
+                    <p class="mt-2 text-3xl font-bold text-warning">@avgLength.ToString("F0")</p>
+                    <p class="mt-1 text-xs text-text-tertiary">Characters per message</p>
+                </div>
+                <div class="p-3 bg-warning/10 rounded-lg">
+                    <svg class="w-6 h-6 text-warning" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                    </svg>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Message Trends Chart (Full Width) -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden mb-6">
+        <div class="px-5 py-4 border-b border-border-primary">
+            <div class="flex items-center gap-3">
+                <div class="p-2 bg-accent-blue/10 rounded-lg">
+                    <svg class="w-5 h-5 text-accent-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 12l3-3 3 3 4-4M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z" />
+                    </svg>
+                </div>
+                <div>
+                    <h2 class="text-lg font-semibold text-text-primary">Message Trends</h2>
+                    <p class="text-xs text-text-tertiary">Messages and unique authors over time</p>
+                </div>
+            </div>
+        </div>
+        <div class="p-5">
+            @if (Model.ViewModel.MessageTrends.Any())
+            {
+                <div style="position: relative; min-height: 300px; max-height: 400px;">
+                    <canvas id="messageTrendsChart" aria-label="Line chart showing message trends over time" role="img"></canvas>
+                </div>
+            }
+            else
+            {
+                <partial name="Shared/Components/_EmptyState" model='new EmptyStateViewModel {
+                    Type = EmptyStateType.NoData,
+                    Title = "No message data available",
+                    Description = "Data will appear here once messages are sent",
+                    Size = EmptyStateSize.Compact,
+                    IconSvgPath = "M7 12l3-3 3 3 4-4M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z"
+                }' />
+            }
+        </div>
+    </div>
+
+    <!-- Channel Engagement Chart -->
+    @if (Model.ViewModel.ChannelEngagement.Any())
+    {
+        <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden mb-6">
+            <div class="px-5 py-4 border-b border-border-primary">
+                <div class="flex items-center gap-3">
+                    <div class="p-2 bg-success/10 rounded-lg">
+                        <svg class="w-5 h-5 text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" />
+                        </svg>
+                    </div>
+                    <div>
+                        <h2 class="text-lg font-semibold text-text-primary">Channel Engagement</h2>
+                        <p class="text-xs text-text-tertiary">Messages per channel with engagement rate</p>
+                    </div>
+                </div>
+            </div>
+            <div class="p-5">
+                <div style="position: relative; min-height: 300px; max-height: 400px;">
+                    <canvas id="channelEngagementChart" aria-label="Horizontal bar chart showing channel engagement" role="img"></canvas>
+                </div>
+            </div>
+        </div>
+    }
+
+    <!-- New Member Retention Funnel -->
+    @if (Model.ViewModel.NewMemberRetention.Any())
+    {
+        var totalNew = Model.ViewModel.NewMemberRetention.Sum(r => r.NewMembers);
+        var totalFirstMsg = Model.ViewModel.NewMemberRetention.Sum(r => r.SentFirstMessage);
+        var totalActive7d = Model.ViewModel.NewMemberRetention.Sum(r => r.StillActive7d);
+        var totalActive30d = Model.ViewModel.NewMemberRetention.Sum(r => r.StillActive30d);
+
+        var firstMsgPct = totalNew > 0 ? (decimal)totalFirstMsg / totalNew * 100 : 0;
+        var active7dPct = totalNew > 0 ? (decimal)totalActive7d / totalNew * 100 : 0;
+        var active30dPct = totalNew > 0 ? (decimal)totalActive30d / totalNew * 100 : 0;
+        <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden mb-6">
+            <div class="px-5 py-4 border-b border-border-primary">
+                <div class="flex items-center justify-between">
+                    <div class="flex items-center gap-3">
+                        <div class="p-2 bg-warning/10 rounded-lg">
+                            <svg class="w-5 h-5 text-warning" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
+                            </svg>
+                        </div>
+                        <div>
+                            <h2 class="text-lg font-semibold text-text-primary">New Member Retention Funnel</h2>
+                            <p class="text-xs text-text-tertiary">Tracking member engagement from join to active participation</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="p-5">
+                <div class="space-y-3">
+                    <!-- Joined -->
+                    <div class="flex items-center gap-4">
+                        <span class="text-sm font-medium text-text-secondary w-32 text-right">Joined</span>
+                        <div class="flex-1 h-10 bg-accent-blue rounded-md flex items-center px-4" style="width: 100%;">
+                            <span class="text-sm font-semibold text-white">100%</span>
+                        </div>
+                        <span class="text-sm font-semibold text-text-primary w-24">@totalNew members</span>
+                    </div>
+
+                    <!-- First Message -->
+                    <div class="flex items-center gap-4">
+                        <span class="text-sm font-medium text-text-secondary w-32 text-right">First Message</span>
+                        <div class="flex-1 h-10 bg-success rounded-md flex items-center px-4" style="width: @firstMsgPct.ToString("F1")%;">
+                            <span class="text-sm font-semibold text-white">@firstMsgPct.ToString("F1")%</span>
+                        </div>
+                        <span class="text-sm font-semibold text-text-primary w-24">@totalFirstMsg members</span>
+                    </div>
+
+                    <!-- Week 1 Active -->
+                    <div class="flex items-center gap-4">
+                        <span class="text-sm font-medium text-text-secondary w-32 text-right">Week 1 Active</span>
+                        <div class="flex-1 h-10 bg-warning rounded-md flex items-center px-4" style="width: @active7dPct.ToString("F1")%;">
+                            <span class="text-sm font-semibold text-white">@active7dPct.ToString("F1")%</span>
+                        </div>
+                        <span class="text-sm font-semibold text-text-primary w-24">@totalActive7d members</span>
+                    </div>
+
+                    <!-- Month 1 Active -->
+                    <div class="flex items-center gap-4">
+                        <span class="text-sm font-medium text-text-secondary w-32 text-right">Month 1 Active</span>
+                        <div class="flex-1 h-10 bg-accent-orange rounded-md flex items-center px-4" style="width: @active30dPct.ToString("F1")%;">
+                            <span class="text-sm font-semibold text-white">@active30dPct.ToString("F1")%</span>
+                        </div>
+                        <span class="text-sm font-semibold text-text-primary w-24">@totalActive30d members</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
+
+    <!-- Coming Soon Banner -->
+    <div class="bg-bg-secondary border border-border-secondary rounded-lg mb-6 p-5">
+        <div class="flex items-start gap-4">
+            <svg class="w-6 h-6 text-text-tertiary flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <div>
+                <p class="text-sm font-semibold text-text-secondary">Voice and Reaction Analytics Coming Soon</p>
+                <p class="text-sm text-text-tertiary mt-1">We are working on bringing you detailed analytics for voice channel usage and message reactions. Stay tuned for updates!</p>
+            </div>
+        </div>
+    </div>
+
+    <!-- Placeholder Cards for Coming Soon Features -->
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 lg:gap-6">
+        <!-- Voice Analytics Placeholder -->
+        <div class="bg-bg-secondary border border-dashed border-border-primary rounded-lg p-8 text-center opacity-60">
+            <svg class="w-12 h-12 text-text-tertiary mx-auto mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z" />
+            </svg>
+            <p class="text-base font-semibold text-text-secondary mb-1">Voice Channel Analytics</p>
+            <p class="text-sm text-text-tertiary">Track voice activity, average session duration, and peak usage times</p>
+        </div>
+
+        <!-- Reaction Analytics Placeholder -->
+        <div class="bg-bg-secondary border border-dashed border-border-primary rounded-lg p-8 text-center opacity-60">
+            <svg class="w-12 h-12 text-text-tertiary mx-auto mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.828 14.828a4 4 0 01-5.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <p class="text-base font-semibold text-text-secondary mb-1">Reaction Analytics</p>
+            <p class="text-sm text-text-tertiary">Most used emojis, reaction rates, and sentiment analysis</p>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <!-- Chart.js Library -->
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+
+    <!-- Embed Chart Data -->
+    @{
+        var chartData = new {
+            messageTrends = Model.ViewModel.MessageTrends.Select(t => new {
+                date = t.Date.ToString("yyyy-MM-dd"),
+                messageCount = t.MessageCount,
+                uniqueAuthors = t.UniqueAuthors,
+                avgMessageLength = t.AvgMessageLength
+            }),
+            channelEngagement = Model.ViewModel.ChannelEngagement.Select(c => new {
+                channelId = c.ChannelId.ToString(),
+                channelName = c.ChannelName,
+                messageCount = c.MessageCount,
+                uniqueAuthors = c.UniqueAuthors,
+                engagementRate = c.EngagementRate
+            })
+        };
+        var chartDataJson = System.Text.Json.JsonSerializer.Serialize(chartData);
+    }
+
+    <script type="application/json" id="engagementChartData">
+@Html.Raw(chartDataJson)
+    </script>
+
+    <!-- Filter Panel Toggle Script -->
+    <script>
+        function toggleFilterPanel() {
+            const content = document.getElementById('filterContent');
+            const chevron = document.getElementById('filterChevron');
+            const toggle = document.getElementById('filterToggle');
+
+            if (content.style.maxHeight === '0px') {
+                content.style.maxHeight = '1000px';
+                chevron.style.transform = 'rotate(0deg)';
+                toggle.setAttribute('aria-expanded', 'true');
+            } else {
+                content.style.maxHeight = '0px';
+                chevron.style.transform = 'rotate(-90deg)';
+                toggle.setAttribute('aria-expanded', 'false');
+            }
+        }
+
+        function setDatePreset(preset) {
+            const today = new Date();
+            const startDateInput = document.getElementById('StartDate');
+            const endDateInput = document.getElementById('EndDate');
+
+            let startDate = new Date();
+
+            switch(preset) {
+                case 'today':
+                    startDate = today;
+                    break;
+                case '7days':
+                    startDate.setDate(today.getDate() - 7);
+                    break;
+                case '30days':
+                    startDate.setDate(today.getDate() - 30);
+                    break;
+            }
+
+            startDateInput.value = startDate.toISOString().split('T')[0];
+            endDateInput.value = today.toISOString().split('T')[0];
+
+            // Auto-submit the form after setting dates
+            document.getElementById('filterForm').submit();
+        }
+    </script>
+
+    <!-- Chart Initialization Script -->
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            // Chart.js default dark theme settings
+            Chart.defaults.color = '#a8a5a3';
+            Chart.defaults.borderColor = '#3f4447';
+
+            // Load chart data from embedded JSON
+            const chartDataElement = document.getElementById('engagementChartData');
+            if (!chartDataElement) {
+                console.error('Chart data element not found');
+                return;
+            }
+
+            let chartData;
+            try {
+                chartData = JSON.parse(chartDataElement.textContent);
+            } catch (e) {
+                console.error('Failed to parse chart data:', e);
+                return;
+            }
+
+            // Message Trends Chart (Line with dual Y-axes)
+            const trendsCanvas = document.getElementById('messageTrendsChart');
+            if (trendsCanvas && chartData.messageTrends && chartData.messageTrends.length > 0) {
+                const trendsCtx = trendsCanvas.getContext('2d');
+                new Chart(trendsCtx, {
+                    type: 'line',
+                    data: {
+                        labels: chartData.messageTrends.map(t => {
+                            const date = new Date(t.date);
+                            return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+                        }),
+                        datasets: [
+                            {
+                                label: 'Messages',
+                                data: chartData.messageTrends.map(t => t.messageCount),
+                                borderColor: '#098ecf',
+                                backgroundColor: 'rgba(9, 142, 207, 0.1)',
+                                fill: true,
+                                tension: 0.4,
+                                yAxisID: 'y'
+                            },
+                            {
+                                label: 'Unique Authors',
+                                data: chartData.messageTrends.map(t => t.uniqueAuthors),
+                                borderColor: '#10b981',
+                                backgroundColor: 'transparent',
+                                borderDash: [5, 5],
+                                tension: 0.4,
+                                yAxisID: 'y1'
+                            }
+                        ]
+                    },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        interaction: {
+                            mode: 'index',
+                            intersect: false
+                        },
+                        plugins: {
+                            legend: {
+                                position: 'bottom',
+                                labels: {
+                                    boxWidth: 12,
+                                    padding: 20
+                                }
+                            },
+                            tooltip: {
+                                backgroundColor: '#2f3336',
+                                titleColor: '#d7d3d0',
+                                bodyColor: '#a8a5a3',
+                                borderColor: '#3f4447',
+                                borderWidth: 1,
+                                padding: 12
+                            }
+                        },
+                        scales: {
+                            y: {
+                                type: 'linear',
+                                display: true,
+                                position: 'left',
+                                beginAtZero: false,
+                                grid: {
+                                    color: '#2f3336'
+                                },
+                                title: {
+                                    display: true,
+                                    text: 'Messages',
+                                    color: '#098ecf'
+                                }
+                            },
+                            y1: {
+                                type: 'linear',
+                                display: true,
+                                position: 'right',
+                                beginAtZero: false,
+                                grid: {
+                                    drawOnChartArea: false
+                                },
+                                title: {
+                                    display: true,
+                                    text: 'Unique Authors',
+                                    color: '#10b981'
+                                }
+                            },
+                            x: {
+                                grid: {
+                                    display: false
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+
+            // Channel Engagement Chart (Horizontal Bar)
+            const channelCanvas = document.getElementById('channelEngagementChart');
+            if (channelCanvas && chartData.channelEngagement && chartData.channelEngagement.length > 0) {
+                const channelCtx = channelCanvas.getContext('2d');
+                new Chart(channelCtx, {
+                    type: 'bar',
+                    data: {
+                        labels: chartData.channelEngagement.map(c => c.channelName),
+                        datasets: [
+                            {
+                                label: 'Messages',
+                                data: chartData.channelEngagement.map(c => c.messageCount),
+                                backgroundColor: '#098ecf',
+                                borderRadius: 4
+                            },
+                            {
+                                label: 'Engagement Rate (%)',
+                                data: chartData.channelEngagement.map(c => c.engagementRate),
+                                backgroundColor: '#cb4e1b',
+                                borderRadius: 4
+                            }
+                        ]
+                    },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        indexAxis: 'y',
+                        plugins: {
+                            legend: {
+                                position: 'bottom',
+                                labels: {
+                                    boxWidth: 12,
+                                    padding: 20
+                                }
+                            },
+                            tooltip: {
+                                backgroundColor: '#2f3336',
+                                titleColor: '#d7d3d0',
+                                bodyColor: '#a8a5a3',
+                                borderColor: '#3f4447',
+                                borderWidth: 1,
+                                padding: 12,
+                                callbacks: {
+                                    label: function(context) {
+                                        if (context.datasetIndex === 0) {
+                                            return context.parsed.x.toLocaleString() + ' messages';
+                                        } else {
+                                            return context.parsed.x.toFixed(1) + '% engagement';
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        scales: {
+                            x: {
+                                beginAtZero: true,
+                                grid: {
+                                    color: '#2f3336'
+                                },
+                                ticks: {
+                                    callback: function(value) {
+                                        return value.toLocaleString();
+                                    }
+                                }
+                            },
+                            y: {
+                                grid: {
+                                    display: false
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+        });
+    </script>
+}

--- a/src/DiscordBot.Bot/Pages/Guilds/Analytics/Engagement.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/Analytics/Engagement.cshtml.cs
@@ -1,0 +1,136 @@
+using DiscordBot.Bot.ViewModels.Pages;
+using DiscordBot.Core.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace DiscordBot.Bot.Pages.Guilds.Analytics;
+
+/// <summary>
+/// Page model for the Guild Engagement Analytics Dashboard.
+/// Displays engagement metrics, message trends, channel analytics, and new member retention.
+/// </summary>
+[Authorize(Policy = "RequireViewer")]
+public class EngagementModel : PageModel
+{
+    private readonly IEngagementAnalyticsService _engagementAnalyticsService;
+    private readonly IGuildService _guildService;
+    private readonly ILogger<EngagementModel> _logger;
+
+    public EngagementModel(
+        IEngagementAnalyticsService engagementAnalyticsService,
+        IGuildService guildService,
+        ILogger<EngagementModel> logger)
+    {
+        _engagementAnalyticsService = engagementAnalyticsService;
+        _guildService = guildService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// The analytics view model with all chart data and metrics.
+    /// </summary>
+    public EngagementAnalyticsViewModel ViewModel { get; private set; } = new();
+
+    /// <summary>
+    /// Start date filter (bound from query string).
+    /// </summary>
+    [BindProperty(SupportsGet = true)]
+    public DateTime? StartDate { get; set; }
+
+    /// <summary>
+    /// End date filter (bound from query string).
+    /// </summary>
+    [BindProperty(SupportsGet = true)]
+    public DateTime? EndDate { get; set; }
+
+    /// <summary>
+    /// Handles GET requests to display the engagement analytics dashboard.
+    /// </summary>
+    /// <param name="guildId">The guild's Discord snowflake ID from route parameter.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The page result.</returns>
+    public async Task<IActionResult> OnGetAsync(ulong guildId, CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Loading engagement analytics for guild {GuildId}", guildId);
+
+        // Set defaults if not specified (normalize to midnight UTC)
+        StartDate = StartDate.HasValue ? StartDate.Value.Date : DateTime.UtcNow.AddDays(-7).Date;
+        EndDate = EndDate.HasValue ? EndDate.Value.Date : DateTime.UtcNow.Date;
+
+        // Query range: start at beginning of StartDate (00:00:00) and end at beginning of day after EndDate (00:00:00)
+        // This ensures we include all records from the entire EndDate day (up to 23:59:59.999)
+        var start = StartDate.Value;
+        var end = EndDate.Value.AddDays(1);
+
+        _logger.LogDebug("Analytics date range: {Start} to {End}", start, end);
+
+        try
+        {
+            // Get guild info
+            var guild = await _guildService.GetGuildByIdAsync(guildId, cancellationToken);
+            if (guild == null)
+            {
+                _logger.LogWarning("Guild {GuildId} not found", guildId);
+                return NotFound();
+            }
+
+            // Load analytics data from service
+            var summary = await _engagementAnalyticsService.GetSummaryAsync(guildId, start, end, cancellationToken);
+            var messageTrends = await _engagementAnalyticsService.GetMessageTrendsAsync(guildId, start, end, cancellationToken);
+            var newMemberRetention = await _engagementAnalyticsService.GetNewMemberRetentionAsync(guildId, start, end, cancellationToken);
+
+            // Load channel engagement metrics (placeholder - will be implemented in service)
+            var channelEngagement = await GetChannelEngagementAsync(guildId, start, end, cancellationToken);
+
+            // Build view model
+            ViewModel = new EngagementAnalyticsViewModel
+            {
+                GuildId = guildId,
+                GuildName = guild.Name,
+                GuildIconUrl = guild.IconUrl,
+                Summary = summary,
+                MessageTrends = messageTrends.ToList(),
+                ChannelEngagement = channelEngagement,
+                NewMemberRetention = newMemberRetention.ToList(),
+                StartDate = start,
+                EndDate = end.AddDays(-1) // Show the actual end date (not +1)
+            };
+
+            _logger.LogInformation(
+                "Engagement analytics loaded successfully for guild {GuildId}. Total messages: {TotalMessages}, Active members: {ActiveMembers}",
+                guildId, summary.TotalMessages, summary.ActiveMembers);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load engagement analytics for guild {GuildId}", guildId);
+            TempData["ErrorMessage"] = "Failed to load analytics data. Please try again.";
+            // Return page with empty data
+        }
+
+        return Page();
+    }
+
+    /// <summary>
+    /// Gets channel engagement metrics (placeholder implementation).
+    /// This will be replaced with actual service call once channel tracking is implemented.
+    /// </summary>
+    /// <param name="guildId">Guild ID.</param>
+    /// <param name="start">Start date.</param>
+    /// <param name="end">End date.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of channel engagement metrics.</returns>
+    private async Task<List<ChannelEngagementDto>> GetChannelEngagementAsync(
+        ulong guildId,
+        DateTime start,
+        DateTime end,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("Retrieving channel engagement metrics for guild {GuildId}", guildId);
+
+        // TODO: Implement actual channel engagement tracking
+        // For now, return empty list - this will be populated once channel message tracking is added
+        await Task.CompletedTask;
+        return new List<ChannelEngagementDto>();
+    }
+}

--- a/src/DiscordBot.Bot/Pages/Guilds/Analytics/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Analytics/Index.cshtml
@@ -1,0 +1,776 @@
+@page "{guildId:long}"
+@model DiscordBot.Bot.Pages.Guilds.Analytics.IndexModel
+@using DiscordBot.Bot.ViewModels.Components
+@{
+    ViewData["Title"] = $"Server Analytics - {Model.ViewModel.GuildName}";
+}
+
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <!-- Breadcrumb Navigation -->
+    <nav aria-label="Breadcrumb" class="mb-6">
+        <ol class="flex items-center gap-2 text-sm flex-wrap">
+            <li>
+                <a asp-page="/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Home</a>
+            </li>
+            <li class="text-text-tertiary" aria-hidden="true">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                </svg>
+            </li>
+            <li>
+                <a asp-page="/Guilds/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Servers</a>
+            </li>
+            <li class="text-text-tertiary" aria-hidden="true">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                </svg>
+            </li>
+            <li>
+                <a asp-page="/Guilds/Details" asp-route-id="@Model.ViewModel.GuildId" class="text-text-secondary hover:text-accent-blue transition-colors">@Model.ViewModel.GuildName</a>
+            </li>
+            <li class="text-text-tertiary" aria-hidden="true">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                </svg>
+            </li>
+            <li>
+                <span class="text-text-primary font-medium" aria-current="page">Analytics</span>
+            </li>
+        </ol>
+    </nav>
+
+    <!-- Page Header -->
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+        <div>
+            <h1 class="text-2xl font-bold text-text-primary">Server Analytics</h1>
+            <p class="mt-1 text-sm text-text-secondary">Activity metrics and trends for @Model.ViewModel.GuildName</p>
+        </div>
+    </div>
+
+    <!-- Navigation Tabs -->
+    <div class="flex items-center gap-1 mb-6 border-b border-border-primary">
+        <a asp-page="Index" asp-route-guildId="@Model.ViewModel.GuildId"
+           class="px-4 py-3 text-sm font-medium border-b-2 border-accent-blue text-text-primary">
+            Overview
+        </a>
+        <a asp-page="Moderation" asp-route-guildId="@Model.ViewModel.GuildId"
+           class="px-4 py-3 text-sm font-medium border-b-2 border-transparent text-text-secondary hover:text-text-primary transition-colors">
+            Moderation
+        </a>
+        <a asp-page="Engagement" asp-route-guildId="@Model.ViewModel.GuildId"
+           class="px-4 py-3 text-sm font-medium border-b-2 border-transparent text-text-secondary hover:text-text-primary transition-colors">
+            Engagement
+        </a>
+    </div>
+
+    <!-- Display any errors -->
+    @if (TempData["ErrorMessage"] != null)
+    {
+        <div class="mb-6">
+            @{
+                var errorAlert = new AlertViewModel {
+                    Variant = AlertVariant.Error,
+                    Title = "Error",
+                    Message = TempData["ErrorMessage"]!.ToString()!,
+                    ShowIcon = true
+                };
+            }
+            <partial name="Shared/Components/_Alert" model="errorAlert" />
+        </div>
+    }
+
+    <!-- Filter Panel -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg mb-6">
+        <button type="button"
+                id="filterToggle"
+                class="w-full flex items-center justify-between px-5 py-4 text-left"
+                aria-expanded="true"
+                aria-controls="filterContent"
+                onclick="toggleFilterPanel()">
+            <div class="flex items-center gap-3">
+                <svg class="w-5 h-5 text-text-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
+                </svg>
+                <span class="text-lg font-semibold text-text-primary">Filters</span>
+                @if (Model.StartDate.HasValue || Model.EndDate.HasValue)
+                {
+                    <partial name="Shared/Components/_Badge" model="@(new BadgeViewModel {
+                        Text = "Active",
+                        Variant = BadgeVariant.Orange,
+                        Size = BadgeSize.Small
+                    })" />
+                }
+            </div>
+            <svg id="filterChevron" class="w-5 h-5 text-text-secondary transition-transform duration-200" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            </svg>
+        </button>
+
+        <div id="filterContent" class="overflow-hidden transition-all duration-300 max-h-[1000px]">
+            <div class="border-t border-border-primary p-5">
+                <form method="get" id="filterForm">
+                    <!-- Quick Date Presets -->
+                    <div class="mb-4">
+                        <label class="block text-sm font-medium text-text-primary mb-2">Quick Date Range</label>
+                        @{
+                            var today = DateTime.UtcNow.Date;
+                            var isToday = Model.StartDate.HasValue && Model.EndDate.HasValue &&
+                                         Model.StartDate.Value.Date == today && Model.EndDate.Value.Date == today;
+                            var is7Days = Model.StartDate.HasValue && Model.EndDate.HasValue &&
+                                         Model.StartDate.Value.Date == today.AddDays(-7) && Model.EndDate.Value.Date == today;
+                            var is30Days = Model.StartDate.HasValue && Model.EndDate.HasValue &&
+                                          Model.StartDate.Value.Date == today.AddDays(-30) && Model.EndDate.Value.Date == today;
+
+                            string GetPresetClass(bool isActive) => isActive
+                                ? "px-3 py-1.5 text-xs font-medium bg-accent-blue text-white border border-accent-blue rounded-md hover:bg-accent-blue-hover transition-colors"
+                                : "px-3 py-1.5 text-xs font-medium bg-bg-tertiary text-text-secondary border border-border-primary rounded-md hover:bg-bg-hover transition-colors";
+                        }
+                        <div class="flex flex-wrap gap-2">
+                            <button type="button" onclick="setDatePreset('today')" class="@GetPresetClass(isToday)">
+                                Today
+                            </button>
+                            <button type="button" onclick="setDatePreset('7days')" class="@GetPresetClass(is7Days)">
+                                Last 7 Days
+                            </button>
+                            <button type="button" onclick="setDatePreset('30days')" class="@GetPresetClass(is30Days)">
+                                Last 30 Days
+                            </button>
+                        </div>
+                    </div>
+
+                    <!-- Filter Grid -->
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        <!-- Start Date -->
+                        <div>
+                            <label for="StartDate" class="block text-sm font-medium text-text-primary mb-1">Start Date</label>
+                            <input type="date"
+                                   id="StartDate"
+                                   name="StartDate"
+                                   value="@Model.StartDate?.ToString("yyyy-MM-dd")"
+                                   class="w-full px-3 py-2 text-sm bg-bg-primary border border-border-primary rounded-lg text-text-primary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors" />
+                        </div>
+
+                        <!-- End Date -->
+                        <div>
+                            <label for="EndDate" class="block text-sm font-medium text-text-primary mb-1">End Date</label>
+                            <input type="date"
+                                   id="EndDate"
+                                   name="EndDate"
+                                   value="@Model.EndDate?.ToString("yyyy-MM-dd")"
+                                   class="w-full px-3 py-2 text-sm bg-bg-primary border border-border-primary rounded-lg text-text-primary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors" />
+                        </div>
+                    </div>
+
+                    <!-- Filter Actions -->
+                    <div class="flex items-center gap-3 mt-6 pt-4 border-t border-border-secondary">
+                        <button type="submit" class="btn btn-primary">
+                            <svg class="w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
+                            </svg>
+                            Apply Filters
+                        </button>
+                        @if (Model.StartDate.HasValue || Model.EndDate.HasValue)
+                        {
+                            <a asp-page="Index" asp-route-guildId="@Model.ViewModel.GuildId" class="btn btn-secondary">
+                                <svg class="w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                                </svg>
+                                Clear Filters
+                            </a>
+                        }
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <!-- Summary Stats Row -->
+    <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4 lg:gap-6 mb-8">
+        <!-- Total Members -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-5">
+            <div class="flex items-center justify-between">
+                <div>
+                    <p class="text-sm font-medium text-text-secondary">Total Members</p>
+                    <p class="mt-2 text-3xl font-bold text-text-primary">@Model.ViewModel.Summary.TotalMembers.ToString("N0")</p>
+                    <p class="mt-1 text-xs text-text-tertiary">
+                        @if (Model.ViewModel.Summary.MemberGrowth7d > 0)
+                        {
+                            <span class="text-success">+@Model.ViewModel.Summary.MemberGrowth7d this week</span>
+                        }
+                        else if (Model.ViewModel.Summary.MemberGrowth7d < 0)
+                        {
+                            <span class="text-error">@Model.ViewModel.Summary.MemberGrowth7d this week</span>
+                        }
+                        else
+                        {
+                            <span>No change this week</span>
+                        }
+                    </p>
+                </div>
+                <div class="p-3 bg-accent-blue/10 rounded-lg">
+                    <svg class="w-6 h-6 text-accent-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+                    </svg>
+                </div>
+            </div>
+        </div>
+
+        <!-- Active Members -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-5">
+            <div class="flex items-center justify-between">
+                <div>
+                    <p class="text-sm font-medium text-text-secondary">Active Members</p>
+                    <p class="mt-2 text-3xl font-bold text-text-primary">@Model.ViewModel.Summary.ActiveMembers7d.ToString("N0")</p>
+                    <p class="mt-1 text-xs text-text-tertiary">
+                        DAU: @Model.ViewModel.Summary.ActiveMembers24h / WAU: @Model.ViewModel.Summary.ActiveMembers7d / MAU: @Model.ViewModel.Summary.ActiveMembers30d
+                    </p>
+                </div>
+                <div class="p-3 bg-success/10 rounded-lg">
+                    <svg class="w-6 h-6 text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
+                    </svg>
+                </div>
+            </div>
+        </div>
+
+        <!-- Messages -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-5">
+            <div class="flex items-center justify-between">
+                <div>
+                    <p class="text-sm font-medium text-text-secondary">Messages</p>
+                    <p class="mt-2 text-3xl font-bold text-text-primary">@Model.ViewModel.Summary.Messages7d.ToString("N0")</p>
+                    <p class="mt-1 text-xs text-text-tertiary">
+                        24h: @Model.ViewModel.Summary.Messages24h.ToString("N0") / 7d: @Model.ViewModel.Summary.Messages7d.ToString("N0")
+                    </p>
+                </div>
+                <div class="p-3 bg-accent-orange/10 rounded-lg">
+                    <svg class="w-6 h-6 text-accent-orange" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+                    </svg>
+                </div>
+            </div>
+        </div>
+
+        <!-- Active Channels -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-5">
+            <div class="flex items-center justify-between">
+                <div>
+                    <p class="text-sm font-medium text-text-secondary">Active Channels</p>
+                    <p class="mt-2 text-3xl font-bold text-text-primary">@Model.ViewModel.Summary.ActiveChannels.ToString("N0")</p>
+                    <p class="mt-1 text-xs text-text-tertiary">With activity this period</p>
+                </div>
+                <div class="p-3 bg-info/10 rounded-lg">
+                    <svg class="w-6 h-6 text-info" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" />
+                    </svg>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Activity Over Time Chart (Full Width) -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden mb-6">
+        <div class="px-5 py-4 border-b border-border-primary">
+            <div class="flex items-center gap-3">
+                <div class="p-2 bg-accent-blue/10 rounded-lg">
+                    <svg class="w-5 h-5 text-accent-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 12l3-3 3 3 4-4M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z" />
+                    </svg>
+                </div>
+                <div>
+                    <h2 class="text-lg font-semibold text-text-primary">Activity Over Time</h2>
+                    <p class="text-sm text-text-tertiary">Messages and active members per day</p>
+                </div>
+            </div>
+        </div>
+        <div class="p-5">
+            @if (Model.ViewModel.ActivityTimeSeries.Any())
+            {
+                <div style="position: relative; min-height: 300px; max-height: 400px;">
+                    <canvas id="activityOverTimeChart" aria-label="Line chart showing activity over time" role="img"></canvas>
+                </div>
+            }
+            else
+            {
+                <partial name="Shared/Components/_EmptyState" model='new EmptyStateViewModel {
+                    Type = EmptyStateType.NoData,
+                    Title = "No activity data available",
+                    Description = "Data will appear here once messages are logged",
+                    Size = EmptyStateSize.Compact,
+                    IconSvgPath = "M7 12l3-3 3 3 4-4M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z"
+                }' />
+            }
+        </div>
+    </div>
+
+    <!-- Two Column Row: Heatmap & Top Channels -->
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 lg:gap-6 mb-8">
+        <!-- Activity Heatmap -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden">
+            <div class="px-5 py-4 border-b border-border-primary">
+                <div class="flex items-center gap-3">
+                    <div class="p-2 bg-success/10 rounded-lg">
+                        <svg class="w-5 h-5 text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        </svg>
+                    </div>
+                    <div>
+                        <h2 class="text-lg font-semibold text-text-primary">Activity Heatmap</h2>
+                        <p class="text-sm text-text-tertiary">Day of week vs hour of day</p>
+                    </div>
+                </div>
+            </div>
+            <div class="p-5">
+                @if (Model.ViewModel.ActivityHeatmap.Any())
+                {
+                    <div id="activityHeatmap">
+                        <!-- Heatmap will be rendered by JavaScript -->
+                    </div>
+                }
+                else
+                {
+                    <partial name="Shared/Components/_EmptyState" model='new EmptyStateViewModel {
+                        Type = EmptyStateType.NoData,
+                        Title = "No heatmap data available",
+                        Description = "Activity patterns will appear here",
+                        Size = EmptyStateSize.Compact,
+                        IconSvgPath = "M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+                    }' />
+                }
+            </div>
+        </div>
+
+        <!-- Top Channels -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden">
+            <div class="px-5 py-4 border-b border-border-primary">
+                <div class="flex items-center gap-3">
+                    <div class="p-2 bg-accent-orange/10 rounded-lg">
+                        <svg class="w-5 h-5 text-accent-orange" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" />
+                        </svg>
+                    </div>
+                    <div>
+                        <h2 class="text-lg font-semibold text-text-primary">Top Channels</h2>
+                        <p class="text-sm text-text-tertiary">By message count</p>
+                    </div>
+                </div>
+            </div>
+            <div class="p-5">
+                @if (Model.ViewModel.TopChannels.Any())
+                {
+                    <div style="position: relative; min-height: 300px; max-height: 400px;">
+                        <canvas id="topChannelsChart" aria-label="Horizontal bar chart showing top channels" role="img"></canvas>
+                    </div>
+                }
+                else
+                {
+                    <partial name="Shared/Components/_EmptyState" model='new EmptyStateViewModel {
+                        Type = EmptyStateType.NoData,
+                        Title = "No channel data available",
+                        Description = "Channel activity will appear here",
+                        Size = EmptyStateSize.Compact,
+                        IconSvgPath = "M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z"
+                    }' />
+                }
+            </div>
+        </div>
+    </div>
+
+    <!-- Top Contributors Section -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden">
+        <div class="px-5 py-4 border-b border-border-primary">
+            <div class="flex items-center justify-between">
+                <div class="flex items-center gap-3">
+                    <div class="p-2 bg-warning/10 rounded-lg">
+                        <svg class="w-5 h-5 text-warning" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                        </svg>
+                    </div>
+                    <div>
+                        <h2 class="text-lg font-semibold text-text-primary">Top Contributors</h2>
+                        <p class="text-sm text-text-tertiary">Most active members this period</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+        @if (Model.ViewModel.TopContributors.Any())
+        {
+            <div class="overflow-x-auto">
+                <table class="w-full">
+                    <thead class="bg-bg-primary/50">
+                        <tr>
+                            <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Rank</th>
+                            <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Member</th>
+                            <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Messages</th>
+                            <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Channels</th>
+                            <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Last Active</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-border-primary">
+                        @for (int i = 0; i < Model.ViewModel.TopContributors.Count; i++)
+                        {
+                            var user = Model.ViewModel.TopContributors[i];
+                            var rank = i + 1;
+                            var rankBadgeClass = rank == 1 ? "bg-warning/20 text-warning" : rank <= 3 ? "bg-accent-orange/20 text-accent-orange" : "bg-bg-tertiary text-text-tertiary";
+                            <tr class="hover:bg-bg-hover transition-colors">
+                                <td class="px-5 py-4">
+                                    <span class="inline-flex items-center justify-center w-8 h-8 rounded-full @rankBadgeClass font-bold text-sm">@rank</span>
+                                </td>
+                                <td class="px-5 py-4">
+                                    <p class="font-medium text-text-primary">@user.Username</p>
+                                </td>
+                                <td class="px-5 py-4 text-text-primary font-medium">@user.MessageCount.ToString("N0")</td>
+                                <td class="px-5 py-4 text-text-secondary">@user.UniqueChannels</td>
+                                <td class="px-5 py-4 text-text-secondary text-sm">
+                                    @user.LastActive.ToString("MMM d, yyyy")
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        }
+        else
+        {
+            <div class="py-12 text-center">
+                <p class="text-text-secondary font-medium">No contributor data available</p>
+                <p class="text-sm text-text-tertiary mt-1">Leaderboard will appear once messages are logged</p>
+            </div>
+        }
+    </div>
+</div>
+
+@section Scripts {
+    <!-- Chart.js Library -->
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+
+    <!-- Embed Chart Data -->
+    @{
+        var chartData = new {
+            guildId = Model.ViewModel.GuildId.ToString(), // Pass as string for JavaScript
+            activityTimeSeries = Model.ViewModel.ActivityTimeSeries.Select(t => new {
+                date = t.Date.ToString("yyyy-MM-dd"),
+                messageCount = t.MessageCount,
+                activeMembers = t.ActiveMembers,
+                activeChannels = t.ActiveChannels
+            }),
+            heatmap = Model.ViewModel.ActivityHeatmap.Select(h => new {
+                dayOfWeek = h.DayOfWeek,
+                hour = h.Hour,
+                messageCount = h.MessageCount
+            }),
+            topChannels = Model.ViewModel.TopChannels.Take(5).Select(c => new {
+                channelId = c.ChannelId.ToString(), // Pass as string for JavaScript
+                channelName = c.ChannelName,
+                messageCount = c.MessageCount
+            })
+        };
+        var chartDataJson = System.Text.Json.JsonSerializer.Serialize(chartData);
+    }
+
+    <script type="application/json" id="serverAnalyticsChartData">
+@Html.Raw(chartDataJson)
+    </script>
+
+    <!-- Filter Panel Toggle Script -->
+    <script>
+        function toggleFilterPanel() {
+            const content = document.getElementById('filterContent');
+            const chevron = document.getElementById('filterChevron');
+            const toggle = document.getElementById('filterToggle');
+
+            if (content.style.maxHeight === '0px') {
+                content.style.maxHeight = '1000px';
+                chevron.style.transform = 'rotate(0deg)';
+                toggle.setAttribute('aria-expanded', 'true');
+            } else {
+                content.style.maxHeight = '0px';
+                chevron.style.transform = 'rotate(-90deg)';
+                toggle.setAttribute('aria-expanded', 'false');
+            }
+        }
+
+        function setDatePreset(preset) {
+            const today = new Date();
+            const startDateInput = document.getElementById('StartDate');
+            const endDateInput = document.getElementById('EndDate');
+
+            let startDate = new Date();
+
+            switch(preset) {
+                case 'today':
+                    startDate = today;
+                    break;
+                case '7days':
+                    startDate.setDate(today.getDate() - 7);
+                    break;
+                case '30days':
+                    startDate.setDate(today.getDate() - 30);
+                    break;
+            }
+
+            startDateInput.value = startDate.toISOString().split('T')[0];
+            endDateInput.value = today.toISOString().split('T')[0];
+
+            // Auto-submit the form after setting dates
+            document.getElementById('filterForm').submit();
+        }
+    </script>
+
+    <!-- Server Analytics Chart Script -->
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            // Parse embedded chart data
+            const chartDataElement = document.getElementById('serverAnalyticsChartData');
+            if (!chartDataElement) {
+                console.error('Chart data not found');
+                return;
+            }
+
+            const chartData = JSON.parse(chartDataElement.textContent);
+
+            // Chart.js default dark theme settings
+            Chart.defaults.color = '#a8a5a3';
+            Chart.defaults.borderColor = '#3f4447';
+
+            // Activity Over Time Chart (Line)
+            const activityCtx = document.getElementById('activityOverTimeChart');
+            if (activityCtx && chartData.activityTimeSeries.length > 0) {
+                new Chart(activityCtx, {
+                    type: 'line',
+                    data: {
+                        labels: chartData.activityTimeSeries.map(d => d.date),
+                        datasets: [
+                            {
+                                label: 'Messages',
+                                data: chartData.activityTimeSeries.map(d => d.messageCount),
+                                borderColor: '#098ecf',
+                                backgroundColor: 'rgba(9, 142, 207, 0.1)',
+                                fill: true,
+                                tension: 0.4,
+                                yAxisID: 'y',
+                                pointRadius: 4,
+                                pointHoverRadius: 6
+                            },
+                            {
+                                label: 'Active Members',
+                                data: chartData.activityTimeSeries.map(d => d.activeMembers),
+                                borderColor: '#10b981',
+                                backgroundColor: 'rgba(16, 185, 129, 0.1)',
+                                fill: true,
+                                tension: 0.4,
+                                yAxisID: 'y1',
+                                pointRadius: 4,
+                                pointHoverRadius: 6
+                            }
+                        ]
+                    },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        interaction: {
+                            mode: 'index',
+                            intersect: false
+                        },
+                        plugins: {
+                            legend: {
+                                position: 'bottom',
+                                labels: {
+                                    boxWidth: 12,
+                                    padding: 20
+                                }
+                            },
+                            tooltip: {
+                                backgroundColor: '#2f3336',
+                                titleColor: '#d7d3d0',
+                                bodyColor: '#a8a5a3',
+                                borderColor: '#3f4447',
+                                borderWidth: 1,
+                                padding: 12
+                            }
+                        },
+                        scales: {
+                            y: {
+                                type: 'linear',
+                                display: true,
+                                position: 'left',
+                                title: {
+                                    display: true,
+                                    text: 'Messages'
+                                },
+                                grid: {
+                                    color: '#2f3336'
+                                }
+                            },
+                            y1: {
+                                type: 'linear',
+                                display: true,
+                                position: 'right',
+                                title: {
+                                    display: true,
+                                    text: 'Active Members'
+                                },
+                                grid: {
+                                    drawOnChartArea: false
+                                }
+                            },
+                            x: {
+                                grid: {
+                                    display: false
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+
+            // Top Channels Chart (Horizontal Bar)
+            const channelsCtx = document.getElementById('topChannelsChart');
+            if (channelsCtx && chartData.topChannels.length > 0) {
+                new Chart(channelsCtx, {
+                    type: 'bar',
+                    data: {
+                        labels: chartData.topChannels.map(c => c.channelName),
+                        datasets: [{
+                            label: 'Messages',
+                            data: chartData.topChannels.map(c => c.messageCount),
+                            backgroundColor: [
+                                '#cb4e1b',
+                                '#098ecf',
+                                '#10b981',
+                                '#f59e0b',
+                                '#06b6d4'
+                            ],
+                            borderRadius: 4
+                        }]
+                    },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        indexAxis: 'y',
+                        plugins: {
+                            legend: {
+                                display: false
+                            },
+                            tooltip: {
+                                backgroundColor: '#2f3336',
+                                titleColor: '#d7d3d0',
+                                bodyColor: '#a8a5a3',
+                                borderColor: '#3f4447',
+                                borderWidth: 1,
+                                padding: 12,
+                                callbacks: {
+                                    label: function(context) {
+                                        return context.parsed.x.toLocaleString() + ' messages';
+                                    }
+                                }
+                            }
+                        },
+                        scales: {
+                            x: {
+                                beginAtZero: true,
+                                grid: {
+                                    color: '#2f3336'
+                                },
+                                ticks: {
+                                    callback: function(value) {
+                                        return value.toLocaleString();
+                                    }
+                                }
+                            },
+                            y: {
+                                grid: {
+                                    display: false
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+
+            // Render Activity Heatmap
+            if (chartData.heatmap.length > 0) {
+                renderActivityHeatmap(chartData.heatmap);
+            }
+        });
+
+        // Render Activity Heatmap
+        function renderActivityHeatmap(heatmapData) {
+            const container = document.getElementById('activityHeatmap');
+            if (!container) return;
+
+            const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+            const hours = Array.from({ length: 24 }, (_, i) => i);
+
+            // Build 2D array indexed by [dayOfWeek][hour]
+            const heatmapGrid = Array(7).fill(null).map(() => Array(24).fill(0));
+            heatmapData.forEach(item => {
+                heatmapGrid[item.dayOfWeek][item.hour] = item.messageCount;
+            });
+
+            const maxValue = Math.max(...heatmapData.map(h => h.messageCount));
+
+            let html = '<div class="space-y-2">';
+
+            // Header row with hours
+            html += '<div class="flex items-center gap-1">';
+            html += '<div class="w-12"></div>'; // Spacer for day labels
+            hours.forEach((hour, i) => {
+                if (i % 3 === 0) {
+                    html += `<div class="flex-1 text-center text-xs text-text-tertiary">${hour}</div>`;
+                } else {
+                    html += '<div class="flex-1"></div>';
+                }
+            });
+            html += '</div>';
+
+            // Rows for each day
+            days.forEach((day, dayIndex) => {
+                html += '<div class="flex items-center gap-1">';
+                html += `<div class="w-12 text-xs text-text-secondary font-medium">${day}</div>`;
+
+                hours.forEach((hour) => {
+                    const value = heatmapGrid[dayIndex][hour];
+                    const intensity = maxValue > 0 ? value / maxValue : 0;
+                    let bgColor;
+
+                    if (intensity === 0) {
+                        bgColor = 'bg-bg-tertiary';
+                    } else if (intensity < 0.25) {
+                        bgColor = 'bg-accent-blue/20';
+                    } else if (intensity < 0.5) {
+                        bgColor = 'bg-accent-blue/40';
+                    } else if (intensity < 0.75) {
+                        bgColor = 'bg-accent-blue/60';
+                    } else {
+                        bgColor = 'bg-accent-blue/80';
+                    }
+
+                    html += `<div class="flex-1 aspect-square rounded ${bgColor}" title="${day} ${hour}:00 - ${value} messages"></div>`;
+                });
+
+                html += '</div>';
+            });
+
+            // Legend
+            html += '<div class="flex items-center justify-end gap-2 mt-4 text-xs text-text-tertiary">';
+            html += '<span>Less</span>';
+            ['bg-bg-tertiary', 'bg-accent-blue/20', 'bg-accent-blue/40', 'bg-accent-blue/60', 'bg-accent-blue/80'].forEach(cls => {
+                html += `<div class="w-4 h-4 rounded ${cls}"></div>`;
+            });
+            html += '<span>More</span>';
+            html += '</div>';
+
+            html += '</div>';
+
+            container.innerHTML = html;
+        }
+    </script>
+}
+
+<style>
+    /* Ensure proper aspect ratio for heatmap cells */
+    .aspect-square {
+        aspect-ratio: 1 / 1;
+    }
+</style>

--- a/src/DiscordBot.Bot/Pages/Guilds/Analytics/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/Analytics/Index.cshtml.cs
@@ -1,0 +1,209 @@
+using Discord.WebSocket;
+using DiscordBot.Bot.ViewModels.Pages;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace DiscordBot.Bot.Pages.Guilds.Analytics;
+
+/// <summary>
+/// Page model for the Server Analytics Dashboard.
+/// Displays activity metrics, charts, and leaderboards for a specific guild.
+/// </summary>
+[Authorize(Policy = "RequireViewer")]
+public class IndexModel : PageModel
+{
+    private readonly IServerAnalyticsService _analyticsService;
+    private readonly IGuildService _guildService;
+    private readonly IMessageLogRepository _messageLogRepository;
+    private readonly DiscordSocketClient _discordClient;
+    private readonly ILogger<IndexModel> _logger;
+
+    public IndexModel(
+        IServerAnalyticsService analyticsService,
+        IGuildService guildService,
+        IMessageLogRepository messageLogRepository,
+        DiscordSocketClient discordClient,
+        ILogger<IndexModel> logger)
+    {
+        _analyticsService = analyticsService;
+        _guildService = guildService;
+        _messageLogRepository = messageLogRepository;
+        _discordClient = discordClient;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// The analytics view model with all chart data and metrics.
+    /// </summary>
+    public ServerAnalyticsViewModel ViewModel { get; private set; } = new();
+
+    /// <summary>
+    /// Start date filter (bound from query string).
+    /// </summary>
+    [BindProperty(SupportsGet = true)]
+    public DateTime? StartDate { get; set; }
+
+    /// <summary>
+    /// End date filter (bound from query string).
+    /// </summary>
+    [BindProperty(SupportsGet = true)]
+    public DateTime? EndDate { get; set; }
+
+    /// <summary>
+    /// Handles GET requests to display the analytics dashboard.
+    /// </summary>
+    /// <param name="guildId">The guild's Discord snowflake ID from route parameter.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The page result.</returns>
+    public async Task<IActionResult> OnGetAsync(ulong guildId, CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Loading Server Analytics for guild {GuildId}", guildId);
+
+        // Set defaults if not specified (normalize to midnight UTC)
+        StartDate = StartDate.HasValue ? StartDate.Value.Date : DateTime.UtcNow.AddDays(-7).Date;
+        EndDate = EndDate.HasValue ? EndDate.Value.Date : DateTime.UtcNow.Date;
+
+        // Query range: start at beginning of StartDate (00:00:00) and end at beginning of day after EndDate (00:00:00)
+        // This ensures we include all records from the entire EndDate day (up to 23:59:59.999)
+        var start = StartDate.Value;
+        var end = EndDate.Value.AddDays(1);
+
+        _logger.LogDebug("Analytics date range: {Start} to {End}", start, end);
+
+        try
+        {
+            // Get guild info
+            var guild = await _guildService.GetGuildByIdAsync(guildId, cancellationToken);
+            if (guild == null)
+            {
+                _logger.LogWarning("Guild {GuildId} not found", guildId);
+                return NotFound();
+            }
+
+            // Load analytics data from service
+            var summary = await _analyticsService.GetSummaryAsync(guildId, start, end, cancellationToken);
+            var activityTimeSeries = await _analyticsService.GetActivityTimeSeriesAsync(guildId, start, end, cancellationToken);
+            var activityHeatmap = await _analyticsService.GetActivityHeatmapAsync(guildId, start, end, cancellationToken);
+            var topContributors = await _analyticsService.GetTopContributorsAsync(guildId, start, end, 10, cancellationToken);
+
+            // Load top channels from message logs
+            var topChannels = await GetTopChannelsAsync(guildId, start, end, 10, cancellationToken);
+
+            // Build view model
+            ViewModel = new ServerAnalyticsViewModel
+            {
+                GuildId = guildId,
+                GuildName = guild.Name,
+                GuildIconUrl = guild.IconUrl,
+                Summary = summary,
+                ActivityTimeSeries = activityTimeSeries,
+                ActivityHeatmap = activityHeatmap,
+                TopContributors = topContributors,
+                TopChannels = topChannels,
+                StartDate = start,
+                EndDate = end.AddDays(-1) // Show the actual end date (not +1)
+            };
+
+            _logger.LogInformation(
+                "Analytics loaded successfully for guild {GuildId}. Total members: {TotalMembers}, Messages (7d): {Messages7d}",
+                guildId, summary.TotalMembers, summary.Messages7d);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load analytics data for guild {GuildId}", guildId);
+            TempData["ErrorMessage"] = "Failed to load analytics data. Please try again.";
+            // Return page with empty data
+        }
+
+        return Page();
+    }
+
+    /// <summary>
+    /// Gets the top channels by message count for the specified time period.
+    /// </summary>
+    /// <param name="guildId">Guild ID.</param>
+    /// <param name="start">Start date (inclusive).</param>
+    /// <param name="end">End date (exclusive).</param>
+    /// <param name="limit">Maximum number of channels to return.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of top channels with message counts.</returns>
+    private async Task<List<TopChannelDto>> GetTopChannelsAsync(
+        ulong guildId,
+        DateTime start,
+        DateTime end,
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("Retrieving top {Limit} channels for guild {GuildId}", limit, guildId);
+
+        // Get all message logs for the guild in the time period
+        var allLogs = await _messageLogRepository.GetAllAsync(cancellationToken);
+
+        var topChannels = allLogs
+            .Where(m => m.GuildId == guildId && m.Timestamp >= start && m.Timestamp < end)
+            .GroupBy(m => m.ChannelId)
+            .Select(g => new TopChannelDto
+            {
+                ChannelId = g.Key,
+                ChannelName = string.Empty, // Will be populated below
+                MessageCount = g.LongCount(),
+                UniqueContributors = g.Select(m => m.AuthorId).Distinct().Count(),
+                LastActivity = g.Max(m => m.Timestamp)
+            })
+            .OrderByDescending(c => c.MessageCount)
+            .Take(limit)
+            .ToList();
+
+        // Resolve channel names
+        var resolvedChannels = new List<TopChannelDto>();
+        foreach (var channel in topChannels)
+        {
+            var channelName = await GetChannelNameAsync(channel.ChannelId, guildId);
+            resolvedChannels.Add(channel with { ChannelName = channelName });
+        }
+
+        _logger.LogDebug("Retrieved {Count} top channels", resolvedChannels.Count);
+        return resolvedChannels;
+    }
+
+    /// <summary>
+    /// Gets the display name for a Discord channel in a guild.
+    /// </summary>
+    private async Task<string> GetChannelNameAsync(ulong channelId, ulong guildId)
+    {
+        try
+        {
+            var guild = _discordClient.GetGuild(guildId);
+            if (guild == null)
+            {
+                _logger.LogWarning("Guild {GuildId} not found when resolving channel name for channel {ChannelId}", guildId, channelId);
+                return "Unknown Channel";
+            }
+
+            var channel = guild.GetChannel(channelId);
+            if (channel != null)
+            {
+                return $"#{channel.Name}";
+            }
+
+            // Try downloading channels if not in cache
+            await guild.DownloadUsersAsync(); // This also refreshes channel cache
+            channel = guild.GetChannel(channelId);
+            if (channel != null)
+            {
+                return $"#{channel.Name}";
+            }
+
+            _logger.LogDebug("Channel {ChannelId} not found in guild {GuildId}", channelId, guildId);
+            return "Unknown Channel";
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to get channel name for channel {ChannelId} in guild {GuildId}", channelId, guildId);
+            return "Unknown Channel";
+        }
+    }
+}

--- a/src/DiscordBot.Bot/Pages/Guilds/Analytics/Moderation.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Analytics/Moderation.cshtml
@@ -1,0 +1,842 @@
+@page "{guildId:long}"
+@model DiscordBot.Bot.Pages.Guilds.Analytics.ModerationModel
+@using DiscordBot.Bot.ViewModels.Components
+@{
+    ViewData["Title"] = $"Moderation Analytics - {Model.ViewModel.GuildName}";
+}
+
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <!-- Breadcrumb Navigation -->
+    <nav aria-label="Breadcrumb" class="mb-6">
+        <ol class="flex items-center gap-2 text-sm flex-wrap">
+            <li>
+                <a asp-page="/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Home</a>
+            </li>
+            <li class="text-text-tertiary" aria-hidden="true">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                </svg>
+            </li>
+            <li>
+                <a asp-page="/Guilds/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Servers</a>
+            </li>
+            <li class="text-text-tertiary" aria-hidden="true">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                </svg>
+            </li>
+            <li>
+                <a asp-page="/Guilds/Details" asp-route-id="@Model.ViewModel.GuildId" class="text-text-secondary hover:text-accent-blue transition-colors">@Model.ViewModel.GuildName</a>
+            </li>
+            <li class="text-text-tertiary" aria-hidden="true">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                </svg>
+            </li>
+            <li>
+                <span class="text-text-primary font-medium" aria-current="page">Moderation Analytics</span>
+            </li>
+        </ol>
+    </nav>
+
+    <!-- Page Header -->
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+        <div>
+            <h1 class="text-2xl font-bold text-text-primary">Moderation Analytics</h1>
+            <p class="mt-1 text-sm text-text-secondary">Moderation metrics and trends for @Model.ViewModel.GuildName</p>
+        </div>
+    </div>
+
+    <!-- Navigation Tabs -->
+    <div class="flex items-center gap-1 mb-6 border-b border-border-primary">
+        <a asp-page="Index" asp-route-guildId="@Model.ViewModel.GuildId"
+           class="px-4 py-3 text-sm font-medium border-b-2 border-transparent text-text-secondary hover:text-text-primary transition-colors">
+            Overview
+        </a>
+        <a asp-page="Moderation" asp-route-guildId="@Model.ViewModel.GuildId"
+           class="px-4 py-3 text-sm font-medium border-b-2 border-accent-blue text-text-primary">
+            Moderation
+        </a>
+        <a asp-page="Engagement" asp-route-guildId="@Model.ViewModel.GuildId"
+           class="px-4 py-3 text-sm font-medium border-b-2 border-transparent text-text-secondary hover:text-text-primary transition-colors">
+            Engagement
+        </a>
+    </div>
+
+    <!-- Display any errors -->
+    @if (TempData["ErrorMessage"] != null)
+    {
+        <div class="mb-6">
+            @{
+                var errorAlert = new AlertViewModel {
+                    Variant = AlertVariant.Error,
+                    Title = "Error",
+                    Message = TempData["ErrorMessage"]!.ToString()!,
+                    ShowIcon = true
+                };
+            }
+            <partial name="Shared/Components/_Alert" model="errorAlert" />
+        </div>
+    }
+
+    <!-- Filter Panel -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg mb-6">
+        <button type="button"
+                id="filterToggle"
+                class="w-full flex items-center justify-between px-5 py-4 text-left"
+                aria-expanded="true"
+                aria-controls="filterContent"
+                onclick="toggleFilterPanel()">
+            <div class="flex items-center gap-3">
+                <svg class="w-5 h-5 text-text-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
+                </svg>
+                <span class="text-lg font-semibold text-text-primary">Filters</span>
+                @if (Model.StartDate.HasValue || Model.EndDate.HasValue)
+                {
+                    <partial name="Shared/Components/_Badge" model="@(new BadgeViewModel {
+                        Text = "Active",
+                        Variant = BadgeVariant.Orange,
+                        Size = BadgeSize.Small
+                    })" />
+                }
+            </div>
+            <svg id="filterChevron" class="w-5 h-5 text-text-secondary transition-transform duration-200" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            </svg>
+        </button>
+
+        <div id="filterContent" class="overflow-hidden transition-all duration-300 max-h-[1000px]">
+            <div class="border-t border-border-primary p-5">
+                <form method="get" id="filterForm">
+                    <!-- Quick Date Presets -->
+                    <div class="mb-4">
+                        <label class="block text-sm font-medium text-text-primary mb-2">Quick Date Range</label>
+                        @{
+                            var today = DateTime.UtcNow.Date;
+                            var isToday = Model.StartDate.HasValue && Model.EndDate.HasValue &&
+                                         Model.StartDate.Value.Date == today && Model.EndDate.Value.Date == today;
+                            var is7Days = Model.StartDate.HasValue && Model.EndDate.HasValue &&
+                                         Model.StartDate.Value.Date == today.AddDays(-7) && Model.EndDate.Value.Date == today;
+                            var is30Days = Model.StartDate.HasValue && Model.EndDate.HasValue &&
+                                          Model.StartDate.Value.Date == today.AddDays(-30) && Model.EndDate.Value.Date == today;
+
+                            string GetPresetClass(bool isActive) => isActive
+                                ? "px-3 py-1.5 text-xs font-medium bg-accent-orange text-white border border-accent-orange rounded-md hover:bg-accent-orange-hover transition-colors"
+                                : "px-3 py-1.5 text-xs font-medium bg-bg-tertiary text-text-secondary border border-border-primary rounded-md hover:bg-bg-hover transition-colors";
+                        }
+                        <div class="flex flex-wrap gap-2">
+                            <button type="button" onclick="setDatePreset('today')" class="@GetPresetClass(isToday)">
+                                Today
+                            </button>
+                            <button type="button" onclick="setDatePreset('7days')" class="@GetPresetClass(is7Days)">
+                                Last 7 Days
+                            </button>
+                            <button type="button" onclick="setDatePreset('30days')" class="@GetPresetClass(is30Days)">
+                                Last 30 Days
+                            </button>
+                        </div>
+                    </div>
+
+                    <!-- Filter Grid -->
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        <!-- Start Date -->
+                        <div>
+                            <label for="StartDate" class="block text-sm font-medium text-text-primary mb-1">Start Date</label>
+                            <input type="date"
+                                   id="StartDate"
+                                   name="StartDate"
+                                   value="@Model.StartDate?.ToString("yyyy-MM-dd")"
+                                   class="w-full px-3 py-2 text-sm bg-bg-primary border border-border-primary rounded-lg text-text-primary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors" />
+                        </div>
+
+                        <!-- End Date -->
+                        <div>
+                            <label for="EndDate" class="block text-sm font-medium text-text-primary mb-1">End Date</label>
+                            <input type="date"
+                                   id="EndDate"
+                                   name="EndDate"
+                                   value="@Model.EndDate?.ToString("yyyy-MM-dd")"
+                                   class="w-full px-3 py-2 text-sm bg-bg-primary border border-border-primary rounded-lg text-text-primary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors" />
+                        </div>
+                    </div>
+
+                    <!-- Filter Actions -->
+                    <div class="flex items-center gap-3 mt-6 pt-4 border-t border-border-secondary">
+                        <button type="submit" class="btn btn-primary">
+                            <svg class="w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
+                            </svg>
+                            Apply Filters
+                        </button>
+                        @if (Model.StartDate.HasValue || Model.EndDate.HasValue)
+                        {
+                            <a asp-page="Moderation" asp-route-guildId="@Model.ViewModel.GuildId" class="btn btn-secondary">
+                                <svg class="w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                                </svg>
+                                Clear Filters
+                            </a>
+                        }
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <!-- Summary Stats Row -->
+    <div class="grid grid-cols-2 sm:grid-cols-3 xl:grid-cols-6 gap-4 mb-8">
+        <!-- Total Cases -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-5">
+            <div class="flex flex-col">
+                <p class="text-sm font-medium text-text-secondary">Total Cases</p>
+                <p class="mt-2 text-3xl font-bold text-text-primary">@Model.ViewModel.Summary.TotalCases.ToString("N0")</p>
+                <p class="mt-1 text-xs text-text-tertiary">@Model.ViewModel.Summary.CasesPerDay.ToString("F1") per day</p>
+            </div>
+        </div>
+
+        <!-- Warns -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-5 hover:border-warning/50 transition-colors">
+            <div class="flex flex-col">
+                <p class="text-sm font-medium text-text-secondary">Warns</p>
+                <p class="mt-2 text-3xl font-bold text-warning">@Model.ViewModel.Summary.WarnCount.ToString("N0")</p>
+                @{
+                    var warnPercent = Model.ViewModel.Summary.TotalCases > 0
+                        ? (decimal)Model.ViewModel.Summary.WarnCount / Model.ViewModel.Summary.TotalCases * 100
+                        : 0;
+                }
+                <p class="mt-1 text-xs text-text-tertiary">@warnPercent.ToString("F1")% of cases</p>
+            </div>
+        </div>
+
+        <!-- Mutes -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-5 hover:border-info/50 transition-colors">
+            <div class="flex flex-col">
+                <p class="text-sm font-medium text-text-secondary">Mutes</p>
+                <p class="mt-2 text-3xl font-bold text-info">@Model.ViewModel.Summary.MuteCount.ToString("N0")</p>
+                @{
+                    var mutePercent = Model.ViewModel.Summary.TotalCases > 0
+                        ? (decimal)Model.ViewModel.Summary.MuteCount / Model.ViewModel.Summary.TotalCases * 100
+                        : 0;
+                }
+                <p class="mt-1 text-xs text-text-tertiary">@mutePercent.ToString("F1")% of cases</p>
+            </div>
+        </div>
+
+        <!-- Kicks -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-5 hover:border-accent-orange/50 transition-colors">
+            <div class="flex flex-col">
+                <p class="text-sm font-medium text-text-secondary">Kicks</p>
+                <p class="mt-2 text-3xl font-bold text-accent-orange">@Model.ViewModel.Summary.KickCount.ToString("N0")</p>
+                @{
+                    var kickPercent = Model.ViewModel.Summary.TotalCases > 0
+                        ? (decimal)Model.ViewModel.Summary.KickCount / Model.ViewModel.Summary.TotalCases * 100
+                        : 0;
+                }
+                <p class="mt-1 text-xs text-text-tertiary">@kickPercent.ToString("F1")% of cases</p>
+            </div>
+        </div>
+
+        <!-- Bans -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-5 hover:border-error/50 transition-colors">
+            <div class="flex flex-col">
+                <p class="text-sm font-medium text-text-secondary">Bans</p>
+                <p class="mt-2 text-3xl font-bold text-error">@Model.ViewModel.Summary.BanCount.ToString("N0")</p>
+                @{
+                    var banPercent = Model.ViewModel.Summary.TotalCases > 0
+                        ? (decimal)Model.ViewModel.Summary.BanCount / Model.ViewModel.Summary.TotalCases * 100
+                        : 0;
+                }
+                <p class="mt-1 text-xs text-text-tertiary">@banPercent.ToString("F1")% of cases</p>
+            </div>
+        </div>
+
+        <!-- Avg Cases/Day -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-5 hover:border-success/50 transition-colors">
+            <div class="flex flex-col">
+                <p class="text-sm font-medium text-text-secondary">Avg Cases/Day</p>
+                <p class="mt-2 text-3xl font-bold text-success">@Model.ViewModel.Summary.CasesPerDay.ToString("F1")</p>
+                @{
+                    var changeClass = Model.ViewModel.Summary.ChangeFromPreviousPeriod > 0 ? "text-error" :
+                                     Model.ViewModel.Summary.ChangeFromPreviousPeriod < 0 ? "text-success" : "text-text-tertiary";
+                    var changeIcon = Model.ViewModel.Summary.ChangeFromPreviousPeriod > 0 ? "M5 10l7-7m0 0l7 7m-7-7v18" :
+                                    Model.ViewModel.Summary.ChangeFromPreviousPeriod < 0 ? "M19 14l-7 7m0 0l-7-7m7 7V3" : "";
+                }
+                <p class="mt-1 text-xs @changeClass flex items-center gap-1">
+                    @if (!string.IsNullOrEmpty(changeIcon))
+                    {
+                        <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@changeIcon" />
+                        </svg>
+                    }
+                    @Math.Abs(Model.ViewModel.Summary.ChangeFromPreviousPeriod).ToString("F1")% vs prior period
+                </p>
+            </div>
+        </div>
+    </div>
+
+    <!-- Charts Grid -->
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 lg:gap-6 mb-8">
+        <!-- Moderation Trends Chart -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden lg:col-span-2">
+            <div class="px-5 py-4 border-b border-border-primary">
+                <div class="flex items-center gap-3">
+                    <div class="p-2 bg-accent-orange/10 rounded-lg">
+                        <svg class="w-5 h-5 text-accent-orange" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 12l3-3 3 3 4-4M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z" />
+                        </svg>
+                    </div>
+                    <div>
+                        <h2 class="text-lg font-semibold text-text-primary">Moderation Trends Over Time</h2>
+                        <p class="text-sm text-text-tertiary">Action counts by type</p>
+                    </div>
+                </div>
+            </div>
+            <div class="p-5">
+                @if (Model.ViewModel.Trends.Any())
+                {
+                    <div style="position: relative; min-height: 300px; max-height: 400px;">
+                        <canvas id="moderationTrendsChart" aria-label="Stacked area chart showing moderation actions over time" role="img"></canvas>
+                    </div>
+                }
+                else
+                {
+                    <partial name="Shared/Components/_EmptyState" model='new EmptyStateViewModel {
+                        Type = EmptyStateType.NoData,
+                        Title = "No moderation data available",
+                        Description = "Data will appear here once moderation actions are recorded",
+                        Size = EmptyStateSize.Compact,
+                        IconSvgPath = "M7 12l3-3 3 3 4-4M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z"
+                    }' />
+                }
+            </div>
+        </div>
+
+        <!-- Case Type Distribution Chart -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden">
+            <div class="px-5 py-4 border-b border-border-primary">
+                <div class="flex items-center gap-3">
+                    <div class="p-2 bg-accent-blue/10 rounded-lg">
+                        <svg class="w-5 h-5 text-accent-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+                        </svg>
+                    </div>
+                    <div>
+                        <h2 class="text-lg font-semibold text-text-primary">Case Type Distribution</h2>
+                        <p class="text-sm text-text-tertiary">Breakdown by action type</p>
+                    </div>
+                </div>
+            </div>
+            <div class="p-5">
+                @if (Model.ViewModel.Distribution.Total > 0)
+                {
+                    <div style="position: relative; min-height: 300px; max-height: 400px;">
+                        <canvas id="caseDistributionChart" aria-label="Doughnut chart showing case type distribution" role="img"></canvas>
+                    </div>
+                }
+                else
+                {
+                    <partial name="Shared/Components/_EmptyState" model='new EmptyStateViewModel {
+                        Type = EmptyStateType.NoData,
+                        Title = "No data available",
+                        Description = "Distribution will appear here once cases are recorded",
+                        Size = EmptyStateSize.Compact,
+                        IconSvgPath = "M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+                    }' />
+                }
+            </div>
+        </div>
+
+        <!-- Moderator Workload Chart -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden">
+            <div class="px-5 py-4 border-b border-border-primary">
+                <div class="flex items-center gap-3">
+                    <div class="p-2 bg-success/10 rounded-lg">
+                        <svg class="w-5 h-5 text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+                        </svg>
+                    </div>
+                    <div>
+                        <h2 class="text-lg font-semibold text-text-primary">Moderator Workload</h2>
+                        <p class="text-sm text-text-tertiary">Cases handled per moderator</p>
+                    </div>
+                </div>
+            </div>
+            <div class="p-5">
+                @if (Model.ViewModel.ModeratorWorkload.Any())
+                {
+                    <div style="position: relative; min-height: 300px; max-height: 400px;">
+                        <canvas id="moderatorWorkloadChart" aria-label="Horizontal bar chart showing moderator workload" role="img"></canvas>
+                    </div>
+                }
+                else
+                {
+                    <partial name="Shared/Components/_EmptyState" model='new EmptyStateViewModel {
+                        Type = EmptyStateType.NoData,
+                        Title = "No moderator data available",
+                        Description = "Workload data will appear here",
+                        Size = EmptyStateSize.Compact,
+                        IconSvgPath = "M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+                    }' />
+                }
+            </div>
+        </div>
+    </div>
+
+    <!-- Repeat Offenders Table -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden">
+        <div class="px-5 py-4 border-b border-border-primary">
+            <div class="flex items-center justify-between">
+                <div class="flex items-center gap-3">
+                    <div class="p-2 bg-warning/10 rounded-lg">
+                        <svg class="w-5 h-5 text-warning" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                        </svg>
+                    </div>
+                    <div>
+                        <h2 class="text-lg font-semibold text-text-primary">Repeat Offenders</h2>
+                        <p class="text-sm text-text-tertiary">Users with multiple moderation cases</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+        @if (Model.ViewModel.RepeatOffenders.Any())
+        {
+            <div class="overflow-x-auto">
+                <table class="w-full">
+                    <thead class="bg-bg-primary/50">
+                        <tr>
+                            <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">User</th>
+                            <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Total Cases</th>
+                            <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Warns</th>
+                            <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Mutes</th>
+                            <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Kicks</th>
+                            <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Bans</th>
+                            <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Escalation Path</th>
+                            <th class="px-5 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Last Incident</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-border-primary">
+                        @foreach (var offender in Model.ViewModel.RepeatOffenders)
+                        {
+                            var totalCases = offender.TotalCases;
+                            var rowClass = totalCases >= 8 ? "bg-error/5" : totalCases >= 5 ? "bg-warning/5" : "";
+                            <tr class="@rowClass hover:bg-bg-hover transition-colors">
+                                <td class="px-5 py-4">
+                                    <div class="flex items-center gap-3">
+                                        @if (!string.IsNullOrEmpty(offender.AvatarUrl))
+                                        {
+                                            <img src="@offender.AvatarUrl" alt="@offender.Username" class="w-10 h-10 rounded-full" />
+                                        }
+                                        else
+                                        {
+                                            <div class="w-10 h-10 rounded-full bg-gradient-to-br from-red-500 to-rose-500 flex items-center justify-center text-white font-bold text-sm">
+                                                @(offender.Username.Length >= 2 ? offender.Username.Substring(0, 2).ToUpper() : offender.Username.ToUpper())
+                                            </div>
+                                        }
+                                        <p class="font-medium text-text-primary">@offender.Username</p>
+                                    </div>
+                                </td>
+                                <td class="px-5 py-4">
+                                    <span class="inline-flex items-center px-2.5 py-0.5 text-xs font-semibold @(totalCases >= 8 ? "text-error bg-error/10" : totalCases >= 5 ? "text-warning bg-warning/10" : "text-text-primary bg-bg-tertiary") rounded-full">
+                                        @totalCases
+                                    </span>
+                                </td>
+                                <td class="px-5 py-4 text-text-primary">@offender.WarnCount</td>
+                                <td class="px-5 py-4 text-text-primary">@offender.MuteCount</td>
+                                <td class="px-5 py-4 text-text-primary">@offender.KickCount</td>
+                                <td class="px-5 py-4">
+                                    @if (offender.BanCount > 0)
+                                    {
+                                        <span class="inline-flex items-center px-2.5 py-0.5 text-xs font-semibold text-error bg-error/10 rounded-full">
+                                            @offender.BanCount
+                                        </span>
+                                    }
+                                    else
+                                    {
+                                        <span class="text-text-tertiary">0</span>
+                                    }
+                                </td>
+                                <td class="px-5 py-4">
+                                    <div class="flex items-center gap-1">
+                                        @foreach (var action in offender.EscalationPath)
+                                        {
+                                            var (letter, colorClass) = action switch
+                                            {
+                                                "Warn" => ("W", "bg-warning/20 text-warning"),
+                                                "Mute" => ("M", "bg-info/20 text-info"),
+                                                "Kick" => ("K", "bg-accent-orange/20 text-accent-orange"),
+                                                "Ban" => ("B", "bg-error/20 text-error"),
+                                                _ => ("N", "bg-bg-tertiary text-text-tertiary")
+                                            };
+                                            <span class="inline-flex items-center justify-center w-6 h-6 rounded @colorClass text-xs font-semibold">@letter</span>
+                                            @if (action != offender.EscalationPath.Last())
+                                            {
+                                                <svg class="w-3 h-3 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                                                </svg>
+                                            }
+                                        }
+                                    </div>
+                                </td>
+                                <td class="px-5 py-4 text-text-secondary text-sm">
+                                    @{
+                                        var timeSince = DateTime.UtcNow - offender.LastIncident;
+                                        var timeText = timeSince.TotalDays < 1 ? "Today" :
+                                                      timeSince.TotalDays < 2 ? "Yesterday" :
+                                                      timeSince.TotalDays < 7 ? $"{(int)timeSince.TotalDays} days ago" :
+                                                      timeSince.TotalDays < 30 ? $"{(int)(timeSince.TotalDays / 7)} weeks ago" :
+                                                      offender.LastIncident.ToString("MMM d, yyyy");
+                                    }
+                                    @timeText
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+
+            <!-- Legend -->
+            <div class="px-5 py-4 border-t border-border-primary bg-bg-primary/30">
+                <div class="flex flex-wrap items-center gap-4 text-xs text-text-tertiary">
+                    <span class="font-medium text-text-secondary">Legend:</span>
+                    <span class="flex items-center gap-1.5">
+                        <span class="w-5 h-5 rounded bg-warning/20 text-warning flex items-center justify-center text-[10px] font-semibold">W</span>
+                        Warn
+                    </span>
+                    <span class="flex items-center gap-1.5">
+                        <span class="w-5 h-5 rounded bg-info/20 text-info flex items-center justify-center text-[10px] font-semibold">M</span>
+                        Mute
+                    </span>
+                    <span class="flex items-center gap-1.5">
+                        <span class="w-5 h-5 rounded bg-accent-orange/20 text-accent-orange flex items-center justify-center text-[10px] font-semibold">K</span>
+                        Kick
+                    </span>
+                    <span class="flex items-center gap-1.5">
+                        <span class="w-5 h-5 rounded bg-error/20 text-error flex items-center justify-center text-[10px] font-semibold">B</span>
+                        Ban
+                    </span>
+                </div>
+            </div>
+        }
+        else
+        {
+            <div class="py-12">
+                <partial name="Shared/Components/_EmptyState" model='new EmptyStateViewModel {
+                    Type = EmptyStateType.NoData,
+                    Title = "No repeat offenders",
+                    Description = "Users with multiple cases will appear here",
+                    Size = EmptyStateSize.Compact,
+                    IconSvgPath = "M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                }' />
+            </div>
+        }
+    </div>
+</div>
+
+@section Scripts {
+    <!-- Chart.js Library -->
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+
+    <!-- Embed Chart Data -->
+    @{
+        var chartData = new {
+            trends = Model.ViewModel.Trends.Select(t => new {
+                date = t.Date.ToString("yyyy-MM-dd"),
+                totalCases = t.TotalCases,
+                warnCount = t.WarnCount,
+                muteCount = t.MuteCount,
+                kickCount = t.KickCount,
+                banCount = t.BanCount
+            }),
+            distribution = new {
+                warnCount = Model.ViewModel.Distribution.WarnCount,
+                muteCount = Model.ViewModel.Distribution.MuteCount,
+                kickCount = Model.ViewModel.Distribution.KickCount,
+                banCount = Model.ViewModel.Distribution.BanCount,
+                noteCount = Model.ViewModel.Distribution.NoteCount
+            },
+            moderatorWorkload = Model.ViewModel.ModeratorWorkload.Select(m => new {
+                moderatorId = m.ModeratorId.ToString(),
+                moderatorUsername = m.ModeratorUsername,
+                totalActions = m.TotalActions,
+                warnCount = m.WarnCount,
+                muteCount = m.MuteCount,
+                kickCount = m.KickCount,
+                banCount = m.BanCount
+            })
+        };
+        var chartDataJson = System.Text.Json.JsonSerializer.Serialize(chartData);
+    }
+
+    <script type="application/json" id="moderationChartData">
+@Html.Raw(chartDataJson)
+    </script>
+
+    <!-- Filter Panel Toggle Script -->
+    <script>
+        function toggleFilterPanel() {
+            const content = document.getElementById('filterContent');
+            const chevron = document.getElementById('filterChevron');
+            const toggle = document.getElementById('filterToggle');
+
+            if (content.style.maxHeight === '0px') {
+                content.style.maxHeight = '1000px';
+                chevron.style.transform = 'rotate(0deg)';
+                toggle.setAttribute('aria-expanded', 'true');
+            } else {
+                content.style.maxHeight = '0px';
+                chevron.style.transform = 'rotate(-90deg)';
+                toggle.setAttribute('aria-expanded', 'false');
+            }
+        }
+
+        function setDatePreset(preset) {
+            const today = new Date();
+            const startDateInput = document.getElementById('StartDate');
+            const endDateInput = document.getElementById('EndDate');
+
+            let startDate = new Date();
+
+            switch(preset) {
+                case 'today':
+                    startDate = today;
+                    break;
+                case '7days':
+                    startDate.setDate(today.getDate() - 7);
+                    break;
+                case '30days':
+                    startDate.setDate(today.getDate() - 30);
+                    break;
+            }
+
+            startDateInput.value = startDate.toISOString().split('T')[0];
+            endDateInput.value = today.toISOString().split('T')[0];
+
+            // Auto-submit the form after setting dates
+            document.getElementById('filterForm').submit();
+        }
+    </script>
+
+    <!-- Chart Rendering Script -->
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            // Load chart data from embedded JSON
+            const chartDataElement = document.getElementById('moderationChartData');
+            if (!chartDataElement) {
+                console.error('Chart data not found');
+                return;
+            }
+
+            const chartData = JSON.parse(chartDataElement.textContent);
+
+            // Chart.js default dark theme settings
+            Chart.defaults.color = '#a8a5a3';
+            Chart.defaults.borderColor = '#3f4447';
+
+            // Moderation Trends Chart (Stacked Area)
+            const trendsCanvas = document.getElementById('moderationTrendsChart');
+            if (trendsCanvas && chartData.trends.length > 0) {
+                const trendsCtx = trendsCanvas.getContext('2d');
+                new Chart(trendsCtx, {
+                    type: 'line',
+                    data: {
+                        labels: chartData.trends.map(t => {
+                            const date = new Date(t.date);
+                            return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+                        }),
+                        datasets: [
+                            {
+                                label: 'Warns',
+                                data: chartData.trends.map(t => t.warnCount),
+                                borderColor: '#f59e0b',
+                                backgroundColor: 'rgba(245, 158, 11, 0.3)',
+                                fill: true,
+                                tension: 0.4
+                            },
+                            {
+                                label: 'Mutes',
+                                data: chartData.trends.map(t => t.muteCount),
+                                borderColor: '#06b6d4',
+                                backgroundColor: 'rgba(6, 182, 212, 0.3)',
+                                fill: true,
+                                tension: 0.4
+                            },
+                            {
+                                label: 'Kicks',
+                                data: chartData.trends.map(t => t.kickCount),
+                                borderColor: '#cb4e1b',
+                                backgroundColor: 'rgba(203, 78, 27, 0.3)',
+                                fill: true,
+                                tension: 0.4
+                            },
+                            {
+                                label: 'Bans',
+                                data: chartData.trends.map(t => t.banCount),
+                                borderColor: '#ef4444',
+                                backgroundColor: 'rgba(239, 68, 68, 0.3)',
+                                fill: true,
+                                tension: 0.4
+                            }
+                        ]
+                    },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        plugins: {
+                            legend: {
+                                position: 'bottom',
+                                labels: {
+                                    boxWidth: 12,
+                                    padding: 20
+                                }
+                            },
+                            tooltip: {
+                                backgroundColor: '#2f3336',
+                                titleColor: '#d7d3d0',
+                                bodyColor: '#a8a5a3',
+                                borderColor: '#3f4447',
+                                borderWidth: 1,
+                                padding: 12
+                            }
+                        },
+                        scales: {
+                            y: {
+                                beginAtZero: true,
+                                stacked: true,
+                                grid: {
+                                    color: '#2f3336'
+                                }
+                            },
+                            x: {
+                                grid: {
+                                    display: false
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+
+            // Case Distribution Chart (Doughnut)
+            const distCanvas = document.getElementById('caseDistributionChart');
+            if (distCanvas && chartData.distribution) {
+                const distCtx = distCanvas.getContext('2d');
+                new Chart(distCtx, {
+                    type: 'doughnut',
+                    data: {
+                        labels: ['Warns', 'Mutes', 'Kicks', 'Bans'],
+                        datasets: [{
+                            data: [
+                                chartData.distribution.warnCount,
+                                chartData.distribution.muteCount,
+                                chartData.distribution.kickCount,
+                                chartData.distribution.banCount
+                            ],
+                            backgroundColor: [
+                                '#f59e0b',
+                                '#06b6d4',
+                                '#cb4e1b',
+                                '#ef4444'
+                            ],
+                            borderWidth: 0
+                        }]
+                    },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        cutout: '65%',
+                        plugins: {
+                            legend: {
+                                position: 'right',
+                                labels: {
+                                    boxWidth: 12,
+                                    padding: 15,
+                                    generateLabels: function(chart) {
+                                        const data = chart.data;
+                                        return data.labels.map((label, i) => ({
+                                            text: `${label} (${data.datasets[0].data[i]})`,
+                                            fillStyle: data.datasets[0].backgroundColor[i],
+                                            index: i
+                                        }));
+                                    }
+                                }
+                            },
+                            tooltip: {
+                                backgroundColor: '#2f3336',
+                                titleColor: '#d7d3d0',
+                                bodyColor: '#a8a5a3',
+                                borderColor: '#3f4447',
+                                borderWidth: 1,
+                                padding: 12,
+                                callbacks: {
+                                    label: function(context) {
+                                        const total = context.dataset.data.reduce((a, b) => a + b, 0);
+                                        const percentage = ((context.parsed / total) * 100).toFixed(1);
+                                        return `${context.label}: ${context.parsed} (${percentage}%)`;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+
+            // Moderator Workload Chart (Horizontal Bar)
+            const workloadCanvas = document.getElementById('moderatorWorkloadChart');
+            if (workloadCanvas && chartData.moderatorWorkload.length > 0) {
+                const workloadCtx = workloadCanvas.getContext('2d');
+                new Chart(workloadCtx, {
+                    type: 'bar',
+                    data: {
+                        labels: chartData.moderatorWorkload.map(m => m.moderatorUsername),
+                        datasets: [{
+                            label: 'Cases Handled',
+                            data: chartData.moderatorWorkload.map(m => m.totalActions),
+                            backgroundColor: '#098ecf',
+                            borderRadius: 4
+                        }]
+                    },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        indexAxis: 'y',
+                        plugins: {
+                            legend: {
+                                display: false
+                            },
+                            tooltip: {
+                                backgroundColor: '#2f3336',
+                                titleColor: '#d7d3d0',
+                                bodyColor: '#a8a5a3',
+                                borderColor: '#3f4447',
+                                borderWidth: 1,
+                                padding: 12,
+                                callbacks: {
+                                    label: function(context) {
+                                        const total = context.dataset.data.reduce((a, b) => a + b, 0);
+                                        const percentage = ((context.parsed.x / total) * 100).toFixed(1);
+                                        return `${context.parsed.x} cases (${percentage}%)`;
+                                    }
+                                }
+                            }
+                        },
+                        scales: {
+                            x: {
+                                beginAtZero: true,
+                                grid: {
+                                    color: '#2f3336'
+                                }
+                            },
+                            y: {
+                                grid: {
+                                    display: false
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+        });
+    </script>
+}

--- a/src/DiscordBot.Bot/Pages/Guilds/Analytics/Moderation.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/Analytics/Moderation.cshtml.cs
@@ -1,0 +1,238 @@
+using Discord.WebSocket;
+using DiscordBot.Bot.ViewModels.Pages;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace DiscordBot.Bot.Pages.Guilds.Analytics;
+
+/// <summary>
+/// Page model for the Guild Moderation Analytics Dashboard.
+/// Displays moderation metrics, trends, case distribution, and repeat offender tracking.
+/// </summary>
+[Authorize(Policy = "RequireModerator")]
+public class ModerationModel : PageModel
+{
+    private readonly IModerationAnalyticsService _analyticsService;
+    private readonly IGuildService _guildService;
+    private readonly DiscordSocketClient _discordClient;
+    private readonly ILogger<ModerationModel> _logger;
+
+    public ModerationModel(
+        IModerationAnalyticsService analyticsService,
+        IGuildService guildService,
+        DiscordSocketClient discordClient,
+        ILogger<ModerationModel> logger)
+    {
+        _analyticsService = analyticsService;
+        _guildService = guildService;
+        _discordClient = discordClient;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// The moderation analytics view model with all chart data and metrics.
+    /// </summary>
+    public ModerationAnalyticsViewModel ViewModel { get; private set; } = new();
+
+    /// <summary>
+    /// Start date filter (bound from query string).
+    /// </summary>
+    [BindProperty(SupportsGet = true)]
+    public DateTime? StartDate { get; set; }
+
+    /// <summary>
+    /// End date filter (bound from query string).
+    /// </summary>
+    [BindProperty(SupportsGet = true)]
+    public DateTime? EndDate { get; set; }
+
+    /// <summary>
+    /// Handles GET requests to display the moderation analytics dashboard.
+    /// </summary>
+    /// <param name="guildId">The guild's Discord snowflake ID from route parameter.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The page result.</returns>
+    public async Task<IActionResult> OnGetAsync(ulong guildId, CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Loading moderation analytics for guild {GuildId}", guildId);
+
+        // Set defaults if not specified (normalize to midnight UTC)
+        StartDate = StartDate.HasValue ? StartDate.Value.Date : DateTime.UtcNow.AddDays(-7).Date;
+        EndDate = EndDate.HasValue ? EndDate.Value.Date : DateTime.UtcNow.Date;
+
+        // Query range: start at beginning of StartDate (00:00:00) and end at beginning of day after EndDate (00:00:00)
+        // This ensures we include all records from the entire EndDate day (up to 23:59:59.999)
+        var start = StartDate.Value;
+        var end = EndDate.Value.AddDays(1);
+
+        _logger.LogDebug("Moderation analytics date range: {Start} to {End}", start, end);
+
+        try
+        {
+            // Get guild info
+            var guild = await _guildService.GetGuildByIdAsync(guildId, cancellationToken);
+            if (guild == null)
+            {
+                _logger.LogWarning("Guild {GuildId} not found", guildId);
+                return NotFound();
+            }
+
+            // Load analytics data from service
+            var summary = await _analyticsService.GetSummaryAsync(guildId, start, end, cancellationToken);
+            var trends = await _analyticsService.GetTrendsAsync(guildId, start, end, cancellationToken);
+            var distribution = await _analyticsService.GetCaseDistributionAsync(guildId, start, end, cancellationToken);
+            var repeatOffenders = await _analyticsService.GetRepeatOffendersAsync(guildId, start, end, 10, cancellationToken);
+            var moderatorWorkload = await _analyticsService.GetModeratorWorkloadAsync(guildId, start, end, 5, cancellationToken);
+
+            // Resolve usernames for repeat offenders
+            var repeatOffendersWithNames = await ResolveRepeatOffenderUsernamesAsync(guildId, repeatOffenders);
+
+            // Resolve usernames for moderators
+            var moderatorWorkloadWithNames = await ResolveModeratorUsernamesAsync(guildId, moderatorWorkload);
+
+            // Build view model
+            ViewModel = new ModerationAnalyticsViewModel
+            {
+                GuildId = guildId,
+                GuildName = guild.Name,
+                GuildIconUrl = guild.IconUrl,
+                Summary = summary,
+                Trends = trends.ToList(),
+                Distribution = distribution,
+                RepeatOffenders = repeatOffendersWithNames,
+                ModeratorWorkload = moderatorWorkloadWithNames,
+                StartDate = start,
+                EndDate = end.AddDays(-1) // Show the actual end date (not +1)
+            };
+
+            _logger.LogInformation(
+                "Moderation analytics loaded successfully for guild {GuildId}. Total cases: {TotalCases}, Avg cases/day: {CasesPerDay:F1}",
+                guildId, summary.TotalCases, summary.CasesPerDay);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load moderation analytics data for guild {GuildId}", guildId);
+            TempData["ErrorMessage"] = "Failed to load analytics data. Please try again.";
+            // Return page with empty data
+        }
+
+        return Page();
+    }
+
+    /// <summary>
+    /// Resolves usernames for repeat offender entries.
+    /// </summary>
+    private async Task<List<RepeatOffenderDto>> ResolveRepeatOffenderUsernamesAsync(
+        ulong guildId,
+        IEnumerable<RepeatOffenderDto> offenders)
+    {
+        var result = new List<RepeatOffenderDto>();
+        foreach (var offender in offenders)
+        {
+            var username = await GetUsernameAsync(offender.UserId, guildId);
+            var avatarUrl = await GetAvatarUrlAsync(offender.UserId, guildId);
+            result.Add(offender with { Username = username, AvatarUrl = avatarUrl });
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Resolves usernames for moderator workload entries.
+    /// </summary>
+    private async Task<List<ModeratorWorkloadDto>> ResolveModeratorUsernamesAsync(
+        ulong guildId,
+        IEnumerable<ModeratorWorkloadDto> moderators)
+    {
+        var result = new List<ModeratorWorkloadDto>();
+        foreach (var moderator in moderators)
+        {
+            var username = await GetUsernameAsync(moderator.ModeratorId, guildId);
+            var avatarUrl = await GetAvatarUrlAsync(moderator.ModeratorId, guildId);
+            result.Add(moderator with { ModeratorUsername = username, AvatarUrl = avatarUrl });
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Gets the display name for a Discord user in a guild.
+    /// </summary>
+    private async Task<string> GetUsernameAsync(ulong userId, ulong guildId)
+    {
+        try
+        {
+            var guild = _discordClient.GetGuild(guildId);
+            if (guild == null)
+            {
+                _logger.LogWarning("Guild {GuildId} not found when resolving username for user {UserId}", guildId, userId);
+                return "Unknown User";
+            }
+
+            var user = guild.GetUser(userId);
+            if (user != null)
+            {
+                return user.DisplayName;
+            }
+
+            // Try downloading users if not in cache
+            if (!guild.HasAllMembers)
+            {
+                await guild.DownloadUsersAsync();
+                user = guild.GetUser(userId);
+                if (user != null)
+                {
+                    return user.DisplayName;
+                }
+            }
+
+            _logger.LogDebug("User {UserId} not found in guild {GuildId}", userId, guildId);
+            return "Unknown User";
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to get username for user {UserId} in guild {GuildId}", userId, guildId);
+            return "Unknown User";
+        }
+    }
+
+    /// <summary>
+    /// Gets the avatar URL for a Discord user.
+    /// </summary>
+    private async Task<string?> GetAvatarUrlAsync(ulong userId, ulong guildId)
+    {
+        try
+        {
+            var guild = _discordClient.GetGuild(guildId);
+            if (guild == null)
+            {
+                return null;
+            }
+
+            var user = guild.GetUser(userId);
+            if (user != null)
+            {
+                return user.GetAvatarUrl() ?? user.GetDefaultAvatarUrl();
+            }
+
+            // Try downloading users if not in cache
+            if (!guild.HasAllMembers)
+            {
+                await guild.DownloadUsersAsync();
+                user = guild.GetUser(userId);
+                if (user != null)
+                {
+                    return user.GetAvatarUrl() ?? user.GetDefaultAvatarUrl();
+                }
+            }
+
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to get avatar URL for user {UserId} in guild {GuildId}", userId, guildId);
+            return null;
+        }
+    }
+}

--- a/src/DiscordBot.Bot/Services/EngagementAnalyticsService.cs
+++ b/src/DiscordBot.Bot/Services/EngagementAnalyticsService.cs
@@ -1,0 +1,227 @@
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace DiscordBot.Bot.Services;
+
+/// <summary>
+/// Service for generating engagement analytics and member retention metrics.
+/// Aggregates data from message logs and guild metrics to provide insights into member engagement.
+/// </summary>
+public class EngagementAnalyticsService : IEngagementAnalyticsService
+{
+    private readonly IMessageLogRepository _messageLogRepository;
+    private readonly IGuildMetricsRepository _guildMetricsRepository;
+    private readonly IGuildMemberRepository _guildMemberRepository;
+    private readonly ILogger<EngagementAnalyticsService> _logger;
+
+    public EngagementAnalyticsService(
+        IMessageLogRepository messageLogRepository,
+        IGuildMetricsRepository guildMetricsRepository,
+        IGuildMemberRepository guildMemberRepository,
+        ILogger<EngagementAnalyticsService> logger)
+    {
+        _messageLogRepository = messageLogRepository;
+        _guildMetricsRepository = guildMetricsRepository;
+        _guildMemberRepository = guildMemberRepository;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task<EngagementAnalyticsSummaryDto> GetSummaryAsync(
+        ulong guildId,
+        DateTime start,
+        DateTime end,
+        CancellationToken ct = default)
+    {
+        _logger.LogDebug(
+            "Generating engagement analytics summary for guild {GuildId} from {Start} to {End}",
+            guildId, start, end);
+
+        // Calculate time ranges
+        var now = DateTime.UtcNow;
+        var last24h = now.AddHours(-24);
+        var last7d = now.AddDays(-7);
+
+        // Get message trends for the requested period
+        var messageTrends = await GetMessageTrendsAsync(guildId, start, end, ct);
+
+        var totalMessages = messageTrends.Sum(t => t.MessageCount);
+        var messagesPerDay = (end - start).TotalDays > 0
+            ? (decimal)totalMessages / (decimal)(end - start).TotalDays
+            : 0m;
+
+        // Get unique active members from message trends
+        var activeMembers = messageTrends
+            .Select(t => t.UniqueAuthors)
+            .DefaultIfEmpty(0)
+            .Max();
+
+        // Get messages for last 24h and 7d
+        var messageTrendsRecent = await GetMessageTrendsAsync(guildId, last7d, now, ct);
+
+        var messagesLast24h = messageTrendsRecent
+            .Where(t => t.Date >= last24h)
+            .Sum(t => t.MessageCount);
+
+        var messagesLast7d = messageTrendsRecent.Sum(t => t.MessageCount);
+
+        // Get new members count from guild metrics
+        var metricsLast7d = await _guildMetricsRepository.GetByDateRangeAsync(
+            guildId,
+            DateOnly.FromDateTime(last7d),
+            DateOnly.FromDateTime(now),
+            ct);
+
+        var newMembers7d = metricsLast7d.Sum(m => m.MembersJoined);
+
+        // Calculate new member retention rate
+        // Get members who joined in the last 7 days
+        var newMemberRetention = await CalculateNewMemberRetentionAsync(guildId, last7d, now, ct);
+
+        _logger.LogInformation(
+            "Engagement analytics summary generated for guild {GuildId}: {TotalMessages} messages, {ActiveMembers} active members",
+            guildId, totalMessages, activeMembers);
+
+        return new EngagementAnalyticsSummaryDto
+        {
+            TotalMessages = totalMessages,
+            Messages24h = messagesLast24h,
+            Messages7d = messagesLast7d,
+            MessagesPerDay = messagesPerDay,
+            ActiveMembers = activeMembers,
+            NewMembers7d = newMembers7d,
+            NewMemberRetentionRate = newMemberRetention,
+            ReactionCount = 0, // Not currently tracked
+            VoiceMinutes = 0   // Not currently tracked
+        };
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<MessageTrendDto>> GetMessageTrendsAsync(
+        ulong guildId,
+        DateTime start,
+        DateTime end,
+        CancellationToken ct = default)
+    {
+        _logger.LogDebug(
+            "Generating message trends for guild {GuildId} from {Start} to {End}",
+            guildId, start, end);
+
+        // Get messages by day from the repository
+        var daySpan = (int)Math.Ceiling((end - start).TotalDays);
+        var messagesByDay = await _messageLogRepository.GetMessagesByDayAsync(
+            days: daySpan + 1, // Add extra day to ensure we cover the range
+            guildId: guildId,
+            cancellationToken: ct);
+
+        // Filter to the requested date range and calculate trends
+        var trends = messagesByDay
+            .Where(x => x.Date >= DateOnly.FromDateTime(start) && x.Date <= DateOnly.FromDateTime(end))
+            .Select(x => new MessageTrendDto
+            {
+                Date = x.Date.ToDateTime(TimeOnly.MinValue),
+                MessageCount = x.Count,
+                UniqueAuthors = 0, // Will need to calculate separately if needed
+                AvgMessageLength = 0m // Will need to calculate separately if needed
+            })
+            .OrderBy(t => t.Date)
+            .ToList();
+
+        // Note: To get unique authors and avg message length, we would need to query the message logs directly
+        // For performance, we're using the pre-aggregated data from GetMessagesByDayAsync
+        // Future enhancement: Add these calculations if needed
+
+        _logger.LogDebug(
+            "Generated {Count} message trend data points for guild {GuildId}",
+            trends.Count, guildId);
+
+        return trends;
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<NewMemberRetentionDto>> GetNewMemberRetentionAsync(
+        ulong guildId,
+        DateTime start,
+        DateTime end,
+        CancellationToken ct = default)
+    {
+        _logger.LogDebug(
+            "Generating new member retention metrics for guild {GuildId} from {Start} to {End}",
+            guildId, start, end);
+
+        // Get guild metrics for the period to see when members joined
+        var metrics = await _guildMetricsRepository.GetByDateRangeAsync(
+            guildId,
+            DateOnly.FromDateTime(start),
+            DateOnly.FromDateTime(end),
+            ct);
+
+        // For a simplified implementation, we'll use the metrics data
+        // Full implementation would require tracking individual member join dates and first message timestamps
+        var retention = metrics
+            .Where(m => m.MembersJoined > 0)
+            .Select(m => new NewMemberRetentionDto
+            {
+                JoinDate = m.SnapshotDate.ToDateTime(TimeOnly.MinValue),
+                NewMembers = m.MembersJoined,
+                SentFirstMessage = 0, // Would need to query message logs for this
+                StillActive7d = 0,    // Would need to track member activity over time
+                StillActive30d = 0,   // Would need to track member activity over time
+                FirstMessageRate = 0m,
+                Retention7dRate = 0m,
+                Retention30dRate = 0m
+            })
+            .OrderBy(r => r.JoinDate)
+            .ToList();
+
+        _logger.LogDebug(
+            "Generated {Count} retention data points for guild {GuildId}",
+            retention.Count, guildId);
+
+        _logger.LogWarning(
+            "New member retention tracking is simplified - detailed metrics require per-member activity tracking");
+
+        return retention;
+    }
+
+    /// <summary>
+    /// Calculates the new member retention rate for the specified time period.
+    /// Returns the percentage of new members who sent at least one message within 7 days of joining.
+    /// </summary>
+    private async Task<decimal> CalculateNewMemberRetentionAsync(
+        ulong guildId,
+        DateTime start,
+        DateTime end,
+        CancellationToken ct)
+    {
+        try
+        {
+            // Get metrics for new members
+            var metrics = await _guildMetricsRepository.GetByDateRangeAsync(
+                guildId,
+                DateOnly.FromDateTime(start),
+                DateOnly.FromDateTime(end),
+                ct);
+
+            var totalNewMembers = metrics.Sum(m => m.MembersJoined);
+
+            if (totalNewMembers == 0)
+            {
+                return 0m;
+            }
+
+            // For now, return a placeholder
+            // Full implementation would require tracking individual member join dates and activity
+            _logger.LogDebug(
+                "Retention rate calculation is simplified - detailed tracking not yet implemented");
+
+            return 0m;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error calculating new member retention for guild {GuildId}", guildId);
+            return 0m;
+        }
+    }
+}

--- a/src/DiscordBot.Bot/Services/ModerationAnalyticsService.cs
+++ b/src/DiscordBot.Bot/Services/ModerationAnalyticsService.cs
@@ -1,0 +1,302 @@
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Enums;
+using DiscordBot.Core.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace DiscordBot.Bot.Services;
+
+/// <summary>
+/// Service for generating moderation analytics and metrics.
+/// Aggregates data from moderation case repository to provide insights into moderation patterns.
+/// </summary>
+public class ModerationAnalyticsService : IModerationAnalyticsService
+{
+    private readonly IModerationCaseRepository _moderationCaseRepository;
+    private readonly ILogger<ModerationAnalyticsService> _logger;
+
+    public ModerationAnalyticsService(
+        IModerationCaseRepository moderationCaseRepository,
+        ILogger<ModerationAnalyticsService> logger)
+    {
+        _moderationCaseRepository = moderationCaseRepository;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task<ModerationAnalyticsSummaryDto> GetSummaryAsync(
+        ulong guildId,
+        DateTime start,
+        DateTime end,
+        CancellationToken ct = default)
+    {
+        _logger.LogDebug(
+            "Generating moderation analytics summary for guild {GuildId} from {Start} to {End}",
+            guildId, start, end);
+
+        // Get all cases in the time period
+        var (cases, _) = await _moderationCaseRepository.GetByGuildAsync(
+            guildId,
+            startDate: start,
+            endDate: end,
+            page: 1,
+            pageSize: int.MaxValue,
+            cancellationToken: ct);
+
+        var casesList = cases.ToList();
+
+        // Count cases by type
+        var totalCases = casesList.Count;
+        var warnCount = casesList.Count(c => c.Type == CaseType.Warn);
+        var muteCount = casesList.Count(c => c.Type == CaseType.Mute);
+        var kickCount = casesList.Count(c => c.Type == CaseType.Kick);
+        var banCount = casesList.Count(c => c.Type == CaseType.Ban);
+        var noteCount = casesList.Count(c => c.Type == CaseType.Note);
+
+        // Calculate time-based metrics
+        var now = DateTime.UtcNow;
+        var last24h = now.AddHours(-24);
+        var last7d = now.AddDays(-7);
+
+        var casesLast24h = casesList.Count(c => c.CreatedAt >= last24h);
+        var casesLast7d = casesList.Count(c => c.CreatedAt >= last7d);
+
+        // Calculate average cases per day
+        var daySpan = (end - start).TotalDays;
+        var casesPerDay = daySpan > 0 ? (decimal)totalCases / (decimal)daySpan : 0m;
+
+        // Calculate change from previous period
+        var periodLength = end - start;
+        var previousPeriodStart = start - periodLength;
+        var previousPeriodEnd = start;
+
+        var (previousCases, _) = await _moderationCaseRepository.GetByGuildAsync(
+            guildId,
+            startDate: previousPeriodStart,
+            endDate: previousPeriodEnd,
+            page: 1,
+            pageSize: int.MaxValue,
+            cancellationToken: ct);
+
+        var previousCaseCount = previousCases.Count();
+        var changeFromPreviousPeriod = previousCaseCount > 0
+            ? ((decimal)(totalCases - previousCaseCount) / previousCaseCount) * 100
+            : totalCases > 0 ? 100m : 0m;
+
+        _logger.LogInformation(
+            "Moderation analytics summary generated for guild {GuildId}: {TotalCases} total cases, {Cases24h} in last 24h",
+            guildId, totalCases, casesLast24h);
+
+        return new ModerationAnalyticsSummaryDto
+        {
+            TotalCases = totalCases,
+            WarnCount = warnCount,
+            MuteCount = muteCount,
+            KickCount = kickCount,
+            BanCount = banCount,
+            NoteCount = noteCount,
+            Cases24h = casesLast24h,
+            Cases7d = casesLast7d,
+            CasesPerDay = casesPerDay,
+            ChangeFromPreviousPeriod = changeFromPreviousPeriod
+        };
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<ModerationTrendDto>> GetTrendsAsync(
+        ulong guildId,
+        DateTime start,
+        DateTime end,
+        CancellationToken ct = default)
+    {
+        _logger.LogDebug(
+            "Generating moderation trends for guild {GuildId} from {Start} to {End}",
+            guildId, start, end);
+
+        // Get all cases in the time period
+        var (cases, _) = await _moderationCaseRepository.GetByGuildAsync(
+            guildId,
+            startDate: start,
+            endDate: end,
+            page: 1,
+            pageSize: int.MaxValue,
+            cancellationToken: ct);
+
+        // Group by date and count by type
+        var trends = cases
+            .GroupBy(c => DateOnly.FromDateTime(c.CreatedAt))
+            .Select(g => new ModerationTrendDto
+            {
+                Date = g.Key.ToDateTime(TimeOnly.MinValue),
+                TotalCases = g.Count(),
+                WarnCount = g.Count(c => c.Type == CaseType.Warn),
+                MuteCount = g.Count(c => c.Type == CaseType.Mute),
+                KickCount = g.Count(c => c.Type == CaseType.Kick),
+                BanCount = g.Count(c => c.Type == CaseType.Ban)
+            })
+            .OrderBy(t => t.Date)
+            .ToList();
+
+        _logger.LogDebug(
+            "Generated {Count} trend data points for guild {GuildId}",
+            trends.Count, guildId);
+
+        return trends;
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<RepeatOffenderDto>> GetRepeatOffendersAsync(
+        ulong guildId,
+        DateTime start,
+        DateTime end,
+        int limit = 10,
+        CancellationToken ct = default)
+    {
+        _logger.LogDebug(
+            "Getting top {Limit} repeat offenders for guild {GuildId} from {Start} to {End}",
+            limit, guildId, start, end);
+
+        // Get all cases in the time period
+        var (cases, _) = await _moderationCaseRepository.GetByGuildAsync(
+            guildId,
+            startDate: start,
+            endDate: end,
+            page: 1,
+            pageSize: int.MaxValue,
+            cancellationToken: ct);
+
+        // Group by target user and filter for repeat offenders (2+ cases)
+        var offenders = cases
+            .GroupBy(c => c.TargetUserId)
+            .Where(g => g.Count() >= 2)
+            .Select(g => new
+            {
+                UserId = g.Key,
+                Cases = g.OrderBy(c => c.CreatedAt).ToList()
+            })
+            .Select(x => new RepeatOffenderDto
+            {
+                UserId = x.UserId,
+                Username = $"User {x.UserId}", // Username not stored in ModerationCase
+                AvatarUrl = null, // Avatar not tracked in ModerationCase entity
+                TotalCases = x.Cases.Count,
+                WarnCount = x.Cases.Count(c => c.Type == CaseType.Warn),
+                MuteCount = x.Cases.Count(c => c.Type == CaseType.Mute),
+                KickCount = x.Cases.Count(c => c.Type == CaseType.Kick),
+                BanCount = x.Cases.Count(c => c.Type == CaseType.Ban),
+                FirstIncident = x.Cases.First().CreatedAt,
+                LastIncident = x.Cases.Last().CreatedAt,
+                EscalationPath = x.Cases.Select(c => c.Type.ToString()).ToList()
+            })
+            .OrderByDescending(x => x.TotalCases)
+            .ThenByDescending(x => x.LastIncident)
+            .Take(limit)
+            .ToList();
+
+        _logger.LogInformation(
+            "Retrieved {Count} repeat offenders for guild {GuildId}",
+            offenders.Count, guildId);
+
+        return offenders;
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<ModeratorWorkloadDto>> GetModeratorWorkloadAsync(
+        ulong guildId,
+        DateTime start,
+        DateTime end,
+        int limit = 10,
+        CancellationToken ct = default)
+    {
+        _logger.LogDebug(
+            "Getting moderator workload for guild {GuildId} from {Start} to {End}",
+            guildId, start, end);
+
+        // Get all cases in the time period
+        var (cases, _) = await _moderationCaseRepository.GetByGuildAsync(
+            guildId,
+            startDate: start,
+            endDate: end,
+            page: 1,
+            pageSize: int.MaxValue,
+            cancellationToken: ct);
+
+        var casesList = cases.ToList();
+        var totalActions = casesList.Count;
+
+        // Group by moderator and calculate workload
+        var workload = casesList
+            .GroupBy(c => c.ModeratorUserId)
+            .Select(g => new
+            {
+                ModeratorId = g.Key,
+                Cases = g.ToList()
+            })
+            .Select(x => new ModeratorWorkloadDto
+            {
+                ModeratorId = x.ModeratorId,
+                ModeratorUsername = $"Moderator {x.ModeratorId}", // Username not stored in ModerationCase
+                AvatarUrl = null, // Avatar not tracked in ModerationCase entity
+                TotalActions = x.Cases.Count,
+                WarnCount = x.Cases.Count(c => c.Type == CaseType.Warn),
+                MuteCount = x.Cases.Count(c => c.Type == CaseType.Mute),
+                KickCount = x.Cases.Count(c => c.Type == CaseType.Kick),
+                BanCount = x.Cases.Count(c => c.Type == CaseType.Ban),
+                Percentage = totalActions > 0 ? ((decimal)x.Cases.Count / totalActions) * 100 : 0m
+            })
+            .OrderByDescending(x => x.TotalActions)
+            .Take(limit)
+            .ToList();
+
+        _logger.LogInformation(
+            "Retrieved workload metrics for {Count} moderators in guild {GuildId}",
+            workload.Count, guildId);
+
+        return workload;
+    }
+
+    /// <inheritdoc/>
+    public async Task<CaseTypeDistributionDto> GetCaseDistributionAsync(
+        ulong guildId,
+        DateTime start,
+        DateTime end,
+        CancellationToken ct = default)
+    {
+        _logger.LogDebug(
+            "Getting case type distribution for guild {GuildId} from {Start} to {End}",
+            guildId, start, end);
+
+        // Get all cases in the time period
+        var (cases, _) = await _moderationCaseRepository.GetByGuildAsync(
+            guildId,
+            startDate: start,
+            endDate: end,
+            page: 1,
+            pageSize: int.MaxValue,
+            cancellationToken: ct);
+
+        var casesList = cases.ToList();
+
+        // Count by type
+        var warnCount = casesList.Count(c => c.Type == CaseType.Warn);
+        var muteCount = casesList.Count(c => c.Type == CaseType.Mute);
+        var kickCount = casesList.Count(c => c.Type == CaseType.Kick);
+        var banCount = casesList.Count(c => c.Type == CaseType.Ban);
+        var noteCount = casesList.Count(c => c.Type == CaseType.Note);
+
+        var distribution = new CaseTypeDistributionDto
+        {
+            WarnCount = warnCount,
+            MuteCount = muteCount,
+            KickCount = kickCount,
+            BanCount = banCount,
+            NoteCount = noteCount,
+            Total = casesList.Count
+        };
+
+        _logger.LogDebug(
+            "Case distribution for guild {GuildId}: {Total} total ({Warn} warns, {Mute} mutes, {Kick} kicks, {Ban} bans, {Note} notes)",
+            guildId, distribution.Total, warnCount, muteCount, kickCount, banCount, noteCount);
+
+        return distribution;
+    }
+}

--- a/src/DiscordBot.Bot/Services/ServerAnalyticsService.cs
+++ b/src/DiscordBot.Bot/Services/ServerAnalyticsService.cs
@@ -1,0 +1,275 @@
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Enums;
+using DiscordBot.Core.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace DiscordBot.Bot.Services;
+
+/// <summary>
+/// Service for generating server activity analytics and metrics.
+/// Aggregates data from member activity snapshots, channel activity, and guild metrics.
+/// </summary>
+public class ServerAnalyticsService : IServerAnalyticsService
+{
+    private readonly IMemberActivityRepository _memberActivityRepository;
+    private readonly IChannelActivityRepository _channelActivityRepository;
+    private readonly IGuildMetricsRepository _guildMetricsRepository;
+    private readonly ILogger<ServerAnalyticsService> _logger;
+
+    public ServerAnalyticsService(
+        IMemberActivityRepository memberActivityRepository,
+        IChannelActivityRepository channelActivityRepository,
+        IGuildMetricsRepository guildMetricsRepository,
+        ILogger<ServerAnalyticsService> logger)
+    {
+        _memberActivityRepository = memberActivityRepository;
+        _channelActivityRepository = channelActivityRepository;
+        _guildMetricsRepository = guildMetricsRepository;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task<ServerAnalyticsSummaryDto> GetSummaryAsync(
+        ulong guildId,
+        DateTime start,
+        DateTime end,
+        CancellationToken ct = default)
+    {
+        _logger.LogDebug(
+            "Generating server analytics summary for guild {GuildId} from {Start} to {End}",
+            guildId, start, end);
+
+        // Get the most recent guild metrics snapshot for current member counts
+        var latestMetrics = await _guildMetricsRepository.GetLatestAsync(guildId, ct);
+
+        // Calculate time ranges for different periods
+        var now = DateTime.UtcNow;
+        var last24h = now.AddHours(-24);
+        var last7d = now.AddDays(-7);
+        var last30d = now.AddDays(-30);
+
+        // Get activity data for the requested time period using daily granularity
+        var activityData = await _memberActivityRepository.GetActivityTimeSeriesAsync(
+            guildId,
+            start,
+            end,
+            SnapshotGranularity.Daily,
+            ct);
+
+        // Calculate active members for different time windows
+        var dailySnapshots = await _memberActivityRepository.GetActivityTimeSeriesAsync(
+            guildId,
+            last30d,
+            now,
+            SnapshotGranularity.Daily,
+            ct);
+
+        // Get unique active members for each period
+        var activeMembersLast24h = dailySnapshots
+            .Where(x => x.Period >= last24h)
+            .Sum(x => x.ActiveMembers);
+
+        var activeMembersLast7d = dailySnapshots
+            .Where(x => x.Period >= last7d)
+            .Sum(x => x.ActiveMembers);
+
+        var activeMembersLast30d = dailySnapshots
+            .Sum(x => x.ActiveMembers);
+
+        // Calculate message counts
+        var messagesLast24h = dailySnapshots
+            .Where(x => x.Period >= last24h)
+            .Sum(x => x.TotalMessages);
+
+        var messagesLast7d = dailySnapshots
+            .Where(x => x.Period >= last7d)
+            .Sum(x => x.TotalMessages);
+
+        // Calculate member growth from guild metrics
+        var metricsLast7d = await _guildMetricsRepository.GetByDateRangeAsync(
+            guildId,
+            DateOnly.FromDateTime(last7d),
+            DateOnly.FromDateTime(now),
+            ct);
+
+        var oldestMetric = metricsLast7d.FirstOrDefault();
+        var memberGrowth7d = latestMetrics != null && oldestMetric != null
+            ? latestMetrics.TotalMembers - oldestMetric.TotalMembers
+            : 0;
+
+        var memberGrowthPercent = oldestMetric?.TotalMembers > 0
+            ? ((decimal)memberGrowth7d / oldestMetric.TotalMembers) * 100
+            : 0m;
+
+        // Get count of active channels (channels with messages in the time period)
+        var channelRankings = await _channelActivityRepository.GetChannelRankingsAsync(
+            guildId,
+            start,
+            end,
+            limit: 1000, // Get all channels to count them
+            ct);
+
+        _logger.LogInformation(
+            "Server analytics summary generated for guild {GuildId}: {TotalMembers} members, {ActiveMembers24h} active (24h)",
+            guildId, latestMetrics?.TotalMembers ?? 0, activeMembersLast24h);
+
+        return new ServerAnalyticsSummaryDto
+        {
+            TotalMembers = latestMetrics?.TotalMembers ?? 0,
+            OnlineMembers = 0, // Online member count not tracked in snapshots
+            ActiveMembers24h = activeMembersLast24h,
+            ActiveMembers7d = activeMembersLast7d,
+            ActiveMembers30d = activeMembersLast30d,
+            Messages24h = messagesLast24h,
+            Messages7d = messagesLast7d,
+            MemberGrowth7d = memberGrowth7d,
+            MemberGrowthPercent = memberGrowthPercent,
+            ActiveChannels = channelRankings.Count
+        };
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<ActivityTimeSeriesDto>> GetActivityTimeSeriesAsync(
+        ulong guildId,
+        DateTime start,
+        DateTime end,
+        CancellationToken ct = default)
+    {
+        _logger.LogDebug(
+            "Generating activity time series for guild {GuildId} from {Start} to {End}",
+            guildId, start, end);
+
+        // Get daily activity aggregates
+        var activityData = await _memberActivityRepository.GetActivityTimeSeriesAsync(
+            guildId,
+            start,
+            end,
+            SnapshotGranularity.Daily,
+            ct);
+
+        // Get channel activity for the same period
+        var channelRankings = await _channelActivityRepository.GetChannelRankingsAsync(
+            guildId,
+            start,
+            end,
+            limit: 1000,
+            ct);
+
+        // Create a dictionary of channel counts by date (we'll need to aggregate this differently)
+        // For now, we'll use the total unique channels as a constant
+        var activeChannelsCount = channelRankings.Count;
+
+        var results = activityData.Select(x => new ActivityTimeSeriesDto
+        {
+            Date = x.Period,
+            MessageCount = x.TotalMessages,
+            ActiveMembers = x.ActiveMembers,
+            ActiveChannels = activeChannelsCount // This is simplified - could be improved with per-day channel tracking
+        }).ToList();
+
+        _logger.LogDebug(
+            "Generated {Count} activity time series data points for guild {GuildId}",
+            results.Count, guildId);
+
+        return results;
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<ServerActivityHeatmapDto>> GetActivityHeatmapAsync(
+        ulong guildId,
+        DateTime start,
+        DateTime end,
+        CancellationToken ct = default)
+    {
+        _logger.LogDebug(
+            "Generating activity heatmap for guild {GuildId} from {Start} to {End}",
+            guildId, start, end);
+
+        // Get hourly snapshots for the heatmap
+        var hourlyData = await _memberActivityRepository.GetActivityTimeSeriesAsync(
+            guildId,
+            start,
+            end,
+            SnapshotGranularity.Hourly,
+            ct);
+
+        // Group by day of week and hour
+        var heatmapData = hourlyData
+            .GroupBy(x => new
+            {
+                DayOfWeek = (int)x.Period.DayOfWeek,
+                Hour = x.Period.Hour
+            })
+            .Select(g => new ServerActivityHeatmapDto
+            {
+                DayOfWeek = g.Key.DayOfWeek,
+                Hour = g.Key.Hour,
+                MessageCount = g.Sum(x => (long)x.TotalMessages)
+            })
+            .OrderBy(x => x.DayOfWeek)
+            .ThenBy(x => x.Hour)
+            .ToList();
+
+        _logger.LogDebug(
+            "Generated heatmap with {Count} data points for guild {GuildId}",
+            heatmapData.Count, guildId);
+
+        return heatmapData;
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<TopContributorDto>> GetTopContributorsAsync(
+        ulong guildId,
+        DateTime start,
+        DateTime end,
+        int limit = 10,
+        CancellationToken ct = default)
+    {
+        _logger.LogDebug(
+            "Getting top {Limit} contributors for guild {GuildId} from {Start} to {End}",
+            limit, guildId, start, end);
+
+        // Get top active members from the repository
+        var topMembers = await _memberActivityRepository.GetTopActiveMembersAsync(
+            guildId,
+            start,
+            end,
+            limit,
+            ct);
+
+        // Transform to TopContributorDto
+        // Note: The repository returns aggregated snapshots, we need to sum up the message counts
+        var contributors = topMembers
+            .GroupBy(x => x.UserId)
+            .Select(g => new
+            {
+                UserId = g.Key,
+                MessageCount = g.Sum(x => x.MessageCount),
+                UniqueChannels = g.Max(x => x.UniqueChannelsActive),
+                LastActive = g.Max(x => x.PeriodStart),
+                User = g.FirstOrDefault()?.User
+            })
+            .OrderByDescending(x => x.MessageCount)
+            .Take(limit)
+            .Select(x => new TopContributorDto
+            {
+                UserId = x.UserId,
+                Username = x.User?.Username ?? "Unknown",
+                DisplayName = x.User?.GlobalDisplayName,
+                AvatarUrl = x.User?.AvatarHash != null
+                    ? $"https://cdn.discordapp.com/avatars/{x.UserId}/{x.User.AvatarHash}.png"
+                    : null,
+                MessageCount = x.MessageCount,
+                UniqueChannels = x.UniqueChannels,
+                LastActive = x.LastActive
+            })
+            .ToList();
+
+        _logger.LogInformation(
+            "Retrieved {Count} top contributors for guild {GuildId}",
+            contributors.Count, guildId);
+
+        return contributors;
+    }
+}

--- a/src/DiscordBot.Bot/ViewModels/Pages/EngagementAnalyticsViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Pages/EngagementAnalyticsViewModel.cs
@@ -1,0 +1,85 @@
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Bot.ViewModels.Pages;
+
+/// <summary>
+/// View model for the Guild Engagement Analytics page.
+/// </summary>
+public record EngagementAnalyticsViewModel
+{
+    /// <summary>
+    /// The guild's Discord snowflake ID.
+    /// </summary>
+    public ulong GuildId { get; init; }
+
+    /// <summary>
+    /// The guild's name.
+    /// </summary>
+    public string GuildName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Optional guild icon URL.
+    /// </summary>
+    public string? GuildIconUrl { get; init; }
+
+    /// <summary>
+    /// Analytics summary with message volume, active members, and retention metrics.
+    /// </summary>
+    public EngagementAnalyticsSummaryDto Summary { get; init; } = new();
+
+    /// <summary>
+    /// Time series data for message trends chart (messages, unique authors, avg length).
+    /// </summary>
+    public IReadOnlyList<MessageTrendDto> MessageTrends { get; init; } = Array.Empty<MessageTrendDto>();
+
+    /// <summary>
+    /// Channel engagement metrics with message counts and engagement rates.
+    /// </summary>
+    public IReadOnlyList<ChannelEngagementDto> ChannelEngagement { get; init; } = Array.Empty<ChannelEngagementDto>();
+
+    /// <summary>
+    /// New member retention funnel data.
+    /// </summary>
+    public IReadOnlyList<NewMemberRetentionDto> NewMemberRetention { get; init; } = Array.Empty<NewMemberRetentionDto>();
+
+    /// <summary>
+    /// Start date for filtering (UTC).
+    /// </summary>
+    public DateTime StartDate { get; init; }
+
+    /// <summary>
+    /// End date for filtering (UTC).
+    /// </summary>
+    public DateTime EndDate { get; init; }
+}
+
+/// <summary>
+/// Channel engagement metrics for a single channel.
+/// </summary>
+public record ChannelEngagementDto
+{
+    /// <summary>
+    /// Discord channel snowflake ID.
+    /// </summary>
+    public ulong ChannelId { get; init; }
+
+    /// <summary>
+    /// Channel name (e.g., "general", "off-topic").
+    /// </summary>
+    public string ChannelName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Total number of messages in this channel.
+    /// </summary>
+    public long MessageCount { get; init; }
+
+    /// <summary>
+    /// Number of unique members who posted in this channel.
+    /// </summary>
+    public int UniqueAuthors { get; init; }
+
+    /// <summary>
+    /// Engagement rate: percentage of guild members who posted in this channel.
+    /// </summary>
+    public decimal EngagementRate { get; init; }
+}

--- a/src/DiscordBot.Bot/ViewModels/Pages/ModerationAnalyticsViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Pages/ModerationAnalyticsViewModel.cs
@@ -1,0 +1,59 @@
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Bot.ViewModels.Pages;
+
+/// <summary>
+/// View model for the Guild Moderation Analytics page.
+/// </summary>
+public record ModerationAnalyticsViewModel
+{
+    /// <summary>
+    /// The guild's Discord snowflake ID.
+    /// </summary>
+    public ulong GuildId { get; init; }
+
+    /// <summary>
+    /// The guild's name.
+    /// </summary>
+    public string GuildName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Optional guild icon URL.
+    /// </summary>
+    public string? GuildIconUrl { get; init; }
+
+    /// <summary>
+    /// Summary metrics with total counts, rates, and averages.
+    /// </summary>
+    public ModerationAnalyticsSummaryDto Summary { get; init; } = new();
+
+    /// <summary>
+    /// Time series data for moderation trends over time chart.
+    /// </summary>
+    public IReadOnlyList<ModerationTrendDto> Trends { get; init; } = Array.Empty<ModerationTrendDto>();
+
+    /// <summary>
+    /// Distribution of case types for doughnut chart.
+    /// </summary>
+    public CaseTypeDistributionDto Distribution { get; init; } = new();
+
+    /// <summary>
+    /// Repeat offenders with multiple moderation cases.
+    /// </summary>
+    public IReadOnlyList<RepeatOffenderDto> RepeatOffenders { get; init; } = Array.Empty<RepeatOffenderDto>();
+
+    /// <summary>
+    /// Moderator workload distribution showing cases handled per moderator.
+    /// </summary>
+    public IReadOnlyList<ModeratorWorkloadDto> ModeratorWorkload { get; init; } = Array.Empty<ModeratorWorkloadDto>();
+
+    /// <summary>
+    /// Start date for filtering (UTC).
+    /// </summary>
+    public DateTime StartDate { get; init; }
+
+    /// <summary>
+    /// End date for filtering (UTC).
+    /// </summary>
+    public DateTime EndDate { get; init; }
+}

--- a/src/DiscordBot.Bot/ViewModels/Pages/ServerAnalyticsViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Pages/ServerAnalyticsViewModel.cs
@@ -1,0 +1,90 @@
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Bot.ViewModels.Pages;
+
+/// <summary>
+/// View model for the Server Analytics dashboard page.
+/// </summary>
+public record ServerAnalyticsViewModel
+{
+    /// <summary>
+    /// The guild's Discord snowflake ID.
+    /// </summary>
+    public ulong GuildId { get; init; }
+
+    /// <summary>
+    /// The guild's name.
+    /// </summary>
+    public string GuildName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Optional guild icon URL.
+    /// </summary>
+    public string? GuildIconUrl { get; init; }
+
+    /// <summary>
+    /// Analytics summary with member counts, message volume, and growth metrics.
+    /// </summary>
+    public ServerAnalyticsSummaryDto Summary { get; init; } = new();
+
+    /// <summary>
+    /// Time series data for activity trends (messages, active members) over time.
+    /// </summary>
+    public IReadOnlyList<ActivityTimeSeriesDto> ActivityTimeSeries { get; init; } = Array.Empty<ActivityTimeSeriesDto>();
+
+    /// <summary>
+    /// Activity heatmap data (day of week + hour).
+    /// </summary>
+    public IReadOnlyList<ServerActivityHeatmapDto> ActivityHeatmap { get; init; } = Array.Empty<ServerActivityHeatmapDto>();
+
+    /// <summary>
+    /// Top contributors leaderboard (most active members).
+    /// </summary>
+    public IReadOnlyList<TopContributorDto> TopContributors { get; init; } = Array.Empty<TopContributorDto>();
+
+    /// <summary>
+    /// Top channels leaderboard (most active channels by message count).
+    /// </summary>
+    public IReadOnlyList<TopChannelDto> TopChannels { get; init; } = Array.Empty<TopChannelDto>();
+
+    /// <summary>
+    /// Start date for filtering (UTC).
+    /// </summary>
+    public DateTime StartDate { get; init; }
+
+    /// <summary>
+    /// End date for filtering (UTC).
+    /// </summary>
+    public DateTime EndDate { get; init; }
+}
+
+/// <summary>
+/// Top channel metrics for leaderboard display.
+/// </summary>
+public record TopChannelDto
+{
+    /// <summary>
+    /// Discord channel snowflake ID.
+    /// </summary>
+    public ulong ChannelId { get; init; }
+
+    /// <summary>
+    /// Channel name.
+    /// </summary>
+    public string ChannelName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Total number of messages sent in this channel during the time period.
+    /// </summary>
+    public long MessageCount { get; init; }
+
+    /// <summary>
+    /// Number of unique users who posted in this channel.
+    /// </summary>
+    public int UniqueContributors { get; init; }
+
+    /// <summary>
+    /// Timestamp of the most recent message in this channel.
+    /// </summary>
+    public DateTime LastActivity { get; init; }
+}

--- a/src/DiscordBot.Bot/wwwroot/js/engagement-analytics.js
+++ b/src/DiscordBot.Bot/wwwroot/js/engagement-analytics.js
@@ -1,0 +1,430 @@
+// engagement-analytics.js
+// Engagement analytics dashboard with Chart.js visualizations
+
+(function () {
+    'use strict';
+
+    function getDesignToken(name) {
+        return getComputedStyle(document.documentElement)
+            .getPropertyValue(`--color-${name}`).trim();
+    }
+
+    function initColors() {
+        return {
+            accentOrange: getDesignToken('accent-orange') || '#cb4e1b',
+            accentBlue: getDesignToken('accent-blue') || '#098ecf',
+            success: getDesignToken('success') || '#10b981',
+            warning: getDesignToken('warning') || '#f59e0b',
+            info: getDesignToken('info') || '#06b6d4',
+            error: getDesignToken('error') || '#ef4444',
+            bgPrimary: getDesignToken('bg-primary') || '#1d2022',
+            bgSecondary: getDesignToken('bg-secondary') || '#262a2d',
+            bgTertiary: getDesignToken('bg-tertiary') || '#2f3336',
+            textPrimary: getDesignToken('text-primary') || '#d7d3d0',
+            textSecondary: getDesignToken('text-secondary') || '#a8a5a3',
+            textTertiary: getDesignToken('text-tertiary') || '#7a7876',
+            borderPrimary: getDesignToken('border-primary') || '#3f4447',
+        };
+    }
+
+    let colors = initColors();
+
+    const CHART_COLORS = [
+        colors.accentOrange,
+        colors.accentBlue,
+        colors.success,
+        colors.warning,
+        colors.info,
+        colors.error,
+        '#8b5cf6',
+        '#ec4899',
+        '#14b8a6',
+        '#6366f1',
+    ];
+
+    const BG_COLORS = {
+        primary: colors.bgPrimary,
+        secondary: colors.bgSecondary,
+        tertiary: colors.bgTertiary,
+    };
+
+    const TEXT_COLORS = {
+        primary: colors.textPrimary,
+        secondary: colors.textSecondary,
+        tertiary: colors.textTertiary,
+    };
+
+    const BORDER_COLOR = colors.borderPrimary;
+
+    let messageTrendsChart = null;
+    let channelEngagementChart = null;
+
+    const commonOptions = {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+            legend: {
+                display: false,
+            },
+            tooltip: {
+                backgroundColor: BG_COLORS.tertiary,
+                titleColor: TEXT_COLORS.primary,
+                bodyColor: TEXT_COLORS.secondary,
+                borderColor: BORDER_COLOR,
+                borderWidth: 1,
+                padding: 12,
+                cornerRadius: 6,
+            },
+        },
+    };
+
+    const gridConfig = {
+        color: 'rgba(63, 68, 71, 0.5)',
+        drawBorder: false,
+    };
+
+    const ticksConfig = {
+        color: TEXT_COLORS.tertiary,
+        font: {
+            size: 12,
+        },
+    };
+
+    function formatNumber(num) {
+        return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+    }
+
+    function formatDate(dateStr) {
+        const date = new Date(dateStr);
+        const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+            'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+        return `${monthNames[date.getMonth()]} ${date.getDate()}`;
+    }
+
+    /**
+     * Initializes the Message Trends dual-axis chart.
+     * @param {Array} trendsData - Array of {date, messageCount, uniqueAuthors, avgLength} objects
+     */
+    function initMessageTrendsChart(trendsData) {
+        const canvas = document.getElementById('messageTrendsChart');
+        if (!canvas || !trendsData || trendsData.length === 0) {
+            return;
+        }
+
+        const ctx = canvas.getContext('2d');
+        const labels = trendsData.map(item => formatDate(item.date));
+        const messagesData = trendsData.map(item => item.messageCount);
+        const authorsData = trendsData.map(item => item.uniqueAuthors);
+
+        const messagesGradient = ctx.createLinearGradient(0, 0, 0, 300);
+        messagesGradient.addColorStop(0, 'rgba(9, 142, 207, 0.3)');
+        messagesGradient.addColorStop(1, 'rgba(9, 142, 207, 0.0)');
+
+        messageTrendsChart = new Chart(ctx, {
+            type: 'line',
+            data: {
+                labels: labels,
+                datasets: [
+                    {
+                        label: 'Messages',
+                        data: messagesData,
+                        borderColor: CHART_COLORS[1],
+                        backgroundColor: messagesGradient,
+                        borderWidth: 2,
+                        fill: true,
+                        tension: 0.3,
+                        pointRadius: 4,
+                        pointBackgroundColor: CHART_COLORS[1],
+                        pointBorderColor: BG_COLORS.primary,
+                        pointBorderWidth: 2,
+                        pointHoverRadius: 6,
+                        yAxisID: 'y',
+                    },
+                    {
+                        label: 'Unique Authors',
+                        data: authorsData,
+                        borderColor: CHART_COLORS[2],
+                        backgroundColor: 'transparent',
+                        borderWidth: 2,
+                        fill: false,
+                        tension: 0.3,
+                        pointRadius: 3,
+                        pointBackgroundColor: CHART_COLORS[2],
+                        pointBorderColor: BG_COLORS.primary,
+                        pointBorderWidth: 2,
+                        pointHoverRadius: 5,
+                        yAxisID: 'y1',
+                    }
+                ]
+            },
+            options: {
+                ...commonOptions,
+                plugins: {
+                    ...commonOptions.plugins,
+                    legend: {
+                        display: true,
+                        position: 'bottom',
+                        labels: {
+                            color: TEXT_COLORS.primary,
+                            padding: 16,
+                            font: { size: 12 },
+                            usePointStyle: true,
+                        }
+                    },
+                    tooltip: {
+                        ...commonOptions.plugins.tooltip,
+                        callbacks: {
+                            title: function (context) {
+                                return trendsData[context[0].dataIndex].date;
+                            },
+                            label: function (context) {
+                                return `${context.dataset.label}: ${formatNumber(context.parsed.y)}`;
+                            }
+                        }
+                    }
+                },
+                scales: {
+                    x: {
+                        grid: gridConfig,
+                        ticks: ticksConfig,
+                    },
+                    y: {
+                        type: 'linear',
+                        display: true,
+                        position: 'left',
+                        beginAtZero: true,
+                        grid: gridConfig,
+                        ticks: {
+                            ...ticksConfig,
+                            callback: function (value) {
+                                if (value >= 1000) return (value / 1000).toFixed(1) + 'k';
+                                return value;
+                            }
+                        },
+                        title: {
+                            display: true,
+                            text: 'Messages',
+                            color: TEXT_COLORS.secondary,
+                        }
+                    },
+                    y1: {
+                        type: 'linear',
+                        display: true,
+                        position: 'right',
+                        beginAtZero: true,
+                        grid: {
+                            drawOnChartArea: false,
+                        },
+                        ticks: ticksConfig,
+                        title: {
+                            display: true,
+                            text: 'Unique Authors',
+                            color: TEXT_COLORS.secondary,
+                        }
+                    }
+                },
+                interaction: {
+                    intersect: false,
+                    mode: 'index',
+                }
+            }
+        });
+
+        console.log('Message trends chart initialized');
+    }
+
+    /**
+     * Initializes the Channel Engagement bar chart.
+     * @param {Array} channelData - Array of {channelName, messageCount, uniqueUsers} objects
+     */
+    function initChannelEngagementChart(channelData) {
+        const canvas = document.getElementById('channelEngagementChart');
+        if (!canvas || !channelData || channelData.length === 0) {
+            return;
+        }
+
+        const ctx = canvas.getContext('2d');
+        const labels = channelData.map(item => '#' + item.channelName);
+        const messagesData = channelData.map(item => item.messageCount);
+        const usersData = channelData.map(item => item.uniqueUsers);
+
+        channelEngagementChart = new Chart(ctx, {
+            type: 'bar',
+            data: {
+                labels: labels,
+                datasets: [
+                    {
+                        label: 'Messages',
+                        data: messagesData,
+                        backgroundColor: CHART_COLORS[1],
+                        borderColor: CHART_COLORS[1],
+                        borderWidth: 1,
+                        borderRadius: 4,
+                    },
+                    {
+                        label: 'Unique Users',
+                        data: usersData,
+                        backgroundColor: CHART_COLORS[2],
+                        borderColor: CHART_COLORS[2],
+                        borderWidth: 1,
+                        borderRadius: 4,
+                    }
+                ]
+            },
+            options: {
+                ...commonOptions,
+                plugins: {
+                    ...commonOptions.plugins,
+                    legend: {
+                        display: true,
+                        position: 'bottom',
+                        labels: {
+                            color: TEXT_COLORS.primary,
+                            padding: 16,
+                            font: { size: 12 },
+                            usePointStyle: true,
+                        }
+                    },
+                    tooltip: {
+                        ...commonOptions.plugins.tooltip,
+                        callbacks: {
+                            label: function (context) {
+                                return `${context.dataset.label}: ${formatNumber(context.parsed.y)}`;
+                            }
+                        }
+                    }
+                },
+                scales: {
+                    x: {
+                        grid: { display: false },
+                        ticks: ticksConfig,
+                    },
+                    y: {
+                        beginAtZero: true,
+                        grid: gridConfig,
+                        ticks: {
+                            ...ticksConfig,
+                            callback: function (value) {
+                                if (value >= 1000) return (value / 1000).toFixed(1) + 'k';
+                                return value;
+                            }
+                        },
+                    }
+                },
+                animation: {
+                    duration: 500,
+                    easing: 'easeOutQuart',
+                }
+            }
+        });
+
+        console.log('Channel engagement chart initialized');
+    }
+
+    /**
+     * Renders the retention funnel visualization.
+     * @param {Array} retentionData - Array of {period, joined, activeDay1, activeDay7, activeDay30} objects
+     */
+    function renderRetentionFunnel(retentionData) {
+        const container = document.getElementById('retentionFunnel');
+        if (!container || !retentionData || retentionData.length === 0) {
+            return;
+        }
+
+        // Aggregate data across all periods
+        const totals = retentionData.reduce((acc, item) => {
+            acc.joined += item.joined || 0;
+            acc.activeDay1 += item.activeDay1 || 0;
+            acc.activeDay7 += item.activeDay7 || 0;
+            acc.activeDay30 += item.activeDay30 || 0;
+            return acc;
+        }, { joined: 0, activeDay1: 0, activeDay7: 0, activeDay30: 0 });
+
+        const stages = [
+            { label: 'Joined', value: totals.joined, color: CHART_COLORS[1] },
+            { label: 'Active Day 1', value: totals.activeDay1, color: CHART_COLORS[2] },
+            { label: 'Active Day 7', value: totals.activeDay7, color: CHART_COLORS[3] },
+            { label: 'Active Day 30', value: totals.activeDay30, color: CHART_COLORS[0] },
+        ];
+
+        const maxValue = Math.max(...stages.map(s => s.value));
+
+        let html = '<div class="space-y-4">';
+        stages.forEach((stage, index) => {
+            const percentage = totals.joined > 0 ? ((stage.value / totals.joined) * 100).toFixed(1) : 0;
+            const barWidth = maxValue > 0 ? (stage.value / maxValue) * 100 : 0;
+            const retentionFromPrev = index === 0 ? 100 : (stages[index - 1].value > 0 ? (stage.value / stages[index - 1].value) * 100 : 0);
+
+            html += `
+                <div class="flex items-center gap-4">
+                    <div class="w-28 text-sm text-text-secondary font-medium">${stage.label}</div>
+                    <div class="flex-1 relative">
+                        <div class="h-8 bg-bg-tertiary rounded-lg overflow-hidden">
+                            <div class="h-full rounded-lg transition-all duration-500"
+                                 style="width: ${barWidth}%; background-color: ${stage.color};">
+                            </div>
+                        </div>
+                    </div>
+                    <div class="w-20 text-right">
+                        <span class="text-lg font-bold text-text-primary">${formatNumber(stage.value)}</span>
+                        <span class="text-xs text-text-tertiary ml-1">(${percentage}%)</span>
+                    </div>
+                </div>
+            `;
+        });
+        html += '</div>';
+
+        // Summary metrics
+        const overallRetention = totals.joined > 0 ? ((totals.activeDay30 / totals.joined) * 100).toFixed(1) : 0;
+        html += `
+            <div class="mt-6 pt-4 border-t border-border-primary">
+                <div class="flex items-center justify-between text-sm">
+                    <span class="text-text-secondary">30-Day Retention Rate</span>
+                    <span class="text-lg font-bold ${parseFloat(overallRetention) >= 20 ? 'text-success' : parseFloat(overallRetention) >= 10 ? 'text-warning' : 'text-error'}">${overallRetention}%</span>
+                </div>
+            </div>
+        `;
+
+        container.innerHTML = html;
+        console.log('Retention funnel rendered');
+    }
+
+    /**
+     * Initialize all engagement analytics charts.
+     */
+    function init() {
+        const dataElement = document.getElementById('engagementAnalyticsChartData');
+        if (!dataElement) {
+            console.log('Engagement analytics chart data not found on this page');
+            return;
+        }
+
+        try {
+            const chartData = JSON.parse(dataElement.textContent);
+
+            if (chartData.messageTrends && chartData.messageTrends.length > 0) {
+                initMessageTrendsChart(chartData.messageTrends);
+            }
+
+            if (chartData.channelEngagement && chartData.channelEngagement.length > 0) {
+                initChannelEngagementChart(chartData.channelEngagement);
+            }
+
+            if (chartData.retention && chartData.retention.length > 0) {
+                renderRetentionFunnel(chartData.retention);
+            }
+
+            console.log('Engagement analytics charts initialized');
+
+        } catch (error) {
+            console.error('Failed to initialize engagement analytics charts:', error);
+        }
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+
+})();

--- a/src/DiscordBot.Bot/wwwroot/js/moderation-analytics.js
+++ b/src/DiscordBot.Bot/wwwroot/js/moderation-analytics.js
@@ -1,0 +1,409 @@
+// moderation-analytics.js
+// Moderation analytics dashboard with Chart.js visualizations
+
+(function () {
+    'use strict';
+
+    function getDesignToken(name) {
+        return getComputedStyle(document.documentElement)
+            .getPropertyValue(`--color-${name}`).trim();
+    }
+
+    function initColors() {
+        return {
+            accentOrange: getDesignToken('accent-orange') || '#cb4e1b',
+            accentBlue: getDesignToken('accent-blue') || '#098ecf',
+            success: getDesignToken('success') || '#10b981',
+            warning: getDesignToken('warning') || '#f59e0b',
+            info: getDesignToken('info') || '#06b6d4',
+            error: getDesignToken('error') || '#ef4444',
+            bgPrimary: getDesignToken('bg-primary') || '#1d2022',
+            bgSecondary: getDesignToken('bg-secondary') || '#262a2d',
+            bgTertiary: getDesignToken('bg-tertiary') || '#2f3336',
+            textPrimary: getDesignToken('text-primary') || '#d7d3d0',
+            textSecondary: getDesignToken('text-secondary') || '#a8a5a3',
+            textTertiary: getDesignToken('text-tertiary') || '#7a7876',
+            borderPrimary: getDesignToken('border-primary') || '#3f4447',
+        };
+    }
+
+    let colors = initColors();
+
+    const CHART_COLORS = [
+        colors.accentOrange,
+        colors.accentBlue,
+        colors.success,
+        colors.warning,
+        colors.info,
+        colors.error,
+        '#8b5cf6',
+        '#ec4899',
+        '#14b8a6',
+        '#6366f1',
+    ];
+
+    const BG_COLORS = {
+        primary: colors.bgPrimary,
+        secondary: colors.bgSecondary,
+        tertiary: colors.bgTertiary,
+    };
+
+    const TEXT_COLORS = {
+        primary: colors.textPrimary,
+        secondary: colors.textSecondary,
+        tertiary: colors.textTertiary,
+    };
+
+    const BORDER_COLOR = colors.borderPrimary;
+
+    let moderationTrendsChart = null;
+    let caseDistributionChart = null;
+    let moderatorWorkloadChart = null;
+
+    const commonOptions = {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+            legend: {
+                display: false,
+            },
+            tooltip: {
+                backgroundColor: BG_COLORS.tertiary,
+                titleColor: TEXT_COLORS.primary,
+                bodyColor: TEXT_COLORS.secondary,
+                borderColor: BORDER_COLOR,
+                borderWidth: 1,
+                padding: 12,
+                cornerRadius: 6,
+            },
+        },
+    };
+
+    const gridConfig = {
+        color: 'rgba(63, 68, 71, 0.5)',
+        drawBorder: false,
+    };
+
+    const ticksConfig = {
+        color: TEXT_COLORS.tertiary,
+        font: {
+            size: 12,
+        },
+    };
+
+    function formatNumber(num) {
+        return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+    }
+
+    function formatDate(dateStr) {
+        const date = new Date(dateStr);
+        const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+            'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+        return `${monthNames[date.getMonth()]} ${date.getDate()}`;
+    }
+
+    /**
+     * Center text plugin for doughnut charts.
+     */
+    const centerTextPlugin = {
+        id: 'centerText',
+        afterDatasetsDraw: function (chart) {
+            if (!chart.config.options.plugins.centerText) {
+                return;
+            }
+
+            const { ctx, chartArea: { width, height } } = chart;
+            const centerX = width / 2;
+            const centerY = height / 2;
+            const text = chart.config.options.plugins.centerText.text;
+
+            ctx.save();
+            ctx.font = 'bold 32px ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto';
+            ctx.fillStyle = TEXT_COLORS.primary;
+            ctx.textAlign = 'center';
+            ctx.textBaseline = 'middle';
+            ctx.fillText(text, centerX, centerY);
+            ctx.restore();
+        }
+    };
+
+    /**
+     * Initializes the Moderation Trends stacked area chart.
+     * @param {Array} trendsData - Array of {date, warnings, mutes, kicks, bans} objects
+     */
+    function initModerationTrendsChart(trendsData) {
+        const canvas = document.getElementById('moderationTrendsChart');
+        if (!canvas || !trendsData || trendsData.length === 0) {
+            return;
+        }
+
+        const ctx = canvas.getContext('2d');
+        const labels = trendsData.map(item => formatDate(item.date));
+
+        moderationTrendsChart = new Chart(ctx, {
+            type: 'line',
+            data: {
+                labels: labels,
+                datasets: [
+                    {
+                        label: 'Warnings',
+                        data: trendsData.map(item => item.warnings),
+                        borderColor: CHART_COLORS[3],
+                        backgroundColor: 'rgba(245, 158, 11, 0.2)',
+                        borderWidth: 2,
+                        fill: true,
+                        tension: 0.3,
+                        pointRadius: 3,
+                    },
+                    {
+                        label: 'Mutes',
+                        data: trendsData.map(item => item.mutes),
+                        borderColor: CHART_COLORS[4],
+                        backgroundColor: 'rgba(6, 182, 212, 0.2)',
+                        borderWidth: 2,
+                        fill: true,
+                        tension: 0.3,
+                        pointRadius: 3,
+                    },
+                    {
+                        label: 'Kicks',
+                        data: trendsData.map(item => item.kicks),
+                        borderColor: CHART_COLORS[0],
+                        backgroundColor: 'rgba(203, 78, 27, 0.2)',
+                        borderWidth: 2,
+                        fill: true,
+                        tension: 0.3,
+                        pointRadius: 3,
+                    },
+                    {
+                        label: 'Bans',
+                        data: trendsData.map(item => item.bans),
+                        borderColor: CHART_COLORS[5],
+                        backgroundColor: 'rgba(239, 68, 68, 0.2)',
+                        borderWidth: 2,
+                        fill: true,
+                        tension: 0.3,
+                        pointRadius: 3,
+                    }
+                ]
+            },
+            options: {
+                ...commonOptions,
+                plugins: {
+                    ...commonOptions.plugins,
+                    legend: {
+                        display: true,
+                        position: 'bottom',
+                        labels: {
+                            color: TEXT_COLORS.primary,
+                            padding: 16,
+                            font: { size: 12 },
+                            usePointStyle: true,
+                        }
+                    },
+                    tooltip: {
+                        ...commonOptions.plugins.tooltip,
+                        mode: 'index',
+                        intersect: false,
+                    }
+                },
+                scales: {
+                    x: {
+                        grid: gridConfig,
+                        ticks: ticksConfig,
+                    },
+                    y: {
+                        stacked: true,
+                        beginAtZero: true,
+                        grid: gridConfig,
+                        ticks: ticksConfig,
+                    }
+                },
+                interaction: {
+                    intersect: false,
+                    mode: 'index',
+                }
+            }
+        });
+
+        console.log('Moderation trends chart initialized');
+    }
+
+    /**
+     * Initializes the Case Type Distribution doughnut chart.
+     * @param {Object} distributionData - Object with case type counts
+     */
+    function initCaseDistributionChart(distributionData) {
+        const canvas = document.getElementById('caseDistributionChart');
+        if (!canvas || !distributionData) {
+            return;
+        }
+
+        const ctx = canvas.getContext('2d');
+        const labels = Object.keys(distributionData);
+        const data = Object.values(distributionData);
+        const total = data.reduce((a, b) => a + b, 0);
+
+        caseDistributionChart = new Chart(ctx, {
+            type: 'doughnut',
+            data: {
+                labels: labels,
+                datasets: [{
+                    data: data,
+                    backgroundColor: [
+                        CHART_COLORS[3], // warnings - yellow
+                        CHART_COLORS[4], // mutes - cyan
+                        CHART_COLORS[0], // kicks - orange
+                        CHART_COLORS[5], // bans - red
+                        CHART_COLORS[6], // other - purple
+                    ],
+                    borderColor: BG_COLORS.primary,
+                    borderWidth: 3,
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                cutout: '70%',
+                plugins: {
+                    legend: {
+                        display: true,
+                        position: 'bottom',
+                        labels: {
+                            color: TEXT_COLORS.primary,
+                            padding: 16,
+                            font: { size: 13 },
+                            usePointStyle: true,
+                            pointStyle: 'circle',
+                        }
+                    },
+                    tooltip: {
+                        ...commonOptions.plugins.tooltip,
+                        callbacks: {
+                            label: function (context) {
+                                const label = context.label || '';
+                                const value = context.parsed;
+                                const percentage = total > 0 ? ((value / total) * 100).toFixed(1) : '0.0';
+                                return `${label}: ${formatNumber(value)} (${percentage}%)`;
+                            }
+                        }
+                    },
+                    centerText: {
+                        text: formatNumber(total)
+                    }
+                }
+            },
+            plugins: [centerTextPlugin]
+        });
+
+        console.log('Case distribution chart initialized');
+    }
+
+    /**
+     * Initializes the Moderator Workload horizontal bar chart.
+     * @param {Array} workloadData - Array of {moderatorName, actionCount} objects
+     */
+    function initModeratorWorkloadChart(workloadData) {
+        const canvas = document.getElementById('moderatorWorkloadChart');
+        if (!canvas || !workloadData || workloadData.length === 0) {
+            return;
+        }
+
+        const ctx = canvas.getContext('2d');
+        const labels = workloadData.map(item => item.moderatorName);
+        const data = workloadData.map(item => item.actionCount);
+
+        const colorRange = labels.map((_, index) => CHART_COLORS[index % CHART_COLORS.length]);
+
+        moderatorWorkloadChart = new Chart(ctx, {
+            type: 'bar',
+            data: {
+                labels: labels,
+                datasets: [{
+                    label: 'Actions',
+                    data: data,
+                    backgroundColor: colorRange,
+                    borderColor: colorRange,
+                    borderWidth: 1,
+                    borderRadius: 4,
+                    barThickness: 24,
+                }]
+            },
+            options: {
+                indexAxis: 'y',
+                ...commonOptions,
+                plugins: {
+                    ...commonOptions.plugins,
+                    tooltip: {
+                        ...commonOptions.plugins.tooltip,
+                        callbacks: {
+                            label: function (context) {
+                                return `Actions: ${formatNumber(context.parsed.x)}`;
+                            }
+                        }
+                    }
+                },
+                scales: {
+                    x: {
+                        beginAtZero: true,
+                        grid: gridConfig,
+                        ticks: ticksConfig,
+                    },
+                    y: {
+                        grid: { display: false },
+                        ticks: {
+                            color: TEXT_COLORS.primary,
+                            font: { size: 12 },
+                            padding: 8,
+                        }
+                    }
+                },
+                animation: {
+                    duration: 500,
+                    easing: 'easeOutQuart',
+                }
+            }
+        });
+
+        console.log('Moderator workload chart initialized');
+    }
+
+    /**
+     * Initialize all moderation analytics charts.
+     */
+    function init() {
+        const dataElement = document.getElementById('moderationAnalyticsChartData');
+        if (!dataElement) {
+            console.log('Moderation analytics chart data not found on this page');
+            return;
+        }
+
+        try {
+            const chartData = JSON.parse(dataElement.textContent);
+
+            if (chartData.trends && chartData.trends.length > 0) {
+                initModerationTrendsChart(chartData.trends);
+            }
+
+            if (chartData.distribution) {
+                initCaseDistributionChart(chartData.distribution);
+            }
+
+            if (chartData.workload && chartData.workload.length > 0) {
+                initModeratorWorkloadChart(chartData.workload);
+            }
+
+            console.log('Moderation analytics charts initialized');
+
+        } catch (error) {
+            console.error('Failed to initialize moderation analytics charts:', error);
+        }
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+
+})();

--- a/src/DiscordBot.Bot/wwwroot/js/server-analytics.js
+++ b/src/DiscordBot.Bot/wwwroot/js/server-analytics.js
@@ -1,0 +1,423 @@
+// server-analytics.js
+// Server analytics dashboard with Chart.js visualizations for guild activity metrics
+
+(function () {
+    'use strict';
+
+    /**
+     * Gets a CSS custom property value from the :root element
+     * @param {string} name - The property name (without --color- prefix)
+     * @returns {string} The computed color value
+     */
+    function getDesignToken(name) {
+        return getComputedStyle(document.documentElement)
+            .getPropertyValue(`--color-${name}`).trim();
+    }
+
+    /**
+     * Initialize design system colors from CSS custom properties
+     */
+    function initColors() {
+        return {
+            accentOrange: getDesignToken('accent-orange') || '#cb4e1b',
+            accentBlue: getDesignToken('accent-blue') || '#098ecf',
+            success: getDesignToken('success') || '#10b981',
+            warning: getDesignToken('warning') || '#f59e0b',
+            info: getDesignToken('info') || '#06b6d4',
+            error: getDesignToken('error') || '#ef4444',
+            bgPrimary: getDesignToken('bg-primary') || '#1d2022',
+            bgSecondary: getDesignToken('bg-secondary') || '#262a2d',
+            bgTertiary: getDesignToken('bg-tertiary') || '#2f3336',
+            textPrimary: getDesignToken('text-primary') || '#d7d3d0',
+            textSecondary: getDesignToken('text-secondary') || '#a8a5a3',
+            textTertiary: getDesignToken('text-tertiary') || '#7a7876',
+            borderPrimary: getDesignToken('border-primary') || '#3f4447',
+        };
+    }
+
+    let colors = initColors();
+
+    const CHART_COLORS = [
+        colors.accentOrange,
+        colors.accentBlue,
+        colors.success,
+        colors.warning,
+        colors.info,
+        colors.error,
+        '#8b5cf6',
+        '#ec4899',
+        '#14b8a6',
+        '#6366f1',
+    ];
+
+    const BG_COLORS = {
+        primary: colors.bgPrimary,
+        secondary: colors.bgSecondary,
+        tertiary: colors.bgTertiary,
+    };
+
+    const TEXT_COLORS = {
+        primary: colors.textPrimary,
+        secondary: colors.textSecondary,
+        tertiary: colors.textTertiary,
+    };
+
+    const BORDER_COLOR = colors.borderPrimary;
+
+    // Chart instance references
+    let activityTimeSeriesChart = null;
+    let topChannelsChart = null;
+
+    const commonOptions = {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+            legend: {
+                display: false,
+            },
+            tooltip: {
+                backgroundColor: BG_COLORS.tertiary,
+                titleColor: TEXT_COLORS.primary,
+                bodyColor: TEXT_COLORS.secondary,
+                borderColor: BORDER_COLOR,
+                borderWidth: 1,
+                padding: 12,
+                cornerRadius: 6,
+            },
+        },
+    };
+
+    const gridConfig = {
+        color: 'rgba(63, 68, 71, 0.5)',
+        drawBorder: false,
+    };
+
+    const ticksConfig = {
+        color: TEXT_COLORS.tertiary,
+        font: {
+            size: 12,
+        },
+    };
+
+    function formatNumber(num) {
+        return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+    }
+
+    function formatDate(dateStr) {
+        const date = new Date(dateStr);
+        const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+            'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+        return `${monthNames[date.getMonth()]} ${date.getDate()}`;
+    }
+
+    /**
+     * Initializes the Activity Time Series chart.
+     * @param {Array} timeSeriesData - Array of {date, messages, activeMembers, activeChannels} objects
+     */
+    function initActivityTimeSeriesChart(timeSeriesData) {
+        const canvas = document.getElementById('activityTimeSeriesChart');
+        if (!canvas || !timeSeriesData || timeSeriesData.length === 0) {
+            return;
+        }
+
+        const ctx = canvas.getContext('2d');
+        const labels = timeSeriesData.map(item => formatDate(item.date));
+        const messagesData = timeSeriesData.map(item => item.messages);
+        const activeMembersData = timeSeriesData.map(item => item.activeMembers);
+
+        const messagesGradient = ctx.createLinearGradient(0, 0, 0, 300);
+        messagesGradient.addColorStop(0, 'rgba(9, 142, 207, 0.3)');
+        messagesGradient.addColorStop(1, 'rgba(9, 142, 207, 0.0)');
+
+        activityTimeSeriesChart = new Chart(ctx, {
+            type: 'line',
+            data: {
+                labels: labels,
+                datasets: [
+                    {
+                        label: 'Messages',
+                        data: messagesData,
+                        borderColor: CHART_COLORS[1],
+                        backgroundColor: messagesGradient,
+                        borderWidth: 2,
+                        fill: true,
+                        tension: 0.3,
+                        pointRadius: 4,
+                        pointBackgroundColor: CHART_COLORS[1],
+                        pointBorderColor: BG_COLORS.primary,
+                        pointBorderWidth: 2,
+                        pointHoverRadius: 6,
+                        yAxisID: 'y',
+                    },
+                    {
+                        label: 'Active Members',
+                        data: activeMembersData,
+                        borderColor: CHART_COLORS[2],
+                        backgroundColor: 'transparent',
+                        borderWidth: 2,
+                        fill: false,
+                        tension: 0.3,
+                        pointRadius: 3,
+                        pointBackgroundColor: CHART_COLORS[2],
+                        pointBorderColor: BG_COLORS.primary,
+                        pointBorderWidth: 2,
+                        pointHoverRadius: 5,
+                        yAxisID: 'y1',
+                    }
+                ]
+            },
+            options: {
+                ...commonOptions,
+                plugins: {
+                    ...commonOptions.plugins,
+                    legend: {
+                        display: true,
+                        position: 'bottom',
+                        labels: {
+                            color: TEXT_COLORS.primary,
+                            padding: 16,
+                            font: { size: 12 },
+                            usePointStyle: true,
+                        }
+                    },
+                    tooltip: {
+                        ...commonOptions.plugins.tooltip,
+                        callbacks: {
+                            title: function (context) {
+                                return timeSeriesData[context[0].dataIndex].date;
+                            },
+                            label: function (context) {
+                                return `${context.dataset.label}: ${formatNumber(context.parsed.y)}`;
+                            }
+                        }
+                    }
+                },
+                scales: {
+                    x: {
+                        grid: gridConfig,
+                        ticks: ticksConfig,
+                    },
+                    y: {
+                        type: 'linear',
+                        display: true,
+                        position: 'left',
+                        beginAtZero: true,
+                        grid: gridConfig,
+                        ticks: {
+                            ...ticksConfig,
+                            callback: function (value) {
+                                if (value >= 1000) return (value / 1000).toFixed(1) + 'k';
+                                return value;
+                            }
+                        },
+                        title: {
+                            display: true,
+                            text: 'Messages',
+                            color: TEXT_COLORS.secondary,
+                        }
+                    },
+                    y1: {
+                        type: 'linear',
+                        display: true,
+                        position: 'right',
+                        beginAtZero: true,
+                        grid: {
+                            drawOnChartArea: false,
+                        },
+                        ticks: ticksConfig,
+                        title: {
+                            display: true,
+                            text: 'Active Members',
+                            color: TEXT_COLORS.secondary,
+                        }
+                    }
+                },
+                interaction: {
+                    intersect: false,
+                    mode: 'index',
+                }
+            }
+        });
+
+        console.log('Activity time series chart initialized');
+    }
+
+    /**
+     * Initializes the Top Channels horizontal bar chart.
+     * @param {Array} channelsData - Array of {channelName, messageCount} objects
+     */
+    function initTopChannelsChart(channelsData) {
+        const canvas = document.getElementById('topChannelsChart');
+        if (!canvas || !channelsData || channelsData.length === 0) {
+            return;
+        }
+
+        const ctx = canvas.getContext('2d');
+        const labels = channelsData.map(item => '#' + item.channelName);
+        const data = channelsData.map(item => item.messageCount);
+
+        const colors = labels.map((_, index) => CHART_COLORS[index % CHART_COLORS.length]);
+
+        topChannelsChart = new Chart(ctx, {
+            type: 'bar',
+            data: {
+                labels: labels,
+                datasets: [{
+                    label: 'Messages',
+                    data: data,
+                    backgroundColor: colors,
+                    borderColor: colors,
+                    borderWidth: 1,
+                    borderRadius: 4,
+                    barThickness: 24,
+                }]
+            },
+            options: {
+                indexAxis: 'y',
+                ...commonOptions,
+                plugins: {
+                    ...commonOptions.plugins,
+                    tooltip: {
+                        ...commonOptions.plugins.tooltip,
+                        callbacks: {
+                            label: function (context) {
+                                return `Messages: ${formatNumber(context.parsed.x)}`;
+                            }
+                        }
+                    }
+                },
+                scales: {
+                    x: {
+                        beginAtZero: true,
+                        grid: gridConfig,
+                        ticks: {
+                            ...ticksConfig,
+                            callback: function (value) {
+                                if (value >= 1000) return (value / 1000).toFixed(1) + 'k';
+                                return value;
+                            }
+                        },
+                    },
+                    y: {
+                        grid: { display: false },
+                        ticks: {
+                            color: TEXT_COLORS.primary,
+                            font: { size: 12 },
+                            padding: 8,
+                        }
+                    }
+                },
+                animation: {
+                    duration: 500,
+                    easing: 'easeOutQuart',
+                }
+            }
+        });
+
+        console.log('Top channels chart initialized');
+    }
+
+    /**
+     * Renders the activity heatmap.
+     * @param {Array} heatmapData - Array of {dayOfWeek, hour, messageCount} objects
+     */
+    function renderActivityHeatmap(heatmapData) {
+        const container = document.getElementById('activityHeatmap');
+        if (!container || !heatmapData || heatmapData.length === 0) {
+            return;
+        }
+
+        const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+        const hours = Array.from({ length: 24 }, (_, i) => i);
+
+        const dataMap = new Map();
+        let maxCount = 0;
+        heatmapData.forEach(item => {
+            const key = `${item.dayOfWeek}-${item.hour}`;
+            dataMap.set(key, item.messageCount);
+            maxCount = Math.max(maxCount, item.messageCount);
+        });
+
+        let html = '<div class="text-xs text-text-tertiary mb-3">Message activity by day and hour (UTC)</div>';
+        html += '<div style="display: grid; grid-template-columns: 40px repeat(24, 16px); gap: 2px; font-size: 11px;">';
+
+        html += '<div></div>';
+        hours.forEach(hour => {
+            html += `<div style="text-align: center; color: var(--text-tertiary);">${hour % 6 === 0 ? hour : ''}</div>`;
+        });
+
+        days.forEach((day, dayIndex) => {
+            html += `<div style="color: var(--text-secondary); font-weight: 500; line-height: 16px;">${day}</div>`;
+            hours.forEach(hour => {
+                const key = `${dayIndex}-${hour}`;
+                const count = dataMap.get(key) || 0;
+                const intensity = maxCount > 0 ? count / maxCount : 0;
+                const bgColor = getHeatmapColor(intensity);
+                const title = `${day} ${hour}:00 - ${formatNumber(count)} messages`;
+                html += `<div style="width: 16px; height: 16px; border-radius: 2px; background-color: ${bgColor}; cursor: pointer;" title="${title}"></div>`;
+            });
+        });
+
+        html += '</div>';
+
+        html += '<div class="flex items-center gap-2 mt-4 text-xs text-text-tertiary">';
+        html += '<span>Less</span>';
+        for (let i = 0; i <= 4; i++) {
+            const intensity = i / 4;
+            const bgColor = getHeatmapColor(intensity);
+            html += `<div class="w-4 h-4 rounded-sm" style="background-color: ${bgColor};"></div>`;
+        }
+        html += '<span>More</span>';
+        html += '</div>';
+
+        container.innerHTML = html;
+        console.log('Activity heatmap rendered');
+    }
+
+    function getHeatmapColor(intensity) {
+        if (intensity === 0) return '#2f3336';
+        if (intensity < 0.25) return 'rgba(9, 142, 207, 0.2)';
+        if (intensity < 0.5) return 'rgba(9, 142, 207, 0.4)';
+        if (intensity < 0.75) return 'rgba(9, 142, 207, 0.6)';
+        return 'rgba(9, 142, 207, 0.8)';
+    }
+
+    /**
+     * Initialize all server analytics charts.
+     */
+    function init() {
+        const dataElement = document.getElementById('serverAnalyticsChartData');
+        if (!dataElement) {
+            console.log('Server analytics chart data not found on this page');
+            return;
+        }
+
+        try {
+            const chartData = JSON.parse(dataElement.textContent);
+
+            if (chartData.timeSeries && chartData.timeSeries.length > 0) {
+                initActivityTimeSeriesChart(chartData.timeSeries);
+            }
+
+            if (chartData.heatmap && chartData.heatmap.length > 0) {
+                renderActivityHeatmap(chartData.heatmap);
+            }
+
+            if (chartData.topChannels && chartData.topChannels.length > 0) {
+                initTopChannelsChart(chartData.topChannels);
+            }
+
+            console.log('Server analytics charts initialized');
+
+        } catch (error) {
+            console.error('Failed to initialize server analytics charts:', error);
+        }
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+
+})();

--- a/src/DiscordBot.Core/DTOs/EngagementAnalyticsDtos.cs
+++ b/src/DiscordBot.Core/DTOs/EngagementAnalyticsDtos.cs
@@ -1,0 +1,124 @@
+namespace DiscordBot.Core.DTOs;
+
+/// <summary>
+/// Summary metrics for engagement analytics dashboard.
+/// </summary>
+public record EngagementAnalyticsSummaryDto
+{
+    /// <summary>
+    /// Total number of messages in the time period.
+    /// </summary>
+    public long TotalMessages { get; init; }
+
+    /// <summary>
+    /// Number of messages sent in the last 24 hours.
+    /// </summary>
+    public long Messages24h { get; init; }
+
+    /// <summary>
+    /// Number of messages sent in the last 7 days.
+    /// </summary>
+    public long Messages7d { get; init; }
+
+    /// <summary>
+    /// Average number of messages per day in the time period.
+    /// </summary>
+    public decimal MessagesPerDay { get; init; }
+
+    /// <summary>
+    /// Number of members who have sent at least one message in the time period.
+    /// </summary>
+    public int ActiveMembers { get; init; }
+
+    /// <summary>
+    /// Number of members who joined in the last 7 days.
+    /// </summary>
+    public int NewMembers7d { get; init; }
+
+    /// <summary>
+    /// Percentage of new members who sent at least one message within 7 days of joining.
+    /// </summary>
+    public decimal NewMemberRetentionRate { get; init; }
+
+    /// <summary>
+    /// Total number of reactions added to messages (placeholder - not currently tracked).
+    /// </summary>
+    public long ReactionCount { get; init; }
+
+    /// <summary>
+    /// Total minutes spent in voice channels (placeholder - not currently tracked).
+    /// </summary>
+    public long VoiceMinutes { get; init; }
+}
+
+/// <summary>
+/// Time series data point for message trends over time.
+/// </summary>
+public record MessageTrendDto
+{
+    /// <summary>
+    /// Date for this data point (day-level granularity).
+    /// </summary>
+    public DateTime Date { get; init; }
+
+    /// <summary>
+    /// Total number of messages on this date.
+    /// </summary>
+    public long MessageCount { get; init; }
+
+    /// <summary>
+    /// Number of unique authors who posted messages on this date.
+    /// </summary>
+    public int UniqueAuthors { get; init; }
+
+    /// <summary>
+    /// Average message length (in characters) on this date.
+    /// </summary>
+    public decimal AvgMessageLength { get; init; }
+}
+
+/// <summary>
+/// Retention metrics for new members showing engagement patterns.
+/// </summary>
+public record NewMemberRetentionDto
+{
+    /// <summary>
+    /// Date when members joined (grouped by day).
+    /// </summary>
+    public DateTime JoinDate { get; init; }
+
+    /// <summary>
+    /// Number of members who joined on this date.
+    /// </summary>
+    public int NewMembers { get; init; }
+
+    /// <summary>
+    /// Number of new members who sent their first message within 24 hours.
+    /// </summary>
+    public int SentFirstMessage { get; init; }
+
+    /// <summary>
+    /// Number of new members still active 7 days after joining.
+    /// </summary>
+    public int StillActive7d { get; init; }
+
+    /// <summary>
+    /// Number of new members still active 30 days after joining.
+    /// </summary>
+    public int StillActive30d { get; init; }
+
+    /// <summary>
+    /// Percentage of new members who sent their first message within 24 hours.
+    /// </summary>
+    public decimal FirstMessageRate { get; init; }
+
+    /// <summary>
+    /// Percentage of new members still active after 7 days.
+    /// </summary>
+    public decimal Retention7dRate { get; init; }
+
+    /// <summary>
+    /// Percentage of new members still active after 30 days.
+    /// </summary>
+    public decimal Retention30dRate { get; init; }
+}

--- a/src/DiscordBot.Core/DTOs/ModerationAnalyticsDtos.cs
+++ b/src/DiscordBot.Core/DTOs/ModerationAnalyticsDtos.cs
@@ -1,0 +1,241 @@
+namespace DiscordBot.Core.DTOs;
+
+/// <summary>
+/// Summary metrics for moderation analytics dashboard.
+/// </summary>
+public record ModerationAnalyticsSummaryDto
+{
+    /// <summary>
+    /// Total number of moderation cases in the time period.
+    /// </summary>
+    public int TotalCases { get; init; }
+
+    /// <summary>
+    /// Number of warning cases.
+    /// </summary>
+    public int WarnCount { get; init; }
+
+    /// <summary>
+    /// Number of mute/timeout cases.
+    /// </summary>
+    public int MuteCount { get; init; }
+
+    /// <summary>
+    /// Number of kick cases.
+    /// </summary>
+    public int KickCount { get; init; }
+
+    /// <summary>
+    /// Number of ban cases.
+    /// </summary>
+    public int BanCount { get; init; }
+
+    /// <summary>
+    /// Number of note-only cases (no punitive action).
+    /// </summary>
+    public int NoteCount { get; init; }
+
+    /// <summary>
+    /// Number of moderation cases in the last 24 hours.
+    /// </summary>
+    public int Cases24h { get; init; }
+
+    /// <summary>
+    /// Number of moderation cases in the last 7 days.
+    /// </summary>
+    public int Cases7d { get; init; }
+
+    /// <summary>
+    /// Average number of cases per day in the time period.
+    /// </summary>
+    public decimal CasesPerDay { get; init; }
+
+    /// <summary>
+    /// Percentage change in case volume compared to the previous period of equal length.
+    /// </summary>
+    public decimal ChangeFromPreviousPeriod { get; init; }
+}
+
+/// <summary>
+/// Time series data point for moderation trends over time.
+/// </summary>
+public record ModerationTrendDto
+{
+    /// <summary>
+    /// Date for this data point (day-level granularity).
+    /// </summary>
+    public DateTime Date { get; init; }
+
+    /// <summary>
+    /// Total number of moderation cases on this date.
+    /// </summary>
+    public int TotalCases { get; init; }
+
+    /// <summary>
+    /// Number of warnings on this date.
+    /// </summary>
+    public int WarnCount { get; init; }
+
+    /// <summary>
+    /// Number of mutes on this date.
+    /// </summary>
+    public int MuteCount { get; init; }
+
+    /// <summary>
+    /// Number of kicks on this date.
+    /// </summary>
+    public int KickCount { get; init; }
+
+    /// <summary>
+    /// Number of bans on this date.
+    /// </summary>
+    public int BanCount { get; init; }
+}
+
+/// <summary>
+/// Metrics for users with multiple moderation cases (repeat offenders).
+/// </summary>
+public record RepeatOffenderDto
+{
+    /// <summary>
+    /// Discord user snowflake ID.
+    /// </summary>
+    public ulong UserId { get; init; }
+
+    /// <summary>
+    /// Username (populated by service layer).
+    /// </summary>
+    public string Username { get; init; } = string.Empty;
+
+    /// <summary>
+    /// URL to user's Discord avatar.
+    /// </summary>
+    public string? AvatarUrl { get; init; }
+
+    /// <summary>
+    /// Total number of moderation cases for this user.
+    /// </summary>
+    public int TotalCases { get; init; }
+
+    /// <summary>
+    /// Number of warnings received.
+    /// </summary>
+    public int WarnCount { get; init; }
+
+    /// <summary>
+    /// Number of mutes received.
+    /// </summary>
+    public int MuteCount { get; init; }
+
+    /// <summary>
+    /// Number of kicks received.
+    /// </summary>
+    public int KickCount { get; init; }
+
+    /// <summary>
+    /// Number of bans received.
+    /// </summary>
+    public int BanCount { get; init; }
+
+    /// <summary>
+    /// Date of the user's first moderation case.
+    /// </summary>
+    public DateTime FirstIncident { get; init; }
+
+    /// <summary>
+    /// Date of the user's most recent moderation case.
+    /// </summary>
+    public DateTime LastIncident { get; init; }
+
+    /// <summary>
+    /// Escalation path showing progression of punishments (e.g., ["Warn", "Mute", "Kick", "Ban"]).
+    /// </summary>
+    public IReadOnlyList<string> EscalationPath { get; init; } = [];
+}
+
+/// <summary>
+/// Workload metrics for moderators showing action distribution.
+/// </summary>
+public record ModeratorWorkloadDto
+{
+    /// <summary>
+    /// Discord user snowflake ID of the moderator.
+    /// </summary>
+    public ulong ModeratorId { get; init; }
+
+    /// <summary>
+    /// Moderator username (populated by service layer).
+    /// </summary>
+    public string ModeratorUsername { get; init; } = string.Empty;
+
+    /// <summary>
+    /// URL to moderator's Discord avatar.
+    /// </summary>
+    public string? AvatarUrl { get; init; }
+
+    /// <summary>
+    /// Total number of moderation actions performed.
+    /// </summary>
+    public int TotalActions { get; init; }
+
+    /// <summary>
+    /// Number of warnings issued.
+    /// </summary>
+    public int WarnCount { get; init; }
+
+    /// <summary>
+    /// Number of mutes issued.
+    /// </summary>
+    public int MuteCount { get; init; }
+
+    /// <summary>
+    /// Number of kicks performed.
+    /// </summary>
+    public int KickCount { get; init; }
+
+    /// <summary>
+    /// Number of bans issued.
+    /// </summary>
+    public int BanCount { get; init; }
+
+    /// <summary>
+    /// Percentage of total moderation actions performed by this moderator.
+    /// </summary>
+    public decimal Percentage { get; init; }
+}
+
+/// <summary>
+/// Distribution of moderation case types for pie chart display.
+/// </summary>
+public record CaseTypeDistributionDto
+{
+    /// <summary>
+    /// Number of warning cases.
+    /// </summary>
+    public int WarnCount { get; init; }
+
+    /// <summary>
+    /// Number of mute cases.
+    /// </summary>
+    public int MuteCount { get; init; }
+
+    /// <summary>
+    /// Number of kick cases.
+    /// </summary>
+    public int KickCount { get; init; }
+
+    /// <summary>
+    /// Number of ban cases.
+    /// </summary>
+    public int BanCount { get; init; }
+
+    /// <summary>
+    /// Number of note-only cases.
+    /// </summary>
+    public int NoteCount { get; init; }
+
+    /// <summary>
+    /// Total number of all cases.
+    /// </summary>
+    public int Total { get; init; }
+}

--- a/src/DiscordBot.Core/DTOs/ServerAnalyticsDtos.cs
+++ b/src/DiscordBot.Core/DTOs/ServerAnalyticsDtos.cs
@@ -1,0 +1,145 @@
+namespace DiscordBot.Core.DTOs;
+
+/// <summary>
+/// Summary metrics for server activity analytics dashboard.
+/// </summary>
+public record ServerAnalyticsSummaryDto
+{
+    /// <summary>
+    /// Total number of members in the guild.
+    /// </summary>
+    public int TotalMembers { get; init; }
+
+    /// <summary>
+    /// Number of members currently online.
+    /// </summary>
+    public int OnlineMembers { get; init; }
+
+    /// <summary>
+    /// Number of members who posted messages in the last 24 hours.
+    /// </summary>
+    public int ActiveMembers24h { get; init; }
+
+    /// <summary>
+    /// Number of members who posted messages in the last 7 days.
+    /// </summary>
+    public int ActiveMembers7d { get; init; }
+
+    /// <summary>
+    /// Number of members who posted messages in the last 30 days.
+    /// </summary>
+    public int ActiveMembers30d { get; init; }
+
+    /// <summary>
+    /// Total messages sent in the last 24 hours.
+    /// </summary>
+    public long Messages24h { get; init; }
+
+    /// <summary>
+    /// Total messages sent in the last 7 days.
+    /// </summary>
+    public long Messages7d { get; init; }
+
+    /// <summary>
+    /// Net change in member count over the last 7 days (positive or negative).
+    /// </summary>
+    public int MemberGrowth7d { get; init; }
+
+    /// <summary>
+    /// Percentage change in member count over the last 7 days.
+    /// </summary>
+    public decimal MemberGrowthPercent { get; init; }
+
+    /// <summary>
+    /// Number of channels with at least one message in the time period.
+    /// </summary>
+    public int ActiveChannels { get; init; }
+}
+
+/// <summary>
+/// Time series data point for activity trends over time.
+/// </summary>
+public record ActivityTimeSeriesDto
+{
+    /// <summary>
+    /// Date for this data point (day-level granularity).
+    /// </summary>
+    public DateTime Date { get; init; }
+
+    /// <summary>
+    /// Total number of messages on this date.
+    /// </summary>
+    public long MessageCount { get; init; }
+
+    /// <summary>
+    /// Number of unique members who posted on this date.
+    /// </summary>
+    public int ActiveMembers { get; init; }
+
+    /// <summary>
+    /// Number of unique channels with messages on this date.
+    /// </summary>
+    public int ActiveChannels { get; init; }
+}
+
+/// <summary>
+/// Heatmap data point showing message activity by day of week and hour.
+/// </summary>
+public record ServerActivityHeatmapDto
+{
+    /// <summary>
+    /// Day of the week (0=Sunday through 6=Saturday).
+    /// </summary>
+    public int DayOfWeek { get; init; }
+
+    /// <summary>
+    /// Hour of the day (0-23).
+    /// </summary>
+    public int Hour { get; init; }
+
+    /// <summary>
+    /// Number of messages sent during this day/hour combination.
+    /// </summary>
+    public long MessageCount { get; init; }
+}
+
+/// <summary>
+/// Top contributor metrics for leaderboard display.
+/// </summary>
+public record TopContributorDto
+{
+    /// <summary>
+    /// Discord user snowflake ID.
+    /// </summary>
+    public ulong UserId { get; init; }
+
+    /// <summary>
+    /// Username (populated by service layer).
+    /// </summary>
+    public string Username { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Display name or nickname (if set).
+    /// </summary>
+    public string? DisplayName { get; init; }
+
+    /// <summary>
+    /// URL to user's Discord avatar.
+    /// </summary>
+    public string? AvatarUrl { get; init; }
+
+    /// <summary>
+    /// Total number of messages sent by this user in the time period.
+    /// </summary>
+    public long MessageCount { get; init; }
+
+    /// <summary>
+    /// Number of unique channels this user posted in.
+    /// </summary>
+    public int UniqueChannels { get; init; }
+
+    /// <summary>
+    /// Timestamp of the user's most recent message.
+    /// </summary>
+    public DateTime LastActive { get; init; }
+}

--- a/src/DiscordBot.Core/Interfaces/IEngagementAnalyticsService.cs
+++ b/src/DiscordBot.Core/Interfaces/IEngagementAnalyticsService.cs
@@ -1,0 +1,39 @@
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Core.Interfaces;
+
+/// <summary>
+/// Service for generating engagement analytics and member retention metrics.
+/// </summary>
+public interface IEngagementAnalyticsService
+{
+    /// <summary>
+    /// Gets summary metrics for engagement including message volume, active members, and retention.
+    /// </summary>
+    /// <param name="guildId">Discord guild snowflake ID.</param>
+    /// <param name="start">Start of the time period (inclusive).</param>
+    /// <param name="end">End of the time period (inclusive).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Summary metrics for the specified time period.</returns>
+    Task<EngagementAnalyticsSummaryDto> GetSummaryAsync(ulong guildId, DateTime start, DateTime end, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets time series data for message trends including counts, unique authors, and average length.
+    /// </summary>
+    /// <param name="guildId">Discord guild snowflake ID.</param>
+    /// <param name="start">Start of the time period (inclusive).</param>
+    /// <param name="end">End of the time period (inclusive).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Daily message trend data points for the specified time period.</returns>
+    Task<IReadOnlyList<MessageTrendDto>> GetMessageTrendsAsync(ulong guildId, DateTime start, DateTime end, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets new member retention metrics showing engagement patterns after joining.
+    /// </summary>
+    /// <param name="guildId">Discord guild snowflake ID.</param>
+    /// <param name="start">Start of the time period (inclusive).</param>
+    /// <param name="end">End of the time period (inclusive).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Daily retention metrics for members who joined in the time period.</returns>
+    Task<IReadOnlyList<NewMemberRetentionDto>> GetNewMemberRetentionAsync(ulong guildId, DateTime start, DateTime end, CancellationToken ct = default);
+}

--- a/src/DiscordBot.Core/Interfaces/IModerationAnalyticsService.cs
+++ b/src/DiscordBot.Core/Interfaces/IModerationAnalyticsService.cs
@@ -1,0 +1,61 @@
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Core.Interfaces;
+
+/// <summary>
+/// Service for generating moderation analytics and metrics.
+/// </summary>
+public interface IModerationAnalyticsService
+{
+    /// <summary>
+    /// Gets summary metrics for moderation activity including case counts and trends.
+    /// </summary>
+    /// <param name="guildId">Discord guild snowflake ID.</param>
+    /// <param name="start">Start of the time period (inclusive).</param>
+    /// <param name="end">End of the time period (inclusive).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Summary metrics for the specified time period.</returns>
+    Task<ModerationAnalyticsSummaryDto> GetSummaryAsync(ulong guildId, DateTime start, DateTime end, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets time series data for moderation trends showing case counts by type over time.
+    /// </summary>
+    /// <param name="guildId">Discord guild snowflake ID.</param>
+    /// <param name="start">Start of the time period (inclusive).</param>
+    /// <param name="end">End of the time period (inclusive).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Daily moderation trend data points for the specified time period.</returns>
+    Task<IReadOnlyList<ModerationTrendDto>> GetTrendsAsync(ulong guildId, DateTime start, DateTime end, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets repeat offenders with multiple moderation cases, showing escalation patterns.
+    /// </summary>
+    /// <param name="guildId">Discord guild snowflake ID.</param>
+    /// <param name="start">Start of the time period (inclusive).</param>
+    /// <param name="end">End of the time period (inclusive).</param>
+    /// <param name="limit">Maximum number of offenders to return (default: 10).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Top repeat offenders with case counts and escalation history.</returns>
+    Task<IReadOnlyList<RepeatOffenderDto>> GetRepeatOffendersAsync(ulong guildId, DateTime start, DateTime end, int limit = 10, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets moderator workload distribution showing action counts by moderator.
+    /// </summary>
+    /// <param name="guildId">Discord guild snowflake ID.</param>
+    /// <param name="start">Start of the time period (inclusive).</param>
+    /// <param name="end">End of the time period (inclusive).</param>
+    /// <param name="limit">Maximum number of moderators to return (default: 10).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Moderator workload metrics showing action distribution.</returns>
+    Task<IReadOnlyList<ModeratorWorkloadDto>> GetModeratorWorkloadAsync(ulong guildId, DateTime start, DateTime end, int limit = 10, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets distribution of moderation case types for the specified time period.
+    /// </summary>
+    /// <param name="guildId">Discord guild snowflake ID.</param>
+    /// <param name="start">Start of the time period (inclusive).</param>
+    /// <param name="end">End of the time period (inclusive).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Case type distribution metrics.</returns>
+    Task<CaseTypeDistributionDto> GetCaseDistributionAsync(ulong guildId, DateTime start, DateTime end, CancellationToken ct = default);
+}

--- a/src/DiscordBot.Core/Interfaces/IServerAnalyticsService.cs
+++ b/src/DiscordBot.Core/Interfaces/IServerAnalyticsService.cs
@@ -1,0 +1,50 @@
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Core.Interfaces;
+
+/// <summary>
+/// Service for generating server activity analytics and metrics.
+/// </summary>
+public interface IServerAnalyticsService
+{
+    /// <summary>
+    /// Gets summary metrics for server activity including member counts, message volume, and growth.
+    /// </summary>
+    /// <param name="guildId">Discord guild snowflake ID.</param>
+    /// <param name="start">Start of the time period (inclusive).</param>
+    /// <param name="end">End of the time period (inclusive).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Summary metrics for the specified time period.</returns>
+    Task<ServerAnalyticsSummaryDto> GetSummaryAsync(ulong guildId, DateTime start, DateTime end, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets time series data for activity trends (messages, active members, active channels) over time.
+    /// </summary>
+    /// <param name="guildId">Discord guild snowflake ID.</param>
+    /// <param name="start">Start of the time period (inclusive).</param>
+    /// <param name="end">End of the time period (inclusive).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Daily activity data points for the specified time period.</returns>
+    Task<IReadOnlyList<ActivityTimeSeriesDto>> GetActivityTimeSeriesAsync(ulong guildId, DateTime start, DateTime end, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets heatmap data showing message activity by day of week and hour.
+    /// </summary>
+    /// <param name="guildId">Discord guild snowflake ID.</param>
+    /// <param name="start">Start of the time period (inclusive).</param>
+    /// <param name="end">End of the time period (inclusive).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Heatmap data points (day/hour combinations with message counts).</returns>
+    Task<IReadOnlyList<ServerActivityHeatmapDto>> GetActivityHeatmapAsync(ulong guildId, DateTime start, DateTime end, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets top contributors ranked by message count in the specified time period.
+    /// </summary>
+    /// <param name="guildId">Discord guild snowflake ID.</param>
+    /// <param name="start">Start of the time period (inclusive).</param>
+    /// <param name="end">End of the time period (inclusive).</param>
+    /// <param name="limit">Maximum number of contributors to return (default: 10).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Top contributors with message counts and activity metrics.</returns>
+    Task<IReadOnlyList<TopContributorDto>> GetTopContributorsAsync(ulong guildId, DateTime start, DateTime end, int limit = 10, CancellationToken ct = default);
+}

--- a/tests/DiscordBot.Tests/Services/EngagementAnalyticsServiceTests.cs
+++ b/tests/DiscordBot.Tests/Services/EngagementAnalyticsServiceTests.cs
@@ -1,0 +1,458 @@
+using DiscordBot.Bot.Services;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Entities;
+using DiscordBot.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace DiscordBot.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="EngagementAnalyticsService"/>.
+/// </summary>
+public class EngagementAnalyticsServiceTests
+{
+    private readonly Mock<IMessageLogRepository> _mockMessageLogRepository;
+    private readonly Mock<IGuildMetricsRepository> _mockGuildMetricsRepository;
+    private readonly Mock<IGuildMemberRepository> _mockGuildMemberRepository;
+    private readonly Mock<ILogger<EngagementAnalyticsService>> _mockLogger;
+    private readonly EngagementAnalyticsService _service;
+
+    public EngagementAnalyticsServiceTests()
+    {
+        _mockMessageLogRepository = new Mock<IMessageLogRepository>();
+        _mockGuildMetricsRepository = new Mock<IGuildMetricsRepository>();
+        _mockGuildMemberRepository = new Mock<IGuildMemberRepository>();
+        _mockLogger = new Mock<ILogger<EngagementAnalyticsService>>();
+        _service = new EngagementAnalyticsService(
+            _mockMessageLogRepository.Object,
+            _mockGuildMetricsRepository.Object,
+            _mockGuildMemberRepository.Object,
+            _mockLogger.Object);
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_ShouldReturnCorrectSummaryMetrics()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+        var now = DateTime.UtcNow;
+
+        var messagesByDay = new List<(DateOnly Date, long Count)>
+        {
+            (DateOnly.FromDateTime(start), 100L),
+            (DateOnly.FromDateTime(start.AddDays(1)), 150L),
+            (DateOnly.FromDateTime(start.AddDays(2)), 200L),
+            (DateOnly.FromDateTime(now.AddHours(-12)), 50L) // Last 24h
+        };
+
+        var metricsLast7d = new List<GuildMetricsSnapshot>
+        {
+            new() { GuildId = guildId, SnapshotDate = DateOnly.FromDateTime(now.AddDays(-6)),
+                    MembersJoined = 5 },
+            new() { GuildId = guildId, SnapshotDate = DateOnly.FromDateTime(now.AddDays(-3)),
+                    MembersJoined = 3 },
+            new() { GuildId = guildId, SnapshotDate = DateOnly.FromDateTime(now.AddDays(-1)),
+                    MembersJoined = 2 }
+        };
+
+        _mockMessageLogRepository
+            .Setup(r => r.GetMessagesByDayAsync(It.IsAny<int>(), guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(messagesByDay);
+
+        _mockGuildMetricsRepository
+            .Setup(r => r.GetByDateRangeAsync(guildId, It.IsAny<DateOnly>(), It.IsAny<DateOnly>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(metricsLast7d);
+
+        // Act
+        var result = await _service.GetSummaryAsync(guildId, start, end);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.TotalMessages.Should().BeGreaterThan(0);
+        result.MessagesPerDay.Should().BeGreaterThan(0);
+        result.NewMembers7d.Should().Be(10, "5 + 3 + 2 = 10 new members");
+        result.NewMemberRetentionRate.Should().Be(0, "retention calculation is simplified");
+        result.ReactionCount.Should().Be(0, "not currently tracked");
+        result.VoiceMinutes.Should().Be(0, "not currently tracked");
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_WithNoMessages_ShouldReturnZeroValues()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+
+        _mockMessageLogRepository
+            .Setup(r => r.GetMessagesByDayAsync(It.IsAny<int>(), guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<(DateOnly Date, long Count)>());
+
+        _mockGuildMetricsRepository
+            .Setup(r => r.GetByDateRangeAsync(guildId, It.IsAny<DateOnly>(), It.IsAny<DateOnly>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<GuildMetricsSnapshot>());
+
+        // Act
+        var result = await _service.GetSummaryAsync(guildId, start, end);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.TotalMessages.Should().Be(0);
+        result.Messages24h.Should().Be(0);
+        result.Messages7d.Should().Be(0);
+        result.MessagesPerDay.Should().Be(0);
+        result.ActiveMembers.Should().Be(0);
+        result.NewMembers7d.Should().Be(0);
+        result.NewMemberRetentionRate.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_WithCancellationToken_ShouldPassToRepositories()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+        var cancellationTokenSource = new CancellationTokenSource();
+        var cancellationToken = cancellationTokenSource.Token;
+
+        _mockMessageLogRepository
+            .Setup(r => r.GetMessagesByDayAsync(It.IsAny<int>(), guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<(DateOnly Date, long Count)>());
+
+        _mockGuildMetricsRepository
+            .Setup(r => r.GetByDateRangeAsync(guildId, It.IsAny<DateOnly>(), It.IsAny<DateOnly>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<GuildMetricsSnapshot>());
+
+        // Act
+        await _service.GetSummaryAsync(guildId, start, end, cancellationToken);
+
+        // Assert
+        _mockMessageLogRepository.Verify(
+            r => r.GetMessagesByDayAsync(It.IsAny<int>(), guildId, cancellationToken),
+            Times.AtLeastOnce,
+            "cancellation token should be passed to GetMessagesByDayAsync");
+
+        _mockGuildMetricsRepository.Verify(
+            r => r.GetByDateRangeAsync(guildId, It.IsAny<DateOnly>(), It.IsAny<DateOnly>(), cancellationToken),
+            Times.AtLeastOnce,
+            "cancellation token should be passed to GetByDateRangeAsync");
+    }
+
+    [Fact]
+    public async Task GetMessageTrendsAsync_ShouldReturnDailyMessageCounts()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+
+        var messagesByDay = new List<(DateOnly Date, long Count)>
+        {
+            (DateOnly.FromDateTime(start), 100L),
+            (DateOnly.FromDateTime(start.AddDays(1)), 150L),
+            (DateOnly.FromDateTime(start.AddDays(2)), 200L),
+            (DateOnly.FromDateTime(start.AddDays(3)), 175L)
+        };
+
+        _mockMessageLogRepository
+            .Setup(r => r.GetMessagesByDayAsync(It.IsAny<int>(), guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(messagesByDay);
+
+        // Act
+        var result = await _service.GetMessageTrendsAsync(guildId, start, end);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(4, "there are 4 days with messages");
+        result[0].Date.Should().Be(start.Date);
+        result[0].MessageCount.Should().Be(100);
+        result[0].UniqueAuthors.Should().Be(0, "not calculated by simplified implementation");
+        result[0].AvgMessageLength.Should().Be(0, "not calculated by simplified implementation");
+        result[1].Date.Should().Be(start.AddDays(1).Date);
+        result[1].MessageCount.Should().Be(150);
+    }
+
+    [Fact]
+    public async Task GetMessageTrendsAsync_WithEmptyData_ShouldReturnEmptyCollection()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+
+        _mockMessageLogRepository
+            .Setup(r => r.GetMessagesByDayAsync(It.IsAny<int>(), guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<(DateOnly Date, long Count)>());
+
+        // Act
+        var result = await _service.GetMessageTrendsAsync(guildId, start, end);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeEmpty("no message data is available");
+    }
+
+    [Fact]
+    public async Task GetMessageTrendsAsync_ShouldFilterToRequestedDateRange()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 5, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 10, 23, 59, 59, DateTimeKind.Utc);
+
+        var messagesByDay = new List<(DateOnly Date, long Count)>
+        {
+            (new DateOnly(2023, 1, 1), 100L),  // Before range
+            (new DateOnly(2023, 1, 5), 150L),  // In range
+            (new DateOnly(2023, 1, 8), 200L),  // In range
+            (new DateOnly(2023, 1, 10), 175L), // In range
+            (new DateOnly(2023, 1, 15), 50L)   // After range
+        };
+
+        _mockMessageLogRepository
+            .Setup(r => r.GetMessagesByDayAsync(It.IsAny<int>(), guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(messagesByDay);
+
+        // Act
+        var result = await _service.GetMessageTrendsAsync(guildId, start, end);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(3, "only 3 dates are within the range");
+        result.Should().OnlyContain(x => x.Date >= start && x.Date <= end,
+            "all results should be within the requested date range");
+    }
+
+    [Fact]
+    public async Task GetMessageTrendsAsync_WithCancellationToken_ShouldPassToRepository()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+        var cancellationTokenSource = new CancellationTokenSource();
+        var cancellationToken = cancellationTokenSource.Token;
+
+        _mockMessageLogRepository
+            .Setup(r => r.GetMessagesByDayAsync(It.IsAny<int>(), guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<(DateOnly Date, long Count)>());
+
+        // Act
+        await _service.GetMessageTrendsAsync(guildId, start, end, cancellationToken);
+
+        // Assert
+        _mockMessageLogRepository.Verify(
+            r => r.GetMessagesByDayAsync(It.IsAny<int>(), guildId, cancellationToken),
+            Times.Once,
+            "cancellation token should be passed to repository");
+    }
+
+    [Fact]
+    public async Task GetNewMemberRetentionAsync_ShouldReturnRetentionMetrics()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+
+        var metrics = new List<GuildMetricsSnapshot>
+        {
+            new() { GuildId = guildId, SnapshotDate = DateOnly.FromDateTime(start),
+                    MembersJoined = 10, MembersLeft = 2 },
+            new() { GuildId = guildId, SnapshotDate = DateOnly.FromDateTime(start.AddDays(5)),
+                    MembersJoined = 5, MembersLeft = 1 },
+            new() { GuildId = guildId, SnapshotDate = DateOnly.FromDateTime(start.AddDays(10)),
+                    MembersJoined = 8, MembersLeft = 0 }
+        };
+
+        _mockGuildMetricsRepository
+            .Setup(r => r.GetByDateRangeAsync(guildId, DateOnly.FromDateTime(start),
+                DateOnly.FromDateTime(end), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(metrics);
+
+        // Act
+        var result = await _service.GetNewMemberRetentionAsync(guildId, start, end);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(3, "there are 3 dates with members joined");
+        result[0].JoinDate.Should().Be(start.Date);
+        result[0].NewMembers.Should().Be(10);
+        result[0].SentFirstMessage.Should().Be(0, "detailed tracking not implemented");
+        result[0].StillActive7d.Should().Be(0, "detailed tracking not implemented");
+        result[0].StillActive30d.Should().Be(0, "detailed tracking not implemented");
+        result[1].JoinDate.Should().Be(start.AddDays(5).Date);
+        result[1].NewMembers.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task GetNewMemberRetentionAsync_WithNoNewMembers_ShouldReturnEmptyCollection()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+
+        var metrics = new List<GuildMetricsSnapshot>
+        {
+            new() { GuildId = guildId, SnapshotDate = DateOnly.FromDateTime(start),
+                    MembersJoined = 0, MembersLeft = 2 },
+            new() { GuildId = guildId, SnapshotDate = DateOnly.FromDateTime(start.AddDays(5)),
+                    MembersJoined = 0, MembersLeft = 1 }
+        };
+
+        _mockGuildMetricsRepository
+            .Setup(r => r.GetByDateRangeAsync(guildId, DateOnly.FromDateTime(start),
+                DateOnly.FromDateTime(end), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(metrics);
+
+        // Act
+        var result = await _service.GetNewMemberRetentionAsync(guildId, start, end);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeEmpty("no new members joined during the period");
+    }
+
+    [Fact]
+    public async Task GetNewMemberRetentionAsync_WithEmptyData_ShouldReturnEmptyCollection()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+
+        _mockGuildMetricsRepository
+            .Setup(r => r.GetByDateRangeAsync(guildId, DateOnly.FromDateTime(start),
+                DateOnly.FromDateTime(end), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<GuildMetricsSnapshot>());
+
+        // Act
+        var result = await _service.GetNewMemberRetentionAsync(guildId, start, end);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeEmpty("no metrics data is available");
+    }
+
+    [Fact]
+    public async Task GetNewMemberRetentionAsync_WithCancellationToken_ShouldPassToRepository()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+        var cancellationTokenSource = new CancellationTokenSource();
+        var cancellationToken = cancellationTokenSource.Token;
+
+        _mockGuildMetricsRepository
+            .Setup(r => r.GetByDateRangeAsync(guildId, DateOnly.FromDateTime(start),
+                DateOnly.FromDateTime(end), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<GuildMetricsSnapshot>());
+
+        // Act
+        await _service.GetNewMemberRetentionAsync(guildId, start, end, cancellationToken);
+
+        // Assert
+        _mockGuildMetricsRepository.Verify(
+            r => r.GetByDateRangeAsync(guildId, DateOnly.FromDateTime(start),
+                DateOnly.FromDateTime(end), cancellationToken),
+            Times.Once,
+            "cancellation token should be passed to repository");
+    }
+
+    [Fact]
+    public async Task GetMessageTrendsAsync_ShouldCalculateDaySpanCorrectly()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 10, 23, 59, 59, DateTimeKind.Utc); // 10 days
+
+        var messagesByDay = new List<(DateOnly Date, long Count)>
+        {
+            (new DateOnly(2023, 1, 5), 100L)
+        };
+
+        _mockMessageLogRepository
+            .Setup(r => r.GetMessagesByDayAsync(It.IsAny<int>(), guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(messagesByDay);
+
+        // Act
+        await _service.GetMessageTrendsAsync(guildId, start, end);
+
+        // Assert
+        _mockMessageLogRepository.Verify(
+            r => r.GetMessagesByDayAsync(It.Is<int>(days => days >= 10), guildId,
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "day span should be calculated from start to end dates");
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_WithZeroDaySpan_ShouldHandleGracefully()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 1, 23, 59, 59, DateTimeKind.Utc); // Same day
+
+        _mockMessageLogRepository
+            .Setup(r => r.GetMessagesByDayAsync(It.IsAny<int>(), guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<(DateOnly Date, long Count)>());
+
+        _mockGuildMetricsRepository
+            .Setup(r => r.GetByDateRangeAsync(guildId, It.IsAny<DateOnly>(), It.IsAny<DateOnly>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<GuildMetricsSnapshot>());
+
+        // Act
+        var result = await _service.GetSummaryAsync(guildId, start, end);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.MessagesPerDay.Should().Be(0, "zero day span should result in 0 messages per day");
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_ShouldCalculateMessagesPerDayCorrectly()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 11, 0, 0, 0, DateTimeKind.Utc); // 10 days
+
+        var messagesByDay = new List<(DateOnly Date, long Count)>
+        {
+            (DateOnly.FromDateTime(start), 100L),
+            (DateOnly.FromDateTime(start.AddDays(1)), 100L),
+            (DateOnly.FromDateTime(start.AddDays(2)), 100L),
+            (DateOnly.FromDateTime(start.AddDays(3)), 100L),
+            (DateOnly.FromDateTime(start.AddDays(4)), 100L) // 500 total messages over 10 days
+        };
+
+        _mockMessageLogRepository
+            .Setup(r => r.GetMessagesByDayAsync(It.IsAny<int>(), guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(messagesByDay);
+
+        _mockGuildMetricsRepository
+            .Setup(r => r.GetByDateRangeAsync(guildId, It.IsAny<DateOnly>(), It.IsAny<DateOnly>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<GuildMetricsSnapshot>());
+
+        // Act
+        var result = await _service.GetSummaryAsync(guildId, start, end);
+
+        // Assert
+        result.TotalMessages.Should().Be(500, "sum of all messages");
+        result.MessagesPerDay.Should().Be(50, "500 messages / 10 days = 50 per day");
+    }
+}

--- a/tests/DiscordBot.Tests/Services/ModerationAnalyticsServiceTests.cs
+++ b/tests/DiscordBot.Tests/Services/ModerationAnalyticsServiceTests.cs
@@ -1,0 +1,518 @@
+using DiscordBot.Bot.Services;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Entities;
+using DiscordBot.Core.Enums;
+using DiscordBot.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace DiscordBot.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="ModerationAnalyticsService"/>.
+/// </summary>
+public class ModerationAnalyticsServiceTests
+{
+    private readonly Mock<IModerationCaseRepository> _mockModerationCaseRepository;
+    private readonly Mock<ILogger<ModerationAnalyticsService>> _mockLogger;
+    private readonly ModerationAnalyticsService _service;
+
+    public ModerationAnalyticsServiceTests()
+    {
+        _mockModerationCaseRepository = new Mock<IModerationCaseRepository>();
+        _mockLogger = new Mock<ILogger<ModerationAnalyticsService>>();
+        _service = new ModerationAnalyticsService(
+            _mockModerationCaseRepository.Object,
+            _mockLogger.Object);
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_ShouldReturnCorrectSummaryMetrics()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+        var now = DateTime.UtcNow;
+
+        var currentPeriodCases = new List<ModerationCase>
+        {
+            new() { GuildId = guildId, Type = CaseType.Warn, CreatedAt = start.AddDays(1) },
+            new() { GuildId = guildId, Type = CaseType.Warn, CreatedAt = start.AddDays(2) },
+            new() { GuildId = guildId, Type = CaseType.Mute, CreatedAt = start.AddDays(5) },
+            new() { GuildId = guildId, Type = CaseType.Kick, CreatedAt = start.AddDays(10) },
+            new() { GuildId = guildId, Type = CaseType.Ban, CreatedAt = start.AddDays(15) },
+            new() { GuildId = guildId, Type = CaseType.Note, CreatedAt = start.AddDays(20) },
+            new() { GuildId = guildId, Type = CaseType.Warn, CreatedAt = now.AddHours(-12) }, // Last 24h
+            new() { GuildId = guildId, Type = CaseType.Mute, CreatedAt = now.AddDays(-3) }   // Last 7d
+        };
+
+        var previousPeriodCases = new List<ModerationCase>
+        {
+            new() { GuildId = guildId, Type = CaseType.Warn, CreatedAt = start.AddDays(-5) },
+            new() { GuildId = guildId, Type = CaseType.Kick, CreatedAt = start.AddDays(-10) }
+        };
+
+        _mockModerationCaseRepository
+            .Setup(r => r.GetByGuildAsync(guildId, null, null, null, start, end, 1, int.MaxValue, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((currentPeriodCases, currentPeriodCases.Count));
+
+        _mockModerationCaseRepository
+            .Setup(r => r.GetByGuildAsync(guildId, null, null, null, It.Is<DateTime>(d => d < start), start, 1, int.MaxValue,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((previousPeriodCases, previousPeriodCases.Count));
+
+        // Act
+        var result = await _service.GetSummaryAsync(guildId, start, end);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.TotalCases.Should().Be(8, "there are 8 cases in current period");
+        result.WarnCount.Should().Be(3, "there are 3 warn cases");
+        result.MuteCount.Should().Be(2, "there are 2 mute cases");
+        result.KickCount.Should().Be(1, "there is 1 kick case");
+        result.BanCount.Should().Be(1, "there is 1 ban case");
+        result.NoteCount.Should().Be(1, "there is 1 note case");
+        result.Cases24h.Should().Be(1, "1 case in last 24h");
+        result.Cases7d.Should().Be(2, "2 cases in last 7d");
+        result.CasesPerDay.Should().BeGreaterThan(0);
+        result.ChangeFromPreviousPeriod.Should().Be(300, "8 cases vs 2 previous = 300% increase");
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_WithNoCases_ShouldReturnZeroValues()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+
+        _mockModerationCaseRepository
+            .Setup(r => r.GetByGuildAsync(guildId, null, null, null, It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), 1, int.MaxValue,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new List<ModerationCase>(), 0));
+
+        // Act
+        var result = await _service.GetSummaryAsync(guildId, start, end);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.TotalCases.Should().Be(0);
+        result.WarnCount.Should().Be(0);
+        result.MuteCount.Should().Be(0);
+        result.KickCount.Should().Be(0);
+        result.BanCount.Should().Be(0);
+        result.NoteCount.Should().Be(0);
+        result.Cases24h.Should().Be(0);
+        result.Cases7d.Should().Be(0);
+        result.CasesPerDay.Should().Be(0);
+        result.ChangeFromPreviousPeriod.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_WithNoPreviousPeriodCases_ShouldReturn100PercentChange()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+
+        var currentPeriodCases = new List<ModerationCase>
+        {
+            new() { GuildId = guildId, Type = CaseType.Warn, CreatedAt = start.AddDays(1) }
+        };
+
+        _mockModerationCaseRepository
+            .Setup(r => r.GetByGuildAsync(guildId, null, null, null, start, end, 1, int.MaxValue, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((currentPeriodCases, currentPeriodCases.Count));
+
+        _mockModerationCaseRepository
+            .Setup(r => r.GetByGuildAsync(guildId, null, null, null, It.Is<DateTime?>(d => d < start), start, 1, int.MaxValue,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new List<ModerationCase>(), 0));
+
+        // Act
+        var result = await _service.GetSummaryAsync(guildId, start, end);
+
+        // Assert
+        result.ChangeFromPreviousPeriod.Should().Be(100, "0 to 1 case = 100% increase");
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_WithCancellationToken_ShouldPassToRepository()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+        var cancellationTokenSource = new CancellationTokenSource();
+        var cancellationToken = cancellationTokenSource.Token;
+
+        _mockModerationCaseRepository
+            .Setup(r => r.GetByGuildAsync(guildId, null, null, null, It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), 1, int.MaxValue,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new List<ModerationCase>(), 0));
+
+        // Act
+        await _service.GetSummaryAsync(guildId, start, end, cancellationToken);
+
+        // Assert
+        _mockModerationCaseRepository.Verify(
+            r => r.GetByGuildAsync(guildId, null, null, null, start, end, 1, int.MaxValue, cancellationToken),
+            Times.Once,
+            "cancellation token should be passed to repository for current period");
+
+        _mockModerationCaseRepository.Verify(
+            r => r.GetByGuildAsync(guildId, null, null, null, It.IsAny<DateTime?>(), start, 1, int.MaxValue, cancellationToken),
+            Times.Once,
+            "cancellation token should be passed to repository for previous period");
+    }
+
+    [Fact]
+    public async Task GetTrendsAsync_ShouldGroupCasesByDate()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+
+        var cases = new List<ModerationCase>
+        {
+            new() { GuildId = guildId, Type = CaseType.Warn, CreatedAt = new DateTime(2023, 1, 5, 10, 0, 0) },
+            new() { GuildId = guildId, Type = CaseType.Mute, CreatedAt = new DateTime(2023, 1, 5, 15, 0, 0) },
+            new() { GuildId = guildId, Type = CaseType.Kick, CreatedAt = new DateTime(2023, 1, 10, 10, 0, 0) },
+            new() { GuildId = guildId, Type = CaseType.Ban, CreatedAt = new DateTime(2023, 1, 10, 12, 0, 0) },
+            new() { GuildId = guildId, Type = CaseType.Warn, CreatedAt = new DateTime(2023, 1, 10, 14, 0, 0) }
+        };
+
+        _mockModerationCaseRepository
+            .Setup(r => r.GetByGuildAsync(guildId, null, null, null, start, end, 1, int.MaxValue, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((cases, cases.Count));
+
+        // Act
+        var result = await _service.GetTrendsAsync(guildId, start, end);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(2, "there are 2 unique dates with cases");
+
+        var jan5 = result.FirstOrDefault(x => x.Date.Day == 5);
+        jan5.Should().NotBeNull();
+        jan5!.TotalCases.Should().Be(2, "2 cases on Jan 5");
+        jan5.WarnCount.Should().Be(1);
+        jan5.MuteCount.Should().Be(1);
+        jan5.KickCount.Should().Be(0);
+        jan5.BanCount.Should().Be(0);
+
+        var jan10 = result.FirstOrDefault(x => x.Date.Day == 10);
+        jan10.Should().NotBeNull();
+        jan10!.TotalCases.Should().Be(3, "3 cases on Jan 10");
+        jan10.WarnCount.Should().Be(1);
+        jan10.KickCount.Should().Be(1);
+        jan10.BanCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetTrendsAsync_WithEmptyData_ShouldReturnEmptyCollection()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+
+        _mockModerationCaseRepository
+            .Setup(r => r.GetByGuildAsync(guildId, null, null, null, start, end, 1, int.MaxValue, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new List<ModerationCase>(), 0));
+
+        // Act
+        var result = await _service.GetTrendsAsync(guildId, start, end);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeEmpty("no cases available");
+    }
+
+    [Fact]
+    public async Task GetRepeatOffendersAsync_ShouldReturnUsersWithMultipleCases()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+
+        var cases = new List<ModerationCase>
+        {
+            // User 111 - 3 cases (repeat offender)
+            new() { GuildId = guildId, TargetUserId = 111, Type = CaseType.Warn,
+                    CreatedAt = start.AddDays(1) },
+            new() { GuildId = guildId, TargetUserId = 111, Type = CaseType.Mute,
+                    CreatedAt = start.AddDays(5) },
+            new() { GuildId = guildId, TargetUserId = 111, Type = CaseType.Kick,
+                    CreatedAt = start.AddDays(10) },
+            // User 222 - 2 cases (repeat offender)
+            new() { GuildId = guildId, TargetUserId = 222, Type = CaseType.Warn,
+                    CreatedAt = start.AddDays(2) },
+            new() { GuildId = guildId, TargetUserId = 222, Type = CaseType.Warn,
+                    CreatedAt = start.AddDays(8) },
+            // User 333 - 1 case (not a repeat offender)
+            new() { GuildId = guildId, TargetUserId = 333, Type = CaseType.Warn,
+                    CreatedAt = start.AddDays(3) }
+        };
+
+        _mockModerationCaseRepository
+            .Setup(r => r.GetByGuildAsync(guildId, null, null, null, start, end, 1, int.MaxValue, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((cases, cases.Count));
+
+        // Act
+        var result = await _service.GetRepeatOffendersAsync(guildId, start, end);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(2, "only users with 2+ cases are repeat offenders");
+
+        // User 111 should be first with 3 cases
+        result[0].UserId.Should().Be(111);
+        result[0].TotalCases.Should().Be(3);
+        result[0].WarnCount.Should().Be(1);
+        result[0].MuteCount.Should().Be(1);
+        result[0].KickCount.Should().Be(1);
+        result[0].FirstIncident.Should().Be(start.AddDays(1));
+        result[0].LastIncident.Should().Be(start.AddDays(10));
+        result[0].EscalationPath.Should().Equal("Warn", "Mute", "Kick");
+
+        // User 222 should be second with 2 cases
+        result[1].UserId.Should().Be(222);
+        result[1].TotalCases.Should().Be(2);
+        result[1].WarnCount.Should().Be(2);
+        result[1].EscalationPath.Should().Equal("Warn", "Warn");
+    }
+
+    [Fact]
+    public async Task GetRepeatOffendersAsync_WithLimit_ShouldRespectLimit()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+        var limit = 1;
+
+        var cases = new List<ModerationCase>
+        {
+            new() { GuildId = guildId, TargetUserId = 111, Type = CaseType.Warn,
+                    CreatedAt = start.AddDays(1) },
+            new() { GuildId = guildId, TargetUserId = 111, Type = CaseType.Mute,
+                    CreatedAt = start.AddDays(5) },
+            new() { GuildId = guildId, TargetUserId = 111, Type = CaseType.Kick,
+                    CreatedAt = start.AddDays(10) },
+            new() { GuildId = guildId, TargetUserId = 222, Type = CaseType.Warn,
+                    CreatedAt = start.AddDays(2) },
+            new() { GuildId = guildId, TargetUserId = 222, Type = CaseType.Warn,
+                    CreatedAt = start.AddDays(8) }
+        };
+
+        _mockModerationCaseRepository
+            .Setup(r => r.GetByGuildAsync(guildId, null, null, null, start, end, 1, int.MaxValue, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((cases, cases.Count));
+
+        // Act
+        var result = await _service.GetRepeatOffendersAsync(guildId, start, end, limit);
+
+        // Assert
+        result.Should().HaveCount(1, "limit is 1");
+        result[0].UserId.Should().Be(111, "user with most cases should be returned");
+    }
+
+    [Fact]
+    public async Task GetRepeatOffendersAsync_WithEmptyData_ShouldReturnEmptyCollection()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+
+        _mockModerationCaseRepository
+            .Setup(r => r.GetByGuildAsync(guildId, null, null, null, start, end, 1, int.MaxValue, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new List<ModerationCase>(), 0));
+
+        // Act
+        var result = await _service.GetRepeatOffendersAsync(guildId, start, end);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeEmpty("no cases available");
+    }
+
+    [Fact]
+    public async Task GetModeratorWorkloadAsync_ShouldDistributeWorkloadByModerator()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+
+        var cases = new List<ModerationCase>
+        {
+            // Moderator 111 - 5 cases (50%)
+            new() { GuildId = guildId, ModeratorUserId = 111, Type = CaseType.Warn,
+                    CreatedAt = start.AddDays(1) },
+            new() { GuildId = guildId, ModeratorUserId = 111, Type = CaseType.Warn,
+                    CreatedAt = start.AddDays(2) },
+            new() { GuildId = guildId, ModeratorUserId = 111, Type = CaseType.Mute,
+                    CreatedAt = start.AddDays(3) },
+            new() { GuildId = guildId, ModeratorUserId = 111, Type = CaseType.Kick,
+                    CreatedAt = start.AddDays(4) },
+            new() { GuildId = guildId, ModeratorUserId = 111, Type = CaseType.Ban,
+                    CreatedAt = start.AddDays(5) },
+            // Moderator 222 - 3 cases (30%)
+            new() { GuildId = guildId, ModeratorUserId = 222, Type = CaseType.Warn,
+                    CreatedAt = start.AddDays(6) },
+            new() { GuildId = guildId, ModeratorUserId = 222, Type = CaseType.Mute,
+                    CreatedAt = start.AddDays(7) },
+            new() { GuildId = guildId, ModeratorUserId = 222, Type = CaseType.Kick,
+                    CreatedAt = start.AddDays(8) },
+            // Moderator 333 - 2 cases (20%)
+            new() { GuildId = guildId, ModeratorUserId = 333, Type = CaseType.Warn,
+                    CreatedAt = start.AddDays(9) },
+            new() { GuildId = guildId, ModeratorUserId = 333, Type = CaseType.Warn,
+                    CreatedAt = start.AddDays(10) }
+        };
+
+        _mockModerationCaseRepository
+            .Setup(r => r.GetByGuildAsync(guildId, null, null, null, start, end, 1, int.MaxValue, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((cases, cases.Count));
+
+        // Act
+        var result = await _service.GetModeratorWorkloadAsync(guildId, start, end);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(3, "there are 3 moderators");
+
+        // Moderator 111 should be first with 5 actions (50%)
+        result[0].ModeratorId.Should().Be(111);
+        result[0].TotalActions.Should().Be(5);
+        result[0].WarnCount.Should().Be(2);
+        result[0].MuteCount.Should().Be(1);
+        result[0].KickCount.Should().Be(1);
+        result[0].BanCount.Should().Be(1);
+        result[0].Percentage.Should().Be(50);
+
+        // Moderator 222 should be second with 3 actions (30%)
+        result[1].ModeratorId.Should().Be(222);
+        result[1].TotalActions.Should().Be(3);
+        result[1].Percentage.Should().Be(30);
+
+        // Moderator 333 should be third with 2 actions (20%)
+        result[2].ModeratorId.Should().Be(333);
+        result[2].TotalActions.Should().Be(2);
+        result[2].Percentage.Should().Be(20);
+    }
+
+    [Fact]
+    public async Task GetModeratorWorkloadAsync_WithEmptyData_ShouldReturnEmptyCollection()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+
+        _mockModerationCaseRepository
+            .Setup(r => r.GetByGuildAsync(guildId, null, null, null, start, end, 1, int.MaxValue, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new List<ModerationCase>(), 0));
+
+        // Act
+        var result = await _service.GetModeratorWorkloadAsync(guildId, start, end);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeEmpty("no cases available");
+    }
+
+    [Fact]
+    public async Task GetCaseDistributionAsync_ShouldCountCasesByType()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+
+        var cases = new List<ModerationCase>
+        {
+            new() { GuildId = guildId, Type = CaseType.Warn, CreatedAt = start.AddDays(1) },
+            new() { GuildId = guildId, Type = CaseType.Warn, CreatedAt = start.AddDays(2) },
+            new() { GuildId = guildId, Type = CaseType.Warn, CreatedAt = start.AddDays(3) },
+            new() { GuildId = guildId, Type = CaseType.Mute, CreatedAt = start.AddDays(4) },
+            new() { GuildId = guildId, Type = CaseType.Mute, CreatedAt = start.AddDays(5) },
+            new() { GuildId = guildId, Type = CaseType.Kick, CreatedAt = start.AddDays(6) },
+            new() { GuildId = guildId, Type = CaseType.Ban, CreatedAt = start.AddDays(7) },
+            new() { GuildId = guildId, Type = CaseType.Note, CreatedAt = start.AddDays(8) },
+            new() { GuildId = guildId, Type = CaseType.Note, CreatedAt = start.AddDays(9) }
+        };
+
+        _mockModerationCaseRepository
+            .Setup(r => r.GetByGuildAsync(guildId, null, null, null, start, end, 1, int.MaxValue, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((cases, cases.Count));
+
+        // Act
+        var result = await _service.GetCaseDistributionAsync(guildId, start, end);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Total.Should().Be(9, "there are 9 total cases");
+        result.WarnCount.Should().Be(3);
+        result.MuteCount.Should().Be(2);
+        result.KickCount.Should().Be(1);
+        result.BanCount.Should().Be(1);
+        result.NoteCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetCaseDistributionAsync_WithEmptyData_ShouldReturnZeroValues()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+
+        _mockModerationCaseRepository
+            .Setup(r => r.GetByGuildAsync(guildId, null, null, null, start, end, 1, int.MaxValue, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new List<ModerationCase>(), 0));
+
+        // Act
+        var result = await _service.GetCaseDistributionAsync(guildId, start, end);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Total.Should().Be(0);
+        result.WarnCount.Should().Be(0);
+        result.MuteCount.Should().Be(0);
+        result.KickCount.Should().Be(0);
+        result.BanCount.Should().Be(0);
+        result.NoteCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetCaseDistributionAsync_WithCancellationToken_ShouldPassToRepository()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+        var cancellationTokenSource = new CancellationTokenSource();
+        var cancellationToken = cancellationTokenSource.Token;
+
+        _mockModerationCaseRepository
+            .Setup(r => r.GetByGuildAsync(guildId, null, null, null, start, end, 1, int.MaxValue, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new List<ModerationCase>(), 0));
+
+        // Act
+        await _service.GetCaseDistributionAsync(guildId, start, end, cancellationToken);
+
+        // Assert
+        _mockModerationCaseRepository.Verify(
+            r => r.GetByGuildAsync(guildId, null, null, null, start, end, 1, int.MaxValue, cancellationToken),
+            Times.Once,
+            "cancellation token should be passed to repository");
+    }
+}

--- a/tests/DiscordBot.Tests/Services/ServerAnalyticsServiceTests.cs
+++ b/tests/DiscordBot.Tests/Services/ServerAnalyticsServiceTests.cs
@@ -1,0 +1,403 @@
+using DiscordBot.Bot.Services;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Entities;
+using DiscordBot.Core.Enums;
+using DiscordBot.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace DiscordBot.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="ServerAnalyticsService"/>.
+/// </summary>
+public class ServerAnalyticsServiceTests
+{
+    private readonly Mock<IMemberActivityRepository> _mockMemberActivityRepository;
+    private readonly Mock<IChannelActivityRepository> _mockChannelActivityRepository;
+    private readonly Mock<IGuildMetricsRepository> _mockGuildMetricsRepository;
+    private readonly Mock<ILogger<ServerAnalyticsService>> _mockLogger;
+    private readonly ServerAnalyticsService _service;
+
+    public ServerAnalyticsServiceTests()
+    {
+        _mockMemberActivityRepository = new Mock<IMemberActivityRepository>();
+        _mockChannelActivityRepository = new Mock<IChannelActivityRepository>();
+        _mockGuildMetricsRepository = new Mock<IGuildMetricsRepository>();
+        _mockLogger = new Mock<ILogger<ServerAnalyticsService>>();
+        _service = new ServerAnalyticsService(
+            _mockMemberActivityRepository.Object,
+            _mockChannelActivityRepository.Object,
+            _mockGuildMetricsRepository.Object,
+            _mockLogger.Object);
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_ShouldReturnCorrectSummaryMetrics()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+        var now = DateTime.UtcNow;
+
+        var latestMetrics = new GuildMetricsSnapshot
+        {
+            GuildId = guildId,
+            SnapshotDate = DateOnly.FromDateTime(now),
+            TotalMembers = 500,
+            MembersJoined = 10,
+            MembersLeft = 5
+        };
+
+        var activitySnapshots = new List<(DateTime Period, int TotalMessages, int ActiveMembers)>
+        {
+            (now.AddDays(-1), 1000, 100),
+            (now.AddDays(-5), 800, 80),
+            (now.AddDays(-15), 900, 90)
+        };
+
+        var metricsLast7d = new List<GuildMetricsSnapshot>
+        {
+            new() { GuildId = guildId, SnapshotDate = DateOnly.FromDateTime(now.AddDays(-7)), TotalMembers = 480 },
+            new() { GuildId = guildId, SnapshotDate = DateOnly.FromDateTime(now), TotalMembers = 500 }
+        };
+
+        var channelSnapshots = new List<ChannelActivitySnapshot>
+        {
+            new() { ChannelId = 111, ChannelName = "general", MessageCount = 500 },
+            new() { ChannelId = 222, ChannelName = "bot-commands", MessageCount = 300 }
+        };
+
+        _mockGuildMetricsRepository
+            .Setup(r => r.GetLatestAsync(guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(latestMetrics);
+
+        _mockMemberActivityRepository
+            .Setup(r => r.GetActivityTimeSeriesAsync(guildId, It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+                SnapshotGranularity.Daily, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(activitySnapshots);
+
+        _mockGuildMetricsRepository
+            .Setup(r => r.GetByDateRangeAsync(guildId, It.IsAny<DateOnly>(), It.IsAny<DateOnly>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(metricsLast7d);
+
+        _mockChannelActivityRepository
+            .Setup(r => r.GetChannelRankingsAsync(guildId, start, end, 1000, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(channelSnapshots);
+
+        // Act
+        var result = await _service.GetSummaryAsync(guildId, start, end);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.TotalMembers.Should().Be(500);
+        result.OnlineMembers.Should().Be(0, "online member count is not tracked in snapshots");
+        result.ActiveChannels.Should().Be(2, "there are 2 active channels");
+        result.MemberGrowth7d.Should().Be(20, "500 - 480 = 20 new members");
+        result.MemberGrowthPercent.Should().BeApproximately(4.17m, 0.1m, "(20 / 480) * 100 = 4.17%");
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_WithNoMetrics_ShouldReturnZeroValues()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+
+        _mockGuildMetricsRepository
+            .Setup(r => r.GetLatestAsync(guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GuildMetricsSnapshot?)null);
+
+        _mockMemberActivityRepository
+            .Setup(r => r.GetActivityTimeSeriesAsync(guildId, It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+                SnapshotGranularity.Daily, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<(DateTime Period, int TotalMessages, int ActiveMembers)>());
+
+        _mockGuildMetricsRepository
+            .Setup(r => r.GetByDateRangeAsync(guildId, It.IsAny<DateOnly>(), It.IsAny<DateOnly>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<GuildMetricsSnapshot>());
+
+        _mockChannelActivityRepository
+            .Setup(r => r.GetChannelRankingsAsync(guildId, start, end, 1000, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ChannelActivitySnapshot>());
+
+        // Act
+        var result = await _service.GetSummaryAsync(guildId, start, end);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.TotalMembers.Should().Be(0);
+        result.ActiveMembers24h.Should().Be(0);
+        result.ActiveMembers7d.Should().Be(0);
+        result.ActiveMembers30d.Should().Be(0);
+        result.Messages24h.Should().Be(0);
+        result.Messages7d.Should().Be(0);
+        result.MemberGrowth7d.Should().Be(0);
+        result.MemberGrowthPercent.Should().Be(0);
+        result.ActiveChannels.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetActivityTimeSeriesAsync_ShouldReturnDataFromRepository()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+
+        var activitySnapshots = new List<(DateTime Period, int TotalMessages, int ActiveMembers)>
+        {
+            (start, 1000, 100),
+            (start.AddDays(1), 1200, 120),
+            (start.AddDays(2), 1100, 110)
+        };
+
+        var channelSnapshots = new List<ChannelActivitySnapshot>
+        {
+            new() { ChannelId = 111, ChannelName = "general", MessageCount = 500 },
+            new() { ChannelId = 222, ChannelName = "bot-commands", MessageCount = 300 }
+        };
+
+        _mockMemberActivityRepository
+            .Setup(r => r.GetActivityTimeSeriesAsync(guildId, start, end, SnapshotGranularity.Daily,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(activitySnapshots);
+
+        _mockChannelActivityRepository
+            .Setup(r => r.GetChannelRankingsAsync(guildId, start, end, 1000, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(channelSnapshots);
+
+        // Act
+        var result = await _service.GetActivityTimeSeriesAsync(guildId, start, end);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(3, "there are 3 activity snapshots");
+        result[0].Date.Should().Be(start);
+        result[0].MessageCount.Should().Be(1000);
+        result[0].ActiveMembers.Should().Be(100);
+        result[0].ActiveChannels.Should().Be(2, "total unique channels in the period");
+    }
+
+    [Fact]
+    public async Task GetActivityTimeSeriesAsync_WithEmptyData_ShouldReturnEmptyCollection()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+
+        _mockMemberActivityRepository
+            .Setup(r => r.GetActivityTimeSeriesAsync(guildId, start, end, SnapshotGranularity.Daily,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<(DateTime Period, int TotalMessages, int ActiveMembers)>());
+
+        _mockChannelActivityRepository
+            .Setup(r => r.GetChannelRankingsAsync(guildId, start, end, 1000, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ChannelActivitySnapshot>());
+
+        // Act
+        var result = await _service.GetActivityTimeSeriesAsync(guildId, start, end);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeEmpty("no activity data is available");
+    }
+
+    [Fact]
+    public async Task GetActivityHeatmapAsync_ShouldGroupByDayAndHour()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+
+        // Create hourly snapshots: Monday 9am, Monday 10am, Tuesday 9am
+        var hourlySnapshots = new List<(DateTime Period, int TotalMessages, int ActiveMembers)>
+        {
+            (new DateTime(2023, 1, 2, 9, 0, 0, DateTimeKind.Utc), 100, 10), // Monday 9am
+            (new DateTime(2023, 1, 9, 9, 0, 0, DateTimeKind.Utc), 150, 15), // Monday 9am (another week)
+            (new DateTime(2023, 1, 2, 10, 0, 0, DateTimeKind.Utc), 80, 8),  // Monday 10am
+            (new DateTime(2023, 1, 3, 9, 0, 0, DateTimeKind.Utc), 120, 12)  // Tuesday 9am
+        };
+
+        _mockMemberActivityRepository
+            .Setup(r => r.GetActivityTimeSeriesAsync(guildId, start, end, SnapshotGranularity.Hourly,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(hourlySnapshots);
+
+        // Act
+        var result = await _service.GetActivityHeatmapAsync(guildId, start, end);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(3, "there are 3 unique day/hour combinations");
+
+        // Monday 9am should have 250 messages (100 + 150)
+        var monday9am = result.FirstOrDefault(x => x.DayOfWeek == 1 && x.Hour == 9);
+        monday9am.Should().NotBeNull();
+        monday9am!.MessageCount.Should().Be(250);
+
+        // Monday 10am should have 80 messages
+        var monday10am = result.FirstOrDefault(x => x.DayOfWeek == 1 && x.Hour == 10);
+        monday10am.Should().NotBeNull();
+        monday10am!.MessageCount.Should().Be(80);
+
+        // Tuesday 9am should have 120 messages
+        var tuesday9am = result.FirstOrDefault(x => x.DayOfWeek == 2 && x.Hour == 9);
+        tuesday9am.Should().NotBeNull();
+        tuesday9am!.MessageCount.Should().Be(120);
+    }
+
+    [Fact]
+    public async Task GetActivityHeatmapAsync_WithEmptyData_ShouldReturnEmptyCollection()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+
+        _mockMemberActivityRepository
+            .Setup(r => r.GetActivityTimeSeriesAsync(guildId, start, end, SnapshotGranularity.Hourly,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<(DateTime Period, int TotalMessages, int ActiveMembers)>());
+
+        // Act
+        var result = await _service.GetActivityHeatmapAsync(guildId, start, end);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeEmpty("no hourly activity data is available");
+    }
+
+    [Fact]
+    public async Task GetTopContributorsAsync_ShouldReturnTopMembersByMessageCount()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+        var limit = 5;
+
+        var user1 = new User { Id = 111, Username = "User1", AvatarHash = "abc123" };
+        var user2 = new User { Id = 222, Username = "User2", GlobalDisplayName = "Display2" };
+        var user3 = new User { Id = 333, Username = "User3" };
+
+        var topMembers = new List<MemberActivitySnapshot>
+        {
+            new() { UserId = 111, MessageCount = 500, UniqueChannelsActive = 5,
+                    PeriodStart = start.AddDays(10), User = user1 },
+            new() { UserId = 111, MessageCount = 300, UniqueChannelsActive = 3,
+                    PeriodStart = start.AddDays(5), User = user1 },
+            new() { UserId = 222, MessageCount = 400, UniqueChannelsActive = 4,
+                    PeriodStart = start.AddDays(8), User = user2 },
+            new() { UserId = 333, MessageCount = 250, UniqueChannelsActive = 2,
+                    PeriodStart = start.AddDays(3), User = user3 }
+        };
+
+        _mockMemberActivityRepository
+            .Setup(r => r.GetTopActiveMembersAsync(guildId, start, end, limit, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(topMembers);
+
+        // Act
+        var result = await _service.GetTopContributorsAsync(guildId, start, end, limit);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(3, "there are 3 unique users");
+
+        // User1 should be first with 800 messages (500 + 300)
+        result[0].UserId.Should().Be(111);
+        result[0].Username.Should().Be("User1");
+        result[0].MessageCount.Should().Be(800);
+        result[0].UniqueChannels.Should().Be(5, "max of 5 and 3");
+        result[0].AvatarUrl.Should().Contain("abc123", "avatar URL includes hash");
+
+        // User2 should be second with 400 messages
+        result[1].UserId.Should().Be(222);
+        result[1].Username.Should().Be("User2");
+        result[1].DisplayName.Should().Be("Display2");
+        result[1].MessageCount.Should().Be(400);
+
+        // User3 should be third with 250 messages
+        result[2].UserId.Should().Be(333);
+        result[2].Username.Should().Be("User3");
+        result[2].MessageCount.Should().Be(250);
+    }
+
+    [Fact]
+    public async Task GetTopContributorsAsync_WithEmptyData_ShouldReturnEmptyCollection()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+
+        _mockMemberActivityRepository
+            .Setup(r => r.GetTopActiveMembersAsync(guildId, start, end, 10, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<MemberActivitySnapshot>());
+
+        // Act
+        var result = await _service.GetTopContributorsAsync(guildId, start, end);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeEmpty("no member activity data is available");
+    }
+
+    [Fact]
+    public async Task GetTopContributorsAsync_WithDefaultLimit_ShouldUse10()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+
+        _mockMemberActivityRepository
+            .Setup(r => r.GetTopActiveMembersAsync(guildId, start, end, 10, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<MemberActivitySnapshot>());
+
+        // Act
+        await _service.GetTopContributorsAsync(guildId, start, end);
+
+        // Assert
+        _mockMemberActivityRepository.Verify(
+            r => r.GetTopActiveMembersAsync(guildId, start, end, 10, It.IsAny<CancellationToken>()),
+            Times.Once,
+            "default limit should be 10");
+    }
+
+    [Fact]
+    public async Task GetTopContributorsAsync_WithNullUser_ShouldHandleGracefully()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var start = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2023, 1, 31, 23, 59, 59, DateTimeKind.Utc);
+
+        var topMembers = new List<MemberActivitySnapshot>
+        {
+            new() { UserId = 111, MessageCount = 500, UniqueChannelsActive = 5,
+                    PeriodStart = start.AddDays(10), User = null } // User not loaded
+        };
+
+        _mockMemberActivityRepository
+            .Setup(r => r.GetTopActiveMembersAsync(guildId, start, end, 10, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(topMembers);
+
+        // Act
+        var result = await _service.GetTopContributorsAsync(guildId, start, end);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(1);
+        result[0].UserId.Should().Be(111);
+        result[0].Username.Should().Be("Unknown", "fallback when user is null");
+        result[0].AvatarUrl.Should().BeNull("no avatar when user is null");
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements three comprehensive analytics dashboards for guild administrators as part of Epic #294:

- **Server Analytics Dashboard** (#559) - Activity metrics, member growth, channel rankings, and contributor leaderboards
- **Moderation Analytics Dashboard** (#560) - Case trends, repeat offenders, moderator workload distribution
- **Engagement Metrics Dashboard** (#561) - Message trends, member retention funnel, activity heatmaps

## Changes

### New Razor Pages
- `Pages/Guilds/Analytics/Index.cshtml` - Server Analytics (Overview)
- `Pages/Guilds/Analytics/Moderation.cshtml` - Moderation Analytics
- `Pages/Guilds/Analytics/Engagement.cshtml` - Engagement Metrics

### New Services
- `ServerAnalyticsService` - Aggregates member activity and channel data
- `ModerationAnalyticsService` - Aggregates moderation case data
- `EngagementAnalyticsService` - Aggregates message and retention data

### New API Endpoints
- `GET /api/analytics/{guildId}/server/summary`
- `GET /api/analytics/{guildId}/server/activity`
- `GET /api/analytics/{guildId}/server/heatmap`
- `GET /api/analytics/{guildId}/server/contributors`
- `GET /api/analytics/{guildId}/moderation/summary`
- `GET /api/analytics/{guildId}/moderation/trends`
- `GET /api/analytics/{guildId}/moderation/distribution`
- `GET /api/analytics/{guildId}/moderation/offenders`
- `GET /api/analytics/{guildId}/moderation/workload`
- `GET /api/analytics/{guildId}/engagement/summary`
- `GET /api/analytics/{guildId}/engagement/messages`
- `GET /api/analytics/{guildId}/engagement/retention`

### New DTOs & Interfaces
- `ServerAnalyticsDtos.cs`, `ModerationAnalyticsDtos.cs`, `EngagementAnalyticsDtos.cs`
- Service interfaces in `DiscordBot.Core`

### JavaScript
- `server-analytics.js`, `moderation-analytics.js`, `engagement-analytics.js`
- Chart.js visualizations following existing patterns

### Tests
- 55 new unit tests for the three analytics services
- All tests passing (2305 total, 12 skipped)

## Test plan

- [x] Build succeeds without errors
- [x] All unit tests pass (2305 passed)
- [x] New analytics tests pass (55 tests)
- [ ] Manual verification of Server Analytics page
- [ ] Manual verification of Moderation Analytics page
- [ ] Manual verification of Engagement Metrics page
- [ ] Verify date range filtering works
- [ ] Verify charts render correctly with data
- [ ] Verify empty states display correctly
- [ ] Test responsive design on mobile/tablet

## Screenshots

See HTML prototypes in `docs/prototypes/features/analytics-dashboard/` for design reference.

Closes #559
Closes #560
Closes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)