### PR TITLE
feat: Add autocomplete to Message Logs filter inputs

### DIFF
--- a/src/DiscordBot.Bot/Pages/Admin/MessageLogs/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/MessageLogs/Index.cshtml
@@ -1,7 +1,46 @@
 @page
 @model DiscordBot.Bot.Pages.Admin.MessageLogs.IndexModel
+@using DiscordBot.Bot.ViewModels.Components
 @{
     ViewData["Title"] = "Message Logs";
+
+    // Autocomplete view models for filter fields
+    var authorAutocomplete = new AutocompleteInputViewModel
+    {
+        Id = "AuthorId",
+        Name = "AuthorId",
+        Label = "User",
+        Placeholder = "Search by username...",
+        Endpoint = "/api/autocomplete/users",
+        InitialValue = Model.AuthorId?.ToString(),
+        InitialDisplayText = Model.AuthorUsername,
+        NoResultsMessage = "No users found"
+    };
+
+    var guildAutocomplete = new AutocompleteInputViewModel
+    {
+        Id = "GuildId",
+        Name = "GuildId",
+        Label = "Guild",
+        Placeholder = "Search by guild name...",
+        Endpoint = "/api/autocomplete/guilds",
+        InitialValue = Model.GuildId?.ToString(),
+        InitialDisplayText = Model.GuildName,
+        NoResultsMessage = "No guilds found"
+    };
+
+    var channelAutocomplete = new AutocompleteInputViewModel
+    {
+        Id = "ChannelId",
+        Name = "ChannelId",
+        Label = "Channel",
+        Placeholder = "Select a guild first...",
+        Endpoint = "/api/autocomplete/channels",
+        GuildIdSourceElement = "GuildId",
+        InitialValue = Model.ChannelId?.ToString(),
+        InitialDisplayText = Model.ChannelName,
+        NoResultsMessage = "No channels found"
+    };
 }
 
 <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -25,47 +64,17 @@
             <h2 class="text-sm font-semibold text-text-primary">Filters</h2>
         </div>
 
-        <form method="get" class="space-y-4">
+        <form method="get" class="space-y-4" id="messageLogsFilterForm">
             <!-- Row 1: User ID, Guild ID, Channel ID -->
             <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                 <!-- Author ID -->
-                <div>
-                    <label for="authorId" class="block text-sm font-medium text-text-primary mb-1">User ID</label>
-                    <input
-                        type="text"
-                        id="authorId"
-                        name="AuthorId"
-                        value="@Model.AuthorId"
-                        placeholder="Enter Discord User ID..."
-                        class="w-full py-2 px-3 text-sm text-text-primary bg-bg-primary border border-border-primary rounded-md placeholder-text-tertiary transition-colors focus:outline-none focus:ring-2 focus:ring-border-focus focus:border-transparent"
-                    />
-                </div>
+                <partial name="Shared/Components/_AutocompleteInput" model="authorAutocomplete" />
 
                 <!-- Guild ID -->
-                <div>
-                    <label for="guildId" class="block text-sm font-medium text-text-primary mb-1">Guild ID</label>
-                    <input
-                        type="text"
-                        id="guildId"
-                        name="GuildId"
-                        value="@Model.GuildId"
-                        placeholder="Enter Guild ID..."
-                        class="w-full py-2 px-3 text-sm text-text-primary bg-bg-primary border border-border-primary rounded-md placeholder-text-tertiary transition-colors focus:outline-none focus:ring-2 focus:ring-border-focus focus:border-transparent"
-                    />
-                </div>
+                <partial name="Shared/Components/_AutocompleteInput" model="guildAutocomplete" />
 
                 <!-- Channel ID -->
-                <div>
-                    <label for="channelId" class="block text-sm font-medium text-text-primary mb-1">Channel ID</label>
-                    <input
-                        type="text"
-                        id="channelId"
-                        name="ChannelId"
-                        value="@Model.ChannelId"
-                        placeholder="Enter Channel ID..."
-                        class="w-full py-2 px-3 text-sm text-text-primary bg-bg-primary border border-border-primary rounded-md placeholder-text-tertiary transition-colors focus:outline-none focus:ring-2 focus:ring-border-focus focus:border-transparent"
-                    />
-                </div>
+                <partial name="Shared/Components/_AutocompleteInput" model="channelAutocomplete" />
             </div>
 
             <!-- Row 2: Date Range -->
@@ -303,3 +312,8 @@
         }
     </div>
 </div>
+
+@section Scripts {
+    <script src="~/js/autocomplete.js" asp-append-version="true"></script>
+    <script src="~/js/message-logs.js" asp-append-version="true"></script>
+}

--- a/src/DiscordBot.Bot/wwwroot/js/message-logs.js
+++ b/src/DiscordBot.Bot/wwwroot/js/message-logs.js
@@ -1,0 +1,100 @@
+/**
+ * Message Logs Page JavaScript
+ * Handles autocomplete initialization and channel/guild dependency logic.
+ */
+(function() {
+    'use strict';
+
+    const CHANNEL_SEARCH_INPUT_ID = 'ChannelId-search';
+    const CHANNEL_HIDDEN_INPUT_ID = 'ChannelId';
+    const GUILD_HIDDEN_INPUT_ID = 'GuildId';
+    const CLEAR_FILTERS_SELECTOR = 'a[href*="MessageLogs"]';
+
+    /**
+     * Updates the channel input state based on guild selection.
+     */
+    function updateChannelInputState() {
+        const guildHiddenInput = document.getElementById(GUILD_HIDDEN_INPUT_ID);
+        const channelSearchInput = document.getElementById(CHANNEL_SEARCH_INPUT_ID);
+
+        if (!channelSearchInput) return;
+
+        const hasGuildSelected = guildHiddenInput && guildHiddenInput.value;
+
+        if (hasGuildSelected) {
+            channelSearchInput.disabled = false;
+            channelSearchInput.placeholder = 'Search by channel name...';
+        } else {
+            channelSearchInput.disabled = true;
+            channelSearchInput.placeholder = 'Select a guild first...';
+
+            // Clear channel value when guild is cleared
+            const channelHiddenInput = document.getElementById(CHANNEL_HIDDEN_INPUT_ID);
+            if (channelHiddenInput) {
+                channelHiddenInput.value = '';
+            }
+            channelSearchInput.value = '';
+
+            // Hide clear button if present
+            const wrapper = channelSearchInput.closest('.autocomplete-wrapper');
+            const clearButton = wrapper?.querySelector('.autocomplete-clear');
+            if (clearButton) {
+                clearButton.classList.add('hidden');
+            }
+        }
+    }
+
+    /**
+     * Initializes the page when DOM is ready.
+     */
+    function init() {
+        // Listen for guild selection changes
+        const guildHiddenInput = document.getElementById(GUILD_HIDDEN_INPUT_ID);
+        if (guildHiddenInput) {
+            guildHiddenInput.addEventListener('change', function() {
+                updateChannelInputState();
+
+                // Clear channel when guild changes
+                const channelInstance = window.AutocompleteManager?.get(CHANNEL_SEARCH_INPUT_ID);
+                if (channelInstance) {
+                    channelInstance.clear();
+                }
+            });
+        }
+
+        // Listen for guild autocomplete clear events
+        const guildSearchInput = document.getElementById('GuildId-search');
+        if (guildSearchInput) {
+            guildSearchInput.addEventListener('autocomplete:clear', function() {
+                updateChannelInputState();
+
+                // Clear channel when guild is cleared
+                const channelInstance = window.AutocompleteManager?.get(CHANNEL_SEARCH_INPUT_ID);
+                if (channelInstance) {
+                    channelInstance.clear();
+                }
+            });
+        }
+
+        // Set initial channel input state
+        updateChannelInputState();
+
+        // Handle Clear Filters link - reset all autocomplete fields
+        const clearFiltersLink = document.querySelector(CLEAR_FILTERS_SELECTOR);
+        if (clearFiltersLink) {
+            clearFiltersLink.addEventListener('click', function() {
+                // Clear all autocomplete instances
+                if (window.AutocompleteManager) {
+                    window.AutocompleteManager.destroyAll();
+                }
+            });
+        }
+    }
+
+    // Initialize when DOM is ready
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();


### PR DESCRIPTION
## Summary

- Replace plain text inputs with autocomplete-enabled inputs for User ID, Guild ID, and Channel ID filters on the Message Logs page
- Channel input is disabled until a guild is selected, then shows only channels from that guild
- Pre-populates display text when returning to filtered results (e.g., shows username instead of just user ID)

## Changes

**Modified:**
- `src/DiscordBot.Bot/Pages/Admin/MessageLogs/Index.cshtml` - Replace text inputs with autocomplete partial views
- `src/DiscordBot.Bot/Pages/Admin/MessageLogs/Index.cshtml.cs` - Add display name properties and lookup logic

**Added:**
- `src/DiscordBot.Bot/wwwroot/js/message-logs.js` - Page-specific JavaScript for channel/guild dependency

## Test Plan

- [ ] Navigate to Message Logs page
- [ ] Verify User field shows autocomplete dropdown when typing usernames
- [ ] Verify Guild field shows autocomplete dropdown when typing guild names
- [ ] Verify Channel field is disabled with "Select a guild first..." placeholder
- [ ] Select a guild, verify Channel field becomes enabled
- [ ] Type in Channel field, verify dropdown shows only channels from selected guild
- [ ] Submit form with filters, verify page reloads with correct values and display names
- [ ] Click Clear Filters, verify all autocomplete fields are reset

Closes #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)