### PR TITLE
fix(ui): Fix timezone display on all Performance dashboard pages

### DIFF
--- a/src/DiscordBot.Bot/Pages/Admin/Performance/Commands.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/Commands.cshtml
@@ -533,7 +533,7 @@ else
                                     @cmd.DurationMs.ToString("F0")ms
                                 </td>
                                 <td>
-                                    <span data-utc-time="@cmd.ExecutedAt.ToString("o")">@cmd.ExecutedAt.ToLocalTime().ToString("MMM dd, HH:mm")</span>
+                                    <span data-utc-time="@cmd.ExecutedAt.ToString("o")">@cmd.ExecutedAt.ToString("MMM dd, HH:mm") UTC</span>
                                 </td>
                                 <td class="text-text-secondary">@cmd.UserId</td>
                                 <td class="text-text-secondary">@(cmd.GuildId?.ToString() ?? "DM")</td>
@@ -579,7 +579,7 @@ else
                                 </td>
                                 <td class="font-medium text-warning">@timeout.TimeoutCount</td>
                                 <td>
-                                    <span data-utc-time="@timeout.LastTimeout.ToString("o")">@timeout.LastTimeout.ToLocalTime().ToString("MMM dd, HH:mm")</span>
+                                    <span data-utc-time="@timeout.LastTimeout.ToString("o")">@timeout.LastTimeout.ToString("MMM dd, HH:mm") UTC</span>
                                 </td>
                                 <td>@timeout.AvgResponseBeforeTimeout.ToString("F0")ms</td>
                                 <td>

--- a/src/DiscordBot.Bot/Pages/Admin/Performance/HealthMetrics.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/HealthMetrics.cshtml
@@ -443,7 +443,14 @@
             <div class="uptime-display">
                 <div class="uptime-percentage healthy">@Model.ViewModel.Uptime30DFormatted</div>
                 <div class="uptime-label">Uptime (30 days)</div>
-                <div class="uptime-since">Online since @Model.ViewModel.SessionStartFormatted</div>
+                @if (Model.ViewModel.SessionStartUtc.HasValue)
+                {
+                    <div class="uptime-since">Online since <span data-utc-time="@Model.ViewModel.SessionStartUtc.Value.ToString("o")">@Model.ViewModel.SessionStartFormatted</span></div>
+                }
+                else
+                {
+                    <div class="uptime-since">Online since Unknown</div>
+                }
             </div>
             <div class="grid grid-cols-2 gap-4 mt-4 pt-4 border-t border-border-primary">
                 <div class="text-center">
@@ -636,7 +643,7 @@
                     <div class="timeline-entry">
                         <div class="timeline-dot @dotClass"></div>
                         <div class="timeline-content">
-                            <div class="timeline-time" data-utc-time="@evt.Timestamp.ToString("o")">@evt.Timestamp.ToLocalTime().ToString("MMM dd, yyyy 'at' HH:mm")</div>
+                            <div class="timeline-time" data-utc-time="@evt.Timestamp.ToString("o")">@evt.Timestamp.ToString("MMM dd, yyyy 'at' HH:mm") UTC</div>
                             <div class="timeline-title">@evt.EventType</div>
                             @if (!string.IsNullOrEmpty(evt.Reason) || !string.IsNullOrEmpty(evt.Details))
                             {

--- a/src/DiscordBot.Bot/Pages/Admin/Performance/HealthMetrics.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/HealthMetrics.cshtml.cs
@@ -78,9 +78,9 @@ public class HealthMetricsModel : PageModel
             var gen2Collections = GC.CollectionCount(2);
             var threadCount = process.Threads.Count;
 
-            // Format session start time
+            // Format session start time (UTC for client-side conversion)
             var sessionStart = _connectionStateService.GetLastConnectedTime();
-            var sessionStartFormatted = sessionStart?.ToLocalTime().ToString("MMM dd, yyyy 'at' HH:mm") ?? "Unknown";
+            var sessionStartFormatted = sessionStart?.ToString("MMM dd, yyyy 'at' HH:mm") + " UTC" ?? "Unknown";
 
             // Create health DTO
             var health = new Core.DTOs.PerformanceHealthDto
@@ -106,6 +106,7 @@ public class HealthMetricsModel : PageModel
                 ConnectionStateClass = HealthMetricsViewModel.GetConnectionStateClass(connectionState.ToString()),
                 LatencyHealthClass = HealthMetricsViewModel.GetLatencyHealthClass(currentLatency),
                 SessionStartFormatted = sessionStartFormatted,
+                SessionStartUtc = sessionStart,
                 WorkingSetMB = workingSetMB,
                 PrivateMemoryMB = privateMemoryMB,
                 MaxAllocatedMemoryMB = maxAllocatedMemoryMB,

--- a/src/DiscordBot.Bot/Pages/Admin/Performance/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/Index.cshtml
@@ -758,7 +758,7 @@
                                 }
                                 <div class="alert-meta">
                                     <span class="@severityBadgeClass">@alert.Severity</span>
-                                    <span data-utc-time="@alert.TriggeredAt.ToString("o")">@((DateTime.UtcNow - alert.TriggeredAt).TotalMinutes < 60 ? $"{(int)(DateTime.UtcNow - alert.TriggeredAt).TotalMinutes} minutes ago" : $"{(int)(DateTime.UtcNow - alert.TriggeredAt).TotalHours} hours ago")</span>
+                                    <span data-utc-time="@alert.TriggeredAt.ToString("o")" data-format="relative">@((DateTime.UtcNow - alert.TriggeredAt).TotalMinutes < 60 ? $"{(int)(DateTime.UtcNow - alert.TriggeredAt).TotalMinutes} minutes ago" : $"{(int)(DateTime.UtcNow - alert.TriggeredAt).TotalHours} hours ago")</span>
                                 </div>
                             </div>
                         </div>
@@ -981,9 +981,59 @@
             }
         }
 
+        // Convert UTC timestamps to local timezone
+        function convertTimestampsToLocal() {
+            const timestampElements = document.querySelectorAll('[data-utc-time]');
+            timestampElements.forEach(element => {
+                const utcTime = element.getAttribute('data-utc-time');
+                const format = element.getAttribute('data-format');
+                if (utcTime) {
+                    try {
+                        const date = new Date(utcTime);
+
+                        if (format === 'relative') {
+                            // For relative times, calculate the difference and format as "X ago"
+                            const now = new Date();
+                            const elapsed = now - date;
+                            const minutes = Math.floor(elapsed / 60000);
+                            const hours = Math.floor(minutes / 60);
+                            const days = Math.floor(hours / 24);
+
+                            let relativeText;
+                            if (days >= 1) {
+                                relativeText = days === 1 ? '1 day ago' : `${days} days ago`;
+                            } else if (hours >= 1) {
+                                relativeText = hours === 1 ? '1 hour ago' : `${hours} hours ago`;
+                            } else if (minutes >= 1) {
+                                relativeText = minutes === 1 ? '1 minute ago' : `${minutes} minutes ago`;
+                            } else {
+                                relativeText = 'Just now';
+                            }
+                            element.textContent = relativeText;
+                        } else {
+                            // For absolute times, format as local date/time
+                            const formatted = date.toLocaleDateString('en-US', {
+                                month: 'short',
+                                day: '2-digit',
+                                year: 'numeric'
+                            }) + ' at ' + date.toLocaleTimeString('en-US', {
+                                hour: '2-digit',
+                                minute: '2-digit',
+                                hour12: false
+                            });
+                            element.textContent = formatted;
+                        }
+                    } catch (e) {
+                        console.error('Failed to parse timestamp:', utcTime, e);
+                    }
+                }
+            });
+        }
+
         // Initialize on page load
         document.addEventListener('DOMContentLoaded', function() {
             initCharts();
+            convertTimestampsToLocal();
 
             // Auto-refresh every 30 seconds
             setInterval(refreshData, 30000);

--- a/src/DiscordBot.Bot/Pages/Admin/Performance/SystemHealth.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/SystemHealth.cshtml
@@ -386,7 +386,7 @@
                                 <code class="text-mono text-xs text-text-secondary">@(query.CommandText.Length > 100 ? query.CommandText.Substring(0, 100) + "..." : query.CommandText)</code>
                             </td>
                             <td class="font-medium @(query.DurationMs > 500 ? "text-error" : "text-warning")">@query.DurationMs.ToString("F0")ms</td>
-                            <td class="text-text-tertiary" data-utc-time="@query.Timestamp.ToString("o")">@query.Timestamp.ToLocalTime().ToString("MMM dd, HH:mm")</td>
+                            <td class="text-text-tertiary" data-utc-time="@query.Timestamp.ToString("o")">@query.Timestamp.ToString("MMM dd, HH:mm") UTC</td>
                             <td class="text-xs text-text-tertiary">@(string.IsNullOrEmpty(query.Parameters) ? "-" : query.Parameters.Length > 50 ? query.Parameters.Substring(0, 50) + "..." : query.Parameters)</td>
                         </tr>
                     }

--- a/src/DiscordBot.Bot/ViewModels/Pages/HealthMetricsViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Pages/HealthMetricsViewModel.cs
@@ -58,9 +58,14 @@ public record HealthMetricsViewModel
     public string LatencyHealthClass { get; init; } = string.Empty;
 
     /// <summary>
-    /// Gets the formatted start time of the current session.
+    /// Gets the formatted start time of the current session (UTC fallback text).
     /// </summary>
     public string SessionStartFormatted { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the UTC start time of the current session for client-side conversion.
+    /// </summary>
+    public DateTime? SessionStartUtc { get; init; }
 
     /// <summary>
     /// Gets the current working set memory in MB.


### PR DESCRIPTION
## Summary
Follow-up fix for #594 - removes remaining `.ToLocalTime()` calls from all Performance pages that were still showing server timezone instead of user's browser timezone.

## Files Changed
- **Commands.cshtml**: Remove `.ToLocalTime()` from recent commands and timeout timestamps
- **HealthMetrics.cshtml**: Remove `.ToLocalTime()` from connection events timeline; add `data-utc-time` for uptime display
- **HealthMetrics.cshtml.cs**: Pass `SessionStartUtc` to ViewModel for client-side conversion
- **HealthMetricsViewModel.cs**: Add `SessionStartUtc` nullable DateTime property
- **SystemHealth.cshtml**: Remove `.ToLocalTime()` from slow queries table
- **Index.cshtml**: Add `convertTimestampsToLocal()` function and `data-format="relative"` for alert timestamps

## Pattern Used
All timestamps now:
1. Show "UTC" suffix in server-rendered fallback (in case JS is disabled)
2. Have `data-utc-time` attribute with ISO 8601 timestamp
3. Are converted to user's local timezone via JavaScript on page load

Closes #594

## Test plan
- [ ] Open Performance Overview page - verify active alert times are correct
- [ ] Open Commands page - verify recent commands and timeout timestamps are local
- [ ] Open Health Metrics page - verify "Online since" time and connection events are local
- [ ] Open System Health page - verify slow queries timestamps are local
- [ ] Compare all displayed times against system clock to confirm no offset

🤖 Generated with [Claude Code](https://claude.com/claude-code)