### PR TITLE
fix(api): Extend command performance API to support 30-day time range

### DIFF
--- a/src/DiscordBot.Bot/Controllers/PerformanceMetricsController.cs
+++ b/src/DiscordBot.Bot/Controllers/PerformanceMetricsController.cs
@@ -223,7 +223,7 @@ public class PerformanceMetricsController : ControllerBase
     /// <summary>
     /// Gets aggregated command performance metrics.
     /// </summary>
-    /// <param name="hours">Number of hours of history to aggregate (1-168, default: 24).</param>
+    /// <param name="hours">Number of hours of history to aggregate (1-720, default: 24).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>List of command performance aggregates.</returns>
     [HttpGet("commands/performance")]
@@ -236,14 +236,14 @@ public class PerformanceMetricsController : ControllerBase
     {
         try
         {
-            if (hours < 1 || hours > 168)
+            if (hours < 1 || hours > 720)
             {
                 _logger.LogWarning("Invalid hours parameter: {Hours}", hours);
 
                 return BadRequest(new ApiErrorDto
                 {
                     Message = "Invalid hours parameter",
-                    Detail = "Hours must be between 1 and 168 (7 days).",
+                    Detail = "Hours must be between 1 and 720 (30 days).",
                     StatusCode = StatusCodes.Status400BadRequest,
                     TraceId = HttpContext.GetCorrelationId()
                 });
@@ -275,7 +275,7 @@ public class PerformanceMetricsController : ControllerBase
     /// Gets the slowest command executions.
     /// </summary>
     /// <param name="limit">Maximum number of results to return (1-100, default: 10).</param>
-    /// <param name="hours">Number of hours of history to query (1-168, default: 24).</param>
+    /// <param name="hours">Number of hours of history to query (1-720, default: 24).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>List of slowest commands.</returns>
     [HttpGet("commands/slowest")]
@@ -302,14 +302,14 @@ public class PerformanceMetricsController : ControllerBase
                 });
             }
 
-            if (hours < 1 || hours > 168)
+            if (hours < 1 || hours > 720)
             {
                 _logger.LogWarning("Invalid hours parameter: {Hours}", hours);
 
                 return BadRequest(new ApiErrorDto
                 {
                     Message = "Invalid hours parameter",
-                    Detail = "Hours must be between 1 and 168 (7 days).",
+                    Detail = "Hours must be between 1 and 720 (30 days).",
                     StatusCode = StatusCodes.Status400BadRequest,
                     TraceId = HttpContext.GetCorrelationId()
                 });
@@ -340,7 +340,7 @@ public class PerformanceMetricsController : ControllerBase
     /// <summary>
     /// Gets command execution throughput over time.
     /// </summary>
-    /// <param name="hours">Number of hours of history to include (1-168, default: 24).</param>
+    /// <param name="hours">Number of hours of history to include (1-720, default: 24).</param>
     /// <param name="granularity">Time bucket granularity: "hour" or "day" (default: "hour").</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>List of throughput measurements over time.</returns>
@@ -355,14 +355,14 @@ public class PerformanceMetricsController : ControllerBase
     {
         try
         {
-            if (hours < 1 || hours > 168)
+            if (hours < 1 || hours > 720)
             {
                 _logger.LogWarning("Invalid hours parameter: {Hours}", hours);
 
                 return BadRequest(new ApiErrorDto
                 {
                     Message = "Invalid hours parameter",
-                    Detail = "Hours must be between 1 and 168 (7 days).",
+                    Detail = "Hours must be between 1 and 720 (30 days).",
                     StatusCode = StatusCodes.Status400BadRequest,
                     TraceId = HttpContext.GetCorrelationId()
                 });
@@ -406,7 +406,7 @@ public class PerformanceMetricsController : ControllerBase
     /// <summary>
     /// Gets command error breakdown and statistics.
     /// </summary>
-    /// <param name="hours">Number of hours of history to analyze (1-168, default: 24).</param>
+    /// <param name="hours">Number of hours of history to analyze (1-720, default: 24).</param>
     /// <param name="limit">Maximum number of commands to return (1-100, default: 50).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Command error summary with rate and breakdown.</returns>
@@ -421,14 +421,14 @@ public class PerformanceMetricsController : ControllerBase
     {
         try
         {
-            if (hours < 1 || hours > 168)
+            if (hours < 1 || hours > 720)
             {
                 _logger.LogWarning("Invalid hours parameter: {Hours}", hours);
 
                 return BadRequest(new ApiErrorDto
                 {
                     Message = "Invalid hours parameter",
-                    Detail = "Hours must be between 1 and 168 (7 days).",
+                    Detail = "Hours must be between 1 and 720 (30 days).",
                     StatusCode = StatusCodes.Status400BadRequest,
                     TraceId = HttpContext.GetCorrelationId()
                 });

--- a/src/DiscordBot.Bot/Pages/Admin/Performance/Commands.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/Commands.cshtml
@@ -620,13 +620,36 @@ else
         const hours = @Model.Hours;
         const granularity = hours >= 168 ? 'day' : 'hour';
 
+        // Show error message in a chart container
+        function showChartError(chartId, message) {
+            const container = document.getElementById(chartId)?.parentElement;
+            if (container) {
+                container.innerHTML = `
+                    <div class="flex flex-col items-center justify-center h-full text-center p-4">
+                        <svg class="w-8 h-8 text-red-500 mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                        </svg>
+                        <div class="text-red-400 font-medium">Failed to load chart</div>
+                        <div class="text-text-secondary text-sm mt-1">${message}</div>
+                    </div>`;
+            }
+        }
+
         // Initialize Response Time Chart
         async function initResponseTimeChart() {
             try {
                 const response = await fetch(`/api/metrics/commands/throughput?hours=${hours}&granularity=${granularity}`);
+                if (!response.ok) {
+                    const errorData = await response.json().catch(() => ({}));
+                    throw new Error(errorData.detail || `HTTP ${response.status}`);
+                }
                 const throughputData = await response.json();
 
                 const aggregatesResponse = await fetch(`/api/metrics/commands/performance?hours=${hours}`);
+                if (!aggregatesResponse.ok) {
+                    const errorData = await aggregatesResponse.json().catch(() => ({}));
+                    throw new Error(errorData.detail || `HTTP ${aggregatesResponse.status}`);
+                }
                 const aggregates = await aggregatesResponse.json();
 
                 // Create labels from throughput data
@@ -737,6 +760,7 @@ else
                 });
             } catch (error) {
                 console.error('Failed to load response time chart:', error);
+                showChartError('responseTimeChart', error.message);
             }
         }
 
@@ -744,6 +768,10 @@ else
         async function initThroughputChart() {
             try {
                 const response = await fetch(`/api/metrics/commands/throughput?hours=${hours}&granularity=${granularity}`);
+                if (!response.ok) {
+                    const errorData = await response.json().catch(() => ({}));
+                    throw new Error(errorData.detail || `HTTP ${response.status}`);
+                }
                 const data = await response.json();
 
                 const labels = data.map(t => {
@@ -809,6 +837,7 @@ else
                 });
             } catch (error) {
                 console.error('Failed to load throughput chart:', error);
+                showChartError('throughputChart', error.message);
             }
         }
 
@@ -816,9 +845,17 @@ else
         async function initErrorRateChart() {
             try {
                 const throughputResponse = await fetch(`/api/metrics/commands/throughput?hours=${hours}&granularity=${granularity}`);
+                if (!throughputResponse.ok) {
+                    const errorData = await throughputResponse.json().catch(() => ({}));
+                    throw new Error(errorData.detail || `HTTP ${throughputResponse.status}`);
+                }
                 const throughputData = await throughputResponse.json();
 
                 const aggregatesResponse = await fetch(`/api/metrics/commands/performance?hours=${hours}`);
+                if (!aggregatesResponse.ok) {
+                    const errorData = await aggregatesResponse.json().catch(() => ({}));
+                    throw new Error(errorData.detail || `HTTP ${aggregatesResponse.status}`);
+                }
                 const aggregates = await aggregatesResponse.json();
 
                 const labels = throughputData.map(t => {
@@ -902,6 +939,7 @@ else
                 });
             } catch (error) {
                 console.error('Failed to load error rate chart:', error);
+                showChartError('errorRateChart', error.message);
             }
         }
 


### PR DESCRIPTION
## Summary
- Extended API validation limit from 168 to 720 hours for command performance endpoints
- Added user-visible error messages when chart API calls fail instead of silent console logging
- Updated XML documentation to reflect new parameter ranges

## Root Cause
The Command Performance page (`/Admin/Performance/Commands`) showed blank charts when the "30d" time range was selected because API endpoints rejected `hours > 168` (7 days) with a 400 Bad Request, while the UI sent `hours=720` (30 days).

## Changes

### Backend (`PerformanceMetricsController.cs`)
- Extended hour validation from `1-168` to `1-720` in 4 endpoints:
  - `GET /api/metrics/commands/performance`
  - `GET /api/metrics/commands/throughput`
  - `GET /api/metrics/commands/slowest`
  - `GET /api/metrics/commands/errors`

### Frontend (`Commands.cshtml`)
- Added `showChartError()` helper function to display user-visible error messages in chart containers
- Added HTTP response status checking before parsing JSON
- Added error display for all 3 charts: Response Times, Throughput, and Error Rate

## Test Plan
- [x] Build succeeds
- [x] All 2437 tests pass
- [ ] Manual verification: Navigate to Command Performance page with 30d selected - charts should load data
- [ ] Manual verification: Test error display by temporarily disabling API (charts should show error message instead of blank)

Closes #592

🤖 Generated with [Claude Code](https://claude.com/claude-code)