### PR TITLE
fix(ui): Remove tab scrollbar and add sample data indicator

### DIFF
--- a/src/DiscordBot.Bot/Pages/Admin/Performance/Alerts.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/Alerts.cshtml
@@ -20,8 +20,6 @@
             gap: 0.5rem;
             border-bottom: 2px solid rgb(63, 68, 71);
             margin-bottom: 1.5rem;
-            overflow-x: auto;
-            scrollbar-width: thin;
         }
 
         .performance-tab {

--- a/src/DiscordBot.Bot/Pages/Admin/Performance/ApiMetrics.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/ApiMetrics.cshtml
@@ -19,8 +19,6 @@
             gap: 0.5rem;
             border-bottom: 2px solid rgb(63, 68, 71);
             margin-bottom: 1.5rem;
-            overflow-x: auto;
-            scrollbar-width: thin;
         }
 
         .performance-tab {

--- a/src/DiscordBot.Bot/Pages/Admin/Performance/Commands.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/Commands.cshtml
@@ -19,8 +19,6 @@
             gap: 0.5rem;
             border-bottom: 2px solid rgb(63, 68, 71);
             margin-bottom: 1.5rem;
-            overflow-x: auto;
-            scrollbar-width: thin;
         }
 
         .performance-tab {

--- a/src/DiscordBot.Bot/Pages/Admin/Performance/HealthMetrics.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/HealthMetrics.cshtml
@@ -18,8 +18,6 @@
             gap: 0.5rem;
             border-bottom: 2px solid rgb(63, 68, 71);
             margin-bottom: 1.5rem;
-            overflow-x: auto;
-            scrollbar-width: thin;
         }
 
         .performance-tab {

--- a/src/DiscordBot.Bot/Pages/Admin/Performance/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/Index.cshtml
@@ -17,8 +17,6 @@
             gap: 0.5rem;
             border-bottom: 2px solid rgb(63, 68, 71);
             margin-bottom: 1.5rem;
-            overflow-x: auto;
-            scrollbar-width: thin;
         }
 
         .performance-tab {

--- a/src/DiscordBot.Bot/Pages/Admin/Performance/SystemHealth.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/SystemHealth.cshtml
@@ -19,8 +19,6 @@
             gap: 0.5rem;
             border-bottom: 2px solid rgb(63, 68, 71);
             margin-bottom: 1.5rem;
-            overflow-x: auto;
-            scrollbar-width: thin;
         }
 
         .performance-tab {
@@ -253,6 +251,26 @@
             background: rgba(9, 142, 207, 0.1);
             color: rgb(9, 142, 207);
         }
+
+        .sample-data-notice {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.5rem;
+            padding: 0.5rem 1rem;
+            margin-top: 1rem;
+            background: rgba(168, 165, 163, 0.1);
+            border: 1px dashed rgb(99, 102, 104);
+            border-radius: 0.375rem;
+            font-size: 0.75rem;
+            color: rgb(168, 165, 163);
+        }
+
+        .sample-data-notice svg {
+            width: 1rem;
+            height: 1rem;
+            flex-shrink: 0;
+        }
     </style>
 }
 
@@ -353,6 +371,12 @@
         <!-- Query Time Chart -->
         <div class="chart-container chart-container-sm">
             <canvas id="queryTimeChart"></canvas>
+        </div>
+        <div class="sample-data-notice">
+            <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <span>Chart shows sample data. Historical metrics collection coming soon.</span>
         </div>
     </div>
 </div>
@@ -570,6 +594,12 @@
 
         <div class="chart-container">
             <canvas id="memoryChart"></canvas>
+        </div>
+        <div class="sample-data-notice">
+            <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <span>Chart shows sample data. Historical metrics collection coming soon.</span>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary

- **#608**: Removed `overflow-x: auto` and `scrollbar-width: thin` from `.performance-tabs` CSS across all 6 Performance dashboard pages to eliminate the unwanted scrollbar in the tab navigation header
- **#610**: Added a "sample data" notice below the Database Performance and Memory & GC charts on the System Health page to clarify that chart timelines show placeholder data until historical metrics collection is implemented

## Changes

| File | Change |
|------|--------|
| `Index.cshtml` | Removed scrollbar styling from `.performance-tabs` |
| `HealthMetrics.cshtml` | Removed scrollbar styling from `.performance-tabs` |
| `Commands.cshtml` | Removed scrollbar styling from `.performance-tabs` |
| `ApiMetrics.cshtml` | Removed scrollbar styling from `.performance-tabs` |
| `SystemHealth.cshtml` | Removed scrollbar styling + added sample-data-notice style + added notices below both charts |
| `Alerts.cshtml` | Removed scrollbar styling from `.performance-tabs` |

## Test plan

- [ ] Navigate to `/Admin/Performance` and verify no scrollbar appears in the tab header
- [ ] Check all 6 performance sub-pages for consistent tab styling
- [ ] On System Health page, verify the "sample data" notices appear below both charts
- [ ] Verify the notices have the correct dashed border styling and info icon

Closes #608
Closes #610

🤖 Generated with [Claude Code](https://claude.com/claude-code)