### PR TITLE
UX: Improve mobile navigation for Performance pages tab header

### DIFF
--- a/src/DiscordBot.Bot/Pages/Admin/Performance/Alerts.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/Alerts.cshtml
@@ -50,48 +50,11 @@
 }
 
 <!-- Navigation Tabs -->
-<div class="performance-tabs mb-6">
-    <a href="/Admin/Performance" class="performance-tab">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-        </svg>
-        Overview
-    </a>
-    <a href="/Admin/Performance/HealthMetrics" class="performance-tab">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
-        </svg>
-        Health Metrics
-    </a>
-    <a href="/Admin/Performance/Commands" class="performance-tab">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
-        </svg>
-        Commands
-    </a>
-    <a href="/Admin/Performance/ApiMetrics" class="performance-tab">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-        </svg>
-        API & Rate Limits
-    </a>
-    <a href="/Admin/Performance/SystemHealth" class="performance-tab">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" />
-        </svg>
-        System
-    </a>
-    <a href="/Admin/Performance/Alerts" class="performance-tab active">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
-        </svg>
-        Alerts
-        @if (Model.ViewModel.AlertSummary.ActiveCount > 0)
-        {
-            <span class="ml-1 px-1.5 py-0.5 text-xs font-bold bg-warning/20 text-warning rounded-full">@Model.ViewModel.AlertSummary.ActiveCount</span>
-        }
-    </a>
-</div>
+@await Html.PartialAsync("Components/_PerformanceTabs", new PerformanceTabsViewModel
+{
+    ActiveTab = "alerts",
+    ActiveAlertCount = Model.ViewModel.AlertSummary.ActiveCount
+})
 
 <!-- Active Alerts Section -->
 <div class="chart-card mb-6">

--- a/src/DiscordBot.Bot/Pages/Admin/Performance/ApiMetrics.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/ApiMetrics.cshtml
@@ -12,46 +12,9 @@
 }
 
 @section Styles {
+    <link rel="stylesheet" href="~/css/performance-pages.css" />
     <style>
-        /* Performance Page Shared Styles */
-        .performance-tabs {
-            display: flex;
-            gap: 0.5rem;
-            border-bottom: 2px solid rgb(63, 68, 71);
-            margin-bottom: 1.5rem;
-        }
-
-        .performance-tab {
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
-            padding: 0.75rem 1rem;
-            font-size: 0.875rem;
-            font-weight: 500;
-            color: rgb(168, 165, 163);
-            border-bottom: 2px solid transparent;
-            margin-bottom: -2px;
-            transition: all 0.2s;
-            white-space: nowrap;
-            text-decoration: none;
-        }
-
-        .performance-tab:hover {
-            color: rgb(215, 211, 208);
-            border-bottom-color: rgb(99, 102, 104);
-        }
-
-        .performance-tab.active {
-            color: rgb(9, 142, 207);
-            border-bottom-color: rgb(9, 142, 207);
-        }
-
-        .tab-icon {
-            width: 1.25rem;
-            height: 1.25rem;
-        }
-
-        /* Metric Cards */
+        /* Metric Cards - page-specific overrides */
         .metric-card {
             background: rgb(35, 38, 40);
             border: 1px solid rgb(63, 68, 71);
@@ -299,44 +262,10 @@
 </div>
 
 <!-- Navigation Tabs -->
-<div class="performance-tabs mb-6">
-    <a href="/Admin/Performance" class="performance-tab">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-        </svg>
-        Overview
-    </a>
-    <a href="/Admin/Performance/HealthMetrics" class="performance-tab">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
-        </svg>
-        Health Metrics
-    </a>
-    <a href="/Admin/Performance/Commands" class="performance-tab">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
-        </svg>
-        Commands
-    </a>
-    <a href="/Admin/Performance/ApiMetrics" class="performance-tab active">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-        </svg>
-        API & Rate Limits
-    </a>
-    <a href="/Admin/Performance/SystemHealth" class="performance-tab">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" />
-        </svg>
-        System
-    </a>
-    <a href="/Admin/Performance/Alerts" class="performance-tab">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
-        </svg>
-        Alerts
-    </a>
-</div>
+@await Html.PartialAsync("Components/_PerformanceTabs", new DiscordBot.Bot.ViewModels.Components.PerformanceTabsViewModel
+{
+    ActiveTab = "api"
+})
 
 @if (Model.ViewModel.TotalRequests == 0)
 {

--- a/src/DiscordBot.Bot/Pages/Admin/Performance/Commands.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/Commands.cshtml
@@ -33,44 +33,10 @@
 </div>
 
 <!-- Navigation Tabs -->
-<div class="performance-tabs mb-6">
-    <a href="/Admin/Performance" class="performance-tab">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-        </svg>
-        Overview
-    </a>
-    <a href="/Admin/Performance/HealthMetrics" class="performance-tab">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
-        </svg>
-        Health Metrics
-    </a>
-    <a href="/Admin/Performance/Commands" class="performance-tab active">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
-        </svg>
-        Commands
-    </a>
-    <a href="/Admin/Performance/ApiMetrics" class="performance-tab">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-        </svg>
-        API & Rate Limits
-    </a>
-    <a href="/Admin/Performance/SystemHealth" class="performance-tab">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" />
-        </svg>
-        System
-    </a>
-    <a href="/Admin/Performance/Alerts" class="performance-tab">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
-        </svg>
-        Alerts
-    </a>
-</div>
+@await Html.PartialAsync("Components/_PerformanceTabs", new DiscordBot.Bot.ViewModels.Components.PerformanceTabsViewModel
+{
+    ActiveTab = "commands"
+})
 
 @if (Model.ViewModel.TotalCommands == 0)
 {

--- a/src/DiscordBot.Bot/Pages/Admin/Performance/HealthMetrics.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/HealthMetrics.cshtml
@@ -29,44 +29,10 @@
 </div>
 
 <!-- Navigation Tabs -->
-<div class="performance-tabs mb-6">
-    <a href="/Admin/Performance" class="performance-tab">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-        </svg>
-        Overview
-    </a>
-    <a href="/Admin/Performance/HealthMetrics" class="performance-tab active">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
-        </svg>
-        Health Metrics
-    </a>
-    <a href="/Admin/Performance/Commands" class="performance-tab">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
-        </svg>
-        Commands
-    </a>
-    <a href="/Admin/Performance/ApiMetrics" class="performance-tab">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-        </svg>
-        API & Rate Limits
-    </a>
-    <a href="/Admin/Performance/SystemHealth" class="performance-tab">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" />
-        </svg>
-        System
-    </a>
-    <a href="/Admin/Performance/Alerts" class="performance-tab">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
-        </svg>
-        Alerts
-    </a>
-</div>
+@await Html.PartialAsync("Components/_PerformanceTabs", new DiscordBot.Bot.ViewModels.Components.PerformanceTabsViewModel
+{
+    ActiveTab = "health"
+})
 
 <!-- Uptime & Connection Status Row -->
 <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">

--- a/src/DiscordBot.Bot/Pages/Admin/Performance/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/Index.cshtml
@@ -10,45 +10,8 @@
 }
 
 @section Styles {
+    <link rel="stylesheet" href="~/css/performance-pages.css" />
     <style>
-        /* Performance Page Shared Styles */
-        .performance-tabs {
-            display: flex;
-            gap: 0.5rem;
-            border-bottom: 2px solid rgb(63, 68, 71);
-            margin-bottom: 1.5rem;
-        }
-
-        .performance-tab {
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
-            padding: 0.75rem 1rem;
-            font-size: 0.875rem;
-            font-weight: 500;
-            color: rgb(168, 165, 163);
-            border-bottom: 2px solid transparent;
-            margin-bottom: -2px;
-            transition: all 0.2s;
-            white-space: nowrap;
-            text-decoration: none;
-        }
-
-        .performance-tab:hover {
-            color: rgb(215, 211, 208);
-            border-bottom-color: rgb(99, 102, 104);
-        }
-
-        .performance-tab.active {
-            color: rgb(9, 142, 207);
-            border-bottom-color: rgb(9, 142, 207);
-        }
-
-        .tab-icon {
-            width: 1.25rem;
-            height: 1.25rem;
-        }
-
         /* Health Status Components */
         .health-status {
             display: inline-flex;
@@ -417,48 +380,11 @@
 </div>
 
 <!-- Navigation Tabs -->
-<div class="performance-tabs mb-6">
-    <a href="/Admin/Performance" class="performance-tab active">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-        </svg>
-        Overview
-    </a>
-    <a href="/Admin/Performance/HealthMetrics" class="performance-tab">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
-        </svg>
-        Health Metrics
-    </a>
-    <a href="/Admin/Performance/Commands" class="performance-tab">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
-        </svg>
-        Commands
-    </a>
-    <a href="/Admin/Performance/ApiMetrics" class="performance-tab">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-        </svg>
-        API & Rate Limits
-    </a>
-    <a href="/Admin/Performance/SystemHealth" class="performance-tab">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" />
-        </svg>
-        System
-    </a>
-    <a href="/Admin/Performance/Alerts" class="performance-tab">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
-        </svg>
-        Alerts
-        @if (Model.ViewModel.ActiveAlertCount > 0)
-        {
-            <span class="ml-1 px-1.5 py-0.5 text-xs font-bold bg-error/20 text-error rounded-full">@Model.ViewModel.ActiveAlertCount</span>
-        }
-    </a>
-</div>
+@await Html.PartialAsync("Components/_PerformanceTabs", new DiscordBot.Bot.ViewModels.Components.PerformanceTabsViewModel
+{
+    ActiveTab = "overview",
+    ActiveAlertCount = Model.ViewModel.ActiveAlertCount
+})
 
 <!-- Quick Status Cards -->
 <div class="status-cards-grid mb-8">

--- a/src/DiscordBot.Bot/Pages/Admin/Performance/SystemHealth.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/SystemHealth.cshtml
@@ -30,44 +30,10 @@
 </div>
 
 <!-- Navigation Tabs -->
-<div class="performance-tabs mb-6">
-    <a href="/Admin/Performance" class="performance-tab">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-        </svg>
-        Overview
-    </a>
-    <a href="/Admin/Performance/HealthMetrics" class="performance-tab">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
-        </svg>
-        Health Metrics
-    </a>
-    <a href="/Admin/Performance/Commands" class="performance-tab">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
-        </svg>
-        Commands
-    </a>
-    <a href="/Admin/Performance/ApiMetrics" class="performance-tab">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-        </svg>
-        API & Rate Limits
-    </a>
-    <a href="/Admin/Performance/SystemHealth" class="performance-tab active">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" />
-        </svg>
-        System
-    </a>
-    <a href="/Admin/Performance/Alerts" class="performance-tab">
-        <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
-        </svg>
-        Alerts
-    </a>
-</div>
+@await Html.PartialAsync("Components/_PerformanceTabs", new DiscordBot.Bot.ViewModels.Components.PerformanceTabsViewModel
+{
+    ActiveTab = "system"
+})
 
 <!-- Database Performance Card -->
 <div class="chart-card mb-6">

--- a/src/DiscordBot.Bot/Pages/Shared/Components/_PerformanceTabs.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/Components/_PerformanceTabs.cshtml
@@ -1,0 +1,111 @@
+@model DiscordBot.Bot.ViewModels.Components.PerformanceTabsViewModel
+@{
+    string GetTabClass(string tab) => Model.ActiveTab == tab ? "performance-tab active" : "performance-tab";
+}
+
+<div class="performance-tabs-container" id="performanceTabsContainer">
+    <nav class="performance-tabs" id="performanceTabs" role="tablist" aria-label="Performance sections">
+        <a href="/Admin/Performance" class="@GetTabClass("overview")" role="tab" aria-selected="@(Model.ActiveTab == "overview" ? "true" : "false")">
+            <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+            </svg>
+            <span>Overview</span>
+        </a>
+        <a href="/Admin/Performance/HealthMetrics" class="@GetTabClass("health")" role="tab" aria-selected="@(Model.ActiveTab == "health" ? "true" : "false")">
+            <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+            </svg>
+            <span class="tab-label-long">Health Metrics</span>
+            <span class="tab-label-short">Health</span>
+        </a>
+        <a href="/Admin/Performance/Commands" class="@GetTabClass("commands")" role="tab" aria-selected="@(Model.ActiveTab == "commands" ? "true" : "false")">
+            <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
+            </svg>
+            <span>Commands</span>
+        </a>
+        <a href="/Admin/Performance/ApiMetrics" class="@GetTabClass("api")" role="tab" aria-selected="@(Model.ActiveTab == "api" ? "true" : "false")">
+            <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            </svg>
+            <span class="tab-label-long">API & Rate Limits</span>
+            <span class="tab-label-short">API</span>
+        </a>
+        <a href="/Admin/Performance/SystemHealth" class="@GetTabClass("system")" role="tab" aria-selected="@(Model.ActiveTab == "system" ? "true" : "false")">
+            <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" />
+            </svg>
+            <span>System</span>
+        </a>
+        <a href="/Admin/Performance/Alerts" class="@GetTabClass("alerts")" role="tab" aria-selected="@(Model.ActiveTab == "alerts" ? "true" : "false")">
+            <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+            </svg>
+            <span>Alerts</span>
+            @if (Model.ActiveAlertCount > 0)
+            {
+                <span class="ml-1 px-1.5 py-0.5 text-xs font-bold bg-error/20 text-error rounded-full">@Model.ActiveAlertCount</span>
+            }
+        </a>
+    </nav>
+</div>
+
+<script>
+    (function() {
+        const container = document.getElementById('performanceTabsContainer');
+        const tabs = document.getElementById('performanceTabs');
+
+        if (!container || !tabs) return;
+
+        function updateScrollIndicators() {
+            const scrollLeft = tabs.scrollLeft;
+            const scrollWidth = tabs.scrollWidth;
+            const clientWidth = tabs.clientWidth;
+
+            // Check if content is scrollable
+            const isScrollable = scrollWidth > clientWidth;
+
+            if (isScrollable) {
+                // Can scroll left if not at the start
+                if (scrollLeft > 5) {
+                    container.classList.add('can-scroll-left');
+                } else {
+                    container.classList.remove('can-scroll-left');
+                }
+
+                // Can scroll right if not at the end
+                if (scrollLeft < scrollWidth - clientWidth - 5) {
+                    container.classList.add('can-scroll-right');
+                } else {
+                    container.classList.remove('can-scroll-right');
+                }
+            } else {
+                container.classList.remove('can-scroll-left', 'can-scroll-right');
+            }
+        }
+
+        // Scroll active tab into view on load
+        function scrollActiveTabIntoView() {
+            const activeTab = tabs.querySelector('.performance-tab.active');
+            if (activeTab) {
+                const tabRect = activeTab.getBoundingClientRect();
+                const containerRect = tabs.getBoundingClientRect();
+
+                // Check if active tab is partially or fully outside view
+                if (tabRect.left < containerRect.left || tabRect.right > containerRect.right) {
+                    activeTab.scrollIntoView({ behavior: 'smooth', inline: 'center', block: 'nearest' });
+                }
+            }
+        }
+
+        // Initial setup
+        updateScrollIndicators();
+        scrollActiveTabIntoView();
+
+        // Update on scroll
+        tabs.addEventListener('scroll', updateScrollIndicators, { passive: true });
+
+        // Update on resize
+        window.addEventListener('resize', updateScrollIndicators, { passive: true });
+    })();
+</script>

--- a/src/DiscordBot.Bot/ViewModels/Components/PerformanceTabsViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Components/PerformanceTabsViewModel.cs
@@ -1,0 +1,18 @@
+namespace DiscordBot.Bot.ViewModels.Components;
+
+/// <summary>
+/// ViewModel for the Performance pages navigation tabs component.
+/// </summary>
+public class PerformanceTabsViewModel
+{
+    /// <summary>
+    /// The currently active tab identifier.
+    /// Valid values: "overview", "health", "commands", "api", "system", "alerts"
+    /// </summary>
+    public string ActiveTab { get; set; } = "overview";
+
+    /// <summary>
+    /// Optional: Number of active alerts to display as a badge on the Alerts tab.
+    /// </summary>
+    public int ActiveAlertCount { get; set; }
+}

--- a/src/DiscordBot.Bot/wwwroot/css/performance-pages.css
+++ b/src/DiscordBot.Bot/wwwroot/css/performance-pages.css
@@ -2,33 +2,61 @@
 /* Shared CSS for Admin/Performance section pages */
 /* Uses design system tokens from main.css */
 
-/* ===== Navigation Tabs ===== */
+/* ===== Navigation Tabs Container ===== */
+.performance-tabs-container {
+    position: relative;
+    margin-bottom: 1.5rem;
+}
+
+/* Scroll fade indicators - show when content is scrollable */
+.performance-tabs-container::before,
+.performance-tabs-container::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 2px; /* Account for border */
+    width: 2rem;
+    pointer-events: none;
+    z-index: 1;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+}
+
+.performance-tabs-container::before {
+    left: 0;
+    background: linear-gradient(to right, var(--color-bg-primary), transparent);
+}
+
+.performance-tabs-container::after {
+    right: 0;
+    background: linear-gradient(to left, var(--color-bg-primary), transparent);
+}
+
+/* Show indicators based on scroll position (controlled via JS) */
+.performance-tabs-container.can-scroll-left::before {
+    opacity: 1;
+}
+
+.performance-tabs-container.can-scroll-right::after {
+    opacity: 1;
+}
+
+/* Navigation Tabs */
 .performance-tabs {
     display: flex;
     gap: 0.5rem;
     border-bottom: 2px solid var(--color-border-primary);
-    margin-bottom: 1.5rem;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
-    scrollbar-width: thin;
+    scrollbar-width: none; /* Hide scrollbar on Firefox */
+    scroll-behavior: smooth;
+    scroll-snap-type: x proximity;
+    padding-bottom: 0; /* Remove extra padding */
 }
 
-/* Custom scrollbar for webkit browsers */
+/* Hide scrollbar on webkit browsers for cleaner look */
 .performance-tabs::-webkit-scrollbar {
-    height: 4px;
-}
-
-.performance-tabs::-webkit-scrollbar-track {
-    background: transparent;
-}
-
-.performance-tabs::-webkit-scrollbar-thumb {
-    background: var(--color-border-primary);
-    border-radius: 2px;
-}
-
-.performance-tabs::-webkit-scrollbar-thumb:hover {
-    background: var(--color-border-secondary);
+    display: none;
 }
 
 .performance-tab {
@@ -44,6 +72,8 @@
     transition: all 0.2s;
     white-space: nowrap;
     text-decoration: none;
+    scroll-snap-align: start;
+    flex-shrink: 0;
 }
 
 .performance-tab:hover {
@@ -59,6 +89,39 @@
 .tab-icon {
     width: 1.25rem;
     height: 1.25rem;
+}
+
+/* Mobile-specific: smaller padding and abbreviated labels */
+@media (max-width: 640px) {
+    .performance-tab {
+        padding: 0.625rem 0.75rem;
+        font-size: 0.8125rem;
+    }
+
+    .tab-icon {
+        width: 1rem;
+        height: 1rem;
+    }
+
+    /* Hide "API & Rate Limits" long text, show short version */
+    .performance-tab .tab-label-long {
+        display: none;
+    }
+
+    .performance-tab .tab-label-short {
+        display: inline;
+    }
+}
+
+@media (min-width: 641px) {
+    /* Show full text on larger screens */
+    .performance-tab .tab-label-long {
+        display: inline;
+    }
+
+    .performance-tab .tab-label-short {
+        display: none;
+    }
 }
 
 /* ===== Chart Cards ===== */


### PR DESCRIPTION
## Summary
- Add scrollable tabs with visual fade indicators showing when more content exists off-screen
- Create shared `_PerformanceTabs` partial view to eliminate code duplication across 6 Performance pages
- Add responsive CSS with abbreviated labels on mobile ("Health Metrics" → "Health", "API & Rate Limits" → "API")
- Include JavaScript to auto-scroll active tab into view and update scroll indicators dynamically

## Changes Made
- **New files:**
  - `Pages/Shared/Components/_PerformanceTabs.cshtml` - Reusable tab navigation component
  - `ViewModels/Components/PerformanceTabsViewModel.cs` - ViewModel for tab configuration
- **Updated files:**
  - `wwwroot/css/performance-pages.css` - Added mobile scroll indicators, scroll snap, and responsive breakpoints
  - Updated all 6 Performance pages to use the shared partial instead of duplicated markup

## Technical Details
- Uses CSS `::before` and `::after` pseudo-elements for fade indicators
- JavaScript updates `can-scroll-left` and `can-scroll-right` classes based on scroll position
- Scroll snap with `proximity` for smooth touch scrolling
- Hidden scrollbar for cleaner appearance on both webkit and Firefox

## Test plan
- [ ] Verify tabs are horizontally scrollable on mobile viewports (<640px)
- [ ] Confirm fade indicators appear/disappear based on scroll position
- [ ] Check abbreviated labels display correctly on mobile
- [ ] Ensure active tab scrolls into view on page load
- [ ] Test touch swipe gesture on mobile devices
- [ ] Verify all 6 Performance pages display tabs consistently

Closes #644

🤖 Generated with [Claude Code](https://claude.com/claude-code)