### PR TITLE
fix: Performance page UI fixes for alert icons and chart Y-axis

### DIFF
--- a/src/DiscordBot.Bot/Pages/Admin/Performance/Commands.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/Commands.cshtml
@@ -917,13 +917,13 @@ else
                         scales: {
                             y: {
                                 beginAtZero: true,
-                                max: Math.max(5, errorRate + 1),
+                                max: Math.ceil(Math.max(5, errorRate + 1)),
                                 grid: {
                                     color: '#2f3336'
                                 },
                                 ticks: {
                                     callback: function(value) {
-                                        return value + '%';
+                                        return value.toFixed(1) + '%';
                                     }
                                 }
                             },

--- a/src/DiscordBot.Bot/Pages/Admin/Performance/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/Index.cshtml
@@ -734,8 +734,8 @@
                         var iconClass = severityStr switch
                         {
                             "critical" => "alert-icon text-error",
-                            "warning" => "alert-icon-warning",
-                            _ => "alert-icon-info"
+                            "warning" => "alert-icon alert-icon-warning",
+                            _ => "alert-icon alert-icon-info"
                         };
                         var severityBadgeClass = severityStr switch
                         {


### PR DESCRIPTION
## Summary

- **Fix alert icons rendering too large in Recent Alerts section (#641)**
  - Added missing base `alert-icon` class to warning and info severity icons
  - Icons now properly sized at 1.25rem instead of filling container

- **Fix error rate Y-axis percentage values not rounded (#643)**
  - Round max scale value using `Math.ceil()` for cleaner axis bounds  
  - Format tick labels with `toFixed(1)` for 1 decimal place precision (e.g., `18.6%` instead of `18.647058823529413%`)

## Test plan

- [ ] Navigate to `/Admin/Performance` and verify Recent Alerts icons display at correct 1.25rem size
- [ ] Navigate to `/Admin/Performance/Commands` and verify Error Rate chart Y-axis shows rounded percentages
- [ ] Verify tooltip values still show precise values (1 decimal place)

Closes #641
Closes #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)