### PR TITLE
fix(alerts): Use camelCase JSON serialization for Alert Frequency chart

### DIFF
--- a/src/DiscordBot.Bot/Pages/Admin/Performance/Alerts.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/Alerts.cshtml
@@ -890,7 +890,7 @@
             const ctx = document.getElementById('alertFrequencyChart');
             if (!ctx) return;
 
-            const data = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.ViewModel.AlertFrequencyData));
+            const data = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.ViewModel.AlertFrequencyData, new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase }));
 
             const labels = data.map(d => {
                 const date = new Date(d.date);


### PR DESCRIPTION
## Summary
- Fixed Alert Frequency chart showing "Invalid Date" and no data bars
- Added explicit camelCase JSON serialization for `AlertFrequencyData` DTO
- JavaScript now correctly accesses `d.date`, `d.criticalCount`, etc.

## Root Cause
The `AlertFrequencyData` DTO was serialized with default PascalCase property names (`Date`, `CriticalCount`), but JavaScript expected camelCase (`date`, `criticalCount`). This caused `d.date` to return `undefined`, resulting in "Invalid Date".

## Changes
- `src/DiscordBot.Bot/Pages/Admin/Performance/Alerts.cshtml` (line 893): Added `PropertyNamingPolicy = JsonNamingPolicy.CamelCase` to the serialization options

## Audit Results
Also audited other pages using `JsonSerializer.Serialize` - they all use inline anonymous types with explicit camelCase property names, so no other changes needed.

## Test plan
- [ ] Navigate to `/Admin/Performance/Alerts`
- [ ] Verify the Alert Frequency chart displays dates correctly on X-axis (e.g., "Jan 2")
- [ ] Verify the bars appear when there is alert data
- [ ] Verify the legend counts (Critical, Warning, Info) match the displayed bars

Closes #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)