### PR TITLE
feat: Add performance metrics collection infrastructure and API endpoints

### DIFF
--- a/src/DiscordBot.Bot/Controllers/PerformanceMetricsController.cs
+++ b/src/DiscordBot.Bot/Controllers/PerformanceMetricsController.cs
@@ -1,0 +1,762 @@
+using DiscordBot.Bot.Extensions;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DiscordBot.Bot.Controllers;
+
+/// <summary>
+/// Controller for performance metrics and monitoring data.
+/// </summary>
+[ApiController]
+[Route("api/metrics")]
+[Authorize(Policy = "RequireViewer")]
+public class PerformanceMetricsController : ControllerBase
+{
+    private readonly IConnectionStateService _connectionStateService;
+    private readonly ILatencyHistoryService _latencyHistoryService;
+    private readonly ICommandPerformanceAggregator _commandPerformanceAggregator;
+    private readonly IApiRequestTracker _apiRequestTracker;
+    private readonly IDatabaseMetricsCollector _databaseMetricsCollector;
+    private readonly IBackgroundServiceHealthRegistry _backgroundServiceHealthRegistry;
+    private readonly IInstrumentedCache _instrumentedCache;
+    private readonly ILogger<PerformanceMetricsController> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PerformanceMetricsController"/> class.
+    /// </summary>
+    /// <param name="connectionStateService">The connection state service.</param>
+    /// <param name="latencyHistoryService">The latency history service.</param>
+    /// <param name="commandPerformanceAggregator">The command performance aggregator.</param>
+    /// <param name="apiRequestTracker">The API request tracker.</param>
+    /// <param name="databaseMetricsCollector">The database metrics collector.</param>
+    /// <param name="backgroundServiceHealthRegistry">The background service health registry.</param>
+    /// <param name="instrumentedCache">The instrumented cache.</param>
+    /// <param name="logger">The logger.</param>
+    public PerformanceMetricsController(
+        IConnectionStateService connectionStateService,
+        ILatencyHistoryService latencyHistoryService,
+        ICommandPerformanceAggregator commandPerformanceAggregator,
+        IApiRequestTracker apiRequestTracker,
+        IDatabaseMetricsCollector databaseMetricsCollector,
+        IBackgroundServiceHealthRegistry backgroundServiceHealthRegistry,
+        IInstrumentedCache instrumentedCache,
+        ILogger<PerformanceMetricsController> logger)
+    {
+        _connectionStateService = connectionStateService;
+        _latencyHistoryService = latencyHistoryService;
+        _commandPerformanceAggregator = commandPerformanceAggregator;
+        _apiRequestTracker = apiRequestTracker;
+        _databaseMetricsCollector = databaseMetricsCollector;
+        _backgroundServiceHealthRegistry = backgroundServiceHealthRegistry;
+        _instrumentedCache = instrumentedCache;
+        _logger = logger;
+    }
+
+    // ============================================================================
+    // Health Endpoints
+    // ============================================================================
+
+    /// <summary>
+    /// Gets overall performance health status with uptime and latency.
+    /// </summary>
+    /// <returns>Performance health snapshot.</returns>
+    [HttpGet("health")]
+    [ProducesResponseType(typeof(PerformanceHealthDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status500InternalServerError)]
+    public ActionResult<PerformanceHealthDto> GetHealth()
+    {
+        try
+        {
+            _logger.LogDebug("Performance health requested");
+
+            var connectionState = _connectionStateService.GetCurrentState();
+            var sessionDuration = _connectionStateService.GetCurrentSessionDuration();
+            var currentLatency = _latencyHistoryService.GetCurrentLatency();
+            var overallStatus = _backgroundServiceHealthRegistry.GetOverallStatus();
+
+            var health = new PerformanceHealthDto
+            {
+                Status = overallStatus,
+                Uptime = sessionDuration,
+                LatencyMs = currentLatency,
+                ConnectionState = connectionState.ToString(),
+                Timestamp = DateTime.UtcNow
+            };
+
+            _logger.LogTrace("Performance health retrieved: Status={Status}, Uptime={Uptime}, Latency={LatencyMs}ms",
+                health.Status, health.Uptime, health.LatencyMs);
+
+            return Ok(health);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to retrieve performance health");
+
+            return StatusCode(StatusCodes.Status500InternalServerError, new ApiErrorDto
+            {
+                Message = "Failed to retrieve performance health",
+                Detail = ex.Message,
+                StatusCode = StatusCodes.Status500InternalServerError,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+    }
+
+    /// <summary>
+    /// Gets latency history with statistical analysis.
+    /// </summary>
+    /// <param name="hours">Number of hours of history to retrieve (1-168, default: 24).</param>
+    /// <returns>Latency history with samples and statistics.</returns>
+    [HttpGet("health/latency")]
+    [ProducesResponseType(typeof(LatencyHistoryDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status500InternalServerError)]
+    public ActionResult<LatencyHistoryDto> GetLatencyHistory([FromQuery] int hours = 24)
+    {
+        try
+        {
+            if (hours < 1 || hours > 168)
+            {
+                _logger.LogWarning("Invalid hours parameter: {Hours}", hours);
+
+                return BadRequest(new ApiErrorDto
+                {
+                    Message = "Invalid hours parameter",
+                    Detail = "Hours must be between 1 and 168 (7 days).",
+                    StatusCode = StatusCodes.Status400BadRequest,
+                    TraceId = HttpContext.GetCorrelationId()
+                });
+            }
+
+            _logger.LogDebug("Latency history requested for {Hours} hours", hours);
+
+            var samples = _latencyHistoryService.GetSamples(hours);
+            var statistics = _latencyHistoryService.GetStatistics(hours);
+
+            var history = new LatencyHistoryDto
+            {
+                Samples = samples,
+                Statistics = statistics
+            };
+
+            _logger.LogTrace("Retrieved {SampleCount} latency samples, avg {AvgMs}ms",
+                statistics.SampleCount, statistics.Average);
+
+            return Ok(history);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to retrieve latency history for {Hours} hours", hours);
+
+            return StatusCode(StatusCodes.Status500InternalServerError, new ApiErrorDto
+            {
+                Message = "Failed to retrieve latency history",
+                Detail = ex.Message,
+                StatusCode = StatusCodes.Status500InternalServerError,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+    }
+
+    /// <summary>
+    /// Gets connection event history and statistics.
+    /// </summary>
+    /// <param name="days">Number of days of history to retrieve (1-30, default: 7).</param>
+    /// <returns>Connection history with events and statistics.</returns>
+    [HttpGet("health/connections")]
+    [ProducesResponseType(typeof(ConnectionHistoryDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status500InternalServerError)]
+    public ActionResult<ConnectionHistoryDto> GetConnectionHistory([FromQuery] int days = 7)
+    {
+        try
+        {
+            if (days < 1 || days > 30)
+            {
+                _logger.LogWarning("Invalid days parameter: {Days}", days);
+
+                return BadRequest(new ApiErrorDto
+                {
+                    Message = "Invalid days parameter",
+                    Detail = "Days must be between 1 and 30.",
+                    StatusCode = StatusCodes.Status400BadRequest,
+                    TraceId = HttpContext.GetCorrelationId()
+                });
+            }
+
+            _logger.LogDebug("Connection history requested for {Days} days", days);
+
+            var events = _connectionStateService.GetConnectionEvents(days);
+            var statistics = _connectionStateService.GetConnectionStats(days);
+
+            var history = new ConnectionHistoryDto
+            {
+                Events = events,
+                Statistics = statistics
+            };
+
+            _logger.LogTrace("Retrieved {EventCount} connection events, uptime {UptimePercentage:F2}%",
+                statistics.TotalEvents, statistics.UptimePercentage);
+
+            return Ok(history);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to retrieve connection history for {Days} days", days);
+
+            return StatusCode(StatusCodes.Status500InternalServerError, new ApiErrorDto
+            {
+                Message = "Failed to retrieve connection history",
+                Detail = ex.Message,
+                StatusCode = StatusCodes.Status500InternalServerError,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+    }
+
+    // ============================================================================
+    // Command Performance Endpoints
+    // ============================================================================
+
+    /// <summary>
+    /// Gets aggregated command performance metrics.
+    /// </summary>
+    /// <param name="hours">Number of hours of history to aggregate (1-168, default: 24).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of command performance aggregates.</returns>
+    [HttpGet("commands/performance")]
+    [ProducesResponseType(typeof(IReadOnlyList<CommandPerformanceAggregateDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult<IReadOnlyList<CommandPerformanceAggregateDto>>> GetCommandPerformance(
+        [FromQuery] int hours = 24,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (hours < 1 || hours > 168)
+            {
+                _logger.LogWarning("Invalid hours parameter: {Hours}", hours);
+
+                return BadRequest(new ApiErrorDto
+                {
+                    Message = "Invalid hours parameter",
+                    Detail = "Hours must be between 1 and 168 (7 days).",
+                    StatusCode = StatusCodes.Status400BadRequest,
+                    TraceId = HttpContext.GetCorrelationId()
+                });
+            }
+
+            _logger.LogDebug("Command performance requested for {Hours} hours", hours);
+
+            var aggregates = await _commandPerformanceAggregator.GetAggregatesAsync(hours);
+
+            _logger.LogTrace("Retrieved performance metrics for {CommandCount} commands", aggregates.Count);
+
+            return Ok(aggregates);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to retrieve command performance for {Hours} hours", hours);
+
+            return StatusCode(StatusCodes.Status500InternalServerError, new ApiErrorDto
+            {
+                Message = "Failed to retrieve command performance",
+                Detail = ex.Message,
+                StatusCode = StatusCodes.Status500InternalServerError,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+    }
+
+    /// <summary>
+    /// Gets the slowest command executions.
+    /// </summary>
+    /// <param name="limit">Maximum number of results to return (1-100, default: 10).</param>
+    /// <param name="hours">Number of hours of history to query (1-168, default: 24).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of slowest commands.</returns>
+    [HttpGet("commands/slowest")]
+    [ProducesResponseType(typeof(IReadOnlyList<SlowestCommandDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult<IReadOnlyList<SlowestCommandDto>>> GetSlowestCommands(
+        [FromQuery] int limit = 10,
+        [FromQuery] int hours = 24,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (limit < 1 || limit > 100)
+            {
+                _logger.LogWarning("Invalid limit parameter: {Limit}", limit);
+
+                return BadRequest(new ApiErrorDto
+                {
+                    Message = "Invalid limit parameter",
+                    Detail = "Limit must be between 1 and 100.",
+                    StatusCode = StatusCodes.Status400BadRequest,
+                    TraceId = HttpContext.GetCorrelationId()
+                });
+            }
+
+            if (hours < 1 || hours > 168)
+            {
+                _logger.LogWarning("Invalid hours parameter: {Hours}", hours);
+
+                return BadRequest(new ApiErrorDto
+                {
+                    Message = "Invalid hours parameter",
+                    Detail = "Hours must be between 1 and 168 (7 days).",
+                    StatusCode = StatusCodes.Status400BadRequest,
+                    TraceId = HttpContext.GetCorrelationId()
+                });
+            }
+
+            _logger.LogDebug("Slowest commands requested: limit={Limit}, hours={Hours}", limit, hours);
+
+            var slowestCommands = await _commandPerformanceAggregator.GetSlowestCommandsAsync(limit, hours);
+
+            _logger.LogTrace("Retrieved {Count} slowest commands", slowestCommands.Count);
+
+            return Ok(slowestCommands);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to retrieve slowest commands for {Hours} hours", hours);
+
+            return StatusCode(StatusCodes.Status500InternalServerError, new ApiErrorDto
+            {
+                Message = "Failed to retrieve slowest commands",
+                Detail = ex.Message,
+                StatusCode = StatusCodes.Status500InternalServerError,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+    }
+
+    /// <summary>
+    /// Gets command execution throughput over time.
+    /// </summary>
+    /// <param name="hours">Number of hours of history to include (1-168, default: 24).</param>
+    /// <param name="granularity">Time bucket granularity: "hour" or "day" (default: "hour").</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of throughput measurements over time.</returns>
+    [HttpGet("commands/throughput")]
+    [ProducesResponseType(typeof(IReadOnlyList<CommandThroughputDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult<IReadOnlyList<CommandThroughputDto>>> GetCommandThroughput(
+        [FromQuery] int hours = 24,
+        [FromQuery] string granularity = "hour",
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (hours < 1 || hours > 168)
+            {
+                _logger.LogWarning("Invalid hours parameter: {Hours}", hours);
+
+                return BadRequest(new ApiErrorDto
+                {
+                    Message = "Invalid hours parameter",
+                    Detail = "Hours must be between 1 and 168 (7 days).",
+                    StatusCode = StatusCodes.Status400BadRequest,
+                    TraceId = HttpContext.GetCorrelationId()
+                });
+            }
+
+            if (granularity != "hour" && granularity != "day")
+            {
+                _logger.LogWarning("Invalid granularity parameter: {Granularity}", granularity);
+
+                return BadRequest(new ApiErrorDto
+                {
+                    Message = "Invalid granularity parameter",
+                    Detail = "Granularity must be 'hour' or 'day'.",
+                    StatusCode = StatusCodes.Status400BadRequest,
+                    TraceId = HttpContext.GetCorrelationId()
+                });
+            }
+
+            _logger.LogDebug("Command throughput requested: hours={Hours}, granularity={Granularity}", hours, granularity);
+
+            var throughput = await _commandPerformanceAggregator.GetThroughputAsync(hours, granularity);
+
+            _logger.LogTrace("Retrieved {DataPointCount} throughput data points", throughput.Count);
+
+            return Ok(throughput);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to retrieve command throughput for {Hours} hours", hours);
+
+            return StatusCode(StatusCodes.Status500InternalServerError, new ApiErrorDto
+            {
+                Message = "Failed to retrieve command throughput",
+                Detail = ex.Message,
+                StatusCode = StatusCodes.Status500InternalServerError,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+    }
+
+    /// <summary>
+    /// Gets command error breakdown and statistics.
+    /// </summary>
+    /// <param name="hours">Number of hours of history to analyze (1-168, default: 24).</param>
+    /// <param name="limit">Maximum number of commands to return (1-100, default: 50).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Command error summary with rate and breakdown.</returns>
+    [HttpGet("commands/errors")]
+    [ProducesResponseType(typeof(CommandErrorsDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult<CommandErrorsDto>> GetCommandErrors(
+        [FromQuery] int hours = 24,
+        [FromQuery] int limit = 50,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (hours < 1 || hours > 168)
+            {
+                _logger.LogWarning("Invalid hours parameter: {Hours}", hours);
+
+                return BadRequest(new ApiErrorDto
+                {
+                    Message = "Invalid hours parameter",
+                    Detail = "Hours must be between 1 and 168 (7 days).",
+                    StatusCode = StatusCodes.Status400BadRequest,
+                    TraceId = HttpContext.GetCorrelationId()
+                });
+            }
+
+            if (limit < 1 || limit > 100)
+            {
+                _logger.LogWarning("Invalid limit parameter: {Limit}", limit);
+
+                return BadRequest(new ApiErrorDto
+                {
+                    Message = "Invalid limit parameter",
+                    Detail = "Limit must be between 1 and 100.",
+                    StatusCode = StatusCodes.Status400BadRequest,
+                    TraceId = HttpContext.GetCorrelationId()
+                });
+            }
+
+            _logger.LogDebug("Command errors requested: hours={Hours}, limit={Limit}", hours, limit);
+
+            var errorBreakdown = await _commandPerformanceAggregator.GetErrorBreakdownAsync(hours, limit);
+
+            // Calculate overall error rate from aggregates
+            var aggregates = await _commandPerformanceAggregator.GetAggregatesAsync(hours);
+            var totalCommands = aggregates.Sum(a => a.ExecutionCount);
+            var totalErrors = aggregates.Sum(a => (int)(a.ExecutionCount * (a.ErrorRate / 100.0)));
+            var overallErrorRate = totalCommands > 0 ? (totalErrors * 100.0 / totalCommands) : 0;
+
+            // Create recent errors list from error breakdown
+            var recentErrors = errorBreakdown
+                .SelectMany(eb => eb.ErrorMessages.Select(em => new RecentCommandErrorDto
+                {
+                    Timestamp = DateTime.UtcNow, // Note: This is approximate, actual timestamps would need to come from command logs
+                    CommandName = eb.CommandName,
+                    ErrorMessage = em.Key,
+                    GuildId = null
+                }))
+                .Take(limit)
+                .ToList();
+
+            var errors = new CommandErrorsDto
+            {
+                ErrorRate = overallErrorRate,
+                ByType = errorBreakdown,
+                RecentErrors = recentErrors
+            };
+
+            _logger.LogTrace("Retrieved error data: overall rate {ErrorRate:F2}%, {BreakdownCount} commands with errors",
+                errors.ErrorRate, errorBreakdown.Count);
+
+            return Ok(errors);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to retrieve command errors for {Hours} hours", hours);
+
+            return StatusCode(StatusCodes.Status500InternalServerError, new ApiErrorDto
+            {
+                Message = "Failed to retrieve command errors",
+                Detail = ex.Message,
+                StatusCode = StatusCodes.Status500InternalServerError,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+    }
+
+    // ============================================================================
+    // API Usage Endpoints
+    // ============================================================================
+
+    /// <summary>
+    /// Gets Discord API usage statistics.
+    /// </summary>
+    /// <param name="hours">Number of hours of history to retrieve (1-168, default: 24).</param>
+    /// <returns>API usage summary with total requests and breakdown by category.</returns>
+    [HttpGet("api/usage")]
+    [ProducesResponseType(typeof(ApiUsageSummaryDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status500InternalServerError)]
+    public ActionResult<ApiUsageSummaryDto> GetApiUsage([FromQuery] int hours = 24)
+    {
+        try
+        {
+            if (hours < 1 || hours > 168)
+            {
+                _logger.LogWarning("Invalid hours parameter: {Hours}", hours);
+
+                return BadRequest(new ApiErrorDto
+                {
+                    Message = "Invalid hours parameter",
+                    Detail = "Hours must be between 1 and 168 (7 days).",
+                    StatusCode = StatusCodes.Status400BadRequest,
+                    TraceId = HttpContext.GetCorrelationId()
+                });
+            }
+
+            _logger.LogDebug("API usage requested for {Hours} hours", hours);
+
+            var usageByCategory = _apiRequestTracker.GetUsageStatistics(hours);
+            var totalRequests = _apiRequestTracker.GetTotalRequests(hours);
+            var rateLimitEvents = _apiRequestTracker.GetRateLimitEvents(hours);
+
+            var usage = new ApiUsageSummaryDto
+            {
+                TotalRequests = totalRequests,
+                ByCategory = usageByCategory,
+                RateLimitHits = rateLimitEvents.Count
+            };
+
+            _logger.LogTrace("Retrieved API usage: {TotalRequests} total requests, {CategoryCount} categories",
+                totalRequests, usageByCategory.Count);
+
+            return Ok(usage);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to retrieve API usage for {Hours} hours", hours);
+
+            return StatusCode(StatusCodes.Status500InternalServerError, new ApiErrorDto
+            {
+                Message = "Failed to retrieve API usage",
+                Detail = ex.Message,
+                StatusCode = StatusCodes.Status500InternalServerError,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+    }
+
+    /// <summary>
+    /// Gets Discord API rate limit events.
+    /// </summary>
+    /// <param name="hours">Number of hours of history to retrieve (1-168, default: 24).</param>
+    /// <returns>Rate limit summary with event count and details.</returns>
+    [HttpGet("api/rate-limits")]
+    [ProducesResponseType(typeof(RateLimitSummaryDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status500InternalServerError)]
+    public ActionResult<RateLimitSummaryDto> GetRateLimits([FromQuery] int hours = 24)
+    {
+        try
+        {
+            if (hours < 1 || hours > 168)
+            {
+                _logger.LogWarning("Invalid hours parameter: {Hours}", hours);
+
+                return BadRequest(new ApiErrorDto
+                {
+                    Message = "Invalid hours parameter",
+                    Detail = "Hours must be between 1 and 168 (7 days).",
+                    StatusCode = StatusCodes.Status400BadRequest,
+                    TraceId = HttpContext.GetCorrelationId()
+                });
+            }
+
+            _logger.LogDebug("Rate limit events requested for {Hours} hours", hours);
+
+            var events = _apiRequestTracker.GetRateLimitEvents(hours);
+
+            var rateLimits = new RateLimitSummaryDto
+            {
+                HitCount = events.Count,
+                Events = events
+            };
+
+            _logger.LogTrace("Retrieved {EventCount} rate limit events", events.Count);
+
+            return Ok(rateLimits);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to retrieve rate limit events for {Hours} hours", hours);
+
+            return StatusCode(StatusCodes.Status500InternalServerError, new ApiErrorDto
+            {
+                Message = "Failed to retrieve rate limit events",
+                Detail = ex.Message,
+                StatusCode = StatusCodes.Status500InternalServerError,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+    }
+
+    // ============================================================================
+    // System Health Endpoints
+    // ============================================================================
+
+    /// <summary>
+    /// Gets database performance metrics and slow queries.
+    /// </summary>
+    /// <param name="limit">Maximum number of slow queries to return (1-100, default: 20).</param>
+    /// <returns>Database metrics summary with overall stats and slow queries.</returns>
+    [HttpGet("system/database")]
+    [ProducesResponseType(typeof(DatabaseMetricsSummaryDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status500InternalServerError)]
+    public ActionResult<DatabaseMetricsSummaryDto> GetDatabaseMetrics([FromQuery] int limit = 20)
+    {
+        try
+        {
+            if (limit < 1 || limit > 100)
+            {
+                _logger.LogWarning("Invalid limit parameter: {Limit}", limit);
+
+                return BadRequest(new ApiErrorDto
+                {
+                    Message = "Invalid limit parameter",
+                    Detail = "Limit must be between 1 and 100.",
+                    StatusCode = StatusCodes.Status400BadRequest,
+                    TraceId = HttpContext.GetCorrelationId()
+                });
+            }
+
+            _logger.LogDebug("Database metrics requested with limit {Limit}", limit);
+
+            var metrics = _databaseMetricsCollector.GetMetrics();
+            var slowQueries = _databaseMetricsCollector.GetSlowQueries(limit);
+
+            var summary = new DatabaseMetricsSummaryDto
+            {
+                Metrics = metrics,
+                RecentSlowQueries = slowQueries
+            };
+
+            _logger.LogTrace("Retrieved database metrics: {TotalQueries} queries, avg {AvgMs}ms, {SlowQueryCount} slow queries",
+                metrics.TotalQueries, metrics.AvgQueryTimeMs, slowQueries.Count);
+
+            return Ok(summary);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to retrieve database metrics");
+
+            return StatusCode(StatusCodes.Status500InternalServerError, new ApiErrorDto
+            {
+                Message = "Failed to retrieve database metrics",
+                Detail = ex.Message,
+                StatusCode = StatusCodes.Status500InternalServerError,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+    }
+
+    /// <summary>
+    /// Gets health status of all background services.
+    /// </summary>
+    /// <returns>List of background service health information.</returns>
+    [HttpGet("system/services")]
+    [ProducesResponseType(typeof(IReadOnlyList<BackgroundServiceHealthDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status500InternalServerError)]
+    public ActionResult<IReadOnlyList<BackgroundServiceHealthDto>> GetBackgroundServicesHealth()
+    {
+        try
+        {
+            _logger.LogDebug("Background services health requested");
+
+            var servicesHealth = _backgroundServiceHealthRegistry.GetAllHealth();
+
+            _logger.LogTrace("Retrieved health for {ServiceCount} background services", servicesHealth.Count);
+
+            return Ok(servicesHealth);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to retrieve background services health");
+
+            return StatusCode(StatusCodes.Status500InternalServerError, new ApiErrorDto
+            {
+                Message = "Failed to retrieve background services health",
+                Detail = ex.Message,
+                StatusCode = StatusCodes.Status500InternalServerError,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+    }
+
+    /// <summary>
+    /// Gets cache statistics with overall and per-prefix breakdown.
+    /// </summary>
+    /// <returns>Cache summary with overall stats and breakdown by key prefix.</returns>
+    [HttpGet("system/cache")]
+    [ProducesResponseType(typeof(CacheSummaryDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status500InternalServerError)]
+    public ActionResult<CacheSummaryDto> GetCacheStatistics()
+    {
+        try
+        {
+            _logger.LogDebug("Cache statistics requested");
+
+            var statisticsByPrefix = _instrumentedCache.GetStatistics();
+
+            // Calculate overall statistics
+            var totalHits = statisticsByPrefix.Sum(s => s.Hits);
+            var totalMisses = statisticsByPrefix.Sum(s => s.Misses);
+            var totalAccesses = totalHits + totalMisses;
+            var overallHitRate = totalAccesses > 0 ? (totalHits * 100.0 / totalAccesses) : 0;
+            var totalSize = statisticsByPrefix.Sum(s => s.Size);
+
+            var overall = new CacheStatisticsDto
+            {
+                KeyPrefix = "Overall",
+                Hits = totalHits,
+                Misses = totalMisses,
+                HitRate = overallHitRate,
+                Size = totalSize
+            };
+
+            var summary = new CacheSummaryDto
+            {
+                Overall = overall,
+                ByType = statisticsByPrefix
+            };
+
+            _logger.LogTrace("Retrieved cache statistics: {HitRate:F2}% hit rate, {PrefixCount} prefixes",
+                overallHitRate, statisticsByPrefix.Count);
+
+            return Ok(summary);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to retrieve cache statistics");
+
+            return StatusCode(StatusCodes.Status500InternalServerError, new ApiErrorDto
+            {
+                Message = "Failed to retrieve cache statistics",
+                Detail = ex.Message,
+                StatusCode = StatusCodes.Status500InternalServerError,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+    }
+}

--- a/src/DiscordBot.Bot/Extensions/PerformanceMetricsServiceExtensions.cs
+++ b/src/DiscordBot.Bot/Extensions/PerformanceMetricsServiceExtensions.cs
@@ -1,0 +1,51 @@
+using DiscordBot.Bot.Services;
+using DiscordBot.Core.Configuration;
+using DiscordBot.Core.Interfaces;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DiscordBot.Bot.Extensions;
+
+/// <summary>
+/// Extension methods for registering performance metrics services.
+/// </summary>
+public static class PerformanceMetricsServiceExtensions
+{
+    /// <summary>
+    /// Adds performance metrics collection and monitoring services to the service collection.
+    /// Registers singleton services for latency tracking, connection state, API monitoring,
+    /// database metrics, cache instrumentation, and background service health.
+    /// </summary>
+    /// <param name="services">The service collection to add services to.</param>
+    /// <param name="configuration">The application configuration.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddPerformanceMetrics(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        // Bind configuration
+        services.Configure<PerformanceMetricsOptions>(
+            configuration.GetSection(PerformanceMetricsOptions.SectionName));
+
+        // Core metrics services (singleton - maintain in-memory state)
+        services.AddSingleton<IConnectionStateService, ConnectionStateService>();
+        services.AddSingleton<ILatencyHistoryService, LatencyHistoryService>();
+        services.AddSingleton<IApiRequestTracker, ApiRequestTracker>();
+        services.AddSingleton<IDatabaseMetricsCollector, DatabaseMetricsCollector>();
+        services.AddSingleton<IBackgroundServiceHealthRegistry, BackgroundServiceHealthRegistry>();
+
+        // Instrumented cache wrapper (singleton)
+        services.AddSingleton<IInstrumentedCache, InstrumentedMemoryCache>();
+
+        // Command performance aggregator as background service
+        services.AddHostedService<CommandPerformanceAggregator>();
+
+        // Register the aggregator interface separately so it can be injected
+        services.AddSingleton<ICommandPerformanceAggregator>(sp =>
+            sp.GetServices<IHostedService>()
+              .OfType<CommandPerformanceAggregator>()
+              .First());
+
+        return services;
+    }
+}

--- a/src/DiscordBot.Bot/Program.cs
+++ b/src/DiscordBot.Bot/Program.cs
@@ -273,6 +273,9 @@ try
     // Add Moderation services (includes detection services and handlers)
     builder.Services.AddModerationServices(builder.Configuration);
 
+    // Add Performance Metrics services (latency, connection state, API tracking, database metrics)
+    builder.Services.AddPerformanceMetrics(builder.Configuration);
+
     // Add HttpClient for Discord API calls
     builder.Services.AddHttpClient("Discord", client =>
     {

--- a/src/DiscordBot.Bot/Services/ApiRequestTracker.cs
+++ b/src/DiscordBot.Bot/Services/ApiRequestTracker.cs
@@ -1,0 +1,265 @@
+using System.Collections.Concurrent;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Interfaces;
+using Microsoft.Extensions.Options;
+using DiscordBot.Core.Configuration;
+
+namespace DiscordBot.Bot.Services;
+
+/// <summary>
+/// Service for tracking Discord API requests and rate limiting events from Discord.NET log messages.
+/// Thread-safe singleton service that parses log events for API usage patterns.
+/// </summary>
+public class ApiRequestTracker : IApiRequestTracker
+{
+    private readonly ILogger<ApiRequestTracker> _logger;
+    private readonly PerformanceMetricsOptions _options;
+    private readonly object _lock = new();
+
+    // Track request counts by category
+    private readonly ConcurrentDictionary<string, ApiCategory> _categories = new();
+
+    // Track rate limit events
+    private readonly ConcurrentQueue<RateLimitEvent> _rateLimitEvents = new();
+    private int _rateLimitEventCount;
+    private const int MaxRateLimitEvents = 1000;
+
+    // Hourly request buckets for the last 24 hours
+    private readonly long[] _hourlyRequests = new long[24];
+    private int _currentHourIndex;
+    private DateTime _lastHourUpdate = DateTime.UtcNow;
+
+    // Severity level mapping
+    private const int SeverityError = 4; // LogSeverity.Error
+    private const int SeverityCritical = 5; // LogSeverity.Critical
+
+    public ApiRequestTracker(
+        ILogger<ApiRequestTracker> logger,
+        IOptions<PerformanceMetricsOptions> options)
+    {
+        _logger = logger;
+        _options = options.Value;
+        _currentHourIndex = DateTime.UtcNow.Hour;
+    }
+
+    /// <inheritdoc/>
+    public void TrackLogEvent(string source, string message, int severity)
+    {
+        if (!_options.ApiRequestTrackingEnabled)
+        {
+            return;
+        }
+
+        try
+        {
+            // Update hourly bucket
+            UpdateHourlyBucket();
+
+            // Parse different types of Discord.NET log messages
+            if (source.Contains("Rest", StringComparison.OrdinalIgnoreCase) ||
+                message.Contains("REST", StringComparison.OrdinalIgnoreCase))
+            {
+                RecordRequest("REST", severity);
+                _logger.LogTrace("Tracked REST API request: {Message}", message);
+            }
+            else if (source.Contains("Gateway", StringComparison.OrdinalIgnoreCase) ||
+                     message.Contains("Gateway", StringComparison.OrdinalIgnoreCase))
+            {
+                RecordRequest("Gateway", severity);
+                _logger.LogTrace("Tracked Gateway event: {Message}", message);
+            }
+
+            // Check for rate limit indicators
+            if (message.Contains("rate limit", StringComparison.OrdinalIgnoreCase) ||
+                message.Contains("429", StringComparison.OrdinalIgnoreCase))
+            {
+                ParseRateLimitEvent(message);
+            }
+        }
+        catch (Exception ex)
+        {
+            // Don't let tracking errors break the application
+            _logger.LogWarning(ex, "Error tracking API request from log message");
+        }
+    }
+
+    /// <inheritdoc/>
+    public void RecordRateLimitHit(string endpoint, int retryAfterMs, bool isGlobal)
+    {
+        var evt = new RateLimitEvent
+        {
+            Timestamp = DateTime.UtcNow,
+            Endpoint = endpoint,
+            RetryAfterMs = retryAfterMs,
+            IsGlobal = isGlobal
+        };
+
+        _rateLimitEvents.Enqueue(evt);
+        Interlocked.Increment(ref _rateLimitEventCount);
+
+        // Trim to max events
+        while (_rateLimitEventCount > MaxRateLimitEvents)
+        {
+            if (_rateLimitEvents.TryDequeue(out _))
+            {
+                Interlocked.Decrement(ref _rateLimitEventCount);
+            }
+        }
+
+        _logger.LogWarning(
+            "Rate limit hit: Endpoint={Endpoint}, RetryAfter={RetryAfterMs}ms, IsGlobal={IsGlobal}",
+            endpoint, retryAfterMs, isGlobal);
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<ApiUsageDto> GetUsageStatistics(int hours = 24)
+    {
+        return _categories.Select(kvp => new ApiUsageDto
+        {
+            Category = kvp.Key,
+            RequestCount = kvp.Value.RequestCount,
+            AvgLatencyMs = kvp.Value.TotalLatencyMs > 0 && kvp.Value.RequestCount > 0
+                ? (double)kvp.Value.TotalLatencyMs / kvp.Value.RequestCount
+                : 0,
+            ErrorCount = kvp.Value.ErrorCount
+        }).ToList();
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<RateLimitEventDto> GetRateLimitEvents(int hours = 24)
+    {
+        var cutoff = DateTime.UtcNow.AddHours(-hours);
+
+        return _rateLimitEvents
+            .Where(e => e.Timestamp >= cutoff)
+            .Select(e => new RateLimitEventDto
+            {
+                Timestamp = e.Timestamp,
+                Endpoint = e.Endpoint,
+                RetryAfterMs = e.RetryAfterMs,
+                IsGlobal = e.IsGlobal
+            })
+            .ToList();
+    }
+
+    /// <inheritdoc/>
+    public long GetTotalRequests(int hours = 24)
+    {
+        lock (_lock)
+        {
+            UpdateHourlyBucket();
+
+            // Sum up the requested number of hours
+            var hoursToSum = Math.Min(hours, 24);
+            long total = 0;
+
+            for (int i = 0; i < hoursToSum; i++)
+            {
+                var index = (_currentHourIndex - i + 24) % 24;
+                total += _hourlyRequests[index];
+            }
+
+            return total;
+        }
+    }
+
+    /// <summary>
+    /// Records an API request for a specific category.
+    /// </summary>
+    private void RecordRequest(string category, int severity)
+    {
+        var apiCategory = _categories.GetOrAdd(category, _ => new ApiCategory());
+
+        Interlocked.Increment(ref apiCategory.RequestCount);
+
+        if (severity == SeverityError || severity == SeverityCritical)
+        {
+            Interlocked.Increment(ref apiCategory.ErrorCount);
+        }
+
+        lock (_lock)
+        {
+            UpdateHourlyBucket();
+            _hourlyRequests[_currentHourIndex]++;
+        }
+    }
+
+    /// <summary>
+    /// Updates the hourly request bucket if we've moved to a new hour.
+    /// </summary>
+    private void UpdateHourlyBucket()
+    {
+        var now = DateTime.UtcNow;
+        var currentHour = now.Hour;
+
+        if (currentHour != _currentHourIndex)
+        {
+            // Reset buckets for hours that have passed
+            var hoursElapsed = (currentHour - _currentHourIndex + 24) % 24;
+            for (int i = 0; i < hoursElapsed; i++)
+            {
+                var indexToReset = (_currentHourIndex + i + 1) % 24;
+                _hourlyRequests[indexToReset] = 0;
+            }
+
+            _currentHourIndex = currentHour;
+            _lastHourUpdate = now;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to parse rate limit information from a log message.
+    /// </summary>
+    private void ParseRateLimitEvent(string message)
+    {
+        try
+        {
+            // Try to extract endpoint and retry-after from the message
+            // This is best-effort parsing since Discord.NET log format may vary
+            var endpoint = "Unknown";
+            var retryAfter = 1000; // Default to 1 second
+            var isGlobal = message.Contains("global", StringComparison.OrdinalIgnoreCase);
+
+            // Look for patterns like "endpoint: /api/..." or similar
+            var endpointMatch = System.Text.RegularExpressions.Regex.Match(message, @"endpoint[:\s]+([^\s,]+)");
+            if (endpointMatch.Success)
+            {
+                endpoint = endpointMatch.Groups[1].Value;
+            }
+
+            // Look for retry-after duration
+            var retryMatch = System.Text.RegularExpressions.Regex.Match(message, @"(\d+)\s*ms");
+            if (retryMatch.Success && int.TryParse(retryMatch.Groups[1].Value, out var parsedRetry))
+            {
+                retryAfter = parsedRetry;
+            }
+
+            RecordRateLimitHit(endpoint, retryAfter, isGlobal);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to parse rate limit event from message: {Message}", message);
+        }
+    }
+
+    /// <summary>
+    /// Internal class for tracking API category metrics.
+    /// </summary>
+    private class ApiCategory
+    {
+        public long RequestCount;
+        public long TotalLatencyMs;
+        public long ErrorCount;
+    }
+
+    /// <summary>
+    /// Internal class for storing rate limit events.
+    /// </summary>
+    private class RateLimitEvent
+    {
+        public required DateTime Timestamp { get; init; }
+        public required string Endpoint { get; init; }
+        public required int RetryAfterMs { get; init; }
+        public required bool IsGlobal { get; init; }
+    }
+}

--- a/src/DiscordBot.Bot/Services/BackgroundServiceHealthRegistry.cs
+++ b/src/DiscordBot.Bot/Services/BackgroundServiceHealthRegistry.cs
@@ -1,0 +1,121 @@
+using System.Collections.Concurrent;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Interfaces;
+
+namespace DiscordBot.Bot.Services;
+
+/// <summary>
+/// Registry for tracking health status of background services.
+/// Provides aggregated health reporting across all registered services.
+/// Thread-safe singleton service using concurrent dictionary.
+/// </summary>
+public class BackgroundServiceHealthRegistry : IBackgroundServiceHealthRegistry
+{
+    private readonly ILogger<BackgroundServiceHealthRegistry> _logger;
+    private readonly ConcurrentDictionary<string, IBackgroundServiceHealth> _services = new();
+
+    public BackgroundServiceHealthRegistry(ILogger<BackgroundServiceHealthRegistry> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public void Register(string name, IBackgroundServiceHealth service)
+    {
+        if (_services.TryAdd(name, service))
+        {
+            _logger.LogInformation("Registered background service for health monitoring: {ServiceName}", name);
+        }
+        else
+        {
+            _logger.LogWarning("Background service already registered: {ServiceName}", name);
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Unregister(string name)
+    {
+        if (_services.TryRemove(name, out _))
+        {
+            _logger.LogInformation("Unregistered background service from health monitoring: {ServiceName}", name);
+        }
+        else
+        {
+            _logger.LogWarning("Attempted to unregister non-existent service: {ServiceName}", name);
+        }
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<BackgroundServiceHealthDto> GetAllHealth()
+    {
+        return _services.Select(kvp => new BackgroundServiceHealthDto
+        {
+            ServiceName = kvp.Value.ServiceName,
+            Status = kvp.Value.Status,
+            LastHeartbeat = kvp.Value.LastHeartbeat,
+            LastError = kvp.Value.LastError
+        }).ToList();
+    }
+
+    /// <inheritdoc/>
+    public BackgroundServiceHealthDto? GetHealth(string serviceName)
+    {
+        if (_services.TryGetValue(serviceName, out var service))
+        {
+            return new BackgroundServiceHealthDto
+            {
+                ServiceName = service.ServiceName,
+                Status = service.Status,
+                LastHeartbeat = service.LastHeartbeat,
+                LastError = service.LastError
+            };
+        }
+
+        return null;
+    }
+
+    /// <inheritdoc/>
+    public string GetOverallStatus()
+    {
+        if (_services.IsEmpty)
+        {
+            return "Unknown";
+        }
+
+        var statuses = _services.Values.Select(s => s.Status).ToList();
+
+        // If any service has an error, overall is unhealthy
+        if (statuses.Any(s => s.Equals("Error", StringComparison.OrdinalIgnoreCase)))
+        {
+            return "Unhealthy";
+        }
+
+        // If any service is stopped, overall is degraded
+        if (statuses.Any(s => s.Equals("Stopped", StringComparison.OrdinalIgnoreCase)))
+        {
+            return "Degraded";
+        }
+
+        // Check for stale heartbeats (no heartbeat in last 5 minutes)
+        var now = DateTime.UtcNow;
+        var staleThreshold = TimeSpan.FromMinutes(5);
+
+        foreach (var service in _services.Values)
+        {
+            if (service.LastHeartbeat.HasValue)
+            {
+                var timeSinceHeartbeat = now - service.LastHeartbeat.Value;
+                if (timeSinceHeartbeat > staleThreshold)
+                {
+                    _logger.LogDebug(
+                        "Service {ServiceName} has stale heartbeat: {TimeSinceHeartbeat}",
+                        service.ServiceName, timeSinceHeartbeat);
+                    return "Degraded";
+                }
+            }
+        }
+
+        // All services running normally
+        return "Healthy";
+    }
+}

--- a/src/DiscordBot.Bot/Services/CommandPerformanceAggregator.cs
+++ b/src/DiscordBot.Bot/Services/CommandPerformanceAggregator.cs
@@ -1,0 +1,282 @@
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Interfaces;
+using Microsoft.Extensions.Options;
+using DiscordBot.Core.Configuration;
+using DiscordBot.Core.Entities;
+
+namespace DiscordBot.Bot.Services;
+
+/// <summary>
+/// Background service that aggregates command performance metrics from the command log repository.
+/// Caches results to avoid expensive recalculations on every API request.
+/// Implements ICommandPerformanceAggregator for query access.
+/// </summary>
+public class CommandPerformanceAggregator : BackgroundService, ICommandPerformanceAggregator
+{
+    private readonly IServiceScopeFactory _serviceScopeFactory;
+    private readonly ILogger<CommandPerformanceAggregator> _logger;
+    private readonly PerformanceMetricsOptions _options;
+    private readonly SemaphoreSlim _cacheLock = new(1, 1);
+
+    private Dictionary<string, CommandPerformanceAggregateDto> _cachedAggregates = new();
+    private DateTime _cacheExpiry = DateTime.MinValue;
+    private TimeSpan _cacheTtl;
+
+    public CommandPerformanceAggregator(
+        IServiceScopeFactory serviceScopeFactory,
+        ILogger<CommandPerformanceAggregator> logger,
+        IOptions<PerformanceMetricsOptions> options)
+    {
+        _serviceScopeFactory = serviceScopeFactory;
+        _logger = logger;
+        _options = options.Value;
+        _cacheTtl = TimeSpan.FromMinutes(_options.CommandAggregationCacheTtlMinutes);
+    }
+
+    /// <summary>
+    /// Background task that periodically refreshes the cache.
+    /// </summary>
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("CommandPerformanceAggregator background service starting");
+
+        // Wait a bit before first execution
+        await Task.Delay(TimeSpan.FromSeconds(30), stoppingToken);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await RefreshCacheAsync(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error refreshing command performance cache");
+            }
+
+            // Wait for the cache TTL before next refresh
+            await Task.Delay(_cacheTtl, stoppingToken);
+        }
+
+        _logger.LogInformation("CommandPerformanceAggregator background service stopping");
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<CommandPerformanceAggregateDto>> GetAggregatesAsync(int hours = 24)
+    {
+        await EnsureCacheValidAsync();
+
+        await _cacheLock.WaitAsync();
+        try
+        {
+            return _cachedAggregates.Values.ToList();
+        }
+        finally
+        {
+            _cacheLock.Release();
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<SlowestCommandDto>> GetSlowestCommandsAsync(int limit = 10, int hours = 24)
+    {
+        using var scope = _serviceScopeFactory.CreateScope();
+        var repository = scope.ServiceProvider.GetRequiredService<ICommandLogRepository>();
+
+        var since = DateTime.UtcNow.AddHours(-hours);
+        var logs = await repository.GetByDateRangeAsync(since, DateTime.UtcNow);
+
+        return logs
+            .OrderByDescending(l => l.ResponseTimeMs)
+            .Take(limit)
+            .Select(l => new SlowestCommandDto
+            {
+                CommandName = l.CommandName,
+                ExecutedAt = l.ExecutedAt,
+                DurationMs = l.ResponseTimeMs,
+                UserId = l.UserId,
+                GuildId = l.GuildId
+            })
+            .ToList();
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<CommandThroughputDto>> GetThroughputAsync(int hours = 24, string granularity = "hour")
+    {
+        using var scope = _serviceScopeFactory.CreateScope();
+        var repository = scope.ServiceProvider.GetRequiredService<ICommandLogRepository>();
+
+        var since = DateTime.UtcNow.AddHours(-hours);
+        var logs = await repository.GetByDateRangeAsync(since, DateTime.UtcNow);
+
+        if (granularity.Equals("day", StringComparison.OrdinalIgnoreCase))
+        {
+            return logs
+                .GroupBy(l => l.ExecutedAt.Date)
+                .Select(g => new CommandThroughputDto
+                {
+                    Timestamp = g.Key,
+                    Count = g.Count(),
+                    Granularity = "day"
+                })
+                .OrderBy(t => t.Timestamp)
+                .ToList();
+        }
+        else // hour
+        {
+            return logs
+                .GroupBy(l => new DateTime(l.ExecutedAt.Year, l.ExecutedAt.Month, l.ExecutedAt.Day, l.ExecutedAt.Hour, 0, 0))
+                .Select(g => new CommandThroughputDto
+                {
+                    Timestamp = g.Key,
+                    Count = g.Count(),
+                    Granularity = "hour"
+                })
+                .OrderBy(t => t.Timestamp)
+                .ToList();
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<CommandErrorBreakdownDto>> GetErrorBreakdownAsync(int hours = 24, int limit = 50)
+    {
+        using var scope = _serviceScopeFactory.CreateScope();
+        var repository = scope.ServiceProvider.GetRequiredService<ICommandLogRepository>();
+
+        var since = DateTime.UtcNow.AddHours(-hours);
+        var logs = await repository.GetByDateRangeAsync(since, DateTime.UtcNow);
+
+        var errorGroups = logs
+            .Where(l => !l.Success && !string.IsNullOrEmpty(l.ErrorMessage))
+            .GroupBy(l => l.CommandName)
+            .Select(g => new
+            {
+                CommandName = g.Key,
+                ErrorCount = g.Count(),
+                ErrorMessages = g.GroupBy(l => l.ErrorMessage!)
+                                 .ToDictionary(eg => eg.Key, eg => eg.Count())
+            })
+            .OrderByDescending(x => x.ErrorCount)
+            .Take(limit);
+
+        return errorGroups.Select(g => new CommandErrorBreakdownDto
+        {
+            CommandName = g.CommandName,
+            ErrorCount = g.ErrorCount,
+            ErrorMessages = g.ErrorMessages
+        }).ToList();
+    }
+
+    /// <inheritdoc/>
+    public void InvalidateCache()
+    {
+        _cacheLock.Wait();
+        try
+        {
+            _cacheExpiry = DateTime.MinValue;
+            _logger.LogInformation("Command performance cache invalidated");
+        }
+        finally
+        {
+            _cacheLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Ensures the cache is valid, refreshing if expired.
+    /// </summary>
+    private async Task EnsureCacheValidAsync()
+    {
+        if (DateTime.UtcNow >= _cacheExpiry)
+        {
+            await RefreshCacheAsync(CancellationToken.None);
+        }
+    }
+
+    /// <summary>
+    /// Refreshes the aggregation cache from the database.
+    /// </summary>
+    private async Task RefreshCacheAsync(CancellationToken cancellationToken)
+    {
+        await _cacheLock.WaitAsync(cancellationToken);
+        try
+        {
+            // Double-check expiry after acquiring lock
+            if (DateTime.UtcNow < _cacheExpiry)
+            {
+                return;
+            }
+
+            _logger.LogDebug("Refreshing command performance cache");
+
+            using var scope = _serviceScopeFactory.CreateScope();
+            var repository = scope.ServiceProvider.GetRequiredService<ICommandLogRepository>();
+
+            var since = DateTime.UtcNow.AddHours(-24);
+            var logs = await repository.GetByDateRangeAsync(since, DateTime.UtcNow, cancellationToken);
+
+            var aggregates = logs
+                .GroupBy(l => l.CommandName)
+                .Select(g => CalculateAggregate(g.Key, g.ToList()))
+                .ToDictionary(a => a.CommandName, a => a);
+
+            _cachedAggregates = aggregates;
+            _cacheExpiry = DateTime.UtcNow.Add(_cacheTtl);
+
+            _logger.LogInformation(
+                "Command performance cache refreshed: {CommandCount} commands, cache valid until {Expiry}",
+                aggregates.Count, _cacheExpiry);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to refresh command performance cache");
+        }
+        finally
+        {
+            _cacheLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Calculates performance aggregate for a command from its logs.
+    /// </summary>
+    private static CommandPerformanceAggregateDto CalculateAggregate(string commandName, List<CommandLog> logs)
+    {
+        var durations = logs.Select(l => (double)l.ResponseTimeMs).OrderBy(d => d).ToList();
+        var errorCount = logs.Count(l => !l.Success);
+
+        return new CommandPerformanceAggregateDto
+        {
+            CommandName = commandName,
+            ExecutionCount = logs.Count,
+            AvgMs = durations.Average(),
+            MinMs = durations.Min(),
+            MaxMs = durations.Max(),
+            P50Ms = CalculatePercentile(durations, 50),
+            P95Ms = CalculatePercentile(durations, 95),
+            P99Ms = CalculatePercentile(durations, 99),
+            ErrorRate = logs.Count > 0 ? (double)errorCount / logs.Count * 100.0 : 0.0
+        };
+    }
+
+    /// <summary>
+    /// Calculates the percentile value from a sorted list of doubles.
+    /// </summary>
+    private static double CalculatePercentile(List<double> sortedValues, double percentile)
+    {
+        if (sortedValues.Count == 0)
+        {
+            return 0;
+        }
+
+        if (sortedValues.Count == 1)
+        {
+            return sortedValues[0];
+        }
+
+        var index = (int)Math.Ceiling((percentile / 100.0) * sortedValues.Count) - 1;
+        index = Math.Max(0, Math.Min(sortedValues.Count - 1, index));
+
+        return sortedValues[index];
+    }
+}

--- a/src/DiscordBot.Bot/Services/ConnectionStateService.cs
+++ b/src/DiscordBot.Bot/Services/ConnectionStateService.cs
@@ -1,0 +1,263 @@
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Interfaces;
+using Microsoft.Extensions.Options;
+using DiscordBot.Core.Configuration;
+
+namespace DiscordBot.Bot.Services;
+
+/// <summary>
+/// Service for tracking Discord gateway connection state changes and calculating uptime metrics.
+/// Thread-safe singleton service that maintains connection event history.
+/// </summary>
+public class ConnectionStateService : IConnectionStateService
+{
+    private readonly ILogger<ConnectionStateService> _logger;
+    private readonly PerformanceMetricsOptions _options;
+    private readonly object _lock = new();
+
+    private readonly List<ConnectionEvent> _connectionEvents = new();
+    private DateTime? _lastConnectedTime;
+    private DateTime? _lastDisconnectedTime;
+    private GatewayConnectionState _currentState = GatewayConnectionState.Disconnected;
+    private long _totalUptimeMs;
+    private readonly DateTime _serviceStartTime;
+
+    public ConnectionStateService(
+        ILogger<ConnectionStateService> logger,
+        IOptions<PerformanceMetricsOptions> options)
+    {
+        _logger = logger;
+        _options = options.Value;
+        _serviceStartTime = DateTime.UtcNow;
+    }
+
+    /// <inheritdoc/>
+    public void RecordConnected()
+    {
+        lock (_lock)
+        {
+            var now = DateTime.UtcNow;
+
+            // If we were previously connected, calculate uptime of that session
+            if (_lastConnectedTime.HasValue && _currentState == GatewayConnectionState.Connected)
+            {
+                var sessionDuration = (now - _lastConnectedTime.Value).TotalMilliseconds;
+                _totalUptimeMs += (long)sessionDuration;
+            }
+
+            _lastConnectedTime = now;
+            _currentState = GatewayConnectionState.Connected;
+
+            var evt = new ConnectionEvent
+            {
+                EventType = "Connected",
+                Timestamp = now,
+                Reason = null,
+                Details = null
+            };
+
+            _connectionEvents.Add(evt);
+            CleanupOldEvents();
+
+            _logger.LogInformation("Gateway connected at {Timestamp}", now);
+        }
+    }
+
+    /// <inheritdoc/>
+    public void RecordDisconnected(Exception? exception)
+    {
+        lock (_lock)
+        {
+            var now = DateTime.UtcNow;
+
+            // Calculate uptime for the session that just ended
+            if (_lastConnectedTime.HasValue && _currentState == GatewayConnectionState.Connected)
+            {
+                var sessionDuration = (now - _lastConnectedTime.Value).TotalMilliseconds;
+                _totalUptimeMs += (long)sessionDuration;
+            }
+
+            _lastDisconnectedTime = now;
+            _currentState = GatewayConnectionState.Disconnected;
+
+            var evt = new ConnectionEvent
+            {
+                EventType = "Disconnected",
+                Timestamp = now,
+                Reason = exception?.Message,
+                Details = exception?.GetType().Name
+            };
+
+            _connectionEvents.Add(evt);
+            CleanupOldEvents();
+
+            if (exception != null)
+            {
+                _logger.LogWarning(exception, "Gateway disconnected at {Timestamp}", now);
+            }
+            else
+            {
+                _logger.LogInformation("Gateway disconnected at {Timestamp}", now);
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public GatewayConnectionState GetCurrentState()
+    {
+        lock (_lock)
+        {
+            return _currentState;
+        }
+    }
+
+    /// <inheritdoc/>
+    public DateTime? GetLastConnectedTime()
+    {
+        lock (_lock)
+        {
+            return _lastConnectedTime;
+        }
+    }
+
+    /// <inheritdoc/>
+    public DateTime? GetLastDisconnectedTime()
+    {
+        lock (_lock)
+        {
+            return _lastDisconnectedTime;
+        }
+    }
+
+    /// <inheritdoc/>
+    public TimeSpan GetCurrentSessionDuration()
+    {
+        lock (_lock)
+        {
+            if (_currentState == GatewayConnectionState.Connected && _lastConnectedTime.HasValue)
+            {
+                return DateTime.UtcNow - _lastConnectedTime.Value;
+            }
+
+            return TimeSpan.Zero;
+        }
+    }
+
+    /// <inheritdoc/>
+    public double GetUptimePercentage(TimeSpan period)
+    {
+        lock (_lock)
+        {
+            var now = DateTime.UtcNow;
+            var periodStart = now - period;
+
+            // Get total uptime in the period
+            long uptimeInPeriod = 0;
+
+            // Add current session uptime if connected
+            if (_currentState == GatewayConnectionState.Connected && _lastConnectedTime.HasValue)
+            {
+                var sessionStart = _lastConnectedTime.Value > periodStart ? _lastConnectedTime.Value : periodStart;
+                uptimeInPeriod += (long)(now - sessionStart).TotalMilliseconds;
+            }
+
+            // Add completed session uptimes within the period
+            for (int i = 0; i < _connectionEvents.Count - 1; i++)
+            {
+                var current = _connectionEvents[i];
+                var next = _connectionEvents[i + 1];
+
+                // If this is a connected event followed by a disconnected event
+                if (current.EventType == "Connected" && next.EventType == "Disconnected")
+                {
+                    if (next.Timestamp >= periodStart && current.Timestamp <= now)
+                    {
+                        var sessionStart = current.Timestamp > periodStart ? current.Timestamp : periodStart;
+                        var sessionEnd = next.Timestamp < now ? next.Timestamp : now;
+                        uptimeInPeriod += (long)(sessionEnd - sessionStart).TotalMilliseconds;
+                    }
+                }
+            }
+
+            var periodMs = period.TotalMilliseconds;
+            return periodMs > 0 ? (uptimeInPeriod / periodMs) * 100.0 : 0.0;
+        }
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<ConnectionEventDto> GetConnectionEvents(int days = 7)
+    {
+        lock (_lock)
+        {
+            var cutoff = DateTime.UtcNow.AddDays(-days);
+            return _connectionEvents
+                .Where(e => e.Timestamp >= cutoff)
+                .Select(e => new ConnectionEventDto
+                {
+                    EventType = e.EventType,
+                    Timestamp = e.Timestamp,
+                    Reason = e.Reason,
+                    Details = e.Details
+                })
+                .ToList();
+        }
+    }
+
+    /// <inheritdoc/>
+    public ConnectionStatsDto GetConnectionStats(int days = 7)
+    {
+        lock (_lock)
+        {
+            var cutoff = DateTime.UtcNow.AddDays(-days);
+            var eventsInPeriod = _connectionEvents.Where(e => e.Timestamp >= cutoff).ToList();
+
+            var totalEvents = eventsInPeriod.Count;
+            var reconnectionCount = eventsInPeriod.Count(e => e.EventType == "Connected") - 1; // First connect doesn't count as reconnect
+            if (reconnectionCount < 0) reconnectionCount = 0;
+
+            // Calculate average session duration
+            var sessionDurations = new List<TimeSpan>();
+            for (int i = 0; i < eventsInPeriod.Count - 1; i++)
+            {
+                if (eventsInPeriod[i].EventType == "Connected" && eventsInPeriod[i + 1].EventType == "Disconnected")
+                {
+                    sessionDurations.Add(eventsInPeriod[i + 1].Timestamp - eventsInPeriod[i].Timestamp);
+                }
+            }
+
+            var avgSessionDuration = sessionDurations.Any()
+                ? TimeSpan.FromMilliseconds(sessionDurations.Average(ts => ts.TotalMilliseconds))
+                : TimeSpan.Zero;
+
+            var uptimePercentage = GetUptimePercentage(TimeSpan.FromDays(days));
+
+            return new ConnectionStatsDto
+            {
+                TotalEvents = totalEvents,
+                ReconnectionCount = reconnectionCount,
+                AverageSessionDuration = avgSessionDuration,
+                UptimePercentage = uptimePercentage
+            };
+        }
+    }
+
+    /// <summary>
+    /// Removes connection events older than the configured retention period.
+    /// </summary>
+    private void CleanupOldEvents()
+    {
+        var cutoff = DateTime.UtcNow.AddDays(-_options.ConnectionEventRetentionDays);
+        _connectionEvents.RemoveAll(e => e.Timestamp < cutoff);
+    }
+
+    /// <summary>
+    /// Internal class for storing connection events.
+    /// </summary>
+    private class ConnectionEvent
+    {
+        public required string EventType { get; init; }
+        public required DateTime Timestamp { get; init; }
+        public string? Reason { get; init; }
+        public string? Details { get; init; }
+    }
+}

--- a/src/DiscordBot.Bot/Services/DatabaseMetricsCollector.cs
+++ b/src/DiscordBot.Bot/Services/DatabaseMetricsCollector.cs
@@ -1,0 +1,174 @@
+using System.Collections.Concurrent;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Interfaces;
+using Microsoft.Extensions.Options;
+using DiscordBot.Core.Configuration;
+
+namespace DiscordBot.Bot.Services;
+
+/// <summary>
+/// Service for collecting database query performance metrics.
+/// Integrates with QueryPerformanceInterceptor to track query execution times and slow queries.
+/// Thread-safe singleton service using concurrent collections.
+/// </summary>
+public class DatabaseMetricsCollector : IDatabaseMetricsCollector
+{
+    private readonly ILogger<DatabaseMetricsCollector> _logger;
+    private readonly PerformanceMetricsOptions _options;
+    private readonly object _lock = new();
+
+    // Metrics
+    private long _totalQueries;
+    private long _totalDurationMs;
+    private long _errorCount;
+
+    // Query duration histogram buckets (in milliseconds)
+    private readonly int[] _histogram = new int[5]; // <10ms, 10-50ms, 50-100ms, 100-500ms, >500ms
+
+    // Slow query tracking
+    private readonly ConcurrentQueue<SlowQuery> _slowQueries = new();
+    private int _slowQueryCount;
+
+    public DatabaseMetricsCollector(
+        ILogger<DatabaseMetricsCollector> logger,
+        IOptions<PerformanceMetricsOptions> options)
+    {
+        _logger = logger;
+        _options = options.Value;
+    }
+
+    /// <inheritdoc/>
+    public void RecordQuery(double durationMs, string commandType)
+    {
+        lock (_lock)
+        {
+            _totalQueries++;
+            _totalDurationMs += (long)durationMs;
+
+            // Update histogram
+            if (durationMs < 10)
+                _histogram[0]++;
+            else if (durationMs < 50)
+                _histogram[1]++;
+            else if (durationMs < 100)
+                _histogram[2]++;
+            else if (durationMs < 500)
+                _histogram[3]++;
+            else
+                _histogram[4]++;
+
+            _logger.LogTrace("Recorded query: Type={CommandType}, Duration={DurationMs}ms", commandType, durationMs);
+        }
+    }
+
+    /// <inheritdoc/>
+    public void RecordQueryError(double durationMs, string error)
+    {
+        lock (_lock)
+        {
+            _errorCount++;
+            _logger.LogDebug("Recorded query error: Duration={DurationMs}ms, Error={Error}", durationMs, error);
+        }
+    }
+
+    /// <inheritdoc/>
+    public void RecordSlowQuery(string commandText, double durationMs, string? parameters)
+    {
+        var slowQuery = new SlowQuery
+        {
+            Timestamp = DateTime.UtcNow,
+            CommandText = commandText,
+            DurationMs = durationMs,
+            Parameters = parameters
+        };
+
+        _slowQueries.Enqueue(slowQuery);
+        Interlocked.Increment(ref _slowQueryCount);
+
+        // Trim to max stored
+        while (_slowQueryCount > _options.SlowQueryMaxStored)
+        {
+            if (_slowQueries.TryDequeue(out _))
+            {
+                Interlocked.Decrement(ref _slowQueryCount);
+            }
+        }
+
+        _logger.LogWarning(
+            "Slow query detected: Duration={DurationMs}ms, Command={Command}",
+            durationMs,
+            commandText.Length > 100 ? commandText[..100] + "..." : commandText);
+    }
+
+    /// <inheritdoc/>
+    public DatabaseMetricsDto GetMetrics()
+    {
+        lock (_lock)
+        {
+            var avgQueryTime = _totalQueries > 0 ? (double)_totalDurationMs / _totalQueries : 0;
+
+            var histogram = new Dictionary<string, int>
+            {
+                ["0-10ms"] = _histogram[0],
+                ["10-50ms"] = _histogram[1],
+                ["50-100ms"] = _histogram[2],
+                ["100-500ms"] = _histogram[3],
+                [">500ms"] = _histogram[4]
+            };
+
+            return new DatabaseMetricsDto
+            {
+                TotalQueries = _totalQueries,
+                AvgQueryTimeMs = avgQueryTime,
+                SlowQueryCount = _slowQueryCount,
+                QueryHistogram = histogram,
+                ConnectionPoolStats = null // Could be populated from DbContext if needed
+            };
+        }
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<SlowQueryDto> GetSlowQueries(int limit = 20)
+    {
+        // Take the most recent slow queries up to the limit
+        return _slowQueries
+            .Reverse()
+            .Take(limit)
+            .Select(sq => new SlowQueryDto
+            {
+                Timestamp = sq.Timestamp,
+                CommandText = sq.CommandText,
+                DurationMs = sq.DurationMs,
+                Parameters = sq.Parameters
+            })
+            .ToList();
+    }
+
+    /// <inheritdoc/>
+    public void Reset()
+    {
+        lock (_lock)
+        {
+            _totalQueries = 0;
+            _totalDurationMs = 0;
+            _errorCount = 0;
+            Array.Clear(_histogram, 0, _histogram.Length);
+
+            while (_slowQueries.TryDequeue(out _)) { }
+            _slowQueryCount = 0;
+
+            _logger.LogInformation("Database metrics reset");
+        }
+    }
+
+    /// <summary>
+    /// Internal class for storing slow query information.
+    /// </summary>
+    private class SlowQuery
+    {
+        public required DateTime Timestamp { get; init; }
+        public required string CommandText { get; init; }
+        public required double DurationMs { get; init; }
+        public string? Parameters { get; init; }
+    }
+}

--- a/src/DiscordBot.Bot/Services/InstrumentedMemoryCache.cs
+++ b/src/DiscordBot.Bot/Services/InstrumentedMemoryCache.cs
@@ -1,0 +1,186 @@
+using System.Collections.Concurrent;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Interfaces;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using DiscordBot.Core.Configuration;
+
+namespace DiscordBot.Bot.Services;
+
+/// <summary>
+/// Instrumented wrapper around IMemoryCache that tracks hit/miss statistics by key prefix.
+/// Thread-safe singleton service using concurrent dictionaries for statistics tracking.
+/// </summary>
+public class InstrumentedMemoryCache : IInstrumentedCache
+{
+    private readonly IMemoryCache _innerCache;
+    private readonly ILogger<InstrumentedMemoryCache> _logger;
+    private readonly PerformanceMetricsOptions _options;
+
+    private readonly ConcurrentDictionary<string, CacheStats> _statsByPrefix = new();
+
+    public InstrumentedMemoryCache(
+        IMemoryCache innerCache,
+        ILogger<InstrumentedMemoryCache> logger,
+        IOptions<PerformanceMetricsOptions> options)
+    {
+        _innerCache = innerCache;
+        _logger = logger;
+        _options = options.Value;
+    }
+
+    /// <inheritdoc/>
+    public bool TryGetValue<T>(object key, out T? value)
+    {
+        var result = _innerCache.TryGetValue(key, out value);
+
+        if (_options.CacheStatisticsEnabled)
+        {
+            var prefix = ExtractKeyPrefix(key);
+            var stats = _statsByPrefix.GetOrAdd(prefix, _ => new CacheStats());
+
+            if (result)
+            {
+                Interlocked.Increment(ref stats.Hits);
+                _logger.LogTrace("Cache hit: {Key} (Prefix: {Prefix})", key, prefix);
+            }
+            else
+            {
+                Interlocked.Increment(ref stats.Misses);
+                _logger.LogTrace("Cache miss: {Key} (Prefix: {Prefix})", key, prefix);
+            }
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public void Set<T>(object key, T value, TimeSpan? absoluteExpiration = null)
+    {
+        var options = new MemoryCacheEntryOptions();
+
+        if (absoluteExpiration.HasValue)
+        {
+            options.AbsoluteExpirationRelativeToNow = absoluteExpiration.Value;
+        }
+
+        _innerCache.Set(key, value, options);
+
+        if (_options.CacheStatisticsEnabled)
+        {
+            var prefix = ExtractKeyPrefix(key);
+            var stats = _statsByPrefix.GetOrAdd(prefix, _ => new CacheStats());
+            Interlocked.Increment(ref stats.Size);
+
+            _logger.LogTrace("Cache set: {Key} (Prefix: {Prefix})", key, prefix);
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Remove(object key)
+    {
+        _innerCache.Remove(key);
+
+        if (_options.CacheStatisticsEnabled)
+        {
+            var prefix = ExtractKeyPrefix(key);
+            if (_statsByPrefix.TryGetValue(prefix, out var stats))
+            {
+                var currentSize = Interlocked.Read(ref stats.Size);
+                if (currentSize > 0)
+                {
+                    Interlocked.Decrement(ref stats.Size);
+                }
+            }
+
+            _logger.LogTrace("Cache remove: {Key} (Prefix: {Prefix})", key, prefix);
+        }
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<CacheStatisticsDto> GetStatistics()
+    {
+        return _statsByPrefix.Select(kvp => CreateStatisticsDto(kvp.Key, kvp.Value)).ToList();
+    }
+
+    /// <inheritdoc/>
+    public CacheStatisticsDto GetStatisticsByPrefix(string prefix)
+    {
+        if (_statsByPrefix.TryGetValue(prefix, out var stats))
+        {
+            return CreateStatisticsDto(prefix, stats);
+        }
+
+        return new CacheStatisticsDto
+        {
+            KeyPrefix = prefix,
+            Hits = 0,
+            Misses = 0,
+            HitRate = 0,
+            Size = 0
+        };
+    }
+
+    /// <inheritdoc/>
+    public void ResetStatistics()
+    {
+        _statsByPrefix.Clear();
+        _logger.LogInformation("Cache statistics reset");
+    }
+
+    /// <summary>
+    /// Extracts the key prefix from a cache key.
+    /// Uses the first segment before ':' or '_' as the prefix.
+    /// </summary>
+    private static string ExtractKeyPrefix(object key)
+    {
+        var keyString = key.ToString() ?? "unknown";
+
+        // Try splitting by ':' first (common pattern like "guilds:123")
+        var colonIndex = keyString.IndexOf(':');
+        if (colonIndex > 0)
+        {
+            return keyString[..colonIndex];
+        }
+
+        // Try splitting by '_' (pattern like "user_123")
+        var underscoreIndex = keyString.IndexOf('_');
+        if (underscoreIndex > 0)
+        {
+            return keyString[..underscoreIndex];
+        }
+
+        // No delimiter found, use the whole key as prefix
+        return keyString;
+    }
+
+    /// <summary>
+    /// Creates a CacheStatisticsDto from internal stats.
+    /// </summary>
+    private static CacheStatisticsDto CreateStatisticsDto(string prefix, CacheStats stats)
+    {
+        var hits = Interlocked.Read(ref stats.Hits);
+        var misses = Interlocked.Read(ref stats.Misses);
+        var total = hits + misses;
+        var hitRate = total > 0 ? (double)hits / total * 100.0 : 0.0;
+
+        return new CacheStatisticsDto
+        {
+            KeyPrefix = prefix,
+            Hits = hits,
+            Misses = misses,
+            HitRate = hitRate,
+            Size = (int)Interlocked.Read(ref stats.Size)
+        };
+    }
+
+    /// <summary>
+    /// Internal class for tracking cache statistics per prefix.
+    /// </summary>
+    private class CacheStats
+    {
+        public long Hits;
+        public long Misses;
+        public long Size;
+    }
+}

--- a/src/DiscordBot.Bot/Services/LatencyHistoryService.cs
+++ b/src/DiscordBot.Bot/Services/LatencyHistoryService.cs
@@ -1,0 +1,219 @@
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Interfaces;
+using Microsoft.Extensions.Options;
+using DiscordBot.Core.Configuration;
+
+namespace DiscordBot.Bot.Services;
+
+/// <summary>
+/// Service for storing Discord gateway latency history using a circular buffer.
+/// Maintains 24 hours of samples at 30-second intervals (2,880 samples) by default.
+/// Thread-safe singleton service with percentile calculation support.
+/// </summary>
+public class LatencyHistoryService : ILatencyHistoryService
+{
+    private readonly ILogger<LatencyHistoryService> _logger;
+    private readonly PerformanceMetricsOptions _options;
+    private readonly object _lock = new();
+
+    private readonly LatencySample[] _samples;
+    private readonly int _maxSamples;
+    private int _currentIndex;
+    private int _sampleCount;
+    private int _currentLatency;
+
+    public LatencyHistoryService(
+        ILogger<LatencyHistoryService> logger,
+        IOptions<PerformanceMetricsOptions> options)
+    {
+        _logger = logger;
+        _options = options.Value;
+
+        // Calculate max samples: (retention hours * 3600 seconds) / sample interval
+        _maxSamples = (_options.LatencyRetentionHours * 3600) / _options.LatencySampleIntervalSeconds;
+        _samples = new LatencySample[_maxSamples];
+        _currentIndex = 0;
+        _sampleCount = 0;
+        _currentLatency = 0;
+
+        _logger.LogInformation(
+            "LatencyHistoryService initialized with capacity for {MaxSamples} samples ({Hours}h at {Interval}s intervals)",
+            _maxSamples, _options.LatencyRetentionHours, _options.LatencySampleIntervalSeconds);
+    }
+
+    /// <inheritdoc/>
+    public void RecordSample(int latencyMs)
+    {
+        lock (_lock)
+        {
+            var sample = new LatencySample
+            {
+                Timestamp = DateTime.UtcNow,
+                LatencyMs = latencyMs
+            };
+
+            _samples[_currentIndex] = sample;
+            _currentIndex = (_currentIndex + 1) % _maxSamples;
+
+            if (_sampleCount < _maxSamples)
+            {
+                _sampleCount++;
+            }
+
+            _currentLatency = latencyMs;
+
+            _logger.LogTrace("Recorded latency sample: {LatencyMs}ms at {Timestamp}", latencyMs, sample.Timestamp);
+        }
+    }
+
+    /// <inheritdoc/>
+    public int GetCurrentLatency()
+    {
+        lock (_lock)
+        {
+            return _currentLatency;
+        }
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<LatencySampleDto> GetSamples(int hours = 24)
+    {
+        lock (_lock)
+        {
+            if (_sampleCount == 0)
+            {
+                return Array.Empty<LatencySampleDto>();
+            }
+
+            var cutoff = DateTime.UtcNow.AddHours(-hours);
+            var result = new List<LatencySampleDto>();
+
+            // Read samples in chronological order
+            var startIndex = _sampleCount < _maxSamples ? 0 : _currentIndex;
+            for (int i = 0; i < _sampleCount; i++)
+            {
+                var index = (startIndex + i) % _maxSamples;
+                var sample = _samples[index];
+
+                if (sample.Timestamp >= cutoff)
+                {
+                    result.Add(new LatencySampleDto
+                    {
+                        Timestamp = sample.Timestamp,
+                        LatencyMs = sample.LatencyMs
+                    });
+                }
+            }
+
+            _logger.LogDebug("Retrieved {Count} latency samples for last {Hours} hours", result.Count, hours);
+            return result;
+        }
+    }
+
+    /// <inheritdoc/>
+    public LatencyStatisticsDto GetStatistics(int hours = 24)
+    {
+        lock (_lock)
+        {
+            if (_sampleCount == 0)
+            {
+                return new LatencyStatisticsDto
+                {
+                    Average = 0,
+                    Min = 0,
+                    Max = 0,
+                    P50 = 0,
+                    P95 = 0,
+                    P99 = 0,
+                    SampleCount = 0
+                };
+            }
+
+            var cutoff = DateTime.UtcNow.AddHours(-hours);
+            var values = new List<int>();
+
+            // Collect all latency values within the time window
+            var startIndex = _sampleCount < _maxSamples ? 0 : _currentIndex;
+            for (int i = 0; i < _sampleCount; i++)
+            {
+                var index = (startIndex + i) % _maxSamples;
+                var sample = _samples[index];
+
+                if (sample.Timestamp >= cutoff)
+                {
+                    values.Add(sample.LatencyMs);
+                }
+            }
+
+            if (values.Count == 0)
+            {
+                return new LatencyStatisticsDto
+                {
+                    Average = 0,
+                    Min = 0,
+                    Max = 0,
+                    P50 = 0,
+                    P95 = 0,
+                    P99 = 0,
+                    SampleCount = 0
+                };
+            }
+
+            // Sort for percentile calculation
+            values.Sort();
+
+            var statistics = new LatencyStatisticsDto
+            {
+                Average = values.Average(),
+                Min = values.Min(),
+                Max = values.Max(),
+                P50 = CalculatePercentile(values, 50),
+                P95 = CalculatePercentile(values, 95),
+                P99 = CalculatePercentile(values, 99),
+                SampleCount = values.Count
+            };
+
+            _logger.LogDebug(
+                "Calculated latency statistics for {Hours}h: Avg={Avg:F1}ms, P50={P50}ms, P95={P95}ms, P99={P99}ms, Samples={Count}",
+                hours, statistics.Average, statistics.P50, statistics.P95, statistics.P99, statistics.SampleCount);
+
+            return statistics;
+        }
+    }
+
+    /// <summary>
+    /// Calculates the percentile value from a sorted list of integers.
+    /// </summary>
+    /// <param name="sortedValues">A sorted list of integer values.</param>
+    /// <param name="percentile">The percentile to calculate (0-100).</param>
+    /// <returns>The value at the specified percentile.</returns>
+    private static int CalculatePercentile(List<int> sortedValues, double percentile)
+    {
+        if (sortedValues.Count == 0)
+        {
+            return 0;
+        }
+
+        if (sortedValues.Count == 1)
+        {
+            return sortedValues[0];
+        }
+
+        // Calculate the index using the nearest-rank method
+        var index = (int)Math.Ceiling((percentile / 100.0) * sortedValues.Count) - 1;
+
+        // Clamp to valid range
+        index = Math.Max(0, Math.Min(sortedValues.Count - 1, index));
+
+        return sortedValues[index];
+    }
+
+    /// <summary>
+    /// Internal class for storing latency samples in the circular buffer.
+    /// </summary>
+    private struct LatencySample
+    {
+        public DateTime Timestamp { get; init; }
+        public int LatencyMs { get; init; }
+    }
+}

--- a/src/DiscordBot.Bot/appsettings.json
+++ b/src/DiscordBot.Bot/appsettings.json
@@ -120,6 +120,16 @@
     "FlaggedEventRetentionDays": 90,
     "EnableDebugLogging": false
   },
+  "PerformanceMetrics": {
+    "LatencySampleIntervalSeconds": 30,
+    "LatencyRetentionHours": 24,
+    "ConnectionEventRetentionDays": 7,
+    "ApiRequestTrackingEnabled": true,
+    "SlowQueryThresholdMs": 100,
+    "SlowQueryMaxStored": 100,
+    "CacheStatisticsEnabled": true,
+    "CommandAggregationCacheTtlMinutes": 5
+  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Information",

--- a/src/DiscordBot.Core/Configuration/PerformanceMetricsOptions.cs
+++ b/src/DiscordBot.Core/Configuration/PerformanceMetricsOptions.cs
@@ -1,0 +1,62 @@
+namespace DiscordBot.Core.Configuration;
+
+/// <summary>
+/// Configuration options for performance metrics collection and monitoring.
+/// </summary>
+public class PerformanceMetricsOptions
+{
+    /// <summary>
+    /// The configuration section name for binding.
+    /// </summary>
+    public const string SectionName = "PerformanceMetrics";
+
+    /// <summary>
+    /// Gets or sets the interval (in seconds) at which latency samples are recorded.
+    /// Default is 30 seconds.
+    /// </summary>
+    public int LatencySampleIntervalSeconds { get; set; } = 30;
+
+    /// <summary>
+    /// Gets or sets the duration (in hours) for which latency history is retained.
+    /// Default is 24 hours.
+    /// </summary>
+    public int LatencyRetentionHours { get; set; } = 24;
+
+    /// <summary>
+    /// Gets or sets the retention period (in days) for connection event history.
+    /// Default is 7 days.
+    /// </summary>
+    public int ConnectionEventRetentionDays { get; set; } = 7;
+
+    /// <summary>
+    /// Gets or sets whether Discord API request tracking is enabled.
+    /// Default is true.
+    /// </summary>
+    public bool ApiRequestTrackingEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the threshold (in milliseconds) that defines a slow database query.
+    /// Queries exceeding this duration are tracked separately.
+    /// Default is 100ms.
+    /// </summary>
+    public int SlowQueryThresholdMs { get; set; } = 100;
+
+    /// <summary>
+    /// Gets or sets the maximum number of slow queries to store in memory.
+    /// Oldest entries are removed when this limit is exceeded.
+    /// Default is 100.
+    /// </summary>
+    public int SlowQueryMaxStored { get; set; } = 100;
+
+    /// <summary>
+    /// Gets or sets whether cache statistics tracking is enabled.
+    /// Default is true.
+    /// </summary>
+    public bool CacheStatisticsEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the time-to-live (in minutes) for cached command performance aggregations.
+    /// Default is 5 minutes.
+    /// </summary>
+    public int CommandAggregationCacheTtlMinutes { get; set; } = 5;
+}

--- a/src/DiscordBot.Core/DTOs/PerformanceMetricsDtos.cs
+++ b/src/DiscordBot.Core/DTOs/PerformanceMetricsDtos.cs
@@ -1,0 +1,608 @@
+namespace DiscordBot.Core.DTOs;
+
+// ============================================================================
+// Health & Status DTOs
+// ============================================================================
+
+/// <summary>
+/// Overall performance health status with uptime and latency information.
+/// </summary>
+public record PerformanceHealthDto
+{
+    /// <summary>
+    /// Gets or sets the overall health status.
+    /// </summary>
+    public string Status { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the bot uptime duration.
+    /// </summary>
+    public TimeSpan Uptime { get; set; }
+
+    /// <summary>
+    /// Gets or sets the current gateway latency in milliseconds.
+    /// </summary>
+    public int LatencyMs { get; set; }
+
+    /// <summary>
+    /// Gets or sets the current connection state.
+    /// </summary>
+    public string ConnectionState { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the timestamp when this health snapshot was taken (UTC).
+    /// </summary>
+    public DateTime Timestamp { get; set; }
+}
+
+/// <summary>
+/// Latency history data with samples and statistical analysis.
+/// </summary>
+public record LatencyHistoryDto
+{
+    /// <summary>
+    /// Gets or sets the collection of latency samples.
+    /// </summary>
+    public IReadOnlyList<LatencySampleDto> Samples { get; set; } = Array.Empty<LatencySampleDto>();
+
+    /// <summary>
+    /// Gets or sets the statistical summary of the latency data.
+    /// </summary>
+    public LatencyStatisticsDto Statistics { get; set; } = new();
+}
+
+/// <summary>
+/// A single latency measurement sample.
+/// </summary>
+public record LatencySampleDto
+{
+    /// <summary>
+    /// Gets or sets the timestamp when the sample was recorded (UTC).
+    /// </summary>
+    public DateTime Timestamp { get; set; }
+
+    /// <summary>
+    /// Gets or sets the latency value in milliseconds.
+    /// </summary>
+    public int LatencyMs { get; set; }
+}
+
+/// <summary>
+/// Statistical analysis of latency samples.
+/// </summary>
+public record LatencyStatisticsDto
+{
+    /// <summary>
+    /// Gets or sets the average latency in milliseconds.
+    /// </summary>
+    public double Average { get; set; }
+
+    /// <summary>
+    /// Gets or sets the minimum latency in milliseconds.
+    /// </summary>
+    public int Min { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum latency in milliseconds.
+    /// </summary>
+    public int Max { get; set; }
+
+    /// <summary>
+    /// Gets or sets the 50th percentile (median) latency in milliseconds.
+    /// </summary>
+    public int P50 { get; set; }
+
+    /// <summary>
+    /// Gets or sets the 95th percentile latency in milliseconds.
+    /// </summary>
+    public int P95 { get; set; }
+
+    /// <summary>
+    /// Gets or sets the 99th percentile latency in milliseconds.
+    /// </summary>
+    public int P99 { get; set; }
+
+    /// <summary>
+    /// Gets or sets the total number of samples included in this statistical analysis.
+    /// </summary>
+    public int SampleCount { get; set; }
+}
+
+// ============================================================================
+// Connection DTOs
+// ============================================================================
+
+/// <summary>
+/// A connection state change event.
+/// </summary>
+public record ConnectionEventDto
+{
+    /// <summary>
+    /// Gets or sets the type of connection event (Connected, Disconnected, Connecting).
+    /// </summary>
+    public string EventType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the timestamp when the event occurred (UTC).
+    /// </summary>
+    public DateTime Timestamp { get; set; }
+
+    /// <summary>
+    /// Gets or sets the reason for the event (e.g., exception message on disconnect).
+    /// </summary>
+    public string? Reason { get; set; }
+
+    /// <summary>
+    /// Gets or sets additional details about the event.
+    /// </summary>
+    public string? Details { get; set; }
+}
+
+/// <summary>
+/// Aggregate statistics about connection events over a time period.
+/// </summary>
+public record ConnectionStatsDto
+{
+    /// <summary>
+    /// Gets or sets the total number of connection events recorded.
+    /// </summary>
+    public int TotalEvents { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of reconnection events.
+    /// </summary>
+    public int ReconnectionCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the average session duration.
+    /// </summary>
+    public TimeSpan AverageSessionDuration { get; set; }
+
+    /// <summary>
+    /// Gets or sets the uptime percentage over the specified period.
+    /// </summary>
+    public double UptimePercentage { get; set; }
+}
+
+// ============================================================================
+// Command Performance DTOs
+// ============================================================================
+
+/// <summary>
+/// Aggregated performance metrics for a command.
+/// </summary>
+public record CommandPerformanceAggregateDto
+{
+    /// <summary>
+    /// Gets or sets the command name.
+    /// </summary>
+    public string CommandName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the total number of times this command was executed.
+    /// </summary>
+    public int ExecutionCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the average execution time in milliseconds.
+    /// </summary>
+    public double AvgMs { get; set; }
+
+    /// <summary>
+    /// Gets or sets the minimum execution time in milliseconds.
+    /// </summary>
+    public double MinMs { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum execution time in milliseconds.
+    /// </summary>
+    public double MaxMs { get; set; }
+
+    /// <summary>
+    /// Gets or sets the 50th percentile execution time in milliseconds.
+    /// </summary>
+    public double P50Ms { get; set; }
+
+    /// <summary>
+    /// Gets or sets the 95th percentile execution time in milliseconds.
+    /// </summary>
+    public double P95Ms { get; set; }
+
+    /// <summary>
+    /// Gets or sets the 99th percentile execution time in milliseconds.
+    /// </summary>
+    public double P99Ms { get; set; }
+
+    /// <summary>
+    /// Gets or sets the error rate as a percentage (0-100).
+    /// </summary>
+    public double ErrorRate { get; set; }
+}
+
+/// <summary>
+/// Details about a slow command execution.
+/// </summary>
+public record SlowestCommandDto
+{
+    /// <summary>
+    /// Gets or sets the command name.
+    /// </summary>
+    public string CommandName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets when the command was executed (UTC).
+    /// </summary>
+    public DateTime ExecutedAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the execution duration in milliseconds.
+    /// </summary>
+    public double DurationMs { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Discord user ID who executed the command.
+    /// </summary>
+    public ulong UserId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Discord guild ID where the command was executed.
+    /// </summary>
+    public ulong? GuildId { get; set; }
+}
+
+/// <summary>
+/// Command execution throughput over time.
+/// </summary>
+public record CommandThroughputDto
+{
+    /// <summary>
+    /// Gets or sets the timestamp for this throughput measurement (UTC).
+    /// </summary>
+    public DateTime Timestamp { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of commands executed in this time bucket.
+    /// </summary>
+    public int Count { get; set; }
+
+    /// <summary>
+    /// Gets or sets the time granularity (hour, day).
+    /// </summary>
+    public string Granularity { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Error breakdown for a command.
+/// </summary>
+public record CommandErrorBreakdownDto
+{
+    /// <summary>
+    /// Gets or sets the command name.
+    /// </summary>
+    public string CommandName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the total number of errors for this command.
+    /// </summary>
+    public int ErrorCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the collection of error messages and their frequency.
+    /// </summary>
+    public IReadOnlyDictionary<string, int> ErrorMessages { get; set; } = new Dictionary<string, int>();
+}
+
+// ============================================================================
+// API Tracking DTOs
+// ============================================================================
+
+/// <summary>
+/// Discord API usage statistics by category.
+/// </summary>
+public record ApiUsageDto
+{
+    /// <summary>
+    /// Gets or sets the API category (REST, Gateway, etc.).
+    /// </summary>
+    public string Category { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the total number of requests in this category.
+    /// </summary>
+    public long RequestCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the average latency in milliseconds for this category.
+    /// </summary>
+    public double AvgLatencyMs { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of errors in this category.
+    /// </summary>
+    public long ErrorCount { get; set; }
+}
+
+/// <summary>
+/// A Discord API rate limit event.
+/// </summary>
+public record RateLimitEventDto
+{
+    /// <summary>
+    /// Gets or sets when the rate limit was hit (UTC).
+    /// </summary>
+    public DateTime Timestamp { get; set; }
+
+    /// <summary>
+    /// Gets or sets the endpoint that was rate limited.
+    /// </summary>
+    public string Endpoint { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the retry-after duration in milliseconds.
+    /// </summary>
+    public int RetryAfterMs { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether this was a global rate limit.
+    /// </summary>
+    public bool IsGlobal { get; set; }
+}
+
+// ============================================================================
+// Database DTOs
+// ============================================================================
+
+/// <summary>
+/// Database query performance metrics.
+/// </summary>
+public record DatabaseMetricsDto
+{
+    /// <summary>
+    /// Gets or sets the total number of queries executed.
+    /// </summary>
+    public long TotalQueries { get; set; }
+
+    /// <summary>
+    /// Gets or sets the average query execution time in milliseconds.
+    /// </summary>
+    public double AvgQueryTimeMs { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of slow queries (exceeding the threshold).
+    /// </summary>
+    public int SlowQueryCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the query execution time distribution histogram.
+    /// Keys are bucket names (e.g., "0-10ms", "10-50ms"), values are counts.
+    /// </summary>
+    public IReadOnlyDictionary<string, int> QueryHistogram { get; set; } = new Dictionary<string, int>();
+
+    /// <summary>
+    /// Gets or sets connection pool statistics (if available).
+    /// </summary>
+    public string? ConnectionPoolStats { get; set; }
+}
+
+/// <summary>
+/// Details about a slow database query.
+/// </summary>
+public record SlowQueryDto
+{
+    /// <summary>
+    /// Gets or sets when the query was executed (UTC).
+    /// </summary>
+    public DateTime Timestamp { get; set; }
+
+    /// <summary>
+    /// Gets or sets the SQL command text.
+    /// </summary>
+    public string CommandText { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the query execution duration in milliseconds.
+    /// </summary>
+    public double DurationMs { get; set; }
+
+    /// <summary>
+    /// Gets or sets the query parameters (if captured).
+    /// </summary>
+    public string? Parameters { get; set; }
+}
+
+// ============================================================================
+// Background Services DTOs
+// ============================================================================
+
+/// <summary>
+/// Health status of a background service.
+/// </summary>
+public record BackgroundServiceHealthDto
+{
+    /// <summary>
+    /// Gets or sets the service name.
+    /// </summary>
+    public string ServiceName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the service status (Running, Stopped, Error).
+    /// </summary>
+    public string Status { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the last heartbeat timestamp (UTC).
+    /// </summary>
+    public DateTime? LastHeartbeat { get; set; }
+
+    /// <summary>
+    /// Gets or sets the last error message (if any).
+    /// </summary>
+    public string? LastError { get; set; }
+}
+
+/// <summary>
+/// Cache hit/miss statistics for a key prefix.
+/// </summary>
+public record CacheStatisticsDto
+{
+    /// <summary>
+    /// Gets or sets the cache key prefix.
+    /// </summary>
+    public string KeyPrefix { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the number of cache hits.
+    /// </summary>
+    public long Hits { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of cache misses.
+    /// </summary>
+    public long Misses { get; set; }
+
+    /// <summary>
+    /// Gets or sets the cache hit rate as a percentage (0-100).
+    /// </summary>
+    public double HitRate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the approximate number of items in the cache for this prefix.
+    /// </summary>
+    public int Size { get; set; }
+}
+
+// ============================================================================
+// Response Wrapper DTOs
+// ============================================================================
+
+/// <summary>
+/// Connection history data with events and aggregate statistics.
+/// </summary>
+public record ConnectionHistoryDto
+{
+    /// <summary>
+    /// Gets or sets the collection of connection events.
+    /// </summary>
+    public IReadOnlyList<ConnectionEventDto> Events { get; init; } = Array.Empty<ConnectionEventDto>();
+
+    /// <summary>
+    /// Gets or sets the aggregate statistics for the connection events.
+    /// </summary>
+    public ConnectionStatsDto Statistics { get; init; } = new();
+}
+
+/// <summary>
+/// Command error summary with error rate, breakdown, and recent errors.
+/// </summary>
+public record CommandErrorsDto
+{
+    /// <summary>
+    /// Gets or sets the overall error rate as a percentage (0-100).
+    /// </summary>
+    public double ErrorRate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the error breakdown by command.
+    /// </summary>
+    public IReadOnlyList<CommandErrorBreakdownDto> ByType { get; init; } = Array.Empty<CommandErrorBreakdownDto>();
+
+    /// <summary>
+    /// Gets or sets the most recent command errors.
+    /// </summary>
+    public IReadOnlyList<RecentCommandErrorDto> RecentErrors { get; init; } = Array.Empty<RecentCommandErrorDto>();
+}
+
+/// <summary>
+/// Details about a recent command error.
+/// </summary>
+public record RecentCommandErrorDto
+{
+    /// <summary>
+    /// Gets or sets when the error occurred (UTC).
+    /// </summary>
+    public DateTime Timestamp { get; init; }
+
+    /// <summary>
+    /// Gets or sets the command name that failed.
+    /// </summary>
+    public string CommandName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the error message.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// Gets or sets the guild ID where the error occurred.
+    /// </summary>
+    public ulong? GuildId { get; init; }
+}
+
+/// <summary>
+/// API usage summary with total requests, breakdown by category, and rate limit hits.
+/// </summary>
+public record ApiUsageSummaryDto
+{
+    /// <summary>
+    /// Gets or sets the total number of API requests.
+    /// </summary>
+    public long TotalRequests { get; init; }
+
+    /// <summary>
+    /// Gets or sets the API usage breakdown by category.
+    /// </summary>
+    public IReadOnlyList<ApiUsageDto> ByCategory { get; init; } = Array.Empty<ApiUsageDto>();
+
+    /// <summary>
+    /// Gets or sets the number of rate limit hits.
+    /// </summary>
+    public int RateLimitHits { get; init; }
+}
+
+/// <summary>
+/// Rate limit summary with hit count and events.
+/// </summary>
+public record RateLimitSummaryDto
+{
+    /// <summary>
+    /// Gets or sets the total number of rate limit hits.
+    /// </summary>
+    public int HitCount { get; init; }
+
+    /// <summary>
+    /// Gets or sets the collection of rate limit events.
+    /// </summary>
+    public IReadOnlyList<RateLimitEventDto> Events { get; init; } = Array.Empty<RateLimitEventDto>();
+}
+
+/// <summary>
+/// Database metrics summary with overall metrics and recent slow queries.
+/// </summary>
+public record DatabaseMetricsSummaryDto
+{
+    /// <summary>
+    /// Gets or sets the overall database metrics.
+    /// </summary>
+    public DatabaseMetricsDto Metrics { get; init; } = new();
+
+    /// <summary>
+    /// Gets or sets the collection of recent slow queries.
+    /// </summary>
+    public IReadOnlyList<SlowQueryDto> RecentSlowQueries { get; init; } = Array.Empty<SlowQueryDto>();
+}
+
+/// <summary>
+/// Cache statistics summary with overall stats and breakdown by type.
+/// </summary>
+public record CacheSummaryDto
+{
+    /// <summary>
+    /// Gets or sets the overall cache statistics across all prefixes.
+    /// </summary>
+    public CacheStatisticsDto Overall { get; init; } = new();
+
+    /// <summary>
+    /// Gets or sets the cache statistics breakdown by key prefix.
+    /// </summary>
+    public IReadOnlyList<CacheStatisticsDto> ByType { get; init; } = Array.Empty<CacheStatisticsDto>();
+}

--- a/src/DiscordBot.Core/Interfaces/IApiRequestTracker.cs
+++ b/src/DiscordBot.Core/Interfaces/IApiRequestTracker.cs
@@ -1,0 +1,46 @@
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Core.Interfaces;
+
+/// <summary>
+/// Service interface for tracking Discord API requests and rate limiting events.
+/// </summary>
+public interface IApiRequestTracker
+{
+    /// <summary>
+    /// Tracks a Discord API log event to extract API request information.
+    /// </summary>
+    /// <param name="source">The source of the log message (e.g., "Rest", "Gateway").</param>
+    /// <param name="message">The log message text.</param>
+    /// <param name="severity">The severity level of the log message.</param>
+    void TrackLogEvent(string source, string message, int severity);
+
+    /// <summary>
+    /// Records a rate limit event from the Discord API.
+    /// </summary>
+    /// <param name="endpoint">The API endpoint that was rate limited.</param>
+    /// <param name="retryAfterMs">The retry-after duration in milliseconds.</param>
+    /// <param name="isGlobal">Whether this is a global rate limit.</param>
+    void RecordRateLimitHit(string endpoint, int retryAfterMs, bool isGlobal);
+
+    /// <summary>
+    /// Gets API usage statistics grouped by category for a specified number of hours.
+    /// </summary>
+    /// <param name="hours">The number of hours of history to retrieve (default: 24).</param>
+    /// <returns>A read-only list of API usage statistics by category.</returns>
+    IReadOnlyList<ApiUsageDto> GetUsageStatistics(int hours = 24);
+
+    /// <summary>
+    /// Gets rate limit events that occurred within a specified number of hours.
+    /// </summary>
+    /// <param name="hours">The number of hours of history to retrieve (default: 24).</param>
+    /// <returns>A read-only list of rate limit events.</returns>
+    IReadOnlyList<RateLimitEventDto> GetRateLimitEvents(int hours = 24);
+
+    /// <summary>
+    /// Gets the total number of API requests made within a specified number of hours.
+    /// </summary>
+    /// <param name="hours">The number of hours to count requests for (default: 24).</param>
+    /// <returns>The total request count.</returns>
+    long GetTotalRequests(int hours = 24);
+}

--- a/src/DiscordBot.Core/Interfaces/IBackgroundServiceHealth.cs
+++ b/src/DiscordBot.Core/Interfaces/IBackgroundServiceHealth.cs
@@ -1,0 +1,27 @@
+namespace DiscordBot.Core.Interfaces;
+
+/// <summary>
+/// Interface that background services can implement to report their health status.
+/// </summary>
+public interface IBackgroundServiceHealth
+{
+    /// <summary>
+    /// Gets the unique name of the background service.
+    /// </summary>
+    string ServiceName { get; }
+
+    /// <summary>
+    /// Gets the current status of the service (e.g., "Running", "Stopped", "Error").
+    /// </summary>
+    string Status { get; }
+
+    /// <summary>
+    /// Gets the timestamp of the last heartbeat or activity (UTC).
+    /// </summary>
+    DateTime? LastHeartbeat { get; }
+
+    /// <summary>
+    /// Gets the last error message, if any.
+    /// </summary>
+    string? LastError { get; }
+}

--- a/src/DiscordBot.Core/Interfaces/IBackgroundServiceHealthRegistry.cs
+++ b/src/DiscordBot.Core/Interfaces/IBackgroundServiceHealthRegistry.cs
@@ -1,0 +1,41 @@
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Core.Interfaces;
+
+/// <summary>
+/// Service interface for registering and querying health status of background services.
+/// </summary>
+public interface IBackgroundServiceHealthRegistry
+{
+    /// <summary>
+    /// Registers a background service for health monitoring.
+    /// </summary>
+    /// <param name="name">The unique name of the service.</param>
+    /// <param name="service">The service instance that implements IBackgroundServiceHealth.</param>
+    void Register(string name, IBackgroundServiceHealth service);
+
+    /// <summary>
+    /// Unregisters a background service from health monitoring.
+    /// </summary>
+    /// <param name="name">The unique name of the service to unregister.</param>
+    void Unregister(string name);
+
+    /// <summary>
+    /// Gets health status for all registered background services.
+    /// </summary>
+    /// <returns>A read-only list of background service health information.</returns>
+    IReadOnlyList<BackgroundServiceHealthDto> GetAllHealth();
+
+    /// <summary>
+    /// Gets health status for a specific background service.
+    /// </summary>
+    /// <param name="serviceName">The unique name of the service.</param>
+    /// <returns>The health information for the service, or null if not registered.</returns>
+    BackgroundServiceHealthDto? GetHealth(string serviceName);
+
+    /// <summary>
+    /// Gets the overall health status across all registered services.
+    /// </summary>
+    /// <returns>Overall status: "Healthy", "Degraded", or "Unhealthy".</returns>
+    string GetOverallStatus();
+}

--- a/src/DiscordBot.Core/Interfaces/ICommandPerformanceAggregator.cs
+++ b/src/DiscordBot.Core/Interfaces/ICommandPerformanceAggregator.cs
@@ -1,0 +1,47 @@
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Core.Interfaces;
+
+/// <summary>
+/// Service interface for aggregating command performance metrics from command logs.
+/// Runs as a background service with caching to avoid expensive recalculations.
+/// </summary>
+public interface ICommandPerformanceAggregator
+{
+    /// <summary>
+    /// Gets aggregated performance metrics for all commands over a specified number of hours.
+    /// Results are cached according to the configured TTL.
+    /// </summary>
+    /// <param name="hours">The number of hours of command history to aggregate (default: 24).</param>
+    /// <returns>A read-only list of command performance aggregates.</returns>
+    Task<IReadOnlyList<CommandPerformanceAggregateDto>> GetAggregatesAsync(int hours = 24);
+
+    /// <summary>
+    /// Gets the slowest command executions over a specified number of hours.
+    /// </summary>
+    /// <param name="limit">The maximum number of results to return (default: 10).</param>
+    /// <param name="hours">The number of hours of command history to query (default: 24).</param>
+    /// <returns>A read-only list of the slowest commands.</returns>
+    Task<IReadOnlyList<SlowestCommandDto>> GetSlowestCommandsAsync(int limit = 10, int hours = 24);
+
+    /// <summary>
+    /// Gets command execution throughput over time with configurable granularity.
+    /// </summary>
+    /// <param name="hours">The number of hours of history to include (default: 24).</param>
+    /// <param name="granularity">The time bucket granularity: "hour" or "day" (default: "hour").</param>
+    /// <returns>A read-only list of throughput measurements over time.</returns>
+    Task<IReadOnlyList<CommandThroughputDto>> GetThroughputAsync(int hours = 24, string granularity = "hour");
+
+    /// <summary>
+    /// Gets error breakdown by command over a specified number of hours.
+    /// </summary>
+    /// <param name="hours">The number of hours of command history to analyze (default: 24).</param>
+    /// <param name="limit">The maximum number of commands to return (default: 50).</param>
+    /// <returns>A read-only list of error breakdowns by command.</returns>
+    Task<IReadOnlyList<CommandErrorBreakdownDto>> GetErrorBreakdownAsync(int hours = 24, int limit = 50);
+
+    /// <summary>
+    /// Invalidates the cached aggregation data, forcing a recalculation on the next request.
+    /// </summary>
+    void InvalidateCache();
+}

--- a/src/DiscordBot.Core/Interfaces/IConnectionStateService.cs
+++ b/src/DiscordBot.Core/Interfaces/IConnectionStateService.cs
@@ -1,0 +1,86 @@
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Core.Interfaces;
+
+/// <summary>
+/// Service interface for tracking Discord gateway connection state changes and uptime.
+/// </summary>
+public interface IConnectionStateService
+{
+    /// <summary>
+    /// Records a successful connection to the Discord gateway.
+    /// </summary>
+    void RecordConnected();
+
+    /// <summary>
+    /// Records a disconnection from the Discord gateway.
+    /// </summary>
+    /// <param name="exception">The exception that caused the disconnection, if any.</param>
+    void RecordDisconnected(Exception? exception);
+
+    /// <summary>
+    /// Gets the current connection state.
+    /// </summary>
+    /// <returns>The current connection state.</returns>
+    GatewayConnectionState GetCurrentState();
+
+    /// <summary>
+    /// Gets the timestamp of the last successful connection (UTC).
+    /// </summary>
+    /// <returns>The last connection timestamp, or null if never connected.</returns>
+    DateTime? GetLastConnectedTime();
+
+    /// <summary>
+    /// Gets the timestamp of the last disconnection (UTC).
+    /// </summary>
+    /// <returns>The last disconnection timestamp, or null if never disconnected.</returns>
+    DateTime? GetLastDisconnectedTime();
+
+    /// <summary>
+    /// Gets the duration of the current connection session.
+    /// </summary>
+    /// <returns>The current session duration, or TimeSpan.Zero if not connected.</returns>
+    TimeSpan GetCurrentSessionDuration();
+
+    /// <summary>
+    /// Calculates the uptime percentage over a specified time period.
+    /// </summary>
+    /// <param name="period">The time period to calculate uptime over.</param>
+    /// <returns>The uptime percentage (0-100).</returns>
+    double GetUptimePercentage(TimeSpan period);
+
+    /// <summary>
+    /// Gets the connection event history for a specified number of days.
+    /// </summary>
+    /// <param name="days">The number of days of history to retrieve (default: 7).</param>
+    /// <returns>A read-only list of connection events.</returns>
+    IReadOnlyList<ConnectionEventDto> GetConnectionEvents(int days = 7);
+
+    /// <summary>
+    /// Gets aggregate connection statistics for a specified number of days.
+    /// </summary>
+    /// <param name="days">The number of days to aggregate over (default: 7).</param>
+    /// <returns>Connection statistics.</returns>
+    ConnectionStatsDto GetConnectionStats(int days = 7);
+}
+
+/// <summary>
+/// Discord gateway connection states.
+/// </summary>
+public enum GatewayConnectionState
+{
+    /// <summary>
+    /// Bot is currently connected to the Discord gateway.
+    /// </summary>
+    Connected,
+
+    /// <summary>
+    /// Bot is disconnected from the Discord gateway.
+    /// </summary>
+    Disconnected,
+
+    /// <summary>
+    /// Bot is in the process of connecting to the Discord gateway.
+    /// </summary>
+    Connecting
+}

--- a/src/DiscordBot.Core/Interfaces/IDatabaseMetricsCollector.cs
+++ b/src/DiscordBot.Core/Interfaces/IDatabaseMetricsCollector.cs
@@ -1,0 +1,50 @@
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Core.Interfaces;
+
+/// <summary>
+/// Service interface for collecting database query performance metrics.
+/// Integrates with QueryPerformanceInterceptor to track query execution.
+/// </summary>
+public interface IDatabaseMetricsCollector
+{
+    /// <summary>
+    /// Records the execution of a database query.
+    /// </summary>
+    /// <param name="durationMs">The query execution duration in milliseconds.</param>
+    /// <param name="commandType">The type of command executed (e.g., "SELECT", "INSERT").</param>
+    void RecordQuery(double durationMs, string commandType);
+
+    /// <summary>
+    /// Records a database query error.
+    /// </summary>
+    /// <param name="durationMs">The duration before the query failed in milliseconds.</param>
+    /// <param name="error">The error message or exception details.</param>
+    void RecordQueryError(double durationMs, string error);
+
+    /// <summary>
+    /// Records a slow database query for detailed tracking.
+    /// </summary>
+    /// <param name="commandText">The SQL command text.</param>
+    /// <param name="durationMs">The query execution duration in milliseconds.</param>
+    /// <param name="parameters">The query parameters (if captured), or null.</param>
+    void RecordSlowQuery(string commandText, double durationMs, string? parameters);
+
+    /// <summary>
+    /// Gets aggregate database metrics including query counts, averages, and histogram.
+    /// </summary>
+    /// <returns>Database metrics summary.</returns>
+    DatabaseMetricsDto GetMetrics();
+
+    /// <summary>
+    /// Gets the most recent slow queries.
+    /// </summary>
+    /// <param name="limit">The maximum number of slow queries to return (default: 20).</param>
+    /// <returns>A read-only list of slow query details.</returns>
+    IReadOnlyList<SlowQueryDto> GetSlowQueries(int limit = 20);
+
+    /// <summary>
+    /// Resets all collected metrics. Use with caution.
+    /// </summary>
+    void Reset();
+}

--- a/src/DiscordBot.Core/Interfaces/IInstrumentedCache.cs
+++ b/src/DiscordBot.Core/Interfaces/IInstrumentedCache.cs
@@ -1,0 +1,52 @@
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Core.Interfaces;
+
+/// <summary>
+/// Service interface for an instrumented cache that tracks hit/miss statistics.
+/// Wraps IMemoryCache to provide metrics by key prefix.
+/// </summary>
+public interface IInstrumentedCache
+{
+    /// <summary>
+    /// Attempts to get a value from the cache.
+    /// </summary>
+    /// <typeparam name="T">The type of the cached value.</typeparam>
+    /// <param name="key">The cache key.</param>
+    /// <param name="value">The cached value if found, or default if not.</param>
+    /// <returns>True if the key was found in the cache; otherwise, false.</returns>
+    bool TryGetValue<T>(object key, out T? value);
+
+    /// <summary>
+    /// Sets a value in the cache with optional expiration.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to cache.</typeparam>
+    /// <param name="key">The cache key.</param>
+    /// <param name="value">The value to cache.</param>
+    /// <param name="absoluteExpiration">Optional absolute expiration time from now.</param>
+    void Set<T>(object key, T value, TimeSpan? absoluteExpiration = null);
+
+    /// <summary>
+    /// Removes a value from the cache.
+    /// </summary>
+    /// <param name="key">The cache key to remove.</param>
+    void Remove(object key);
+
+    /// <summary>
+    /// Gets cache statistics for all tracked key prefixes.
+    /// </summary>
+    /// <returns>A read-only list of cache statistics by prefix.</returns>
+    IReadOnlyList<CacheStatisticsDto> GetStatistics();
+
+    /// <summary>
+    /// Gets cache statistics for a specific key prefix.
+    /// </summary>
+    /// <param name="prefix">The key prefix to get statistics for.</param>
+    /// <returns>Cache statistics for the specified prefix.</returns>
+    CacheStatisticsDto GetStatisticsByPrefix(string prefix);
+
+    /// <summary>
+    /// Resets all cache statistics counters. Does not clear the cache itself.
+    /// </summary>
+    void ResetStatistics();
+}

--- a/src/DiscordBot.Core/Interfaces/ILatencyHistoryService.cs
+++ b/src/DiscordBot.Core/Interfaces/ILatencyHistoryService.cs
@@ -1,0 +1,35 @@
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Core.Interfaces;
+
+/// <summary>
+/// Service interface for storing and analyzing Discord gateway latency history.
+/// </summary>
+public interface ILatencyHistoryService
+{
+    /// <summary>
+    /// Records a new latency sample from the Discord gateway.
+    /// </summary>
+    /// <param name="latencyMs">The latency value in milliseconds.</param>
+    void RecordSample(int latencyMs);
+
+    /// <summary>
+    /// Gets the most recently recorded latency value.
+    /// </summary>
+    /// <returns>The current latency in milliseconds.</returns>
+    int GetCurrentLatency();
+
+    /// <summary>
+    /// Gets latency samples for a specified number of hours.
+    /// </summary>
+    /// <param name="hours">The number of hours of history to retrieve (default: 24).</param>
+    /// <returns>A read-only list of latency samples in chronological order.</returns>
+    IReadOnlyList<LatencySampleDto> GetSamples(int hours = 24);
+
+    /// <summary>
+    /// Gets statistical analysis of latency samples over a specified number of hours.
+    /// </summary>
+    /// <param name="hours">The number of hours to analyze (default: 24).</param>
+    /// <returns>Statistical summary including average, min, max, and percentiles.</returns>
+    LatencyStatisticsDto GetStatistics(int hours = 24);
+}

--- a/tests/DiscordBot.Tests/Services/BackgroundServiceHealthRegistryTests.cs
+++ b/tests/DiscordBot.Tests/Services/BackgroundServiceHealthRegistryTests.cs
@@ -1,0 +1,153 @@
+using DiscordBot.Bot.Services;
+using DiscordBot.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace DiscordBot.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="BackgroundServiceHealthRegistry"/>.
+/// Tests cover service registration, unregistration, health status retrieval,
+/// and overall health status aggregation logic.
+/// </summary>
+public class BackgroundServiceHealthRegistryTests
+{
+    private readonly BackgroundServiceHealthRegistry _registry;
+
+    public BackgroundServiceHealthRegistryTests()
+    {
+        _registry = new BackgroundServiceHealthRegistry(
+            NullLogger<BackgroundServiceHealthRegistry>.Instance);
+    }
+
+    [Fact]
+    public void Register_AddsServiceToRegistry()
+    {
+        // Arrange
+        var mockService = CreateMockService("TestService", "Running", DateTime.UtcNow, null);
+
+        // Act
+        _registry.Register("TestService", mockService.Object);
+
+        // Assert
+        var allHealth = _registry.GetAllHealth();
+        allHealth.Should().HaveCount(1, "one service was registered");
+        allHealth[0].ServiceName.Should().Be("TestService", "service name should match");
+    }
+
+    [Fact]
+    public void Unregister_RemovesServiceFromRegistry()
+    {
+        // Arrange
+        var mockService = CreateMockService("TestService", "Running", DateTime.UtcNow, null);
+        _registry.Register("TestService", mockService.Object);
+
+        // Act
+        _registry.Unregister("TestService");
+
+        // Assert
+        var allHealth = _registry.GetAllHealth();
+        allHealth.Should().BeEmpty("service should be removed from registry");
+    }
+
+    [Fact]
+    public void GetAllHealth_ReturnsAllRegisteredServices()
+    {
+        // Arrange
+        var service1 = CreateMockService("Service1", "Running", DateTime.UtcNow, null);
+        var service2 = CreateMockService("Service2", "Running", DateTime.UtcNow, null);
+        var service3 = CreateMockService("Service3", "Stopped", DateTime.UtcNow, "Stopped by user");
+
+        _registry.Register("Service1", service1.Object);
+        _registry.Register("Service2", service2.Object);
+        _registry.Register("Service3", service3.Object);
+
+        // Act
+        var allHealth = _registry.GetAllHealth();
+
+        // Assert
+        allHealth.Should().HaveCount(3, "three services were registered");
+        allHealth.Should().Contain(h => h.ServiceName == "Service1", "Service1 should be included");
+        allHealth.Should().Contain(h => h.ServiceName == "Service2", "Service2 should be included");
+        allHealth.Should().Contain(h => h.ServiceName == "Service3", "Service3 should be included");
+    }
+
+    [Fact]
+    public void GetHealth_ReturnsNullForUnknownService()
+    {
+        // Act
+        var health = _registry.GetHealth("NonExistentService");
+
+        // Assert
+        health.Should().BeNull("service does not exist in registry");
+    }
+
+    [Fact]
+    public void GetOverallStatus_ReturnsHealthyWhenAllHealthy()
+    {
+        // Arrange - All services running with recent heartbeats
+        var service1 = CreateMockService("Service1", "Running", DateTime.UtcNow, null);
+        var service2 = CreateMockService("Service2", "Running", DateTime.UtcNow, null);
+
+        _registry.Register("Service1", service1.Object);
+        _registry.Register("Service2", service2.Object);
+
+        // Act
+        var overallStatus = _registry.GetOverallStatus();
+
+        // Assert
+        overallStatus.Should().Be("Healthy", "all services are running normally");
+    }
+
+    [Fact]
+    public void GetOverallStatus_ReturnsDegradedWhenAnyDegraded()
+    {
+        // Arrange - One service stopped, others running
+        var service1 = CreateMockService("Service1", "Running", DateTime.UtcNow, null);
+        var service2 = CreateMockService("Service2", "Stopped", DateTime.UtcNow, null);
+
+        _registry.Register("Service1", service1.Object);
+        _registry.Register("Service2", service2.Object);
+
+        // Act
+        var overallStatus = _registry.GetOverallStatus();
+
+        // Assert
+        overallStatus.Should().Be("Degraded", "one service is stopped");
+    }
+
+    [Fact]
+    public void GetOverallStatus_ReturnsUnhealthyWhenAnyError()
+    {
+        // Arrange - One service with error, others running
+        var service1 = CreateMockService("Service1", "Running", DateTime.UtcNow, null);
+        var service2 = CreateMockService("Service2", "Error", DateTime.UtcNow, "Fatal exception");
+
+        _registry.Register("Service1", service1.Object);
+        _registry.Register("Service2", service2.Object);
+
+        // Act
+        var overallStatus = _registry.GetOverallStatus();
+
+        // Assert
+        overallStatus.Should().Be("Unhealthy", "one service has an error");
+    }
+
+    /// <summary>
+    /// Creates a mock IBackgroundServiceHealth with specified properties.
+    /// </summary>
+    private static Mock<IBackgroundServiceHealth> CreateMockService(
+        string serviceName,
+        string status,
+        DateTime? lastHeartbeat,
+        string? lastError)
+    {
+        var mock = new Mock<IBackgroundServiceHealth>();
+        mock.Setup(s => s.ServiceName).Returns(serviceName);
+        mock.Setup(s => s.Status).Returns(status);
+        mock.Setup(s => s.LastHeartbeat).Returns(lastHeartbeat);
+        mock.Setup(s => s.LastError).Returns(lastError);
+        return mock;
+    }
+}

--- a/tests/DiscordBot.Tests/Services/ConnectionStateServiceTests.cs
+++ b/tests/DiscordBot.Tests/Services/ConnectionStateServiceTests.cs
@@ -1,0 +1,180 @@
+using DiscordBot.Bot.Services;
+using DiscordBot.Core.Configuration;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace DiscordBot.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="ConnectionStateService"/>.
+/// Tests cover connection state tracking, session duration calculation, uptime percentage,
+/// connection event history, and reconnection statistics.
+/// </summary>
+public class ConnectionStateServiceTests
+{
+    private readonly ConnectionStateService _service;
+    private readonly PerformanceMetricsOptions _options;
+
+    public ConnectionStateServiceTests()
+    {
+        _options = new PerformanceMetricsOptions
+        {
+            ConnectionEventRetentionDays = 7
+        };
+
+        _service = new ConnectionStateService(
+            NullLogger<ConnectionStateService>.Instance,
+            Options.Create(_options));
+    }
+
+    [Fact]
+    public void RecordConnected_UpdatesCurrentStateToConnected()
+    {
+        // Act
+        _service.RecordConnected();
+
+        // Assert
+        var state = _service.GetCurrentState();
+        state.Should().Be(GatewayConnectionState.Connected, "state should be connected after recording connection");
+
+        var lastConnectedTime = _service.GetLastConnectedTime();
+        lastConnectedTime.Should().NotBeNull("last connected time should be set");
+        lastConnectedTime.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1), "timestamp should be recent");
+    }
+
+    [Fact]
+    public void RecordDisconnected_UpdatesCurrentStateToDisconnected()
+    {
+        // Arrange
+        _service.RecordConnected();
+
+        // Act
+        _service.RecordDisconnected(exception: null);
+
+        // Assert
+        var state = _service.GetCurrentState();
+        state.Should().Be(GatewayConnectionState.Disconnected, "state should be disconnected after recording disconnection");
+
+        var lastDisconnectedTime = _service.GetLastDisconnectedTime();
+        lastDisconnectedTime.Should().NotBeNull("last disconnected time should be set");
+        lastDisconnectedTime.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1), "timestamp should be recent");
+    }
+
+    [Fact]
+    public void RecordDisconnected_StoresExceptionMessage()
+    {
+        // Arrange
+        _service.RecordConnected();
+        var exception = new InvalidOperationException("Connection lost");
+
+        // Act
+        _service.RecordDisconnected(exception);
+
+        // Assert
+        var events = _service.GetConnectionEvents(days: 7);
+        var disconnectEvent = events.LastOrDefault(e => e.EventType == "Disconnected");
+
+        disconnectEvent.Should().NotBeNull("disconnect event should be recorded");
+        disconnectEvent!.Reason.Should().Be("Connection lost", "exception message should be stored");
+        disconnectEvent.Details.Should().Be("InvalidOperationException", "exception type should be stored");
+    }
+
+    [Fact]
+    public void GetCurrentSessionDuration_ReturnsZeroWhenNotConnected()
+    {
+        // Act
+        var duration = _service.GetCurrentSessionDuration();
+
+        // Assert
+        duration.Should().Be(TimeSpan.Zero, "session duration should be zero when not connected");
+    }
+
+    [Fact]
+    public void GetCurrentSessionDuration_ReturnsDurationWhenConnected()
+    {
+        // Arrange
+        _service.RecordConnected();
+        Thread.Sleep(100); // Wait a bit to accumulate duration
+
+        // Act
+        var duration = _service.GetCurrentSessionDuration();
+
+        // Assert
+        duration.Should().BeGreaterThan(TimeSpan.Zero, "session duration should be positive when connected");
+        duration.Should().BeLessThan(TimeSpan.FromSeconds(2), "duration should be reasonable for this test");
+    }
+
+    [Fact]
+    public void GetUptimePercentage_CalculatesCorrectly()
+    {
+        // Arrange - Simulate 50% uptime over a 2-second period
+        _service.RecordConnected();
+        Thread.Sleep(500); // Connected for 500ms
+        _service.RecordDisconnected(exception: null);
+        Thread.Sleep(500); // Disconnected for 500ms
+
+        // Act
+        var uptimePercentage = _service.GetUptimePercentage(TimeSpan.FromSeconds(1));
+
+        // Assert
+        uptimePercentage.Should().BeInRange(0, 100, "uptime percentage should be between 0 and 100");
+        // Note: Due to timing variations, we can't assert exact percentage, but it should be reasonable
+    }
+
+    [Fact]
+    public void GetConnectionEvents_ReturnsEventsWithinTimeRange()
+    {
+        // Arrange
+        _service.RecordConnected();
+        _service.RecordDisconnected(exception: null);
+        _service.RecordConnected();
+
+        // Act
+        var events = _service.GetConnectionEvents(days: 7);
+
+        // Assert
+        events.Should().HaveCount(3, "three events were recorded");
+        events[0].EventType.Should().Be("Connected", "first event should be connected");
+        events[1].EventType.Should().Be("Disconnected", "second event should be disconnected");
+        events[2].EventType.Should().Be("Connected", "third event should be connected");
+        events.Should().BeInAscendingOrder(e => e.Timestamp, "events should be in chronological order");
+    }
+
+    [Fact]
+    public void GetConnectionEvents_RespectsDaysParameter()
+    {
+        // Arrange - Record an event
+        _service.RecordConnected();
+
+        // Act - Request events from last 0 days (should be empty or very recent only)
+        var recentEvents = _service.GetConnectionEvents(days: 7);
+        var allEvents = _service.GetConnectionEvents(days: 30);
+
+        // Assert
+        recentEvents.Should().NotBeEmpty("recent events should include the connection");
+        allEvents.Should().NotBeEmpty("all events should include the connection");
+        recentEvents.Count.Should().BeLessThanOrEqualTo(allEvents.Count, "recent range should not have more events than wider range");
+    }
+
+    [Fact]
+    public void GetConnectionStats_CalculatesReconnectionCountCorrectly()
+    {
+        // Arrange - Simulate multiple connect/disconnect cycles
+        _service.RecordConnected(); // Initial connection
+        _service.RecordDisconnected(exception: null);
+        _service.RecordConnected(); // Reconnection 1
+        _service.RecordDisconnected(exception: null);
+        _service.RecordConnected(); // Reconnection 2
+
+        // Act
+        var stats = _service.GetConnectionStats(days: 7);
+
+        // Assert
+        stats.TotalEvents.Should().Be(5, "five events were recorded");
+        stats.ReconnectionCount.Should().Be(2, "two reconnections occurred after initial connection");
+        stats.UptimePercentage.Should().BeInRange(0, 100, "uptime percentage should be valid");
+    }
+}

--- a/tests/DiscordBot.Tests/Services/DatabaseMetricsCollectorTests.cs
+++ b/tests/DiscordBot.Tests/Services/DatabaseMetricsCollectorTests.cs
@@ -1,0 +1,209 @@
+using DiscordBot.Bot.Services;
+using DiscordBot.Core.Configuration;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace DiscordBot.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="DatabaseMetricsCollector"/>.
+/// Tests cover query recording, duration histogram tracking, error counting,
+/// slow query detection and storage, and metrics reset functionality.
+/// </summary>
+public class DatabaseMetricsCollectorTests
+{
+    private readonly DatabaseMetricsCollector _collector;
+    private readonly PerformanceMetricsOptions _options;
+
+    public DatabaseMetricsCollectorTests()
+    {
+        _options = new PerformanceMetricsOptions
+        {
+            SlowQueryThresholdMs = 100,
+            SlowQueryMaxStored = 10
+        };
+
+        _collector = new DatabaseMetricsCollector(
+            NullLogger<DatabaseMetricsCollector>.Instance,
+            Options.Create(_options));
+    }
+
+    [Fact]
+    public void RecordQuery_IncrementsQueryCount()
+    {
+        // Arrange
+        const double durationMs = 50.0;
+        const string commandType = "SELECT";
+
+        // Act
+        _collector.RecordQuery(durationMs, commandType);
+        _collector.RecordQuery(durationMs, commandType);
+        _collector.RecordQuery(durationMs, commandType);
+
+        // Assert
+        var metrics = _collector.GetMetrics();
+        metrics.TotalQueries.Should().Be(3, "three queries were recorded");
+    }
+
+    [Fact]
+    public void RecordQuery_AddsToTotalDuration()
+    {
+        // Arrange
+        _collector.RecordQuery(50.0, "SELECT");
+        _collector.RecordQuery(100.0, "INSERT");
+        _collector.RecordQuery(150.0, "UPDATE");
+
+        // Act
+        var metrics = _collector.GetMetrics();
+
+        // Assert
+        metrics.TotalQueries.Should().Be(3, "three queries were recorded");
+        metrics.AvgQueryTimeMs.Should().Be(100.0, "average of 50, 100, 150 is 100");
+    }
+
+    [Fact]
+    public void RecordQuery_UpdatesHistogramBuckets()
+    {
+        // Arrange - Record queries in different duration ranges
+        _collector.RecordQuery(5.0, "SELECT");       // <10ms bucket
+        _collector.RecordQuery(25.0, "SELECT");      // 10-50ms bucket
+        _collector.RecordQuery(75.0, "UPDATE");      // 50-100ms bucket
+        _collector.RecordQuery(250.0, "INSERT");     // 100-500ms bucket
+        _collector.RecordQuery(600.0, "DELETE");     // >500ms bucket
+
+        // Act
+        var metrics = _collector.GetMetrics();
+
+        // Assert
+        metrics.QueryHistogram.Should().ContainKey("0-10ms", "histogram should track fast queries");
+        metrics.QueryHistogram.Should().ContainKey("10-50ms", "histogram should track medium-fast queries");
+        metrics.QueryHistogram.Should().ContainKey("50-100ms", "histogram should track medium queries");
+        metrics.QueryHistogram.Should().ContainKey("100-500ms", "histogram should track slow queries");
+        metrics.QueryHistogram.Should().ContainKey(">500ms", "histogram should track very slow queries");
+
+        metrics.QueryHistogram["0-10ms"].Should().Be(1, "one query in <10ms range");
+        metrics.QueryHistogram["10-50ms"].Should().Be(1, "one query in 10-50ms range");
+        metrics.QueryHistogram["50-100ms"].Should().Be(1, "one query in 50-100ms range");
+        metrics.QueryHistogram["100-500ms"].Should().Be(1, "one query in 100-500ms range");
+        metrics.QueryHistogram[">500ms"].Should().Be(1, "one query in >500ms range");
+    }
+
+    [Fact]
+    public void RecordQueryError_IncrementsErrorCount()
+    {
+        // Arrange
+        const double durationMs = 50.0;
+        const string error = "Connection timeout";
+
+        // Act
+        _collector.RecordQueryError(durationMs, error);
+        _collector.RecordQueryError(durationMs, error);
+
+        // Assert - Note: Error count is tracked internally but not exposed in GetMetrics()
+        // We verify it doesn't throw and can be called multiple times
+        var metrics = _collector.GetMetrics();
+        metrics.Should().NotBeNull("metrics should still be retrievable after errors");
+    }
+
+    [Fact]
+    public void RecordSlowQuery_StoresQueryDetails()
+    {
+        // Arrange
+        const string commandText = "SELECT * FROM Users WHERE Id = @id";
+        const double durationMs = 250.0;
+        const string parameters = "@id=123";
+
+        // Act
+        _collector.RecordSlowQuery(commandText, durationMs, parameters);
+
+        // Assert
+        var slowQueries = _collector.GetSlowQueries(limit: 10);
+        slowQueries.Should().HaveCount(1, "one slow query was recorded");
+
+        var slowQuery = slowQueries[0];
+        slowQuery.CommandText.Should().Be(commandText, "command text should match");
+        slowQuery.DurationMs.Should().Be(durationMs, "duration should match");
+        slowQuery.Parameters.Should().Be(parameters, "parameters should match");
+        slowQuery.Timestamp.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1), "timestamp should be recent");
+
+        var metrics = _collector.GetMetrics();
+        metrics.SlowQueryCount.Should().Be(1, "slow query count should be tracked");
+    }
+
+    [Fact]
+    public void RecordSlowQuery_RespectsMaxStoredLimit()
+    {
+        // Arrange - Max stored is 10 in our test options
+        const int excessQueries = 5;
+        const int totalQueries = 10 + excessQueries;
+
+        // Act - Record more slow queries than the max stored limit
+        for (int i = 0; i < totalQueries; i++)
+        {
+            _collector.RecordSlowQuery(
+                $"SELECT * FROM Table{i}",
+                150.0 + i,
+                $"@id={i}");
+        }
+
+        // Assert
+        var slowQueries = _collector.GetSlowQueries(limit: 100);
+        slowQueries.Should().HaveCount(10, "only the max stored limit should be kept");
+
+        var metrics = _collector.GetMetrics();
+        metrics.SlowQueryCount.Should().Be(10, "slow query count should respect max stored limit");
+
+        // Verify oldest queries were removed (first 5 should be gone)
+        slowQueries.Should().NotContain(sq => sq.CommandText.Contains("Table0"), "oldest query should be removed");
+        slowQueries.Should().NotContain(sq => sq.CommandText.Contains("Table4"), "oldest queries should be removed");
+        slowQueries.Should().Contain(sq => sq.CommandText.Contains("Table14"), "newest query should be present");
+    }
+
+    [Fact]
+    public void GetMetrics_ReturnsCorrectAverageQueryTime()
+    {
+        // Arrange
+        _collector.RecordQuery(10.0, "SELECT");
+        _collector.RecordQuery(20.0, "INSERT");
+        _collector.RecordQuery(30.0, "UPDATE");
+
+        // Act
+        var metrics = _collector.GetMetrics();
+
+        // Assert
+        metrics.AvgQueryTimeMs.Should().Be(20.0, "average of 10, 20, 30 is 20");
+    }
+
+    [Fact]
+    public void Reset_ClearsAllMetrics()
+    {
+        // Arrange - Record various metrics
+        _collector.RecordQuery(50.0, "SELECT");
+        _collector.RecordQuery(100.0, "INSERT");
+        _collector.RecordQueryError(25.0, "Error");
+        _collector.RecordSlowQuery("SELECT * FROM Users", 200.0, "@id=1");
+
+        // Verify metrics exist
+        var beforeMetrics = _collector.GetMetrics();
+        beforeMetrics.TotalQueries.Should().BeGreaterThan(0, "queries should be recorded before reset");
+
+        // Act
+        _collector.Reset();
+
+        // Assert
+        var afterMetrics = _collector.GetMetrics();
+        afterMetrics.TotalQueries.Should().Be(0, "total queries should be reset");
+        afterMetrics.AvgQueryTimeMs.Should().Be(0, "average query time should be reset");
+        afterMetrics.SlowQueryCount.Should().Be(0, "slow query count should be reset");
+
+        afterMetrics.QueryHistogram["0-10ms"].Should().Be(0, "histogram bucket should be cleared");
+        afterMetrics.QueryHistogram["10-50ms"].Should().Be(0, "histogram bucket should be cleared");
+        afterMetrics.QueryHistogram["50-100ms"].Should().Be(0, "histogram bucket should be cleared");
+        afterMetrics.QueryHistogram["100-500ms"].Should().Be(0, "histogram bucket should be cleared");
+        afterMetrics.QueryHistogram[">500ms"].Should().Be(0, "histogram bucket should be cleared");
+
+        var slowQueries = _collector.GetSlowQueries();
+        slowQueries.Should().BeEmpty("slow queries should be cleared");
+    }
+}

--- a/tests/DiscordBot.Tests/Services/InstrumentedMemoryCacheTests.cs
+++ b/tests/DiscordBot.Tests/Services/InstrumentedMemoryCacheTests.cs
@@ -1,0 +1,196 @@
+using DiscordBot.Bot.Services;
+using DiscordBot.Core.Configuration;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace DiscordBot.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="InstrumentedMemoryCache"/>.
+/// Tests cover cache operations (get, set, remove), hit/miss tracking,
+/// statistics aggregation by key prefix, and statistics reset functionality.
+/// </summary>
+public class InstrumentedMemoryCacheTests
+{
+    private readonly IMemoryCache _innerCache;
+    private readonly InstrumentedMemoryCache _cache;
+    private readonly PerformanceMetricsOptions _options;
+
+    public InstrumentedMemoryCacheTests()
+    {
+        _innerCache = new MemoryCache(new MemoryCacheOptions());
+        _options = new PerformanceMetricsOptions
+        {
+            CacheStatisticsEnabled = true
+        };
+
+        _cache = new InstrumentedMemoryCache(
+            _innerCache,
+            NullLogger<InstrumentedMemoryCache>.Instance,
+            Options.Create(_options));
+    }
+
+    [Fact]
+    public void TryGetValue_RecordsHitOnExistingKey()
+    {
+        // Arrange
+        const string key = "test:key1";
+        const string value = "test value";
+        _cache.Set(key, value);
+
+        // Reset statistics to start fresh for this test
+        _cache.ResetStatistics();
+
+        // Act
+        var result = _cache.TryGetValue<string>(key, out var retrievedValue);
+
+        // Assert
+        result.Should().BeTrue("key exists in cache");
+        retrievedValue.Should().Be(value, "retrieved value should match stored value");
+
+        var stats = _cache.GetStatisticsByPrefix("test");
+        stats.Hits.Should().Be(1, "one cache hit was recorded");
+        stats.Misses.Should().Be(0, "no cache misses");
+        stats.HitRate.Should().Be(100.0, "hit rate should be 100%");
+    }
+
+    [Fact]
+    public void TryGetValue_RecordsMissOnMissingKey()
+    {
+        // Arrange
+        const string key = "missing:key1";
+
+        // Act
+        var result = _cache.TryGetValue<string>(key, out var retrievedValue);
+
+        // Assert
+        result.Should().BeFalse("key does not exist in cache");
+        retrievedValue.Should().BeNull("no value should be retrieved");
+
+        var stats = _cache.GetStatisticsByPrefix("missing");
+        stats.Hits.Should().Be(0, "no cache hits");
+        stats.Misses.Should().Be(1, "one cache miss was recorded");
+        stats.HitRate.Should().Be(0.0, "hit rate should be 0%");
+    }
+
+    [Fact]
+    public void Set_StoresValueInCache()
+    {
+        // Arrange
+        const string key = "user:123";
+        const string value = "John Doe";
+
+        // Act
+        _cache.Set(key, value);
+
+        // Assert
+        var result = _innerCache.TryGetValue<string>(key, out var retrievedValue);
+        result.Should().BeTrue("value should be stored in underlying cache");
+        retrievedValue.Should().Be(value, "stored value should match");
+
+        var stats = _cache.GetStatisticsByPrefix("user");
+        stats.Size.Should().BeGreaterThanOrEqualTo(1, "cache size should be tracked");
+    }
+
+    [Fact]
+    public void Remove_RemovesValueFromCache()
+    {
+        // Arrange
+        const string key = "guild:456";
+        const string value = "Test Guild";
+        _cache.Set(key, value);
+
+        // Act
+        _cache.Remove(key);
+
+        // Assert
+        var result = _innerCache.TryGetValue<string>(key, out _);
+        result.Should().BeFalse("value should be removed from underlying cache");
+
+        // Note: Size decrement happens, but might not be exactly 0 due to other operations
+        var stats = _cache.GetStatisticsByPrefix("guild");
+        stats.Should().NotBeNull("statistics should still exist for prefix");
+    }
+
+    [Fact]
+    public void GetStatistics_ReturnsHitMissRatios()
+    {
+        // Arrange
+        _cache.Set("data:1", "value1");
+        _cache.Set("data:2", "value2");
+
+        // 3 hits
+        _cache.TryGetValue<string>("data:1", out _);
+        _cache.TryGetValue<string>("data:2", out _);
+        _cache.TryGetValue<string>("data:1", out _);
+
+        // 1 miss
+        _cache.TryGetValue<string>("data:3", out _);
+
+        // Act
+        var allStats = _cache.GetStatistics();
+
+        // Assert
+        var dataStats = allStats.FirstOrDefault(s => s.KeyPrefix == "data");
+        dataStats.Should().NotBeNull("statistics should exist for 'data' prefix");
+        dataStats!.Hits.Should().Be(3, "three cache hits");
+        dataStats.Misses.Should().Be(1, "one cache miss");
+        dataStats.HitRate.Should().Be(75.0, "hit rate should be 75% (3 hits out of 4 total)");
+    }
+
+    [Fact]
+    public void GetStatisticsByPrefix_GroupsByKeyPrefix()
+    {
+        // Arrange - Create entries with different prefixes
+        _cache.Set("users:1", "User 1");
+        _cache.Set("users:2", "User 2");
+        _cache.Set("guilds:1", "Guild 1");
+
+        _cache.TryGetValue<string>("users:1", out _); // Hit
+        _cache.TryGetValue<string>("users:3", out _); // Miss
+        _cache.TryGetValue<string>("guilds:1", out _); // Hit
+
+        // Act
+        var userStats = _cache.GetStatisticsByPrefix("users");
+        var guildStats = _cache.GetStatisticsByPrefix("guilds");
+
+        // Assert
+        userStats.KeyPrefix.Should().Be("users", "prefix should match");
+        userStats.Hits.Should().Be(1, "one hit for users prefix");
+        userStats.Misses.Should().Be(1, "one miss for users prefix");
+        userStats.HitRate.Should().Be(50.0, "hit rate should be 50%");
+
+        guildStats.KeyPrefix.Should().Be("guilds", "prefix should match");
+        guildStats.Hits.Should().Be(1, "one hit for guilds prefix");
+        guildStats.Misses.Should().Be(0, "no misses for guilds prefix");
+        guildStats.HitRate.Should().Be(100.0, "hit rate should be 100%");
+    }
+
+    [Fact]
+    public void ResetStatistics_ClearsAllCounts()
+    {
+        // Arrange - Generate some statistics
+        _cache.Set("test:1", "value1");
+        _cache.TryGetValue<string>("test:1", out _);
+        _cache.TryGetValue<string>("test:2", out _);
+
+        // Verify statistics exist
+        var beforeStats = _cache.GetStatisticsByPrefix("test");
+        beforeStats.Hits.Should().BeGreaterThan(0, "statistics should exist before reset");
+
+        // Act
+        _cache.ResetStatistics();
+
+        // Assert
+        var afterStats = _cache.GetStatisticsByPrefix("test");
+        afterStats.Hits.Should().Be(0, "hits should be reset");
+        afterStats.Misses.Should().Be(0, "misses should be reset");
+        afterStats.Size.Should().Be(0, "size should be reset");
+        afterStats.HitRate.Should().Be(0, "hit rate should be reset");
+
+        var allStats = _cache.GetStatistics();
+        allStats.Should().BeEmpty("all statistics should be cleared");
+    }
+}

--- a/tests/DiscordBot.Tests/Services/LatencyHistoryServiceTests.cs
+++ b/tests/DiscordBot.Tests/Services/LatencyHistoryServiceTests.cs
@@ -1,0 +1,199 @@
+using DiscordBot.Bot.Services;
+using DiscordBot.Core.Configuration;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace DiscordBot.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="LatencyHistoryService"/>.
+/// Tests cover recording samples, retrieving current latency, querying time-windowed samples,
+/// calculating statistics with percentiles, and circular buffer overflow behavior.
+/// </summary>
+public class LatencyHistoryServiceTests
+{
+    private readonly LatencyHistoryService _service;
+    private readonly PerformanceMetricsOptions _options;
+
+    public LatencyHistoryServiceTests()
+    {
+        _options = new PerformanceMetricsOptions
+        {
+            LatencyRetentionHours = 24,
+            LatencySampleIntervalSeconds = 30
+        };
+
+        _service = new LatencyHistoryService(
+            NullLogger<LatencyHistoryService>.Instance,
+            Options.Create(_options));
+    }
+
+    [Fact]
+    public void RecordSample_StoresSampleWithTimestamp()
+    {
+        // Arrange
+        const int latencyMs = 50;
+        var beforeTimestamp = DateTime.UtcNow;
+
+        // Act
+        _service.RecordSample(latencyMs);
+
+        // Assert
+        var samples = _service.GetSamples(hours: 1);
+        samples.Should().HaveCount(1, "one sample was recorded");
+
+        var sample = samples[0];
+        sample.LatencyMs.Should().Be(latencyMs, "latency value should match");
+        sample.Timestamp.Should().BeOnOrAfter(beforeTimestamp, "timestamp should be recent");
+        sample.Timestamp.Should().BeOnOrBefore(DateTime.UtcNow, "timestamp should not be in the future");
+    }
+
+    [Fact]
+    public void GetCurrentLatency_ReturnsLastRecordedValue()
+    {
+        // Arrange
+        _service.RecordSample(50);
+        _service.RecordSample(75);
+        _service.RecordSample(100);
+
+        // Act
+        var currentLatency = _service.GetCurrentLatency();
+
+        // Assert
+        currentLatency.Should().Be(100, "should return the most recently recorded latency");
+    }
+
+    [Fact]
+    public void GetCurrentLatency_ReturnsZeroWhenNoSamples()
+    {
+        // Act
+        var currentLatency = _service.GetCurrentLatency();
+
+        // Assert
+        currentLatency.Should().Be(0, "should return zero when no samples have been recorded");
+    }
+
+    [Fact]
+    public void GetSamples_ReturnsAllSamplesWithinTimeRange()
+    {
+        // Arrange
+        _service.RecordSample(50);
+        _service.RecordSample(60);
+        _service.RecordSample(70);
+
+        // Act
+        var samples = _service.GetSamples(hours: 24);
+
+        // Assert
+        samples.Should().HaveCount(3, "all recent samples should be returned");
+        samples.Should().BeInAscendingOrder(s => s.Timestamp, "samples should be in chronological order");
+    }
+
+    [Fact]
+    public void GetSamples_ReturnsEmptyWhenNoSamplesInRange()
+    {
+        // Arrange - service has no samples
+
+        // Act
+        var samples = _service.GetSamples(hours: 1);
+
+        // Assert
+        samples.Should().BeEmpty("no samples exist");
+    }
+
+    [Fact]
+    public void GetStatistics_CalculatesAverageMinMaxCorrectly()
+    {
+        // Arrange
+        _service.RecordSample(50);
+        _service.RecordSample(100);
+        _service.RecordSample(150);
+
+        // Act
+        var stats = _service.GetStatistics(hours: 24);
+
+        // Assert
+        stats.SampleCount.Should().Be(3, "three samples were recorded");
+        stats.Average.Should().Be(100.0, "average of 50, 100, 150 is 100");
+        stats.Min.Should().Be(50, "minimum value is 50");
+        stats.Max.Should().Be(150, "maximum value is 150");
+    }
+
+    [Fact]
+    public void GetStatistics_CalculatesPercentilesCorrectly()
+    {
+        // Arrange - Record values from 1 to 100
+        for (int i = 1; i <= 100; i++)
+        {
+            _service.RecordSample(i);
+        }
+
+        // Act
+        var stats = _service.GetStatistics(hours: 24);
+
+        // Assert
+        stats.SampleCount.Should().Be(100, "100 samples were recorded");
+        stats.P50.Should().BeInRange(49, 51, "P50 should be near the median");
+        stats.P95.Should().BeInRange(94, 96, "P95 should be near the 95th percentile");
+        stats.P99.Should().BeInRange(98, 100, "P99 should be near the 99th percentile");
+    }
+
+    [Fact]
+    public void CircularBuffer_OldestSamplesAreOverwritten()
+    {
+        // Arrange - Create a service with very small capacity (2 samples)
+        var smallOptions = new PerformanceMetricsOptions
+        {
+            LatencyRetentionHours = 1,
+            LatencySampleIntervalSeconds = 1800 // 30 minutes interval = 2 samples for 1 hour
+        };
+
+        var smallService = new LatencyHistoryService(
+            NullLogger<LatencyHistoryService>.Instance,
+            Options.Create(smallOptions));
+
+        // Act - Record more samples than capacity
+        smallService.RecordSample(10);
+        smallService.RecordSample(20);
+        smallService.RecordSample(30); // This should overwrite the first sample (10)
+
+        // Assert
+        var samples = smallService.GetSamples(hours: 24);
+        samples.Should().HaveCount(2, "circular buffer maintains max capacity");
+        samples.Should().NotContain(s => s.LatencyMs == 10, "oldest sample should be overwritten");
+        samples.Should().Contain(s => s.LatencyMs == 20, "second sample should remain");
+        samples.Should().Contain(s => s.LatencyMs == 30, "newest sample should be present");
+    }
+
+    [Fact]
+    public void ThreadSafety_ConcurrentRecordingsDoNotCorrupt()
+    {
+        // Arrange
+        const int threadCount = 10;
+        const int samplesPerThread = 100;
+
+        // Act - Record samples concurrently from multiple threads
+        var tasks = Enumerable.Range(0, threadCount).Select(threadId =>
+            Task.Run(() =>
+            {
+                for (int i = 0; i < samplesPerThread; i++)
+                {
+                    _service.RecordSample(threadId * 1000 + i);
+                }
+            })
+        ).ToArray();
+
+        Task.WaitAll(tasks);
+
+        // Assert
+        var samples = _service.GetSamples(hours: 24);
+        samples.Should().HaveCount(threadCount * samplesPerThread, "all samples from all threads should be recorded");
+
+        var currentLatency = _service.GetCurrentLatency();
+        currentLatency.Should().BeGreaterThanOrEqualTo(0, "current latency should be valid");
+
+        var stats = _service.GetStatistics(hours: 24);
+        stats.SampleCount.Should().Be(threadCount * samplesPerThread, "statistics should reflect all samples");
+    }
+}


### PR DESCRIPTION
## Summary
- Implements performance metrics collection infrastructure (Issue #571)
- Adds 12 REST API endpoints for dashboard consumption (Issue #572)
- Part of Epic #295 (Bot Performance Dashboard)

## Metrics Collection Services
| Service | Purpose |
|---------|---------|
| `ConnectionStateService` | Gateway connection tracking with uptime calculation |
| `LatencyHistoryService` | Circular buffer for 24h latency samples with P50/P95/P99 percentiles |
| `ApiRequestTracker` | Discord API request tracking via log message parsing |
| `CommandPerformanceAggregator` | Background service for command metrics with 5-min cache |
| `DatabaseMetricsCollector` | Query histogram and slow query tracking |
| `InstrumentedMemoryCache` | Cache wrapper with hit/miss tracking by key prefix |
| `BackgroundServiceHealthRegistry` | Aggregates health from all background services |

## API Endpoints
All endpoints require `RequireViewer` policy and are under `/api/metrics/`:

### Health Endpoints
- `GET /health` - Overall status, uptime, latency
- `GET /health/latency?hours=24` - Latency samples with statistics
- `GET /health/connections?days=7` - Connection events history

### Command Performance
- `GET /commands/performance?hours=24` - Aggregated command metrics
- `GET /commands/slowest?limit=10&hours=24` - Slowest commands
- `GET /commands/throughput?hours=24&granularity=hour` - Throughput over time
- `GET /commands/errors?hours=24&limit=50` - Error breakdown

### API Usage
- `GET /api/usage?hours=24` - Discord API request statistics
- `GET /api/rate-limits?hours=24` - Rate limit events

### System Health
- `GET /system/database?limit=20` - Database metrics and slow queries
- `GET /system/services` - Background service health
- `GET /system/cache` - Cache hit/miss statistics

## Test Plan
- [x] 40 unit tests for all metrics services
- [x] Thread safety validation for concurrent access
- [x] Circular buffer overflow testing
- [x] Percentile calculation verification
- [x] Build passes with no errors
- [x] All existing tests still pass (2347 passed)

## Documentation
- Updated `/docs/articles/api-endpoints.md` with all new endpoints

Closes #571
Closes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)