### PR TITLE
[Task] Create reusable Razor partial for autocomplete inputs

### DIFF
--- a/src/DiscordBot.Bot/Pages/Shared/Components/_AutocompleteInput.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/Components/_AutocompleteInput.cshtml
@@ -1,0 +1,70 @@
+@model DiscordBot.Bot.ViewModels.Components.AutocompleteInputViewModel
+@{
+    var searchInputId = $"{Model.Id}-search";
+    var helpTextId = $"{Model.Id}-help";
+}
+
+<div class="space-y-1.5">
+    @if (!string.IsNullOrEmpty(Model.Label))
+    {
+        <label for="@searchInputId" class="block text-sm font-medium text-text-primary">
+            @Model.Label
+            @if (Model.IsRequired)
+            {
+                <span class="text-error">*</span>
+            }
+        </label>
+    }
+
+    <div class="autocomplete-wrapper">
+        <input
+            type="text"
+            id="@searchInputId"
+            class="form-input w-full"
+            placeholder="@(Model.Placeholder ?? "Search...")"
+            value="@Model.InitialDisplayText"
+            autocomplete="off"
+            @if (Model.IsRequired)
+            {
+                @:aria-required="true"
+            }
+            @if (!string.IsNullOrEmpty(Model.HelpText))
+            {
+                @:aria-describedby="@helpTextId"
+            }
+        />
+        <input
+            type="hidden"
+            id="@Model.Id"
+            name="@Model.Name"
+            value="@Model.InitialValue"
+        />
+        @* Dropdown and clear button are created dynamically by JavaScript *@
+    </div>
+
+    @if (!string.IsNullOrEmpty(Model.HelpText))
+    {
+        <p id="@helpTextId" class="text-xs text-text-secondary">@Model.HelpText</p>
+    }
+</div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        if (typeof AutocompleteManager !== 'undefined') {
+            AutocompleteManager.init({
+                inputId: '@searchInputId',
+                hiddenInputId: '@Model.Id',
+                endpoint: '@Model.Endpoint',
+                @if (!string.IsNullOrEmpty(Model.GuildIdSourceElement))
+                {
+                    @:guildIdSource: '@Model.GuildIdSourceElement',
+                }
+                minChars: @Model.MinChars,
+                debounceMs: @Model.DebounceMs,
+                maxResults: @Model.MaxResults,
+                placeholder: '@(Model.Placeholder ?? "Search...")',
+                noResultsMessage: '@Model.NoResultsMessage'
+            });
+        }
+    });
+</script>

--- a/src/DiscordBot.Bot/ViewModels/Components/AutocompleteInputViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Components/AutocompleteInputViewModel.cs
@@ -1,0 +1,82 @@
+// src/DiscordBot.Bot/ViewModels/Components/AutocompleteInputViewModel.cs
+namespace DiscordBot.Bot.ViewModels.Components;
+
+/// <summary>
+/// ViewModel for the autocomplete input partial view.
+/// Configures the HTML structure and JavaScript behavior of autocomplete inputs.
+/// </summary>
+public record AutocompleteInputViewModel
+{
+    /// <summary>
+    /// The ID for the hidden input element that stores the selected value.
+    /// Also used as the base for generating related element IDs.
+    /// </summary>
+    public string Id { get; init; } = string.Empty;
+
+    /// <summary>
+    /// The form name for the hidden input element used during form submission.
+    /// </summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>
+    /// The label text displayed above the input.
+    /// </summary>
+    public string? Label { get; init; }
+
+    /// <summary>
+    /// Placeholder text for the search input.
+    /// </summary>
+    public string? Placeholder { get; init; }
+
+    /// <summary>
+    /// The API endpoint for autocomplete search requests.
+    /// Example: "/api/autocomplete/users"
+    /// </summary>
+    public string Endpoint { get; init; } = string.Empty;
+
+    /// <summary>
+    /// The initial value (ID) for the hidden input when editing existing data.
+    /// </summary>
+    public string? InitialValue { get; init; }
+
+    /// <summary>
+    /// The initial display text for the search input when editing existing data.
+    /// </summary>
+    public string? InitialDisplayText { get; init; }
+
+    /// <summary>
+    /// Optional ID of an element containing the guild ID to include in search requests.
+    /// Used for guild-scoped searches (e.g., searching users within a specific guild).
+    /// </summary>
+    public string? GuildIdSourceElement { get; init; }
+
+    /// <summary>
+    /// Whether this field is required for form submission.
+    /// </summary>
+    public bool IsRequired { get; init; }
+
+    /// <summary>
+    /// Minimum characters before triggering search. Defaults to 2.
+    /// </summary>
+    public int MinChars { get; init; } = 2;
+
+    /// <summary>
+    /// Debounce delay in milliseconds. Defaults to 300.
+    /// </summary>
+    public int DebounceMs { get; init; } = 300;
+
+    /// <summary>
+    /// Maximum number of results to display. Defaults to 25.
+    /// </summary>
+    public int MaxResults { get; init; } = 25;
+
+    /// <summary>
+    /// Message displayed when no results are found.
+    /// </summary>
+    public string NoResultsMessage { get; init; } = "No results found";
+
+    /// <summary>
+    /// Optional help text displayed below the input.
+    /// </summary>
+    public string? HelpText { get; init; }
+}


### PR DESCRIPTION
## Summary

- Add `AutocompleteInputViewModel` with configuration properties for endpoint, placeholder, initial values, guild-scoped searches, and customization options
- Add `_AutocompleteInput.cshtml` partial view that generates both visible search input and hidden value input with proper accessibility attributes
- Auto-initializes `AutocompleteManager` JavaScript on DOMContentLoaded

## Usage Example

```razor
<partial name="Shared/Components/_AutocompleteInput" model="new AutocompleteInputViewModel {
    Id = "authorId",
    Name = "AuthorId",
    Label = "User",
    Placeholder = "Search for user...",
    Endpoint = "/api/autocomplete/users",
    InitialValue = Model.AuthorId?.ToString(),
    InitialDisplayText = Model.AuthorUsername
}" />
```

## Test plan

- [x] Solution builds successfully
- [x] Autocomplete-related tests pass (25 tests)
- [ ] Manual verification: Use partial in a filter form and verify autocomplete functionality works

Closes #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)