### PR TITLE
feat: Add autocomplete to Audit Logs and Command Logs filters

### DIFF
--- a/src/DiscordBot.Bot/Pages/Admin/AuditLogs/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/AuditLogs/Index.cshtml
@@ -1,8 +1,22 @@
 @page
 @model DiscordBot.Bot.Pages.Admin.AuditLogs.IndexModel
 @using DiscordBot.Core.Enums
+@using DiscordBot.Bot.ViewModels.Components
 @{
     ViewData["Title"] = "Audit Logs";
+
+    // Autocomplete view model for Actor ID filter
+    var actorAutocomplete = new AutocompleteInputViewModel
+    {
+        Id = "ActorId",
+        Name = "ActorId",
+        Label = "Actor",
+        Placeholder = "Search by username...",
+        Endpoint = "/api/autocomplete/users",
+        InitialValue = Model.ActorId,
+        InitialDisplayText = Model.ActorDisplayName,
+        NoResultsMessage = "No users found"
+    };
 }
 
 <style>
@@ -170,17 +184,7 @@
             <!-- Row 3: Actor and Target Type -->
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <!-- Actor Filter -->
-                <div>
-                    <label for="actorId" class="block text-sm font-medium text-text-primary mb-1">Actor ID</label>
-                    <input
-                        type="text"
-                        id="actorId"
-                        name="ActorId"
-                        value="@Model.ActorId"
-                        placeholder="Search by actor ID or username..."
-                        class="w-full py-2 px-3 text-sm text-text-primary bg-bg-primary border border-border-primary rounded-md placeholder-text-tertiary transition-colors focus:outline-none focus:ring-2 focus:ring-border-focus focus:border-transparent"
-                    />
-                </div>
+                <partial name="Shared/Components/_AutocompleteInput" model="actorAutocomplete" />
 
                 <!-- Target Type Dropdown -->
                 <div>
@@ -687,6 +691,7 @@
 </div>
 
 @section Scripts {
+    <script src="~/js/autocomplete.js" asp-append-version="true"></script>
     <script>
         // Toggle filters visibility
         document.getElementById('toggleFilters')?.addEventListener('click', function() {

--- a/src/DiscordBot.Bot/Pages/CommandLogs/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/CommandLogs/Index.cshtml
@@ -6,6 +6,19 @@
     ViewData["Title"] = "Command Logs";
     var startItem = Model.ViewModel.TotalCount > 0 ? (Model.ViewModel.CurrentPage - 1) * Model.ViewModel.PageSize + 1 : 0;
     var endItem = Math.Min(Model.ViewModel.CurrentPage * Model.ViewModel.PageSize, Model.ViewModel.TotalCount);
+
+    // Autocomplete view model for Command Name filter
+    var commandAutocomplete = new AutocompleteInputViewModel
+    {
+        Id = "CommandName",
+        Name = "CommandName",
+        Label = "Command",
+        Placeholder = "Search by command name...",
+        Endpoint = "/api/autocomplete/commands",
+        InitialValue = Model.CommandName,
+        InitialDisplayText = Model.CommandName,
+        NoResultsMessage = "No commands found"
+    };
 }
 
 <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -145,15 +158,7 @@
                         </div>
 
                         <!-- Command Name Filter -->
-                        <div>
-                            <label for="CommandName" class="block text-sm font-medium text-text-primary mb-1">Command</label>
-                            <input type="text"
-                                   id="CommandName"
-                                   name="CommandName"
-                                   value="@Model.CommandName"
-                                   placeholder="e.g., ping, help"
-                                   class="w-full px-3 py-2 text-sm bg-bg-primary border border-border-primary rounded-lg text-text-primary placeholder-text-tertiary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors" />
-                        </div>
+                        <partial name="Shared/Components/_AutocompleteInput" model="commandAutocomplete" />
 
                         <!-- Status Filter -->
                         <div>
@@ -445,6 +450,7 @@
 }
 
 @section Scripts {
+    <script src="~/js/autocomplete.js" asp-append-version="true"></script>
     <script>
         function toggleFilterPanel() {
             const content = document.getElementById('filterContent');


### PR DESCRIPTION
## Summary

- Add autocomplete to Actor ID filter on Audit Logs page (#550)
- Add autocomplete to Command Name filter on Command Logs page (#552)

Both use the existing autocomplete infrastructure (JS component, CSS styles, and API endpoints).

## Changes

**Audit Logs (Issue #550):**
- `src/DiscordBot.Bot/Pages/Admin/AuditLogs/Index.cshtml` - Replace text input with autocomplete partial, add autocomplete.js script
- `src/DiscordBot.Bot/Pages/Admin/AuditLogs/Index.cshtml.cs` - Add `IMessageLogRepository` dependency and `ActorDisplayName` property for pre-populating autocomplete

**Command Logs (Issue #552):**
- `src/DiscordBot.Bot/Pages/CommandLogs/Index.cshtml` - Replace text input with autocomplete partial, add autocomplete.js script

## Test Plan

**Audit Logs:**
- [ ] Navigate to Audit Logs page
- [ ] Verify Actor field shows autocomplete dropdown when typing usernames
- [ ] Form submission includes correct Actor ID
- [ ] Existing filter value populates autocomplete on page load
- [ ] Existing filters (Category, Action, Guild, Target Type) unchanged

**Command Logs:**
- [ ] Navigate to Command Logs page
- [ ] Verify Command field shows autocomplete dropdown when typing command names
- [ ] Results include grouped commands (e.g., "ratwatch start")
- [ ] Form submission includes correct command name
- [ ] Existing filter value populates autocomplete on page load
- [ ] Existing filters (Server, Status) unchanged

Closes #550
Closes #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)