### PR TITLE
feat: Add distributed tracing for business service layer

### DIFF
--- a/src/DiscordBot.Bot/Services/GuildService.cs
+++ b/src/DiscordBot.Bot/Services/GuildService.cs
@@ -1,4 +1,5 @@
 using Discord.WebSocket;
+using DiscordBot.Bot.Tracing;
 using DiscordBot.Core.DTOs;
 using DiscordBot.Core.Entities;
 using DiscordBot.Core.Enums;
@@ -39,39 +40,52 @@ public class GuildService : IGuildService
     /// <inheritdoc/>
     public async Task<IReadOnlyList<GuildDto>> GetAllGuildsAsync(CancellationToken cancellationToken = default)
     {
-        _logger.LogDebug("Retrieving all guilds with merged Discord and database data");
+        using var activity = BotActivitySource.StartServiceActivity("guild", "get_all");
 
-        var dbGuilds = await _guildRepository.GetAllAsync(cancellationToken);
-        var dbGuildIds = dbGuilds.Select(g => g.Id).ToHashSet();
-        var guilds = new List<GuildDto>();
-
-        // Add guilds from database, enriched with live Discord data
-        foreach (var dbGuild in dbGuilds)
+        try
         {
-            var discordGuild = _client.GetGuild(dbGuild.Id);
-            guilds.Add(MapToDto(dbGuild, discordGuild));
-        }
+            _logger.LogDebug("Retrieving all guilds with merged Discord and database data");
 
-        // Add guilds from Discord client that aren't in the database yet
-        foreach (var discordGuild in _client.Guilds)
-        {
-            if (!dbGuildIds.Contains(discordGuild.Id))
+            var dbGuilds = await _guildRepository.GetAllAsync(cancellationToken);
+            var dbGuildIds = dbGuilds.Select(g => g.Id).ToHashSet();
+            var guilds = new List<GuildDto>();
+
+            // Add guilds from database, enriched with live Discord data
+            foreach (var dbGuild in dbGuilds)
             {
-                guilds.Add(new GuildDto
-                {
-                    Id = discordGuild.Id,
-                    Name = discordGuild.Name,
-                    JoinedAt = discordGuild.CurrentUser?.JoinedAt?.UtcDateTime ?? DateTime.UtcNow,
-                    IsActive = true,
-                    MemberCount = discordGuild.MemberCount,
-                    IconUrl = discordGuild.IconUrl
-                });
+                var discordGuild = _client.GetGuild(dbGuild.Id);
+                guilds.Add(MapToDto(dbGuild, discordGuild));
             }
+
+            // Add guilds from Discord client that aren't in the database yet
+            foreach (var discordGuild in _client.Guilds)
+            {
+                if (!dbGuildIds.Contains(discordGuild.Id))
+                {
+                    guilds.Add(new GuildDto
+                    {
+                        Id = discordGuild.Id,
+                        Name = discordGuild.Name,
+                        JoinedAt = discordGuild.CurrentUser?.JoinedAt?.UtcDateTime ?? DateTime.UtcNow,
+                        IsActive = true,
+                        MemberCount = discordGuild.MemberCount,
+                        IconUrl = discordGuild.IconUrl
+                    });
+                }
+            }
+
+            _logger.LogInformation("Retrieved {Count} guilds", guilds.Count);
+
+            var result = guilds.AsReadOnly();
+            BotActivitySource.SetRecordsReturned(activity, result.Count);
+            BotActivitySource.SetSuccess(activity);
+            return result;
         }
-
-        _logger.LogInformation("Retrieved {Count} guilds", guilds.Count);
-
-        return guilds.AsReadOnly();
+        catch (Exception ex)
+        {
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
     }
 
     /// <inheritdoc/>
@@ -79,261 +93,326 @@ public class GuildService : IGuildService
         GuildSearchQueryDto query,
         CancellationToken cancellationToken = default)
     {
-        _logger.LogDebug("Retrieving guilds with query: Search={Search}, IsActive={IsActive}, " +
-            "Page={Page}, PageSize={PageSize}, SortBy={SortBy}, SortDesc={SortDesc}",
-            query.SearchTerm, query.IsActive, query.Page, query.PageSize,
-            query.SortBy, query.SortDescending);
+        using var activity = BotActivitySource.StartServiceActivity("guild", "get_guilds");
 
-        // Get all guilds first (using existing method)
-        var allGuilds = await GetAllGuildsAsync(cancellationToken);
-
-        // Apply filters
-        var filtered = allGuilds.AsEnumerable();
-
-        if (!string.IsNullOrWhiteSpace(query.SearchTerm))
+        try
         {
-            var searchLower = query.SearchTerm.ToLowerInvariant();
-            filtered = filtered.Where(g =>
-                g.Name.ToLowerInvariant().Contains(searchLower) ||
-                g.Id.ToString().Contains(searchLower));
+            _logger.LogDebug("Retrieving guilds with query: Search={Search}, IsActive={IsActive}, " +
+                "Page={Page}, PageSize={PageSize}, SortBy={SortBy}, SortDesc={SortDesc}",
+                query.SearchTerm, query.IsActive, query.Page, query.PageSize,
+                query.SortBy, query.SortDescending);
+
+            // Get all guilds first (using existing method)
+            var allGuilds = await GetAllGuildsAsync(cancellationToken);
+
+            // Apply filters
+            var filtered = allGuilds.AsEnumerable();
+
+            if (!string.IsNullOrWhiteSpace(query.SearchTerm))
+            {
+                var searchLower = query.SearchTerm.ToLowerInvariant();
+                filtered = filtered.Where(g =>
+                    g.Name.ToLowerInvariant().Contains(searchLower) ||
+                    g.Id.ToString().Contains(searchLower));
+            }
+
+            if (query.IsActive.HasValue)
+            {
+                filtered = filtered.Where(g => g.IsActive == query.IsActive.Value);
+            }
+
+            // Apply sorting
+            filtered = query.SortBy?.ToLowerInvariant() switch
+            {
+                "membercount" => query.SortDescending
+                    ? filtered.OrderByDescending(g => g.MemberCount ?? 0)
+                    : filtered.OrderBy(g => g.MemberCount ?? 0),
+                "joinedat" => query.SortDescending
+                    ? filtered.OrderByDescending(g => g.JoinedAt)
+                    : filtered.OrderBy(g => g.JoinedAt),
+                _ => query.SortDescending
+                    ? filtered.OrderByDescending(g => g.Name)
+                    : filtered.OrderBy(g => g.Name)
+            };
+
+            var filteredList = filtered.ToList();
+            var totalCount = filteredList.Count;
+
+            // Apply pagination
+            var items = filteredList
+                .Skip((query.Page - 1) * query.PageSize)
+                .Take(query.PageSize)
+                .ToList();
+
+            _logger.LogInformation("Retrieved {Count} of {Total} guilds for page {Page}",
+                items.Count, totalCount, query.Page);
+
+            var result = new PaginatedResponseDto<GuildDto>
+            {
+                Items = items,
+                Page = query.Page,
+                PageSize = query.PageSize,
+                TotalCount = totalCount
+            };
+
+            BotActivitySource.SetRecordsReturned(activity, items.Count);
+            BotActivitySource.SetSuccess(activity);
+            return result;
         }
-
-        if (query.IsActive.HasValue)
+        catch (Exception ex)
         {
-            filtered = filtered.Where(g => g.IsActive == query.IsActive.Value);
+            BotActivitySource.RecordException(activity, ex);
+            throw;
         }
-
-        // Apply sorting
-        filtered = query.SortBy?.ToLowerInvariant() switch
-        {
-            "membercount" => query.SortDescending
-                ? filtered.OrderByDescending(g => g.MemberCount ?? 0)
-                : filtered.OrderBy(g => g.MemberCount ?? 0),
-            "joinedat" => query.SortDescending
-                ? filtered.OrderByDescending(g => g.JoinedAt)
-                : filtered.OrderBy(g => g.JoinedAt),
-            _ => query.SortDescending
-                ? filtered.OrderByDescending(g => g.Name)
-                : filtered.OrderBy(g => g.Name)
-        };
-
-        var filteredList = filtered.ToList();
-        var totalCount = filteredList.Count;
-
-        // Apply pagination
-        var items = filteredList
-            .Skip((query.Page - 1) * query.PageSize)
-            .Take(query.PageSize)
-            .ToList();
-
-        _logger.LogInformation("Retrieved {Count} of {Total} guilds for page {Page}",
-            items.Count, totalCount, query.Page);
-
-        return new PaginatedResponseDto<GuildDto>
-        {
-            Items = items,
-            Page = query.Page,
-            PageSize = query.PageSize,
-            TotalCount = totalCount
-        };
     }
 
     /// <inheritdoc/>
     public async Task<GuildDto?> GetGuildByIdAsync(ulong guildId, CancellationToken cancellationToken = default)
     {
-        _logger.LogDebug("Retrieving guild {GuildId}", guildId);
+        using var activity = BotActivitySource.StartServiceActivity("guild", "get_by_id", guildId: guildId);
 
-        var dbGuild = await _guildRepository.GetByDiscordIdAsync(guildId, cancellationToken);
-        if (dbGuild == null)
+        try
         {
-            _logger.LogWarning("Guild {GuildId} not found in database", guildId);
-            return null;
+            _logger.LogDebug("Retrieving guild {GuildId}", guildId);
+
+            var dbGuild = await _guildRepository.GetByDiscordIdAsync(guildId, cancellationToken);
+            if (dbGuild == null)
+            {
+                _logger.LogWarning("Guild {GuildId} not found in database", guildId);
+                BotActivitySource.SetSuccess(activity);
+                return null;
+            }
+
+            var discordGuild = _client.GetGuild(guildId);
+            var dto = MapToDto(dbGuild, discordGuild);
+
+            _logger.LogDebug("Retrieved guild {GuildId}: {GuildName}", guildId, dto.Name);
+
+            BotActivitySource.SetSuccess(activity);
+            return dto;
         }
-
-        var discordGuild = _client.GetGuild(guildId);
-        var dto = MapToDto(dbGuild, discordGuild);
-
-        _logger.LogDebug("Retrieved guild {GuildId}: {GuildName}", guildId, dto.Name);
-
-        return dto;
+        catch (Exception ex)
+        {
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
     }
 
     /// <inheritdoc/>
     public async Task<GuildDto?> UpdateGuildAsync(ulong guildId, GuildUpdateRequestDto request, CancellationToken cancellationToken = default)
     {
-        _logger.LogInformation("Updating guild {GuildId} with request: Prefix={Prefix}, IsActive={IsActive}",
-            guildId, request.Prefix, request.IsActive);
+        using var activity = BotActivitySource.StartServiceActivity("guild", "update", guildId: guildId);
 
-        var dbGuild = await _guildRepository.GetByDiscordIdAsync(guildId, cancellationToken);
-        if (dbGuild == null)
+        try
         {
-            _logger.LogWarning("Guild {GuildId} not found in database, cannot update", guildId);
-            return null;
-        }
+            _logger.LogInformation("Updating guild {GuildId} with request: Prefix={Prefix}, IsActive={IsActive}",
+                guildId, request.Prefix, request.IsActive);
 
-        // Track changes for audit logging
-        var changes = new Dictionary<string, object?>();
-
-        // Apply updates only for non-null fields
-        if (request.Prefix != null)
-        {
-            changes["prefix"] = new { old = dbGuild.Prefix, @new = request.Prefix };
-            dbGuild.Prefix = request.Prefix;
-        }
-
-        if (request.Settings != null)
-        {
-            changes["settings"] = new { changed = true };
-            dbGuild.Settings = request.Settings;
-            _logger.LogDebug(
-                "Guild {GuildId} settings updated: {SanitizedSettings}",
-                guildId,
-                LogSanitizer.SanitizeString(request.Settings));
-        }
-
-        if (request.IsActive.HasValue)
-        {
-            changes["isActive"] = new { old = dbGuild.IsActive, @new = request.IsActive.Value };
-            dbGuild.IsActive = request.IsActive.Value;
-        }
-
-        await _guildRepository.UpdateAsync(dbGuild, cancellationToken);
-
-        // Audit log
-        if (changes.Count > 0)
-        {
-            try
+            var dbGuild = await _guildRepository.GetByDiscordIdAsync(guildId, cancellationToken);
+            if (dbGuild == null)
             {
-                _auditLogService.CreateBuilder()
-                    .ForCategory(AuditLogCategory.Guild)
-                    .WithAction(AuditLogAction.SettingChanged)
-                    .BySystem()
-                    .InGuild(guildId)
-                    .OnTarget("Guild", guildId.ToString())
-                    .WithDetails(changes)
-                    .Enqueue();
+                _logger.LogWarning("Guild {GuildId} not found in database, cannot update", guildId);
+                BotActivitySource.SetSuccess(activity);
+                return null;
             }
-            catch (Exception ex)
+
+            // Track changes for audit logging
+            var changes = new Dictionary<string, object?>();
+
+            // Apply updates only for non-null fields
+            if (request.Prefix != null)
             {
-                _logger.LogError(ex, "Failed to log audit entry for guild update {GuildId}", guildId);
+                changes["prefix"] = new { old = dbGuild.Prefix, @new = request.Prefix };
+                dbGuild.Prefix = request.Prefix;
             }
+
+            if (request.Settings != null)
+            {
+                changes["settings"] = new { changed = true };
+                dbGuild.Settings = request.Settings;
+                _logger.LogDebug(
+                    "Guild {GuildId} settings updated: {SanitizedSettings}",
+                    guildId,
+                    LogSanitizer.SanitizeString(request.Settings));
+            }
+
+            if (request.IsActive.HasValue)
+            {
+                changes["isActive"] = new { old = dbGuild.IsActive, @new = request.IsActive.Value };
+                dbGuild.IsActive = request.IsActive.Value;
+            }
+
+            await _guildRepository.UpdateAsync(dbGuild, cancellationToken);
+
+            // Audit log
+            if (changes.Count > 0)
+            {
+                try
+                {
+                    _auditLogService.CreateBuilder()
+                        .ForCategory(AuditLogCategory.Guild)
+                        .WithAction(AuditLogAction.SettingChanged)
+                        .BySystem()
+                        .InGuild(guildId)
+                        .OnTarget("Guild", guildId.ToString())
+                        .WithDetails(changes)
+                        .Enqueue();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to log audit entry for guild update {GuildId}", guildId);
+                }
+            }
+
+            _logger.LogInformation("Guild {GuildId} updated successfully", guildId);
+
+            var discordGuild = _client.GetGuild(guildId);
+            var result = MapToDto(dbGuild, discordGuild);
+
+            BotActivitySource.SetSuccess(activity);
+            return result;
         }
-
-        _logger.LogInformation("Guild {GuildId} updated successfully", guildId);
-
-        var discordGuild = _client.GetGuild(guildId);
-        return MapToDto(dbGuild, discordGuild);
+        catch (Exception ex)
+        {
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
     }
 
     /// <inheritdoc/>
     public async Task<bool> SyncGuildAsync(ulong guildId, CancellationToken cancellationToken = default)
     {
-        _logger.LogInformation("Syncing guild {GuildId} from Discord to database", guildId);
+        using var activity = BotActivitySource.StartServiceActivity("guild", "sync", guildId: guildId);
 
-        var discordGuild = _client.GetGuild(guildId);
-        if (discordGuild == null)
-        {
-            _logger.LogWarning("Guild {GuildId} not found in Discord client, cannot sync", guildId);
-            return false;
-        }
-
-        // Check if guild exists to preserve IsActive setting
-        var existingGuild = await _guildRepository.GetByDiscordIdAsync(guildId, cancellationToken);
-
-        var guild = new Guild
-        {
-            Id = discordGuild.Id,
-            Name = discordGuild.Name,
-            JoinedAt = discordGuild.CurrentUser?.JoinedAt?.UtcDateTime ?? DateTime.UtcNow,
-            IsActive = existingGuild?.IsActive ?? true // Preserve existing setting, default to true for new guilds
-        };
-
-        await _guildRepository.UpsertAsync(guild, cancellationToken);
-
-        // Audit log
         try
         {
-            _auditLogService.CreateBuilder()
-                .ForCategory(AuditLogCategory.Guild)
-                .WithAction(AuditLogAction.Updated)
-                .BySystem()
-                .InGuild(guildId)
-                .OnTarget("Guild", guildId.ToString())
-                .WithDetails(new { action = "guild_sync", guildName = guild.Name })
-                .Enqueue();
+            _logger.LogInformation("Syncing guild {GuildId} from Discord to database", guildId);
+
+            var discordGuild = _client.GetGuild(guildId);
+            if (discordGuild == null)
+            {
+                _logger.LogWarning("Guild {GuildId} not found in Discord client, cannot sync", guildId);
+                BotActivitySource.SetSuccess(activity);
+                return false;
+            }
+
+            // Check if guild exists to preserve IsActive setting
+            var existingGuild = await _guildRepository.GetByDiscordIdAsync(guildId, cancellationToken);
+
+            var guild = new Guild
+            {
+                Id = discordGuild.Id,
+                Name = discordGuild.Name,
+                JoinedAt = discordGuild.CurrentUser?.JoinedAt?.UtcDateTime ?? DateTime.UtcNow,
+                IsActive = existingGuild?.IsActive ?? true // Preserve existing setting, default to true for new guilds
+            };
+
+            await _guildRepository.UpsertAsync(guild, cancellationToken);
+
+            // Audit log
+            try
+            {
+                _auditLogService.CreateBuilder()
+                    .ForCategory(AuditLogCategory.Guild)
+                    .WithAction(AuditLogAction.Updated)
+                    .BySystem()
+                    .InGuild(guildId)
+                    .OnTarget("Guild", guildId.ToString())
+                    .WithDetails(new { action = "guild_sync", guildName = guild.Name })
+                    .Enqueue();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to log audit entry for guild sync {GuildId}", guildId);
+            }
+
+            _logger.LogInformation("Guild {GuildId} synced successfully: {GuildName}", guildId, guild.Name);
+
+            BotActivitySource.SetSuccess(activity);
+            return true;
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to log audit entry for guild sync {GuildId}", guildId);
+            BotActivitySource.RecordException(activity, ex);
+            throw;
         }
-
-        _logger.LogInformation("Guild {GuildId} synced successfully: {GuildName}", guildId, guild.Name);
-
-        return true;
     }
 
     /// <inheritdoc/>
     public async Task<int> SyncAllGuildsAsync(CancellationToken cancellationToken = default)
     {
-        _logger.LogInformation("Syncing all connected guilds from Discord to database");
+        using var activity = BotActivitySource.StartServiceActivity("guild", "sync_all");
 
-        var connectedGuilds = _client.Guilds;
-        if (connectedGuilds.Count == 0)
+        try
         {
-            _logger.LogWarning("No guilds connected to sync");
-            return 0;
-        }
+            _logger.LogInformation("Syncing all connected guilds from Discord to database");
 
-        // Get all existing guilds to preserve their IsActive settings
-        var existingGuilds = await _guildRepository.GetAllAsync(cancellationToken);
-        var existingGuildMap = existingGuilds.ToDictionary(g => g.Id);
+            var connectedGuilds = _client.Guilds;
+            if (connectedGuilds.Count == 0)
+            {
+                _logger.LogWarning("No guilds connected to sync");
+                BotActivitySource.SetSuccess(activity);
+                return 0;
+            }
 
-        var syncedCount = 0;
+            // Get all existing guilds to preserve their IsActive settings
+            var existingGuilds = await _guildRepository.GetAllAsync(cancellationToken);
+            var existingGuildMap = existingGuilds.ToDictionary(g => g.Id);
 
-        foreach (var discordGuild in connectedGuilds)
-        {
+            var syncedCount = 0;
+
+            foreach (var discordGuild in connectedGuilds)
+            {
+                try
+                {
+                    existingGuildMap.TryGetValue(discordGuild.Id, out var existingGuild);
+
+                    var guild = new Guild
+                    {
+                        Id = discordGuild.Id,
+                        Name = discordGuild.Name,
+                        JoinedAt = discordGuild.CurrentUser?.JoinedAt?.UtcDateTime ?? DateTime.UtcNow,
+                        IsActive = existingGuild?.IsActive ?? true // Preserve existing setting, default to true for new guilds
+                    };
+
+                    await _guildRepository.UpsertAsync(guild, cancellationToken);
+                    syncedCount++;
+
+                    _logger.LogDebug("Synced guild {GuildId}: {GuildName}", guild.Id, guild.Name);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to sync guild {GuildId}: {GuildName}", discordGuild.Id, discordGuild.Name);
+                }
+            }
+
+            _logger.LogInformation("Synced {SyncedCount} of {TotalCount} guilds successfully", syncedCount, connectedGuilds.Count);
+
+            // Audit log
             try
             {
-                existingGuildMap.TryGetValue(discordGuild.Id, out var existingGuild);
-
-                var guild = new Guild
-                {
-                    Id = discordGuild.Id,
-                    Name = discordGuild.Name,
-                    JoinedAt = discordGuild.CurrentUser?.JoinedAt?.UtcDateTime ?? DateTime.UtcNow,
-                    IsActive = existingGuild?.IsActive ?? true // Preserve existing setting, default to true for new guilds
-                };
-
-                await _guildRepository.UpsertAsync(guild, cancellationToken);
-                syncedCount++;
-
-                _logger.LogDebug("Synced guild {GuildId}: {GuildName}", guild.Id, guild.Name);
+                _auditLogService.CreateBuilder()
+                    .ForCategory(AuditLogCategory.System)
+                    .WithAction(AuditLogAction.Updated)
+                    .BySystem()
+                    .OnTarget("System", "GuildSync")
+                    .WithDetails(new { action = "sync_all_guilds", syncedCount, totalCount = connectedGuilds.Count })
+                    .Enqueue();
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to sync guild {GuildId}: {GuildName}", discordGuild.Id, discordGuild.Name);
+                _logger.LogError(ex, "Failed to log audit entry for sync all guilds");
             }
-        }
 
-        _logger.LogInformation("Synced {SyncedCount} of {TotalCount} guilds successfully", syncedCount, connectedGuilds.Count);
-
-        // Audit log
-        try
-        {
-            _auditLogService.CreateBuilder()
-                .ForCategory(AuditLogCategory.System)
-                .WithAction(AuditLogAction.Updated)
-                .BySystem()
-                .OnTarget("System", "GuildSync")
-                .WithDetails(new { action = "sync_all_guilds", syncedCount, totalCount = connectedGuilds.Count })
-                .Enqueue();
+            BotActivitySource.SetRecordsReturned(activity, syncedCount);
+            BotActivitySource.SetSuccess(activity);
+            return syncedCount;
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to log audit entry for sync all guilds");
+            BotActivitySource.RecordException(activity, ex);
+            throw;
         }
-
-        return syncedCount;
     }
 
     /// <summary>

--- a/src/DiscordBot.Bot/Services/MessageLogService.cs
+++ b/src/DiscordBot.Bot/Services/MessageLogService.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using DiscordBot.Bot.Tracing;
 using DiscordBot.Core.Configuration;
 using DiscordBot.Core.DTOs;
 using DiscordBot.Core.Entities;
@@ -35,232 +36,325 @@ public class MessageLogService : IMessageLogService
     /// <inheritdoc/>
     public async Task<PaginatedResponseDto<MessageLogDto>> GetLogsAsync(MessageLogQueryDto query, CancellationToken cancellationToken = default)
     {
-        _logger.LogDebug(
-            "Querying message logs with filters: AuthorId={AuthorId}, GuildId={GuildId}, ChannelId={ChannelId}, Source={Source}, SearchTerm={SearchTerm}, Page={Page}, PageSize={PageSize}",
-            query.AuthorId, query.GuildId, query.ChannelId, query.Source, query.SearchTerm, query.Page, query.PageSize);
+        using var activity = BotActivitySource.StartServiceActivity(
+            "message_log",
+            "get_logs",
+            guildId: query.GuildId,
+            userId: query.AuthorId);
 
-        // Validate pagination parameters
-        if (query.Page < 1)
+        try
         {
-            query.Page = 1;
+            _logger.LogDebug(
+                "Querying message logs with filters: AuthorId={AuthorId}, GuildId={GuildId}, ChannelId={ChannelId}, Source={Source}, SearchTerm={SearchTerm}, Page={Page}, PageSize={PageSize}",
+                query.AuthorId, query.GuildId, query.ChannelId, query.Source, query.SearchTerm, query.Page, query.PageSize);
+
+            // Validate pagination parameters
+            if (query.Page < 1)
+            {
+                query.Page = 1;
+            }
+
+            if (query.PageSize < 1 || query.PageSize > 100)
+            {
+                query.PageSize = 25;
+            }
+
+            // Execute repository query
+            var (items, totalCount) = await _repository.GetPaginatedAsync(query, cancellationToken);
+
+            // Map entities to DTOs
+            var dtos = items.Select(MapToDto).ToList();
+
+            _logger.LogInformation(
+                "Retrieved {Count} of {TotalCount} message logs (Page {Page}/{TotalPages})",
+                dtos.Count, totalCount, query.Page, (int)Math.Ceiling((double)totalCount / query.PageSize));
+
+            var result = new PaginatedResponseDto<MessageLogDto>
+            {
+                Items = dtos.AsReadOnly(),
+                Page = query.Page,
+                PageSize = query.PageSize,
+                TotalCount = totalCount
+            };
+
+            BotActivitySource.SetRecordsReturned(activity, dtos.Count);
+            BotActivitySource.SetSuccess(activity);
+            return result;
         }
-
-        if (query.PageSize < 1 || query.PageSize > 100)
+        catch (Exception ex)
         {
-            query.PageSize = 25;
+            BotActivitySource.RecordException(activity, ex);
+            throw;
         }
-
-        // Execute repository query
-        var (items, totalCount) = await _repository.GetPaginatedAsync(query, cancellationToken);
-
-        // Map entities to DTOs
-        var dtos = items.Select(MapToDto).ToList();
-
-        _logger.LogInformation(
-            "Retrieved {Count} of {TotalCount} message logs (Page {Page}/{TotalPages})",
-            dtos.Count, totalCount, query.Page, (int)Math.Ceiling((double)totalCount / query.PageSize));
-
-        return new PaginatedResponseDto<MessageLogDto>
-        {
-            Items = dtos.AsReadOnly(),
-            Page = query.Page,
-            PageSize = query.PageSize,
-            TotalCount = totalCount
-        };
     }
 
     /// <inheritdoc/>
     public async Task<MessageLogDto?> GetByIdAsync(long id, CancellationToken cancellationToken = default)
     {
-        _logger.LogDebug("Retrieving message log with ID {Id}", id);
+        using var activity = BotActivitySource.StartServiceActivity(
+            "message_log",
+            "get_by_id");
 
-        var log = await _repository.GetByIdAsync(id, cancellationToken);
-
-        if (log is null)
+        try
         {
-            _logger.LogWarning("Message log with ID {Id} not found", id);
-            return null;
+            _logger.LogDebug("Retrieving message log with ID {Id}", id);
+
+            var log = await _repository.GetByIdAsync(id, cancellationToken);
+
+            if (log is null)
+            {
+                _logger.LogWarning("Message log with ID {Id} not found", id);
+                BotActivitySource.SetSuccess(activity);
+                return null;
+            }
+
+            _logger.LogDebug("Retrieved message log {Id} for author {AuthorId}", id, log.AuthorId);
+
+            var result = MapToDto(log);
+            BotActivitySource.SetSuccess(activity);
+            return result;
         }
-
-        _logger.LogDebug("Retrieved message log {Id} for author {AuthorId}", id, log.AuthorId);
-
-        return MapToDto(log);
+        catch (Exception ex)
+        {
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
     }
 
     /// <inheritdoc/>
     public async Task<MessageLogStatsDto> GetStatsAsync(ulong? guildId = null, CancellationToken cancellationToken = default)
     {
-        _logger.LogDebug("Retrieving message statistics for guildId: {GuildId}", guildId);
+        using var activity = BotActivitySource.StartServiceActivity(
+            "message_log",
+            "get_stats",
+            guildId: guildId);
 
-        // Get basic statistics
-        var (total, dmCount, serverCount, uniqueAuthors) = await _repository.GetBasicStatsAsync(guildId, cancellationToken);
-
-        // Get trend data for last 7 days
-        var messagesByDay = await _repository.GetMessagesByDayAsync(7, guildId, cancellationToken);
-        var dailyCounts = messagesByDay
-            .Select(x => new DailyMessageCount(x.Date, x.Count))
-            .ToList();
-
-        // Get oldest and newest message timestamps
-        var oldestMessage = await _repository.GetOldestMessageDateAsync(cancellationToken);
-        var newestMessage = await _repository.GetNewestMessageDateAsync(cancellationToken);
-
-        var stats = new MessageLogStatsDto
+        try
         {
-            TotalMessages = total,
-            DmMessages = dmCount,
-            ServerMessages = serverCount,
-            UniqueAuthors = uniqueAuthors,
-            MessagesByDay = dailyCounts,
-            OldestMessage = oldestMessage,
-            NewestMessage = newestMessage
-        };
+            _logger.LogDebug("Retrieving message statistics for guildId: {GuildId}", guildId);
 
-        _logger.LogInformation(
-            "Retrieved message statistics - Total: {Total}, DM: {DmCount}, Server: {ServerCount}, UniqueAuthors: {UniqueAuthors}",
-            total, dmCount, serverCount, uniqueAuthors);
+            // Get basic statistics
+            var (total, dmCount, serverCount, uniqueAuthors) = await _repository.GetBasicStatsAsync(guildId, cancellationToken);
 
-        return stats;
+            // Get trend data for last 7 days
+            var messagesByDay = await _repository.GetMessagesByDayAsync(7, guildId, cancellationToken);
+            var dailyCounts = messagesByDay
+                .Select(x => new DailyMessageCount(x.Date, x.Count))
+                .ToList();
+
+            // Get oldest and newest message timestamps
+            var oldestMessage = await _repository.GetOldestMessageDateAsync(cancellationToken);
+            var newestMessage = await _repository.GetNewestMessageDateAsync(cancellationToken);
+
+            var stats = new MessageLogStatsDto
+            {
+                TotalMessages = total,
+                DmMessages = dmCount,
+                ServerMessages = serverCount,
+                UniqueAuthors = uniqueAuthors,
+                MessagesByDay = dailyCounts,
+                OldestMessage = oldestMessage,
+                NewestMessage = newestMessage
+            };
+
+            _logger.LogInformation(
+                "Retrieved message statistics - Total: {Total}, DM: {DmCount}, Server: {ServerCount}, UniqueAuthors: {UniqueAuthors}",
+                total, dmCount, serverCount, uniqueAuthors);
+
+            BotActivitySource.SetSuccess(activity);
+            return stats;
+        }
+        catch (Exception ex)
+        {
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
     }
 
     /// <inheritdoc/>
     public async Task<int> DeleteUserMessagesAsync(ulong userId, CancellationToken cancellationToken = default)
     {
-        _logger.LogInformation("Deleting all messages for user {UserId} (GDPR compliance)", userId);
+        using var activity = BotActivitySource.StartServiceActivity(
+            "message_log",
+            "delete_user_messages",
+            userId: userId);
 
-        var deletedCount = await _repository.DeleteByUserIdAsync(userId, cancellationToken);
+        try
+        {
+            _logger.LogInformation("Deleting all messages for user {UserId} (GDPR compliance)", userId);
 
-        _logger.LogInformation(
-            "Deleted {Count} messages for user {UserId} per GDPR data deletion request",
-            deletedCount, userId);
+            var deletedCount = await _repository.DeleteByUserIdAsync(userId, cancellationToken);
 
-        return deletedCount;
+            _logger.LogInformation(
+                "Deleted {Count} messages for user {UserId} per GDPR data deletion request",
+                deletedCount, userId);
+
+            BotActivitySource.SetRecordsReturned(activity, deletedCount);
+            BotActivitySource.SetSuccess(activity);
+            return deletedCount;
+        }
+        catch (Exception ex)
+        {
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
     }
 
     /// <inheritdoc/>
     public async Task<int> CleanupOldMessagesAsync(CancellationToken cancellationToken = default)
     {
-        var options = _retentionOptions.Value;
+        using var activity = BotActivitySource.StartServiceActivity(
+            "message_log",
+            "cleanup_old_messages");
 
-        if (!options.Enabled)
+        try
         {
-            _logger.LogDebug("Message log cleanup is disabled in configuration");
-            return 0;
-        }
+            var options = _retentionOptions.Value;
 
-        var cutoffDate = DateTime.UtcNow.AddDays(-options.RetentionDays);
-
-        _logger.LogInformation(
-            "Starting message log cleanup: deleting messages older than {CutoffDate} (RetentionDays: {RetentionDays})",
-            cutoffDate, options.RetentionDays);
-
-        var totalDeleted = 0;
-        var batchCount = 0;
-
-        // Delete in batches to prevent long-running transactions
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            var batchDeleted = await _repository.DeleteBatchOlderThanAsync(
-                cutoffDate,
-                options.CleanupBatchSize,
-                cancellationToken);
-
-            if (batchDeleted == 0)
+            if (!options.Enabled)
             {
-                // No more records to delete
-                break;
+                _logger.LogDebug("Message log cleanup is disabled in configuration");
+                BotActivitySource.SetSuccess(activity);
+                return 0;
             }
 
-            totalDeleted += batchDeleted;
-            batchCount++;
+            var cutoffDate = DateTime.UtcNow.AddDays(-options.RetentionDays);
 
-            _logger.LogDebug(
-                "Cleanup batch {BatchCount} deleted {BatchDeleted} messages (total: {TotalDeleted})",
-                batchCount, batchDeleted, totalDeleted);
-
-            // If we deleted fewer than the batch size, we're done
-            if (batchDeleted < options.CleanupBatchSize)
-            {
-                break;
-            }
-        }
-
-        if (totalDeleted > 0)
-        {
             _logger.LogInformation(
-                "Message log cleanup completed: deleted {TotalDeleted} messages in {BatchCount} batches",
-                totalDeleted, batchCount);
-        }
-        else
-        {
-            _logger.LogDebug("Message log cleanup completed: no old messages to delete");
-        }
+                "Starting message log cleanup: deleting messages older than {CutoffDate} (RetentionDays: {RetentionDays})",
+                cutoffDate, options.RetentionDays);
 
-        return totalDeleted;
+            var totalDeleted = 0;
+            var batchCount = 0;
+
+            // Delete in batches to prevent long-running transactions
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var batchDeleted = await _repository.DeleteBatchOlderThanAsync(
+                    cutoffDate,
+                    options.CleanupBatchSize,
+                    cancellationToken);
+
+                if (batchDeleted == 0)
+                {
+                    // No more records to delete
+                    break;
+                }
+
+                totalDeleted += batchDeleted;
+                batchCount++;
+
+                _logger.LogDebug(
+                    "Cleanup batch {BatchCount} deleted {BatchDeleted} messages (total: {TotalDeleted})",
+                    batchCount, batchDeleted, totalDeleted);
+
+                // If we deleted fewer than the batch size, we're done
+                if (batchDeleted < options.CleanupBatchSize)
+                {
+                    break;
+                }
+            }
+
+            if (totalDeleted > 0)
+            {
+                _logger.LogInformation(
+                    "Message log cleanup completed: deleted {TotalDeleted} messages in {BatchCount} batches",
+                    totalDeleted, batchCount);
+            }
+            else
+            {
+                _logger.LogDebug("Message log cleanup completed: no old messages to delete");
+            }
+
+            BotActivitySource.SetRecordsReturned(activity, totalDeleted);
+            BotActivitySource.SetSuccess(activity);
+            return totalDeleted;
+        }
+        catch (Exception ex)
+        {
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
     }
 
     /// <inheritdoc/>
     public async Task<byte[]> ExportToCsvAsync(MessageLogQueryDto query, CancellationToken cancellationToken = default)
     {
-        _logger.LogInformation(
-            "Exporting message logs to CSV with filters: AuthorId={AuthorId}, GuildId={GuildId}, ChannelId={ChannelId}, Source={Source}",
-            query.AuthorId, query.GuildId, query.ChannelId, query.Source);
+        using var activity = BotActivitySource.StartServiceActivity(
+            "message_log",
+            "export_to_csv",
+            guildId: query.GuildId,
+            userId: query.AuthorId);
 
-        // Set large page size to get all matching records (or use chunked export for very large datasets)
-        var exportQuery = new MessageLogQueryDto
+        try
         {
-            AuthorId = query.AuthorId,
-            GuildId = query.GuildId,
-            ChannelId = query.ChannelId,
-            Source = query.Source,
-            StartDate = query.StartDate,
-            EndDate = query.EndDate,
-            SearchTerm = query.SearchTerm,
-            Page = 1,
-            PageSize = 10000 // Export up to 10k records at once
-        };
+            _logger.LogInformation(
+                "Exporting message logs to CSV with filters: AuthorId={AuthorId}, GuildId={GuildId}, ChannelId={ChannelId}, Source={Source}",
+                query.AuthorId, query.GuildId, query.ChannelId, query.Source);
 
-        var (items, totalCount) = await _repository.GetPaginatedAsync(exportQuery, cancellationToken);
+            // Set large page size to get all matching records (or use chunked export for very large datasets)
+            var exportQuery = new MessageLogQueryDto
+            {
+                AuthorId = query.AuthorId,
+                GuildId = query.GuildId,
+                ChannelId = query.ChannelId,
+                Source = query.Source,
+                StartDate = query.StartDate,
+                EndDate = query.EndDate,
+                SearchTerm = query.SearchTerm,
+                Page = 1,
+                PageSize = 10000 // Export up to 10k records at once
+            };
 
-        if (totalCount > 10000)
-        {
-            _logger.LogWarning(
-                "Export query matched {TotalCount} records, but only exporting first {PageSize}. Consider adding filters.",
-                totalCount, exportQuery.PageSize);
+            var (items, totalCount) = await _repository.GetPaginatedAsync(exportQuery, cancellationToken);
+
+            if (totalCount > 10000)
+            {
+                _logger.LogWarning(
+                    "Export query matched {TotalCount} records, but only exporting first {PageSize}. Consider adding filters.",
+                    totalCount, exportQuery.PageSize);
+            }
+
+            // Build CSV content
+            var csv = new StringBuilder();
+
+            // Write CSV header
+            csv.AppendLine("Id,DiscordMessageId,AuthorId,ChannelId,GuildId,Source,Content,Timestamp,LoggedAt,HasAttachments,HasEmbeds,ReplyToMessageId");
+
+            // Write data rows
+            foreach (var message in items)
+            {
+                csv.AppendLine(FormatCsvRow(
+                    message.Id,
+                    message.DiscordMessageId,
+                    message.AuthorId,
+                    message.ChannelId,
+                    message.GuildId?.ToString() ?? "",
+                    message.Source.ToString(),
+                    EscapeCsvField(message.Content),
+                    message.Timestamp.ToString("O"),
+                    message.LoggedAt.ToString("O"),
+                    message.HasAttachments,
+                    message.HasEmbeds,
+                    message.ReplyToMessageId?.ToString() ?? ""
+                ));
+            }
+
+            var csvBytes = Encoding.UTF8.GetBytes(csv.ToString());
+
+            _logger.LogInformation(
+                "Exported {Count} message logs to CSV ({Size} bytes)",
+                items.Count(), csvBytes.Length);
+
+            BotActivitySource.SetRecordsReturned(activity, items.Count());
+            BotActivitySource.SetSuccess(activity);
+            return csvBytes;
         }
-
-        // Build CSV content
-        var csv = new StringBuilder();
-
-        // Write CSV header
-        csv.AppendLine("Id,DiscordMessageId,AuthorId,ChannelId,GuildId,Source,Content,Timestamp,LoggedAt,HasAttachments,HasEmbeds,ReplyToMessageId");
-
-        // Write data rows
-        foreach (var message in items)
+        catch (Exception ex)
         {
-            csv.AppendLine(FormatCsvRow(
-                message.Id,
-                message.DiscordMessageId,
-                message.AuthorId,
-                message.ChannelId,
-                message.GuildId?.ToString() ?? "",
-                message.Source.ToString(),
-                EscapeCsvField(message.Content),
-                message.Timestamp.ToString("O"),
-                message.LoggedAt.ToString("O"),
-                message.HasAttachments,
-                message.HasEmbeds,
-                message.ReplyToMessageId?.ToString() ?? ""
-            ));
+            BotActivitySource.RecordException(activity, ex);
+            throw;
         }
-
-        var csvBytes = Encoding.UTF8.GetBytes(csv.ToString());
-
-        _logger.LogInformation(
-            "Exported {Count} message logs to CSV ({Size} bytes)",
-            items.Count(), csvBytes.Length);
-
-        return csvBytes;
     }
 
     /// <summary>

--- a/src/DiscordBot.Bot/Services/ModTagService.cs
+++ b/src/DiscordBot.Bot/Services/ModTagService.cs
@@ -1,4 +1,5 @@
 using Discord.WebSocket;
+using DiscordBot.Bot.Tracing;
 using DiscordBot.Core.DTOs;
 using DiscordBot.Core.Entities;
 using DiscordBot.Core.Interfaces;
@@ -36,237 +37,366 @@ public class ModTagService : IModTagService
     /// <inheritdoc/>
     public async Task<ModTagDto> CreateTagAsync(ulong guildId, ModTagCreateDto dto, CancellationToken ct = default)
     {
-        _logger.LogInformation("Creating mod tag '{TagName}' in guild {GuildId}", dto.Name, guildId);
+        using var activity = BotActivitySource.StartServiceActivity(
+            "mod_tag",
+            "create_tag",
+            guildId: guildId);
 
-        // Validate color format
-        if (!HexColorRegex.IsMatch(dto.Color))
+        try
         {
-            _logger.LogWarning("Invalid color format for tag '{TagName}': {Color}", dto.Name, dto.Color);
-            throw new ArgumentException($"Color must be in hex format (#RRGGBB). Got: {dto.Color}", nameof(dto.Color));
-        }
+            _logger.LogInformation("Creating mod tag '{TagName}' in guild {GuildId}", dto.Name, guildId);
 
-        // Check if tag with same name already exists
-        var existing = await _tagRepository.GetByNameAsync(guildId, dto.Name, ct);
-        if (existing != null)
-        {
-            _logger.LogWarning("Tag '{TagName}' already exists in guild {GuildId}", dto.Name, guildId);
-            throw new InvalidOperationException($"A tag with the name '{dto.Name}' already exists.");
-        }
-
-        var tag = new ModTag
-        {
-            Id = Guid.NewGuid(),
-            GuildId = guildId,
-            Name = dto.Name,
-            Color = dto.Color.ToUpperInvariant(),
-            Category = dto.Category,
-            Description = dto.Description,
-            IsFromTemplate = false,
-            CreatedAt = DateTime.UtcNow
-        };
-
-        await _tagRepository.AddAsync(tag, ct);
-
-        _logger.LogInformation("Mod tag '{TagName}' created successfully in guild {GuildId} with ID {TagId}",
-            dto.Name, guildId, tag.Id);
-
-        return await MapToDtoAsync(tag, ct);
-    }
-
-    /// <inheritdoc/>
-    public async Task<bool> DeleteTagAsync(ulong guildId, string tagName, CancellationToken ct = default)
-    {
-        _logger.LogInformation("Deleting mod tag '{TagName}' in guild {GuildId}", tagName, guildId);
-
-        var tag = await _tagRepository.GetByNameAsync(guildId, tagName, ct);
-        if (tag == null)
-        {
-            _logger.LogWarning("Mod tag '{TagName}' not found in guild {GuildId}", tagName, guildId);
-            return false;
-        }
-
-        // Delete the tag (cascade will remove all user tag assignments)
-        await _tagRepository.DeleteAsync(tag, ct);
-
-        _logger.LogInformation("Mod tag '{TagName}' deleted successfully from guild {GuildId}", tagName, guildId);
-
-        return true;
-    }
-
-    /// <inheritdoc/>
-    public async Task<IEnumerable<ModTagDto>> GetGuildTagsAsync(ulong guildId, CancellationToken ct = default)
-    {
-        _logger.LogDebug("Retrieving all mod tags for guild {GuildId}", guildId);
-
-        var tags = await _tagRepository.GetByGuildAsync(guildId, ct);
-        var tagsList = tags.ToList();
-
-        var dtos = new List<ModTagDto>();
-        foreach (var tag in tagsList)
-        {
-            dtos.Add(await MapToDtoAsync(tag, ct));
-        }
-
-        _logger.LogDebug("Retrieved {Count} mod tags for guild {GuildId}", dtos.Count, guildId);
-
-        return dtos;
-    }
-
-    /// <inheritdoc/>
-    public async Task<ModTagDto?> GetTagByNameAsync(ulong guildId, string name, CancellationToken ct = default)
-    {
-        _logger.LogDebug("Retrieving mod tag '{TagName}' in guild {GuildId}", name, guildId);
-
-        var tag = await _tagRepository.GetByNameAsync(guildId, name, ct);
-        if (tag == null)
-        {
-            _logger.LogWarning("Mod tag '{TagName}' not found in guild {GuildId}", name, guildId);
-            return null;
-        }
-
-        return await MapToDtoAsync(tag, ct);
-    }
-
-    /// <inheritdoc/>
-    public async Task<UserModTagDto?> ApplyTagAsync(ulong guildId, ulong userId, string tagName, ulong appliedById, CancellationToken ct = default)
-    {
-        _logger.LogInformation("Applying tag '{TagName}' to user {UserId} in guild {GuildId} by moderator {AppliedById}",
-            tagName, userId, guildId, appliedById);
-
-        // Get the tag
-        var tag = await _tagRepository.GetByNameAsync(guildId, tagName, ct);
-        if (tag == null)
-        {
-            _logger.LogWarning("Mod tag '{TagName}' not found in guild {GuildId}", tagName, guildId);
-            return null;
-        }
-
-        // Check if tag is already applied
-        var existing = await _userTagRepository.ExistsAsync(guildId, userId, tag.Id, ct);
-        if (existing)
-        {
-            _logger.LogWarning("Tag '{TagName}' is already applied to user {UserId} in guild {GuildId}",
-                tagName, userId, guildId);
-            throw new InvalidOperationException($"Tag '{tagName}' is already applied to this user.");
-        }
-
-        var userTag = new UserModTag
-        {
-            Id = Guid.NewGuid(),
-            GuildId = guildId,
-            UserId = userId,
-            TagId = tag.Id,
-            AppliedByUserId = appliedById,
-            AppliedAt = DateTime.UtcNow
-            // Note: Do NOT set Tag navigation property here - it causes EF Core tracking
-            // errors when the tag's Guild is already tracked. The foreign key is sufficient.
-        };
-
-        await _userTagRepository.AddAsync(userTag, ct);
-
-        _logger.LogInformation("Tag '{TagName}' applied successfully to user {UserId} in guild {GuildId}",
-            tagName, userId, guildId);
-
-        return await MapUserTagToDtoAsync(userTag, tag, ct);
-    }
-
-    /// <inheritdoc/>
-    public async Task<bool> RemoveTagAsync(ulong guildId, ulong userId, string tagName, CancellationToken ct = default)
-    {
-        _logger.LogInformation("Removing tag '{TagName}' from user {UserId} in guild {GuildId}",
-            tagName, userId, guildId);
-
-        // Get the tag
-        var tag = await _tagRepository.GetByNameAsync(guildId, tagName, ct);
-        if (tag == null)
-        {
-            _logger.LogWarning("Mod tag '{TagName}' not found in guild {GuildId}", tagName, guildId);
-            return false;
-        }
-
-        // Get the user tag assignment
-        var userTag = await _userTagRepository.GetAssignmentAsync(guildId, userId, tag.Id, ct);
-        if (userTag == null)
-        {
-            _logger.LogWarning("Tag '{TagName}' is not applied to user {UserId} in guild {GuildId}",
-                tagName, userId, guildId);
-            return false;
-        }
-
-        await _userTagRepository.DeleteAsync(userTag, ct);
-
-        _logger.LogInformation("Tag '{TagName}' removed successfully from user {UserId} in guild {GuildId}",
-            tagName, userId, guildId);
-
-        return true;
-    }
-
-    /// <inheritdoc/>
-    public async Task<IEnumerable<UserModTagDto>> GetUserTagsAsync(ulong guildId, ulong userId, CancellationToken ct = default)
-    {
-        _logger.LogDebug("Retrieving tags for user {UserId} in guild {GuildId}", userId, guildId);
-
-        var userTags = await _userTagRepository.GetByUserAsync(guildId, userId, ct);
-        var userTagsList = userTags.ToList();
-
-        var dtos = new List<UserModTagDto>();
-        foreach (var userTag in userTagsList)
-        {
-            dtos.Add(await MapUserTagToDtoAsync(userTag, null, ct));
-        }
-
-        _logger.LogDebug("Retrieved {Count} tags for user {UserId} in guild {GuildId}",
-            dtos.Count, userId, guildId);
-
-        return dtos;
-    }
-
-    /// <inheritdoc/>
-    public async Task<int> ImportTemplateTagsAsync(ulong guildId, IEnumerable<string> templateNames, CancellationToken ct = default)
-    {
-        _logger.LogInformation("Importing template tags for guild {GuildId}: {Templates}",
-            guildId, string.Join(", ", templateNames));
-
-        var imported = 0;
-
-        foreach (var templateName in templateNames)
-        {
-            var template = ModTagTemplates.GetByName(templateName);
-            if (template == null)
+            // Validate color format
+            if (!HexColorRegex.IsMatch(dto.Color))
             {
-                _logger.LogWarning("Template tag '{TemplateName}' not found", templateName);
-                continue;
+                _logger.LogWarning("Invalid color format for tag '{TagName}': {Color}", dto.Name, dto.Color);
+                throw new ArgumentException($"Color must be in hex format (#RRGGBB). Got: {dto.Color}", nameof(dto.Color));
             }
 
-            // Check if tag already exists
-            var exists = await _tagRepository.NameExistsAsync(guildId, template.Name, ct);
-            if (exists)
+            // Check if tag with same name already exists
+            var existing = await _tagRepository.GetByNameAsync(guildId, dto.Name, ct);
+            if (existing != null)
             {
-                _logger.LogDebug("Tag '{TagName}' already exists in guild {GuildId}, skipping", template.Name, guildId);
-                continue;
+                _logger.LogWarning("Tag '{TagName}' already exists in guild {GuildId}", dto.Name, guildId);
+                throw new InvalidOperationException($"A tag with the name '{dto.Name}' already exists.");
             }
 
             var tag = new ModTag
             {
                 Id = Guid.NewGuid(),
                 GuildId = guildId,
-                Name = template.Name,
-                Color = template.Color,
-                Category = template.Category,
-                Description = template.Description,
-                IsFromTemplate = true,
+                Name = dto.Name,
+                Color = dto.Color.ToUpperInvariant(),
+                Category = dto.Category,
+                Description = dto.Description,
+                IsFromTemplate = false,
                 CreatedAt = DateTime.UtcNow
             };
 
             await _tagRepository.AddAsync(tag, ct);
-            imported++;
 
-            _logger.LogDebug("Imported template tag '{TagName}' to guild {GuildId}", template.Name, guildId);
+            _logger.LogInformation("Mod tag '{TagName}' created successfully in guild {GuildId} with ID {TagId}",
+                dto.Name, guildId, tag.Id);
+
+            var result = await MapToDtoAsync(tag, ct);
+
+            BotActivitySource.SetSuccess(activity);
+            return result;
         }
+        catch (Exception ex)
+        {
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
+    }
 
-        _logger.LogInformation("Imported {Count} template tags to guild {GuildId}", imported, guildId);
+    /// <inheritdoc/>
+    public async Task<bool> DeleteTagAsync(ulong guildId, string tagName, CancellationToken ct = default)
+    {
+        using var activity = BotActivitySource.StartServiceActivity(
+            "mod_tag",
+            "delete_tag",
+            guildId: guildId);
 
-        return imported;
+        try
+        {
+            _logger.LogInformation("Deleting mod tag '{TagName}' in guild {GuildId}", tagName, guildId);
+
+            var tag = await _tagRepository.GetByNameAsync(guildId, tagName, ct);
+            if (tag == null)
+            {
+                _logger.LogWarning("Mod tag '{TagName}' not found in guild {GuildId}", tagName, guildId);
+                BotActivitySource.SetSuccess(activity);
+                return false;
+            }
+
+            // Delete the tag (cascade will remove all user tag assignments)
+            await _tagRepository.DeleteAsync(tag, ct);
+
+            _logger.LogInformation("Mod tag '{TagName}' deleted successfully from guild {GuildId}", tagName, guildId);
+
+            BotActivitySource.SetSuccess(activity);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<ModTagDto>> GetGuildTagsAsync(ulong guildId, CancellationToken ct = default)
+    {
+        using var activity = BotActivitySource.StartServiceActivity(
+            "mod_tag",
+            "get_guild_tags",
+            guildId: guildId);
+
+        try
+        {
+            _logger.LogDebug("Retrieving all mod tags for guild {GuildId}", guildId);
+
+            var tags = await _tagRepository.GetByGuildAsync(guildId, ct);
+            var tagsList = tags.ToList();
+
+            var dtos = new List<ModTagDto>();
+            foreach (var tag in tagsList)
+            {
+                dtos.Add(await MapToDtoAsync(tag, ct));
+            }
+
+            _logger.LogDebug("Retrieved {Count} mod tags for guild {GuildId}", dtos.Count, guildId);
+
+            BotActivitySource.SetRecordsReturned(activity, dtos.Count);
+            BotActivitySource.SetSuccess(activity);
+            return dtos;
+        }
+        catch (Exception ex)
+        {
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<ModTagDto?> GetTagByNameAsync(ulong guildId, string name, CancellationToken ct = default)
+    {
+        using var activity = BotActivitySource.StartServiceActivity(
+            "mod_tag",
+            "get_tag_by_name",
+            guildId: guildId);
+
+        try
+        {
+            _logger.LogDebug("Retrieving mod tag '{TagName}' in guild {GuildId}", name, guildId);
+
+            var tag = await _tagRepository.GetByNameAsync(guildId, name, ct);
+            if (tag == null)
+            {
+                _logger.LogWarning("Mod tag '{TagName}' not found in guild {GuildId}", name, guildId);
+                BotActivitySource.SetSuccess(activity);
+                return null;
+            }
+
+            var result = await MapToDtoAsync(tag, ct);
+
+            BotActivitySource.SetSuccess(activity);
+            return result;
+        }
+        catch (Exception ex)
+        {
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<UserModTagDto?> ApplyTagAsync(ulong guildId, ulong userId, string tagName, ulong appliedById, CancellationToken ct = default)
+    {
+        using var activity = BotActivitySource.StartServiceActivity(
+            "mod_tag",
+            "apply_tag",
+            guildId: guildId,
+            userId: userId);
+
+        try
+        {
+            _logger.LogInformation("Applying tag '{TagName}' to user {UserId} in guild {GuildId} by moderator {AppliedById}",
+                tagName, userId, guildId, appliedById);
+
+            // Get the tag
+            var tag = await _tagRepository.GetByNameAsync(guildId, tagName, ct);
+            if (tag == null)
+            {
+                _logger.LogWarning("Mod tag '{TagName}' not found in guild {GuildId}", tagName, guildId);
+                BotActivitySource.SetSuccess(activity);
+                return null;
+            }
+
+            // Check if tag is already applied
+            var existing = await _userTagRepository.ExistsAsync(guildId, userId, tag.Id, ct);
+            if (existing)
+            {
+                _logger.LogWarning("Tag '{TagName}' is already applied to user {UserId} in guild {GuildId}",
+                    tagName, userId, guildId);
+                throw new InvalidOperationException($"Tag '{tagName}' is already applied to this user.");
+            }
+
+            var userTag = new UserModTag
+            {
+                Id = Guid.NewGuid(),
+                GuildId = guildId,
+                UserId = userId,
+                TagId = tag.Id,
+                AppliedByUserId = appliedById,
+                AppliedAt = DateTime.UtcNow
+                // Note: Do NOT set Tag navigation property here - it causes EF Core tracking
+                // errors when the tag's Guild is already tracked. The foreign key is sufficient.
+            };
+
+            await _userTagRepository.AddAsync(userTag, ct);
+
+            _logger.LogInformation("Tag '{TagName}' applied successfully to user {UserId} in guild {GuildId}",
+                tagName, userId, guildId);
+
+            var result = await MapUserTagToDtoAsync(userTag, tag, ct);
+
+            BotActivitySource.SetSuccess(activity);
+            return result;
+        }
+        catch (Exception ex)
+        {
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> RemoveTagAsync(ulong guildId, ulong userId, string tagName, CancellationToken ct = default)
+    {
+        using var activity = BotActivitySource.StartServiceActivity(
+            "mod_tag",
+            "remove_tag",
+            guildId: guildId,
+            userId: userId);
+
+        try
+        {
+            _logger.LogInformation("Removing tag '{TagName}' from user {UserId} in guild {GuildId}",
+                tagName, userId, guildId);
+
+            // Get the tag
+            var tag = await _tagRepository.GetByNameAsync(guildId, tagName, ct);
+            if (tag == null)
+            {
+                _logger.LogWarning("Mod tag '{TagName}' not found in guild {GuildId}", tagName, guildId);
+                BotActivitySource.SetSuccess(activity);
+                return false;
+            }
+
+            // Get the user tag assignment
+            var userTag = await _userTagRepository.GetAssignmentAsync(guildId, userId, tag.Id, ct);
+            if (userTag == null)
+            {
+                _logger.LogWarning("Tag '{TagName}' is not applied to user {UserId} in guild {GuildId}",
+                    tagName, userId, guildId);
+                BotActivitySource.SetSuccess(activity);
+                return false;
+            }
+
+            await _userTagRepository.DeleteAsync(userTag, ct);
+
+            _logger.LogInformation("Tag '{TagName}' removed successfully from user {UserId} in guild {GuildId}",
+                tagName, userId, guildId);
+
+            BotActivitySource.SetSuccess(activity);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<UserModTagDto>> GetUserTagsAsync(ulong guildId, ulong userId, CancellationToken ct = default)
+    {
+        using var activity = BotActivitySource.StartServiceActivity(
+            "mod_tag",
+            "get_user_tags",
+            guildId: guildId,
+            userId: userId);
+
+        try
+        {
+            _logger.LogDebug("Retrieving tags for user {UserId} in guild {GuildId}", userId, guildId);
+
+            var userTags = await _userTagRepository.GetByUserAsync(guildId, userId, ct);
+            var userTagsList = userTags.ToList();
+
+            var dtos = new List<UserModTagDto>();
+            foreach (var userTag in userTagsList)
+            {
+                dtos.Add(await MapUserTagToDtoAsync(userTag, null, ct));
+            }
+
+            _logger.LogDebug("Retrieved {Count} tags for user {UserId} in guild {GuildId}",
+                dtos.Count, userId, guildId);
+
+            BotActivitySource.SetRecordsReturned(activity, dtos.Count);
+            BotActivitySource.SetSuccess(activity);
+            return dtos;
+        }
+        catch (Exception ex)
+        {
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<int> ImportTemplateTagsAsync(ulong guildId, IEnumerable<string> templateNames, CancellationToken ct = default)
+    {
+        using var activity = BotActivitySource.StartServiceActivity(
+            "mod_tag",
+            "import_template_tags",
+            guildId: guildId);
+
+        try
+        {
+            _logger.LogInformation("Importing template tags for guild {GuildId}: {Templates}",
+                guildId, string.Join(", ", templateNames));
+
+            var imported = 0;
+
+            foreach (var templateName in templateNames)
+            {
+                var template = ModTagTemplates.GetByName(templateName);
+                if (template == null)
+                {
+                    _logger.LogWarning("Template tag '{TemplateName}' not found", templateName);
+                    continue;
+                }
+
+                // Check if tag already exists
+                var exists = await _tagRepository.NameExistsAsync(guildId, template.Name, ct);
+                if (exists)
+                {
+                    _logger.LogDebug("Tag '{TagName}' already exists in guild {GuildId}, skipping", template.Name, guildId);
+                    continue;
+                }
+
+                var tag = new ModTag
+                {
+                    Id = Guid.NewGuid(),
+                    GuildId = guildId,
+                    Name = template.Name,
+                    Color = template.Color,
+                    Category = template.Category,
+                    Description = template.Description,
+                    IsFromTemplate = true,
+                    CreatedAt = DateTime.UtcNow
+                };
+
+                await _tagRepository.AddAsync(tag, ct);
+                imported++;
+
+                _logger.LogDebug("Imported template tag '{TagName}' to guild {GuildId}", template.Name, guildId);
+            }
+
+            _logger.LogInformation("Imported {Count} template tags to guild {GuildId}", imported, guildId);
+
+            BotActivitySource.SetRecordsReturned(activity, imported);
+            BotActivitySource.SetSuccess(activity);
+            return imported;
+        }
+        catch (Exception ex)
+        {
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
     }
 
     /// <summary>

--- a/src/DiscordBot.Bot/Services/ModerationAnalyticsService.cs
+++ b/src/DiscordBot.Bot/Services/ModerationAnalyticsService.cs
@@ -1,3 +1,4 @@
+using DiscordBot.Bot.Tracing;
 using DiscordBot.Core.DTOs;
 using DiscordBot.Core.Enums;
 using DiscordBot.Core.Interfaces;
@@ -29,76 +30,92 @@ public class ModerationAnalyticsService : IModerationAnalyticsService
         DateTime end,
         CancellationToken ct = default)
     {
-        _logger.LogDebug(
-            "Generating moderation analytics summary for guild {GuildId} from {Start} to {End}",
-            guildId, start, end);
+        using var activity = BotActivitySource.StartServiceActivity(
+            "moderation_analytics",
+            "get_summary",
+            guildId: guildId);
 
-        // Get all cases in the time period
-        var (cases, _) = await _moderationCaseRepository.GetByGuildAsync(
-            guildId,
-            startDate: start,
-            endDate: end,
-            page: 1,
-            pageSize: int.MaxValue,
-            cancellationToken: ct);
-
-        var casesList = cases.ToList();
-
-        // Count cases by type
-        var totalCases = casesList.Count;
-        var warnCount = casesList.Count(c => c.Type == CaseType.Warn);
-        var muteCount = casesList.Count(c => c.Type == CaseType.Mute);
-        var kickCount = casesList.Count(c => c.Type == CaseType.Kick);
-        var banCount = casesList.Count(c => c.Type == CaseType.Ban);
-        var noteCount = casesList.Count(c => c.Type == CaseType.Note);
-
-        // Calculate time-based metrics
-        var now = DateTime.UtcNow;
-        var last24h = now.AddHours(-24);
-        var last7d = now.AddDays(-7);
-
-        var casesLast24h = casesList.Count(c => c.CreatedAt >= last24h);
-        var casesLast7d = casesList.Count(c => c.CreatedAt >= last7d);
-
-        // Calculate average cases per day
-        var daySpan = (end - start).TotalDays;
-        var casesPerDay = daySpan > 0 ? (decimal)totalCases / (decimal)daySpan : 0m;
-
-        // Calculate change from previous period
-        var periodLength = end - start;
-        var previousPeriodStart = start - periodLength;
-        var previousPeriodEnd = start;
-
-        var (previousCases, _) = await _moderationCaseRepository.GetByGuildAsync(
-            guildId,
-            startDate: previousPeriodStart,
-            endDate: previousPeriodEnd,
-            page: 1,
-            pageSize: int.MaxValue,
-            cancellationToken: ct);
-
-        var previousCaseCount = previousCases.Count();
-        var changeFromPreviousPeriod = previousCaseCount > 0
-            ? ((decimal)(totalCases - previousCaseCount) / previousCaseCount) * 100
-            : totalCases > 0 ? 100m : 0m;
-
-        _logger.LogInformation(
-            "Moderation analytics summary generated for guild {GuildId}: {TotalCases} total cases, {Cases24h} in last 24h",
-            guildId, totalCases, casesLast24h);
-
-        return new ModerationAnalyticsSummaryDto
+        try
         {
-            TotalCases = totalCases,
-            WarnCount = warnCount,
-            MuteCount = muteCount,
-            KickCount = kickCount,
-            BanCount = banCount,
-            NoteCount = noteCount,
-            Cases24h = casesLast24h,
-            Cases7d = casesLast7d,
-            CasesPerDay = casesPerDay,
-            ChangeFromPreviousPeriod = changeFromPreviousPeriod
-        };
+            _logger.LogDebug(
+                "Generating moderation analytics summary for guild {GuildId} from {Start} to {End}",
+                guildId, start, end);
+
+            // Get all cases in the time period
+            var (cases, _) = await _moderationCaseRepository.GetByGuildAsync(
+                guildId,
+                startDate: start,
+                endDate: end,
+                page: 1,
+                pageSize: int.MaxValue,
+                cancellationToken: ct);
+
+            var casesList = cases.ToList();
+
+            // Count cases by type
+            var totalCases = casesList.Count;
+            var warnCount = casesList.Count(c => c.Type == CaseType.Warn);
+            var muteCount = casesList.Count(c => c.Type == CaseType.Mute);
+            var kickCount = casesList.Count(c => c.Type == CaseType.Kick);
+            var banCount = casesList.Count(c => c.Type == CaseType.Ban);
+            var noteCount = casesList.Count(c => c.Type == CaseType.Note);
+
+            // Calculate time-based metrics
+            var now = DateTime.UtcNow;
+            var last24h = now.AddHours(-24);
+            var last7d = now.AddDays(-7);
+
+            var casesLast24h = casesList.Count(c => c.CreatedAt >= last24h);
+            var casesLast7d = casesList.Count(c => c.CreatedAt >= last7d);
+
+            // Calculate average cases per day
+            var daySpan = (end - start).TotalDays;
+            var casesPerDay = daySpan > 0 ? (decimal)totalCases / (decimal)daySpan : 0m;
+
+            // Calculate change from previous period
+            var periodLength = end - start;
+            var previousPeriodStart = start - periodLength;
+            var previousPeriodEnd = start;
+
+            var (previousCases, _) = await _moderationCaseRepository.GetByGuildAsync(
+                guildId,
+                startDate: previousPeriodStart,
+                endDate: previousPeriodEnd,
+                page: 1,
+                pageSize: int.MaxValue,
+                cancellationToken: ct);
+
+            var previousCaseCount = previousCases.Count();
+            var changeFromPreviousPeriod = previousCaseCount > 0
+                ? ((decimal)(totalCases - previousCaseCount) / previousCaseCount) * 100
+                : totalCases > 0 ? 100m : 0m;
+
+            _logger.LogInformation(
+                "Moderation analytics summary generated for guild {GuildId}: {TotalCases} total cases, {Cases24h} in last 24h",
+                guildId, totalCases, casesLast24h);
+
+            var result = new ModerationAnalyticsSummaryDto
+            {
+                TotalCases = totalCases,
+                WarnCount = warnCount,
+                MuteCount = muteCount,
+                KickCount = kickCount,
+                BanCount = banCount,
+                NoteCount = noteCount,
+                Cases24h = casesLast24h,
+                Cases7d = casesLast7d,
+                CasesPerDay = casesPerDay,
+                ChangeFromPreviousPeriod = changeFromPreviousPeriod
+            };
+
+            BotActivitySource.SetSuccess(activity);
+            return result;
+        }
+        catch (Exception ex)
+        {
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
     }
 
     /// <inheritdoc/>
@@ -108,39 +125,53 @@ public class ModerationAnalyticsService : IModerationAnalyticsService
         DateTime end,
         CancellationToken ct = default)
     {
-        _logger.LogDebug(
-            "Generating moderation trends for guild {GuildId} from {Start} to {End}",
-            guildId, start, end);
+        using var activity = BotActivitySource.StartServiceActivity(
+            "moderation_analytics",
+            "get_trends",
+            guildId: guildId);
 
-        // Get all cases in the time period
-        var (cases, _) = await _moderationCaseRepository.GetByGuildAsync(
-            guildId,
-            startDate: start,
-            endDate: end,
-            page: 1,
-            pageSize: int.MaxValue,
-            cancellationToken: ct);
+        try
+        {
+            _logger.LogDebug(
+                "Generating moderation trends for guild {GuildId} from {Start} to {End}",
+                guildId, start, end);
 
-        // Group by date and count by type
-        var trends = cases
-            .GroupBy(c => DateOnly.FromDateTime(c.CreatedAt))
-            .Select(g => new ModerationTrendDto
-            {
-                Date = g.Key.ToDateTime(TimeOnly.MinValue),
-                TotalCases = g.Count(),
-                WarnCount = g.Count(c => c.Type == CaseType.Warn),
-                MuteCount = g.Count(c => c.Type == CaseType.Mute),
-                KickCount = g.Count(c => c.Type == CaseType.Kick),
-                BanCount = g.Count(c => c.Type == CaseType.Ban)
-            })
-            .OrderBy(t => t.Date)
-            .ToList();
+            // Get all cases in the time period
+            var (cases, _) = await _moderationCaseRepository.GetByGuildAsync(
+                guildId,
+                startDate: start,
+                endDate: end,
+                page: 1,
+                pageSize: int.MaxValue,
+                cancellationToken: ct);
 
-        _logger.LogDebug(
-            "Generated {Count} trend data points for guild {GuildId}",
-            trends.Count, guildId);
+            // Group by date and count by type
+            var trends = cases
+                .GroupBy(c => DateOnly.FromDateTime(c.CreatedAt))
+                .Select(g => new ModerationTrendDto
+                {
+                    Date = g.Key.ToDateTime(TimeOnly.MinValue),
+                    TotalCases = g.Count(),
+                    WarnCount = g.Count(c => c.Type == CaseType.Warn),
+                    MuteCount = g.Count(c => c.Type == CaseType.Mute),
+                    KickCount = g.Count(c => c.Type == CaseType.Kick),
+                    BanCount = g.Count(c => c.Type == CaseType.Ban)
+                })
+                .OrderBy(t => t.Date)
+                .ToList();
 
-        return trends;
+            _logger.LogDebug(
+                "Generated {Count} trend data points for guild {GuildId}",
+                trends.Count, guildId);
+
+            BotActivitySource.SetSuccess(activity);
+            return trends;
+        }
+        catch (Exception ex)
+        {
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
     }
 
     /// <inheritdoc/>
@@ -151,52 +182,66 @@ public class ModerationAnalyticsService : IModerationAnalyticsService
         int limit = 10,
         CancellationToken ct = default)
     {
-        _logger.LogDebug(
-            "Getting top {Limit} repeat offenders for guild {GuildId} from {Start} to {End}",
-            limit, guildId, start, end);
+        using var activity = BotActivitySource.StartServiceActivity(
+            "moderation_analytics",
+            "get_repeat_offenders",
+            guildId: guildId);
 
-        // Get all cases in the time period
-        var (cases, _) = await _moderationCaseRepository.GetByGuildAsync(
-            guildId,
-            startDate: start,
-            endDate: end,
-            page: 1,
-            pageSize: int.MaxValue,
-            cancellationToken: ct);
+        try
+        {
+            _logger.LogDebug(
+                "Getting top {Limit} repeat offenders for guild {GuildId} from {Start} to {End}",
+                limit, guildId, start, end);
 
-        // Group by target user and filter for repeat offenders (2+ cases)
-        var offenders = cases
-            .GroupBy(c => c.TargetUserId)
-            .Where(g => g.Count() >= 2)
-            .Select(g => new
-            {
-                UserId = g.Key,
-                Cases = g.OrderBy(c => c.CreatedAt).ToList()
-            })
-            .Select(x => new RepeatOffenderDto
-            {
-                UserId = x.UserId,
-                Username = $"User {x.UserId}", // Username not stored in ModerationCase
-                AvatarUrl = null, // Avatar not tracked in ModerationCase entity
-                TotalCases = x.Cases.Count,
-                WarnCount = x.Cases.Count(c => c.Type == CaseType.Warn),
-                MuteCount = x.Cases.Count(c => c.Type == CaseType.Mute),
-                KickCount = x.Cases.Count(c => c.Type == CaseType.Kick),
-                BanCount = x.Cases.Count(c => c.Type == CaseType.Ban),
-                FirstIncident = x.Cases.First().CreatedAt,
-                LastIncident = x.Cases.Last().CreatedAt,
-                EscalationPath = x.Cases.Select(c => c.Type.ToString()).ToList()
-            })
-            .OrderByDescending(x => x.TotalCases)
-            .ThenByDescending(x => x.LastIncident)
-            .Take(limit)
-            .ToList();
+            // Get all cases in the time period
+            var (cases, _) = await _moderationCaseRepository.GetByGuildAsync(
+                guildId,
+                startDate: start,
+                endDate: end,
+                page: 1,
+                pageSize: int.MaxValue,
+                cancellationToken: ct);
 
-        _logger.LogInformation(
-            "Retrieved {Count} repeat offenders for guild {GuildId}",
-            offenders.Count, guildId);
+            // Group by target user and filter for repeat offenders (2+ cases)
+            var offenders = cases
+                .GroupBy(c => c.TargetUserId)
+                .Where(g => g.Count() >= 2)
+                .Select(g => new
+                {
+                    UserId = g.Key,
+                    Cases = g.OrderBy(c => c.CreatedAt).ToList()
+                })
+                .Select(x => new RepeatOffenderDto
+                {
+                    UserId = x.UserId,
+                    Username = $"User {x.UserId}", // Username not stored in ModerationCase
+                    AvatarUrl = null, // Avatar not tracked in ModerationCase entity
+                    TotalCases = x.Cases.Count,
+                    WarnCount = x.Cases.Count(c => c.Type == CaseType.Warn),
+                    MuteCount = x.Cases.Count(c => c.Type == CaseType.Mute),
+                    KickCount = x.Cases.Count(c => c.Type == CaseType.Kick),
+                    BanCount = x.Cases.Count(c => c.Type == CaseType.Ban),
+                    FirstIncident = x.Cases.First().CreatedAt,
+                    LastIncident = x.Cases.Last().CreatedAt,
+                    EscalationPath = x.Cases.Select(c => c.Type.ToString()).ToList()
+                })
+                .OrderByDescending(x => x.TotalCases)
+                .ThenByDescending(x => x.LastIncident)
+                .Take(limit)
+                .ToList();
 
-        return offenders;
+            _logger.LogInformation(
+                "Retrieved {Count} repeat offenders for guild {GuildId}",
+                offenders.Count, guildId);
+
+            BotActivitySource.SetSuccess(activity);
+            return offenders;
+        }
+        catch (Exception ex)
+        {
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
     }
 
     /// <inheritdoc/>
@@ -207,51 +252,65 @@ public class ModerationAnalyticsService : IModerationAnalyticsService
         int limit = 10,
         CancellationToken ct = default)
     {
-        _logger.LogDebug(
-            "Getting moderator workload for guild {GuildId} from {Start} to {End}",
-            guildId, start, end);
+        using var activity = BotActivitySource.StartServiceActivity(
+            "moderation_analytics",
+            "get_moderator_workload",
+            guildId: guildId);
 
-        // Get all cases in the time period
-        var (cases, _) = await _moderationCaseRepository.GetByGuildAsync(
-            guildId,
-            startDate: start,
-            endDate: end,
-            page: 1,
-            pageSize: int.MaxValue,
-            cancellationToken: ct);
+        try
+        {
+            _logger.LogDebug(
+                "Getting moderator workload for guild {GuildId} from {Start} to {End}",
+                guildId, start, end);
 
-        var casesList = cases.ToList();
-        var totalActions = casesList.Count;
+            // Get all cases in the time period
+            var (cases, _) = await _moderationCaseRepository.GetByGuildAsync(
+                guildId,
+                startDate: start,
+                endDate: end,
+                page: 1,
+                pageSize: int.MaxValue,
+                cancellationToken: ct);
 
-        // Group by moderator and calculate workload
-        var workload = casesList
-            .GroupBy(c => c.ModeratorUserId)
-            .Select(g => new
-            {
-                ModeratorId = g.Key,
-                Cases = g.ToList()
-            })
-            .Select(x => new ModeratorWorkloadDto
-            {
-                ModeratorId = x.ModeratorId,
-                ModeratorUsername = $"Moderator {x.ModeratorId}", // Username not stored in ModerationCase
-                AvatarUrl = null, // Avatar not tracked in ModerationCase entity
-                TotalActions = x.Cases.Count,
-                WarnCount = x.Cases.Count(c => c.Type == CaseType.Warn),
-                MuteCount = x.Cases.Count(c => c.Type == CaseType.Mute),
-                KickCount = x.Cases.Count(c => c.Type == CaseType.Kick),
-                BanCount = x.Cases.Count(c => c.Type == CaseType.Ban),
-                Percentage = totalActions > 0 ? ((decimal)x.Cases.Count / totalActions) * 100 : 0m
-            })
-            .OrderByDescending(x => x.TotalActions)
-            .Take(limit)
-            .ToList();
+            var casesList = cases.ToList();
+            var totalActions = casesList.Count;
 
-        _logger.LogInformation(
-            "Retrieved workload metrics for {Count} moderators in guild {GuildId}",
-            workload.Count, guildId);
+            // Group by moderator and calculate workload
+            var workload = casesList
+                .GroupBy(c => c.ModeratorUserId)
+                .Select(g => new
+                {
+                    ModeratorId = g.Key,
+                    Cases = g.ToList()
+                })
+                .Select(x => new ModeratorWorkloadDto
+                {
+                    ModeratorId = x.ModeratorId,
+                    ModeratorUsername = $"Moderator {x.ModeratorId}", // Username not stored in ModerationCase
+                    AvatarUrl = null, // Avatar not tracked in ModerationCase entity
+                    TotalActions = x.Cases.Count,
+                    WarnCount = x.Cases.Count(c => c.Type == CaseType.Warn),
+                    MuteCount = x.Cases.Count(c => c.Type == CaseType.Mute),
+                    KickCount = x.Cases.Count(c => c.Type == CaseType.Kick),
+                    BanCount = x.Cases.Count(c => c.Type == CaseType.Ban),
+                    Percentage = totalActions > 0 ? ((decimal)x.Cases.Count / totalActions) * 100 : 0m
+                })
+                .OrderByDescending(x => x.TotalActions)
+                .Take(limit)
+                .ToList();
 
-        return workload;
+            _logger.LogInformation(
+                "Retrieved workload metrics for {Count} moderators in guild {GuildId}",
+                workload.Count, guildId);
+
+            BotActivitySource.SetSuccess(activity);
+            return workload;
+        }
+        catch (Exception ex)
+        {
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
     }
 
     /// <inheritdoc/>
@@ -261,42 +320,56 @@ public class ModerationAnalyticsService : IModerationAnalyticsService
         DateTime end,
         CancellationToken ct = default)
     {
-        _logger.LogDebug(
-            "Getting case type distribution for guild {GuildId} from {Start} to {End}",
-            guildId, start, end);
+        using var activity = BotActivitySource.StartServiceActivity(
+            "moderation_analytics",
+            "get_case_distribution",
+            guildId: guildId);
 
-        // Get all cases in the time period
-        var (cases, _) = await _moderationCaseRepository.GetByGuildAsync(
-            guildId,
-            startDate: start,
-            endDate: end,
-            page: 1,
-            pageSize: int.MaxValue,
-            cancellationToken: ct);
-
-        var casesList = cases.ToList();
-
-        // Count by type
-        var warnCount = casesList.Count(c => c.Type == CaseType.Warn);
-        var muteCount = casesList.Count(c => c.Type == CaseType.Mute);
-        var kickCount = casesList.Count(c => c.Type == CaseType.Kick);
-        var banCount = casesList.Count(c => c.Type == CaseType.Ban);
-        var noteCount = casesList.Count(c => c.Type == CaseType.Note);
-
-        var distribution = new CaseTypeDistributionDto
+        try
         {
-            WarnCount = warnCount,
-            MuteCount = muteCount,
-            KickCount = kickCount,
-            BanCount = banCount,
-            NoteCount = noteCount,
-            Total = casesList.Count
-        };
+            _logger.LogDebug(
+                "Getting case type distribution for guild {GuildId} from {Start} to {End}",
+                guildId, start, end);
 
-        _logger.LogDebug(
-            "Case distribution for guild {GuildId}: {Total} total ({Warn} warns, {Mute} mutes, {Kick} kicks, {Ban} bans, {Note} notes)",
-            guildId, distribution.Total, warnCount, muteCount, kickCount, banCount, noteCount);
+            // Get all cases in the time period
+            var (cases, _) = await _moderationCaseRepository.GetByGuildAsync(
+                guildId,
+                startDate: start,
+                endDate: end,
+                page: 1,
+                pageSize: int.MaxValue,
+                cancellationToken: ct);
 
-        return distribution;
+            var casesList = cases.ToList();
+
+            // Count by type
+            var warnCount = casesList.Count(c => c.Type == CaseType.Warn);
+            var muteCount = casesList.Count(c => c.Type == CaseType.Mute);
+            var kickCount = casesList.Count(c => c.Type == CaseType.Kick);
+            var banCount = casesList.Count(c => c.Type == CaseType.Ban);
+            var noteCount = casesList.Count(c => c.Type == CaseType.Note);
+
+            var distribution = new CaseTypeDistributionDto
+            {
+                WarnCount = warnCount,
+                MuteCount = muteCount,
+                KickCount = kickCount,
+                BanCount = banCount,
+                NoteCount = noteCount,
+                Total = casesList.Count
+            };
+
+            _logger.LogDebug(
+                "Case distribution for guild {GuildId}: {Total} total ({Warn} warns, {Mute} mutes, {Kick} kicks, {Ban} bans, {Note} notes)",
+                guildId, distribution.Total, warnCount, muteCount, kickCount, banCount, noteCount);
+
+            BotActivitySource.SetSuccess(activity);
+            return distribution;
+        }
+        catch (Exception ex)
+        {
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
     }
 }

--- a/src/DiscordBot.Bot/Services/ScheduledMessageService.cs
+++ b/src/DiscordBot.Bot/Services/ScheduledMessageService.cs
@@ -1,6 +1,7 @@
 using Cronos;
 using Discord;
 using Discord.WebSocket;
+using DiscordBot.Bot.Tracing;
 using DiscordBot.Core.DTOs;
 using DiscordBot.Core.Entities;
 using DiscordBot.Core.Enums;
@@ -40,19 +41,34 @@ public class ScheduledMessageService : IScheduledMessageService
     /// <inheritdoc/>
     public async Task<ScheduledMessageDto?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
     {
-        _logger.LogDebug("Retrieving scheduled message {MessageId}", id);
+        using var activity = BotActivitySource.StartServiceActivity(
+            "scheduled_message",
+            "get_by_id",
+            entityId: id.ToString());
 
-        var message = await _repository.GetByIdWithGuildAsync(id, cancellationToken);
-        if (message == null)
+        try
         {
-            _logger.LogWarning("Scheduled message {MessageId} not found", id);
-            return null;
+            _logger.LogDebug("Retrieving scheduled message {MessageId}", id);
+
+            var message = await _repository.GetByIdWithGuildAsync(id, cancellationToken);
+            if (message == null)
+            {
+                _logger.LogWarning("Scheduled message {MessageId} not found", id);
+                BotActivitySource.SetSuccess(activity);
+                return null;
+            }
+
+            var dto = MapToDto(message);
+            _logger.LogDebug("Retrieved scheduled message {MessageId}: {Title}", id, dto.Title);
+
+            BotActivitySource.SetSuccess(activity);
+            return dto;
         }
-
-        var dto = MapToDto(message);
-        _logger.LogDebug("Retrieved scheduled message {MessageId}: {Title}", id, dto.Title);
-
-        return dto;
+        catch (Exception ex)
+        {
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
     }
 
     /// <inheritdoc/>
@@ -62,158 +78,56 @@ public class ScheduledMessageService : IScheduledMessageService
         int pageSize,
         CancellationToken cancellationToken = default)
     {
-        _logger.LogDebug("Retrieving scheduled messages for guild {GuildId}, page {Page}, pageSize {PageSize}",
-            guildId, page, pageSize);
+        using var activity = BotActivitySource.StartServiceActivity(
+            "scheduled_message",
+            "get_by_guild",
+            guildId: guildId);
 
-        var (messages, totalCount) = await _repository.GetByGuildIdAsync(guildId, page, pageSize, cancellationToken);
-        var dtos = messages.Select(MapToDto);
+        try
+        {
+            _logger.LogDebug("Retrieving scheduled messages for guild {GuildId}, page {Page}, pageSize {PageSize}",
+                guildId, page, pageSize);
 
-        _logger.LogInformation("Retrieved {Count} of {Total} scheduled messages for guild {GuildId}",
-            messages.Count(), totalCount, guildId);
+            var (messages, totalCount) = await _repository.GetByGuildIdAsync(guildId, page, pageSize, cancellationToken);
+            var dtos = messages.Select(MapToDto);
 
-        return (dtos, totalCount);
+            _logger.LogInformation("Retrieved {Count} of {Total} scheduled messages for guild {GuildId}",
+                messages.Count(), totalCount, guildId);
+
+            BotActivitySource.SetRecordsReturned(activity, messages.Count());
+            BotActivitySource.SetSuccess(activity);
+            return (dtos, totalCount);
+        }
+        catch (Exception ex)
+        {
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
     }
 
     /// <inheritdoc/>
     public async Task<ScheduledMessageDto> CreateAsync(ScheduledMessageCreateDto dto, CancellationToken cancellationToken = default)
     {
-        _logger.LogInformation("Creating scheduled message for guild {GuildId}, channel {ChannelId}: {Title}",
-            dto.GuildId, dto.ChannelId, dto.Title);
+        using var activity = BotActivitySource.StartServiceActivity(
+            "scheduled_message",
+            "create",
+            guildId: dto.GuildId);
 
-        // Validate cron expression if frequency is Custom
-        if (dto.Frequency == ScheduleFrequency.Custom)
-        {
-            if (string.IsNullOrWhiteSpace(dto.CronExpression))
-            {
-                var error = "Cron expression is required when frequency is Custom";
-                _logger.LogWarning(error);
-                throw new ArgumentException(error, nameof(dto));
-            }
-
-            var (isValid, errorMessage) = await ValidateCronExpressionAsync(dto.CronExpression);
-            if (!isValid)
-            {
-                _logger.LogWarning("Invalid cron expression: {Error}", errorMessage);
-                throw new ArgumentException(errorMessage, nameof(dto));
-            }
-        }
-
-        var now = DateTime.UtcNow;
-        var message = new ScheduledMessage
-        {
-            Id = Guid.NewGuid(),
-            GuildId = dto.GuildId,
-            ChannelId = dto.ChannelId,
-            Title = dto.Title,
-            Content = dto.Content,
-            CronExpression = dto.CronExpression,
-            Frequency = dto.Frequency,
-            IsEnabled = dto.IsEnabled,
-            NextExecutionAt = dto.NextExecutionAt,
-            CreatedAt = now,
-            UpdatedAt = now,
-            CreatedBy = dto.CreatedBy
-        };
-
-        await _repository.AddAsync(message, cancellationToken);
-
-        // Audit log
         try
         {
-            var builder = _auditLogService.CreateBuilder()
-                .ForCategory(AuditLogCategory.Message)
-                .WithAction(AuditLogAction.Created)
-                .InGuild(dto.GuildId)
-                .OnTarget("ScheduledMessage", message.Id.ToString())
-                .WithDetails(new
-                {
-                    title = dto.Title,
-                    channelId = dto.ChannelId,
-                    frequency = dto.Frequency.ToString(),
-                    isEnabled = dto.IsEnabled,
-                    guildId = dto.GuildId
-                });
+            _logger.LogInformation("Creating scheduled message for guild {GuildId}, channel {ChannelId}: {Title}",
+                dto.GuildId, dto.ChannelId, dto.Title);
 
-            // Use ByUser if CreatedBy is provided, otherwise BySystem
-            if (!string.IsNullOrEmpty(dto.CreatedBy))
+            // Validate cron expression if frequency is Custom
+            if (dto.Frequency == ScheduleFrequency.Custom)
             {
-                builder.ByUser(dto.CreatedBy);
-            }
-            else
-            {
-                builder.BySystem();
-            }
-
-            builder.Enqueue();
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to log audit entry for scheduled message creation {MessageId}", message.Id);
-        }
-
-        _logger.LogInformation("Scheduled message {MessageId} created successfully for guild {GuildId}",
-            message.Id, dto.GuildId);
-
-        return MapToDto(message);
-    }
-
-    /// <inheritdoc/>
-    public async Task<ScheduledMessageDto?> UpdateAsync(Guid id, ScheduledMessageUpdateDto dto, CancellationToken cancellationToken = default)
-    {
-        _logger.LogInformation("Updating scheduled message {MessageId}", id);
-
-        var message = await _repository.GetByIdAsync(id, cancellationToken);
-        if (message == null)
-        {
-            _logger.LogWarning("Scheduled message {MessageId} not found for update", id);
-            return null;
-        }
-
-        // Apply updates only for non-null fields
-        if (dto.ChannelId.HasValue)
-        {
-            message.ChannelId = dto.ChannelId.Value;
-        }
-
-        if (dto.Title != null)
-        {
-            message.Title = dto.Title;
-        }
-
-        if (dto.Content != null)
-        {
-            message.Content = dto.Content;
-        }
-
-        if (dto.Frequency.HasValue)
-        {
-            message.Frequency = dto.Frequency.Value;
-
-            // Validate cron expression if frequency is changed to Custom
-            if (dto.Frequency.Value == ScheduleFrequency.Custom)
-            {
-                var cronExpr = dto.CronExpression ?? message.CronExpression;
-                if (string.IsNullOrWhiteSpace(cronExpr))
+                if (string.IsNullOrWhiteSpace(dto.CronExpression))
                 {
                     var error = "Cron expression is required when frequency is Custom";
                     _logger.LogWarning(error);
                     throw new ArgumentException(error, nameof(dto));
                 }
 
-                var (isValid, errorMessage) = await ValidateCronExpressionAsync(cronExpr);
-                if (!isValid)
-                {
-                    _logger.LogWarning("Invalid cron expression: {Error}", errorMessage);
-                    throw new ArgumentException(errorMessage, nameof(dto));
-                }
-            }
-        }
-
-        if (dto.CronExpression != null)
-        {
-            // Validate if frequency is Custom
-            if (message.Frequency == ScheduleFrequency.Custom)
-            {
                 var (isValid, errorMessage) = await ValidateCronExpressionAsync(dto.CronExpression);
                 if (!isValid)
                 {
@@ -222,90 +136,251 @@ public class ScheduledMessageService : IScheduledMessageService
                 }
             }
 
-            message.CronExpression = dto.CronExpression;
-        }
+            var now = DateTime.UtcNow;
+            var message = new ScheduledMessage
+            {
+                Id = Guid.NewGuid(),
+                GuildId = dto.GuildId,
+                ChannelId = dto.ChannelId,
+                Title = dto.Title,
+                Content = dto.Content,
+                CronExpression = dto.CronExpression,
+                Frequency = dto.Frequency,
+                IsEnabled = dto.IsEnabled,
+                NextExecutionAt = dto.NextExecutionAt,
+                CreatedAt = now,
+                UpdatedAt = now,
+                CreatedBy = dto.CreatedBy
+            };
 
-        if (dto.IsEnabled.HasValue)
-        {
-            message.IsEnabled = dto.IsEnabled.Value;
-        }
+            await _repository.AddAsync(message, cancellationToken);
 
-        if (dto.NextExecutionAt.HasValue)
-        {
-            message.NextExecutionAt = dto.NextExecutionAt.Value;
-        }
+            // Audit log
+            try
+            {
+                var builder = _auditLogService.CreateBuilder()
+                    .ForCategory(AuditLogCategory.Message)
+                    .WithAction(AuditLogAction.Created)
+                    .InGuild(dto.GuildId)
+                    .OnTarget("ScheduledMessage", message.Id.ToString())
+                    .WithDetails(new
+                    {
+                        title = dto.Title,
+                        channelId = dto.ChannelId,
+                        frequency = dto.Frequency.ToString(),
+                        isEnabled = dto.IsEnabled,
+                        guildId = dto.GuildId
+                    });
 
-        message.UpdatedAt = DateTime.UtcNow;
-
-        await _repository.UpdateAsync(message, cancellationToken);
-
-        // Audit log
-        try
-        {
-            _auditLogService.CreateBuilder()
-                .ForCategory(AuditLogCategory.Message)
-                .WithAction(AuditLogAction.Updated)
-                .BySystem()
-                .InGuild(message.GuildId)
-                .OnTarget("ScheduledMessage", id.ToString())
-                .WithDetails(new
+                // Use ByUser if CreatedBy is provided, otherwise BySystem
+                if (!string.IsNullOrEmpty(dto.CreatedBy))
                 {
-                    title = message.Title,
-                    channelId = message.ChannelId,
-                    frequency = message.Frequency.ToString(),
-                    isEnabled = message.IsEnabled,
-                    guildId = message.GuildId
-                })
-                .Enqueue();
+                    builder.ByUser(dto.CreatedBy);
+                }
+                else
+                {
+                    builder.BySystem();
+                }
+
+                builder.Enqueue();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to log audit entry for scheduled message creation {MessageId}", message.Id);
+            }
+
+            _logger.LogInformation("Scheduled message {MessageId} created successfully for guild {GuildId}",
+                message.Id, dto.GuildId);
+
+            BotActivitySource.SetSuccess(activity);
+            return MapToDto(message);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to log audit entry for scheduled message update {MessageId}", id);
+            BotActivitySource.RecordException(activity, ex);
+            throw;
         }
+    }
 
-        _logger.LogInformation("Scheduled message {MessageId} updated successfully", id);
+    /// <inheritdoc/>
+    public async Task<ScheduledMessageDto?> UpdateAsync(Guid id, ScheduledMessageUpdateDto dto, CancellationToken cancellationToken = default)
+    {
+        using var activity = BotActivitySource.StartServiceActivity(
+            "scheduled_message",
+            "update",
+            entityId: id.ToString());
 
-        return MapToDto(message);
+        try
+        {
+            _logger.LogInformation("Updating scheduled message {MessageId}", id);
+
+            var message = await _repository.GetByIdAsync(id, cancellationToken);
+            if (message == null)
+            {
+                _logger.LogWarning("Scheduled message {MessageId} not found for update", id);
+                BotActivitySource.SetSuccess(activity);
+                return null;
+            }
+
+            // Apply updates only for non-null fields
+            if (dto.ChannelId.HasValue)
+            {
+                message.ChannelId = dto.ChannelId.Value;
+            }
+
+            if (dto.Title != null)
+            {
+                message.Title = dto.Title;
+            }
+
+            if (dto.Content != null)
+            {
+                message.Content = dto.Content;
+            }
+
+            if (dto.Frequency.HasValue)
+            {
+                message.Frequency = dto.Frequency.Value;
+
+                // Validate cron expression if frequency is changed to Custom
+                if (dto.Frequency.Value == ScheduleFrequency.Custom)
+                {
+                    var cronExpr = dto.CronExpression ?? message.CronExpression;
+                    if (string.IsNullOrWhiteSpace(cronExpr))
+                    {
+                        var error = "Cron expression is required when frequency is Custom";
+                        _logger.LogWarning(error);
+                        throw new ArgumentException(error, nameof(dto));
+                    }
+
+                    var (isValid, errorMessage) = await ValidateCronExpressionAsync(cronExpr);
+                    if (!isValid)
+                    {
+                        _logger.LogWarning("Invalid cron expression: {Error}", errorMessage);
+                        throw new ArgumentException(errorMessage, nameof(dto));
+                    }
+                }
+            }
+
+            if (dto.CronExpression != null)
+            {
+                // Validate if frequency is Custom
+                if (message.Frequency == ScheduleFrequency.Custom)
+                {
+                    var (isValid, errorMessage) = await ValidateCronExpressionAsync(dto.CronExpression);
+                    if (!isValid)
+                    {
+                        _logger.LogWarning("Invalid cron expression: {Error}", errorMessage);
+                        throw new ArgumentException(errorMessage, nameof(dto));
+                    }
+                }
+
+                message.CronExpression = dto.CronExpression;
+            }
+
+            if (dto.IsEnabled.HasValue)
+            {
+                message.IsEnabled = dto.IsEnabled.Value;
+            }
+
+            if (dto.NextExecutionAt.HasValue)
+            {
+                message.NextExecutionAt = dto.NextExecutionAt.Value;
+            }
+
+            message.UpdatedAt = DateTime.UtcNow;
+
+            await _repository.UpdateAsync(message, cancellationToken);
+
+            // Audit log
+            try
+            {
+                _auditLogService.CreateBuilder()
+                    .ForCategory(AuditLogCategory.Message)
+                    .WithAction(AuditLogAction.Updated)
+                    .BySystem()
+                    .InGuild(message.GuildId)
+                    .OnTarget("ScheduledMessage", id.ToString())
+                    .WithDetails(new
+                    {
+                        title = message.Title,
+                        channelId = message.ChannelId,
+                        frequency = message.Frequency.ToString(),
+                        isEnabled = message.IsEnabled,
+                        guildId = message.GuildId
+                    })
+                    .Enqueue();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to log audit entry for scheduled message update {MessageId}", id);
+            }
+
+            _logger.LogInformation("Scheduled message {MessageId} updated successfully", id);
+
+            BotActivitySource.SetSuccess(activity);
+            return MapToDto(message);
+        }
+        catch (Exception ex)
+        {
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
     }
 
     /// <inheritdoc/>
     public async Task<bool> DeleteAsync(Guid id, CancellationToken cancellationToken = default)
     {
-        _logger.LogInformation("Deleting scheduled message {MessageId}", id);
+        using var activity = BotActivitySource.StartServiceActivity(
+            "scheduled_message",
+            "delete",
+            entityId: id.ToString());
 
-        var message = await _repository.GetByIdAsync(id, cancellationToken);
-        if (message == null)
-        {
-            _logger.LogWarning("Scheduled message {MessageId} not found for deletion", id);
-            return false;
-        }
-
-        // Capture details before deletion
-        var guildId = message.GuildId;
-        var title = message.Title;
-
-        await _repository.DeleteAsync(message, cancellationToken);
-
-        // Audit log
         try
         {
-            _auditLogService.CreateBuilder()
-                .ForCategory(AuditLogCategory.Message)
-                .WithAction(AuditLogAction.Deleted)
-                .BySystem()
-                .InGuild(guildId)
-                .OnTarget("ScheduledMessage", id.ToString())
-                .WithDetails(new { title, guildId })
-                .Enqueue();
+            _logger.LogInformation("Deleting scheduled message {MessageId}", id);
+
+            var message = await _repository.GetByIdAsync(id, cancellationToken);
+            if (message == null)
+            {
+                _logger.LogWarning("Scheduled message {MessageId} not found for deletion", id);
+                BotActivitySource.SetSuccess(activity);
+                return false;
+            }
+
+            // Capture details before deletion
+            var guildId = message.GuildId;
+            var title = message.Title;
+
+            await _repository.DeleteAsync(message, cancellationToken);
+
+            // Audit log
+            try
+            {
+                _auditLogService.CreateBuilder()
+                    .ForCategory(AuditLogCategory.Message)
+                    .WithAction(AuditLogAction.Deleted)
+                    .BySystem()
+                    .InGuild(guildId)
+                    .OnTarget("ScheduledMessage", id.ToString())
+                    .WithDetails(new { title, guildId })
+                    .Enqueue();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to log audit entry for scheduled message deletion {MessageId}", id);
+            }
+
+            _logger.LogInformation("Scheduled message {MessageId} deleted successfully", id);
+
+            BotActivitySource.SetSuccess(activity);
+            return true;
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to log audit entry for scheduled message deletion {MessageId}", id);
+            BotActivitySource.RecordException(activity, ex);
+            throw;
         }
-
-        _logger.LogInformation("Scheduled message {MessageId} deleted successfully", id);
-
-        return true;
     }
 
     /// <inheritdoc/>
@@ -314,10 +389,14 @@ public class ScheduledMessageService : IScheduledMessageService
         string? cronExpression,
         DateTime? baseTime = null)
     {
-        var now = baseTime ?? DateTime.UtcNow;
+        using var activity = BotActivitySource.StartServiceActivity(
+            "scheduled_message",
+            "calculate_next_execution");
 
         try
         {
+            var now = baseTime ?? DateTime.UtcNow;
+
             var nextExecution = frequency switch
             {
                 ScheduleFrequency.Once => null,
@@ -332,11 +411,13 @@ public class ScheduledMessageService : IScheduledMessageService
             _logger.LogDebug("Calculated next execution for {Frequency}: {NextExecution}",
                 frequency, nextExecution);
 
+            BotActivitySource.SetSuccess(activity);
             return Task.FromResult(nextExecution);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to calculate next execution for frequency {Frequency}", frequency);
+            BotActivitySource.RecordException(activity, ex);
             return Task.FromResult<DateTime?>(null);
         }
     }
@@ -344,151 +425,185 @@ public class ScheduledMessageService : IScheduledMessageService
     /// <inheritdoc/>
     public async Task<bool> ExecuteScheduledMessageAsync(Guid id, CancellationToken cancellationToken = default)
     {
-        _logger.LogInformation("Executing scheduled message {MessageId}", id);
-
-        var message = await _repository.GetByIdAsync(id, cancellationToken);
-        if (message == null)
-        {
-            _logger.LogWarning("Scheduled message {MessageId} not found for execution", id);
-            return false;
-        }
+        using var activity = BotActivitySource.StartServiceActivity(
+            "scheduled_message",
+            "execute",
+            entityId: id.ToString());
 
         try
         {
-            // Get the Discord channel
-            var channel = _client.GetChannel(message.ChannelId) as IMessageChannel;
-            if (channel == null)
+            _logger.LogInformation("Executing scheduled message {MessageId}", id);
+
+            var message = await _repository.GetByIdAsync(id, cancellationToken);
+            if (message == null)
             {
-                _logger.LogError("Channel {ChannelId} not found for scheduled message {MessageId}",
-                    message.ChannelId, id);
+                _logger.LogWarning("Scheduled message {MessageId} not found for execution", id);
+                BotActivitySource.SetSuccess(activity);
                 return false;
             }
 
-            // Store the original scheduled time BEFORE updating it
-            // This is used to calculate the next execution time to prevent drift
-            var originalScheduledTime = message.NextExecutionAt;
-
-            // Send the message to Discord
-            await channel.SendMessageAsync(message.Content);
-
-            _logger.LogInformation("Scheduled message {MessageId} sent successfully to channel {ChannelId}",
-                id, message.ChannelId);
-
-            // Audit log
             try
             {
-                _auditLogService.CreateBuilder()
-                    .ForCategory(AuditLogCategory.Message)
-                    .WithAction(AuditLogAction.CommandExecuted)
-                    .BySystem()
-                    .InGuild(message.GuildId)
-                    .OnTarget("ScheduledMessage", id.ToString())
-                    .WithDetails(new
-                    {
-                        title = message.Title,
-                        channelId = message.ChannelId,
-                        guildId = message.GuildId,
-                        action = "message_executed"
-                    })
-                    .Enqueue();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to log audit entry for scheduled message execution {MessageId}", id);
-            }
-
-            // Update execution state
-            message.LastExecutedAt = DateTime.UtcNow;
-
-            // Calculate next execution time or disable if OneTime
-            if (message.Frequency == ScheduleFrequency.Once)
-            {
-                message.IsEnabled = false;
-                message.NextExecutionAt = null;
-                _logger.LogInformation("Scheduled message {MessageId} disabled after one-time execution", id);
-            }
-            else
-            {
-                // Use the ORIGINAL scheduled time as the base for calculating the next execution,
-                // NOT the actual execution time. This prevents time drift when execution is
-                // slightly early or late (e.g., scheduled for 10:58 but runs at 10:56).
-                var baseTime = originalScheduledTime ?? message.LastExecutedAt;
-
-                var nextExecution = await CalculateNextExecutionAsync(
-                    message.Frequency,
-                    message.CronExpression,
-                    baseTime);
-
-                // If the calculated next time is in the past (e.g., we missed executions),
-                // keep adding intervals until we get a future time
-                while (nextExecution.HasValue && nextExecution.Value <= DateTime.UtcNow)
+                // Get the Discord channel
+                var channel = _client.GetChannel(message.ChannelId) as IMessageChannel;
+                if (channel == null)
                 {
-                    nextExecution = await CalculateNextExecutionAsync(
-                        message.Frequency,
-                        message.CronExpression,
-                        nextExecution.Value);
+                    _logger.LogError("Channel {ChannelId} not found for scheduled message {MessageId}",
+                        message.ChannelId, id);
+                    BotActivitySource.SetSuccess(activity);
+                    return false;
                 }
 
-                if (nextExecution.HasValue)
+                // Store the original scheduled time BEFORE updating it
+                // This is used to calculate the next execution time to prevent drift
+                var originalScheduledTime = message.NextExecutionAt;
+
+                // Send the message to Discord
+                await channel.SendMessageAsync(message.Content);
+
+                _logger.LogInformation("Scheduled message {MessageId} sent successfully to channel {ChannelId}",
+                    id, message.ChannelId);
+
+                // Audit log
+                try
                 {
-                    message.NextExecutionAt = nextExecution.Value;
-                    _logger.LogDebug("Next execution for message {MessageId} scheduled at {NextExecution}",
-                        id, nextExecution.Value);
+                    _auditLogService.CreateBuilder()
+                        .ForCategory(AuditLogCategory.Message)
+                        .WithAction(AuditLogAction.CommandExecuted)
+                        .BySystem()
+                        .InGuild(message.GuildId)
+                        .OnTarget("ScheduledMessage", id.ToString())
+                        .WithDetails(new
+                        {
+                            title = message.Title,
+                            channelId = message.ChannelId,
+                            guildId = message.GuildId,
+                            action = "message_executed"
+                        })
+                        .Enqueue();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to log audit entry for scheduled message execution {MessageId}", id);
+                }
+
+                // Update execution state
+                message.LastExecutedAt = DateTime.UtcNow;
+
+                // Calculate next execution time or disable if OneTime
+                if (message.Frequency == ScheduleFrequency.Once)
+                {
+                    message.IsEnabled = false;
+                    message.NextExecutionAt = null;
+                    _logger.LogInformation("Scheduled message {MessageId} disabled after one-time execution", id);
                 }
                 else
                 {
-                    _logger.LogWarning("Failed to calculate next execution for message {MessageId}, disabling", id);
-                    message.IsEnabled = false;
-                    message.NextExecutionAt = null;
+                    // Use the ORIGINAL scheduled time as the base for calculating the next execution,
+                    // NOT the actual execution time. This prevents time drift when execution is
+                    // slightly early or late (e.g., scheduled for 10:58 but runs at 10:56).
+                    var baseTime = originalScheduledTime ?? message.LastExecutedAt;
+
+                    var nextExecution = await CalculateNextExecutionAsync(
+                        message.Frequency,
+                        message.CronExpression,
+                        baseTime);
+
+                    // If the calculated next time is in the past (e.g., we missed executions),
+                    // keep adding intervals until we get a future time
+                    while (nextExecution.HasValue && nextExecution.Value <= DateTime.UtcNow)
+                    {
+                        nextExecution = await CalculateNextExecutionAsync(
+                            message.Frequency,
+                            message.CronExpression,
+                            nextExecution.Value);
+                    }
+
+                    if (nextExecution.HasValue)
+                    {
+                        message.NextExecutionAt = nextExecution.Value;
+                        _logger.LogDebug("Next execution for message {MessageId} scheduled at {NextExecution}",
+                            id, nextExecution.Value);
+                    }
+                    else
+                    {
+                        _logger.LogWarning("Failed to calculate next execution for message {MessageId}, disabling", id);
+                        message.IsEnabled = false;
+                        message.NextExecutionAt = null;
+                    }
                 }
+
+                message.UpdatedAt = DateTime.UtcNow;
+                await _repository.UpdateAsync(message, cancellationToken);
+
+                BotActivitySource.SetSuccess(activity);
+                return true;
             }
-
-            message.UpdatedAt = DateTime.UtcNow;
-            await _repository.UpdateAsync(message, cancellationToken);
-
-            return true;
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to execute scheduled message {MessageId}", id);
+                BotActivitySource.RecordException(activity, ex);
+                return false;
+            }
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to execute scheduled message {MessageId}", id);
-            return false;
+            BotActivitySource.RecordException(activity, ex);
+            throw;
         }
     }
 
     /// <inheritdoc/>
     public Task<(bool IsValid, string? ErrorMessage)> ValidateCronExpressionAsync(string cronExpression)
     {
-        if (string.IsNullOrWhiteSpace(cronExpression))
-        {
-            return Task.FromResult<(bool, string?)>((false, "Cron expression cannot be empty"));
-        }
+        using var activity = BotActivitySource.StartServiceActivity(
+            "scheduled_message",
+            "validate_cron_expression");
 
         try
         {
-            // Try to parse the cron expression
-            var expression = CronExpression.Parse(cronExpression, CronFormat.IncludeSeconds);
-
-            // Try to get next occurrence to verify it's valid
-            var next = expression.GetNextOccurrence(DateTime.UtcNow, TimeZoneInfo.Utc);
-            if (!next.HasValue)
+            if (string.IsNullOrWhiteSpace(cronExpression))
             {
-                return Task.FromResult<(bool, string?)>((false, "Cron expression has no future occurrences"));
+                BotActivitySource.SetSuccess(activity);
+                return Task.FromResult<(bool, string?)>((false, "Cron expression cannot be empty"));
             }
 
-            _logger.LogDebug("Cron expression validated: {CronExpression}, next occurrence: {Next}",
-                cronExpression, next.Value);
+            try
+            {
+                // Try to parse the cron expression
+                var expression = CronExpression.Parse(cronExpression, CronFormat.IncludeSeconds);
 
-            return Task.FromResult<(bool, string?)>((true, null));
-        }
-        catch (CronFormatException ex)
-        {
-            _logger.LogWarning(ex, "Invalid cron expression: {CronExpression}", cronExpression);
-            return Task.FromResult<(bool, string?)>((false, $"Invalid cron expression format: {ex.Message}"));
+                // Try to get next occurrence to verify it's valid
+                var next = expression.GetNextOccurrence(DateTime.UtcNow, TimeZoneInfo.Utc);
+                if (!next.HasValue)
+                {
+                    BotActivitySource.SetSuccess(activity);
+                    return Task.FromResult<(bool, string?)>((false, "Cron expression has no future occurrences"));
+                }
+
+                _logger.LogDebug("Cron expression validated: {CronExpression}, next occurrence: {Next}",
+                    cronExpression, next.Value);
+
+                BotActivitySource.SetSuccess(activity);
+                return Task.FromResult<(bool, string?)>((true, null));
+            }
+            catch (CronFormatException ex)
+            {
+                _logger.LogWarning(ex, "Invalid cron expression: {CronExpression}", cronExpression);
+                BotActivitySource.SetSuccess(activity);
+                return Task.FromResult<(bool, string?)>((false, $"Invalid cron expression format: {ex.Message}"));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error validating cron expression: {CronExpression}", cronExpression);
+                BotActivitySource.RecordException(activity, ex);
+                return Task.FromResult<(bool, string?)>((false, $"Error validating cron expression: {ex.Message}"));
+            }
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error validating cron expression: {CronExpression}", cronExpression);
-            return Task.FromResult<(bool, string?)>((false, $"Error validating cron expression: {ex.Message}"));
+            BotActivitySource.RecordException(activity, ex);
+            throw;
         }
     }
 

--- a/src/DiscordBot.Bot/Services/ServerAnalyticsService.cs
+++ b/src/DiscordBot.Bot/Services/ServerAnalyticsService.cs
@@ -1,3 +1,4 @@
+using DiscordBot.Bot.Tracing;
 using DiscordBot.Core.DTOs;
 using DiscordBot.Core.Enums;
 using DiscordBot.Core.Interfaces;
@@ -38,95 +39,111 @@ public class ServerAnalyticsService : IServerAnalyticsService
         DateTime end,
         CancellationToken ct = default)
     {
-        _logger.LogDebug(
-            "Generating server analytics summary for guild {GuildId} from {Start} to {End}",
-            guildId, start, end);
+        using var activity = BotActivitySource.StartServiceActivity(
+            "server_analytics",
+            "get_summary",
+            guildId: guildId);
 
-        // Get the most recent guild metrics snapshot for current member counts
-        var latestMetrics = await _guildMetricsRepository.GetLatestAsync(guildId, ct);
-
-        // Calculate time ranges for different periods
-        var now = DateTime.UtcNow;
-        var last24h = now.AddHours(-24);
-        var last7d = now.AddDays(-7);
-        var last30d = now.AddDays(-30);
-
-        // Calculate active members for different time windows using member activity snapshots
-        var dailySnapshots = await _memberActivityRepository.GetActivityTimeSeriesAsync(
-            guildId,
-            last30d,
-            now,
-            SnapshotGranularity.Daily,
-            ct);
-
-        // Get unique active members for each period
-        var activeMembersLast24h = dailySnapshots
-            .Where(x => x.Period >= last24h)
-            .Sum(x => x.ActiveMembers);
-
-        var activeMembersLast7d = dailySnapshots
-            .Where(x => x.Period >= last7d)
-            .Sum(x => x.ActiveMembers);
-
-        var activeMembersLast30d = dailySnapshots
-            .Sum(x => x.ActiveMembers);
-
-        // Get message counts directly from MessageLogs for real-time accuracy
-        // This ensures consistent data with EngagementAnalyticsService
-        var messagesByDay = await _messageLogRepository.GetMessagesByDayAsync(
-            days: 30,
-            guildId: guildId,
-            cancellationToken: ct);
-
-        var messagesLast24h = messagesByDay
-            .Where(x => x.Date >= DateOnly.FromDateTime(last24h))
-            .Sum(x => x.Count);
-
-        var messagesLast7d = messagesByDay
-            .Where(x => x.Date >= DateOnly.FromDateTime(last7d))
-            .Sum(x => x.Count);
-
-        // Calculate member growth from guild metrics
-        var metricsLast7d = await _guildMetricsRepository.GetByDateRangeAsync(
-            guildId,
-            DateOnly.FromDateTime(last7d),
-            DateOnly.FromDateTime(now),
-            ct);
-
-        var oldestMetric = metricsLast7d.FirstOrDefault();
-        var memberGrowth7d = latestMetrics != null && oldestMetric != null
-            ? latestMetrics.TotalMembers - oldestMetric.TotalMembers
-            : 0;
-
-        var memberGrowthPercent = oldestMetric?.TotalMembers > 0
-            ? ((decimal)memberGrowth7d / oldestMetric.TotalMembers) * 100
-            : 0m;
-
-        // Get count of active channels (channels with messages in the time period)
-        var channelRankings = await _channelActivityRepository.GetChannelRankingsAsync(
-            guildId,
-            start,
-            end,
-            limit: 1000, // Get all channels to count them
-            ct);
-
-        _logger.LogInformation(
-            "Server analytics summary generated for guild {GuildId}: {TotalMembers} members, {ActiveMembers24h} active (24h)",
-            guildId, latestMetrics?.TotalMembers ?? 0, activeMembersLast24h);
-
-        return new ServerAnalyticsSummaryDto
+        try
         {
-            TotalMembers = latestMetrics?.TotalMembers ?? 0,
-            OnlineMembers = 0, // Online member count not tracked in snapshots
-            ActiveMembers24h = activeMembersLast24h,
-            ActiveMembers7d = activeMembersLast7d,
-            ActiveMembers30d = activeMembersLast30d,
-            Messages24h = messagesLast24h,
-            Messages7d = messagesLast7d,
-            MemberGrowth7d = memberGrowth7d,
-            MemberGrowthPercent = memberGrowthPercent,
-            ActiveChannels = channelRankings.Count
-        };
+            _logger.LogDebug(
+                "Generating server analytics summary for guild {GuildId} from {Start} to {End}",
+                guildId, start, end);
+
+            // Get the most recent guild metrics snapshot for current member counts
+            var latestMetrics = await _guildMetricsRepository.GetLatestAsync(guildId, ct);
+
+            // Calculate time ranges for different periods
+            var now = DateTime.UtcNow;
+            var last24h = now.AddHours(-24);
+            var last7d = now.AddDays(-7);
+            var last30d = now.AddDays(-30);
+
+            // Calculate active members for different time windows using member activity snapshots
+            var dailySnapshots = await _memberActivityRepository.GetActivityTimeSeriesAsync(
+                guildId,
+                last30d,
+                now,
+                SnapshotGranularity.Daily,
+                ct);
+
+            // Get unique active members for each period
+            var activeMembersLast24h = dailySnapshots
+                .Where(x => x.Period >= last24h)
+                .Sum(x => x.ActiveMembers);
+
+            var activeMembersLast7d = dailySnapshots
+                .Where(x => x.Period >= last7d)
+                .Sum(x => x.ActiveMembers);
+
+            var activeMembersLast30d = dailySnapshots
+                .Sum(x => x.ActiveMembers);
+
+            // Get message counts directly from MessageLogs for real-time accuracy
+            // This ensures consistent data with EngagementAnalyticsService
+            var messagesByDay = await _messageLogRepository.GetMessagesByDayAsync(
+                days: 30,
+                guildId: guildId,
+                cancellationToken: ct);
+
+            var messagesLast24h = messagesByDay
+                .Where(x => x.Date >= DateOnly.FromDateTime(last24h))
+                .Sum(x => x.Count);
+
+            var messagesLast7d = messagesByDay
+                .Where(x => x.Date >= DateOnly.FromDateTime(last7d))
+                .Sum(x => x.Count);
+
+            // Calculate member growth from guild metrics
+            var metricsLast7d = await _guildMetricsRepository.GetByDateRangeAsync(
+                guildId,
+                DateOnly.FromDateTime(last7d),
+                DateOnly.FromDateTime(now),
+                ct);
+
+            var oldestMetric = metricsLast7d.FirstOrDefault();
+            var memberGrowth7d = latestMetrics != null && oldestMetric != null
+                ? latestMetrics.TotalMembers - oldestMetric.TotalMembers
+                : 0;
+
+            var memberGrowthPercent = oldestMetric?.TotalMembers > 0
+                ? ((decimal)memberGrowth7d / oldestMetric.TotalMembers) * 100
+                : 0m;
+
+            // Get count of active channels (channels with messages in the time period)
+            var channelRankings = await _channelActivityRepository.GetChannelRankingsAsync(
+                guildId,
+                start,
+                end,
+                limit: 1000, // Get all channels to count them
+                ct);
+
+            _logger.LogInformation(
+                "Server analytics summary generated for guild {GuildId}: {TotalMembers} members, {ActiveMembers24h} active (24h)",
+                guildId, latestMetrics?.TotalMembers ?? 0, activeMembersLast24h);
+
+            var result = new ServerAnalyticsSummaryDto
+            {
+                TotalMembers = latestMetrics?.TotalMembers ?? 0,
+                OnlineMembers = 0, // Online member count not tracked in snapshots
+                ActiveMembers24h = activeMembersLast24h,
+                ActiveMembers7d = activeMembersLast7d,
+                ActiveMembers30d = activeMembersLast30d,
+                Messages24h = messagesLast24h,
+                Messages7d = messagesLast7d,
+                MemberGrowth7d = memberGrowth7d,
+                MemberGrowthPercent = memberGrowthPercent,
+                ActiveChannels = channelRankings.Count
+            };
+
+            BotActivitySource.SetSuccess(activity);
+            return result;
+        }
+        catch (Exception ex)
+        {
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
     }
 
     /// <inheritdoc/>
@@ -136,75 +153,89 @@ public class ServerAnalyticsService : IServerAnalyticsService
         DateTime end,
         CancellationToken ct = default)
     {
-        _logger.LogDebug(
-            "Generating activity time series for guild {GuildId} from {Start} to {End}",
-            guildId, start, end);
+        using var activity = BotActivitySource.StartServiceActivity(
+            "server_analytics",
+            "get_activity_time_series",
+            guildId: guildId);
 
-        // Get daily activity aggregates for active member counts
-        var activityData = await _memberActivityRepository.GetActivityTimeSeriesAsync(
-            guildId,
-            start,
-            end,
-            SnapshotGranularity.Daily,
-            ct);
-
-        // Get message counts directly from MessageLogs for real-time accuracy
-        var daySpan = (int)Math.Ceiling((end - start).TotalDays) + 1;
-        var messagesByDay = await _messageLogRepository.GetMessagesByDayAsync(
-            days: daySpan,
-            guildId: guildId,
-            cancellationToken: ct);
-
-        // Create a lookup for message counts by date
-        var messageLookup = messagesByDay
-            .Where(x => x.Date >= DateOnly.FromDateTime(start) && x.Date <= DateOnly.FromDateTime(end))
-            .ToDictionary(x => x.Date, x => x.Count);
-
-        // Get channel activity for the same period
-        var channelRankings = await _channelActivityRepository.GetChannelRankingsAsync(
-            guildId,
-            start,
-            end,
-            limit: 1000,
-            ct);
-
-        // For now, we'll use the total unique channels as a constant
-        var activeChannelsCount = channelRankings.Count;
-
-        // Combine activity data with message counts from MessageLogs
-        var results = activityData.Select(x => new ActivityTimeSeriesDto
+        try
         {
-            Date = x.Period,
-            MessageCount = messageLookup.TryGetValue(DateOnly.FromDateTime(x.Period), out var count)
-                ? (int)count
-                : 0,
-            ActiveMembers = x.ActiveMembers,
-            ActiveChannels = activeChannelsCount
-        }).ToList();
+            _logger.LogDebug(
+                "Generating activity time series for guild {GuildId} from {Start} to {End}",
+                guildId, start, end);
 
-        // If there are dates with messages but no activity snapshots, add them
-        foreach (var (date, count) in messageLookup)
-        {
-            var dateTime = date.ToDateTime(TimeOnly.MinValue);
-            if (!results.Any(r => DateOnly.FromDateTime(r.Date) == date))
+            // Get daily activity aggregates for active member counts
+            var activityData = await _memberActivityRepository.GetActivityTimeSeriesAsync(
+                guildId,
+                start,
+                end,
+                SnapshotGranularity.Daily,
+                ct);
+
+            // Get message counts directly from MessageLogs for real-time accuracy
+            var daySpan = (int)Math.Ceiling((end - start).TotalDays) + 1;
+            var messagesByDay = await _messageLogRepository.GetMessagesByDayAsync(
+                days: daySpan,
+                guildId: guildId,
+                cancellationToken: ct);
+
+            // Create a lookup for message counts by date
+            var messageLookup = messagesByDay
+                .Where(x => x.Date >= DateOnly.FromDateTime(start) && x.Date <= DateOnly.FromDateTime(end))
+                .ToDictionary(x => x.Date, x => x.Count);
+
+            // Get channel activity for the same period
+            var channelRankings = await _channelActivityRepository.GetChannelRankingsAsync(
+                guildId,
+                start,
+                end,
+                limit: 1000,
+                ct);
+
+            // For now, we'll use the total unique channels as a constant
+            var activeChannelsCount = channelRankings.Count;
+
+            // Combine activity data with message counts from MessageLogs
+            var results = activityData.Select(x => new ActivityTimeSeriesDto
             {
-                results.Add(new ActivityTimeSeriesDto
+                Date = x.Period,
+                MessageCount = messageLookup.TryGetValue(DateOnly.FromDateTime(x.Period), out var count)
+                    ? (int)count
+                    : 0,
+                ActiveMembers = x.ActiveMembers,
+                ActiveChannels = activeChannelsCount
+            }).ToList();
+
+            // If there are dates with messages but no activity snapshots, add them
+            foreach (var (date, count) in messageLookup)
+            {
+                var dateTime = date.ToDateTime(TimeOnly.MinValue);
+                if (!results.Any(r => DateOnly.FromDateTime(r.Date) == date))
                 {
-                    Date = dateTime,
-                    MessageCount = (int)count,
-                    ActiveMembers = 0,
-                    ActiveChannels = activeChannelsCount
-                });
+                    results.Add(new ActivityTimeSeriesDto
+                    {
+                        Date = dateTime,
+                        MessageCount = (int)count,
+                        ActiveMembers = 0,
+                        ActiveChannels = activeChannelsCount
+                    });
+                }
             }
+
+            results = results.OrderBy(r => r.Date).ToList();
+
+            _logger.LogDebug(
+                "Generated {Count} activity time series data points for guild {GuildId}",
+                results.Count, guildId);
+
+            BotActivitySource.SetSuccess(activity);
+            return results;
         }
-
-        results = results.OrderBy(r => r.Date).ToList();
-
-        _logger.LogDebug(
-            "Generated {Count} activity time series data points for guild {GuildId}",
-            results.Count, guildId);
-
-        return results;
+        catch (Exception ex)
+        {
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
     }
 
     /// <inheritdoc/>
@@ -214,40 +245,54 @@ public class ServerAnalyticsService : IServerAnalyticsService
         DateTime end,
         CancellationToken ct = default)
     {
-        _logger.LogDebug(
-            "Generating activity heatmap for guild {GuildId} from {Start} to {End}",
-            guildId, start, end);
+        using var activity = BotActivitySource.StartServiceActivity(
+            "server_analytics",
+            "get_activity_heatmap",
+            guildId: guildId);
 
-        // Get hourly snapshots for the heatmap
-        var hourlyData = await _memberActivityRepository.GetActivityTimeSeriesAsync(
-            guildId,
-            start,
-            end,
-            SnapshotGranularity.Hourly,
-            ct);
+        try
+        {
+            _logger.LogDebug(
+                "Generating activity heatmap for guild {GuildId} from {Start} to {End}",
+                guildId, start, end);
 
-        // Group by day of week and hour
-        var heatmapData = hourlyData
-            .GroupBy(x => new
-            {
-                DayOfWeek = (int)x.Period.DayOfWeek,
-                Hour = x.Period.Hour
-            })
-            .Select(g => new ServerActivityHeatmapDto
-            {
-                DayOfWeek = g.Key.DayOfWeek,
-                Hour = g.Key.Hour,
-                MessageCount = g.Sum(x => (long)x.TotalMessages)
-            })
-            .OrderBy(x => x.DayOfWeek)
-            .ThenBy(x => x.Hour)
-            .ToList();
+            // Get hourly snapshots for the heatmap
+            var hourlyData = await _memberActivityRepository.GetActivityTimeSeriesAsync(
+                guildId,
+                start,
+                end,
+                SnapshotGranularity.Hourly,
+                ct);
 
-        _logger.LogDebug(
-            "Generated heatmap with {Count} data points for guild {GuildId}",
-            heatmapData.Count, guildId);
+            // Group by day of week and hour
+            var heatmapData = hourlyData
+                .GroupBy(x => new
+                {
+                    DayOfWeek = (int)x.Period.DayOfWeek,
+                    Hour = x.Period.Hour
+                })
+                .Select(g => new ServerActivityHeatmapDto
+                {
+                    DayOfWeek = g.Key.DayOfWeek,
+                    Hour = g.Key.Hour,
+                    MessageCount = g.Sum(x => (long)x.TotalMessages)
+                })
+                .OrderBy(x => x.DayOfWeek)
+                .ThenBy(x => x.Hour)
+                .ToList();
 
-        return heatmapData;
+            _logger.LogDebug(
+                "Generated heatmap with {Count} data points for guild {GuildId}",
+                heatmapData.Count, guildId);
+
+            BotActivitySource.SetSuccess(activity);
+            return heatmapData;
+        }
+        catch (Exception ex)
+        {
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
     }
 
     /// <inheritdoc/>
@@ -258,50 +303,64 @@ public class ServerAnalyticsService : IServerAnalyticsService
         int limit = 10,
         CancellationToken ct = default)
     {
-        _logger.LogDebug(
-            "Getting top {Limit} contributors for guild {GuildId} from {Start} to {End}",
-            limit, guildId, start, end);
+        using var activity = BotActivitySource.StartServiceActivity(
+            "server_analytics",
+            "get_top_contributors",
+            guildId: guildId);
 
-        // Get top active members from the repository
-        var topMembers = await _memberActivityRepository.GetTopActiveMembersAsync(
-            guildId,
-            start,
-            end,
-            limit,
-            ct);
+        try
+        {
+            _logger.LogDebug(
+                "Getting top {Limit} contributors for guild {GuildId} from {Start} to {End}",
+                limit, guildId, start, end);
 
-        // Transform to TopContributorDto
-        // Note: The repository returns aggregated snapshots, we need to sum up the message counts
-        var contributors = topMembers
-            .GroupBy(x => x.UserId)
-            .Select(g => new
-            {
-                UserId = g.Key,
-                MessageCount = g.Sum(x => x.MessageCount),
-                UniqueChannels = g.Max(x => x.UniqueChannelsActive),
-                LastActive = g.Max(x => x.PeriodStart),
-                User = g.FirstOrDefault()?.User
-            })
-            .OrderByDescending(x => x.MessageCount)
-            .Take(limit)
-            .Select(x => new TopContributorDto
-            {
-                UserId = x.UserId,
-                Username = x.User?.Username ?? "Unknown",
-                DisplayName = x.User?.GlobalDisplayName,
-                AvatarUrl = x.User?.AvatarHash != null
-                    ? $"https://cdn.discordapp.com/avatars/{x.UserId}/{x.User.AvatarHash}.png"
-                    : null,
-                MessageCount = x.MessageCount,
-                UniqueChannels = x.UniqueChannels,
-                LastActive = x.LastActive
-            })
-            .ToList();
+            // Get top active members from the repository
+            var topMembers = await _memberActivityRepository.GetTopActiveMembersAsync(
+                guildId,
+                start,
+                end,
+                limit,
+                ct);
 
-        _logger.LogInformation(
-            "Retrieved {Count} top contributors for guild {GuildId}",
-            contributors.Count, guildId);
+            // Transform to TopContributorDto
+            // Note: The repository returns aggregated snapshots, we need to sum up the message counts
+            var contributors = topMembers
+                .GroupBy(x => x.UserId)
+                .Select(g => new
+                {
+                    UserId = g.Key,
+                    MessageCount = g.Sum(x => x.MessageCount),
+                    UniqueChannels = g.Max(x => x.UniqueChannelsActive),
+                    LastActive = g.Max(x => x.PeriodStart),
+                    User = g.FirstOrDefault()?.User
+                })
+                .OrderByDescending(x => x.MessageCount)
+                .Take(limit)
+                .Select(x => new TopContributorDto
+                {
+                    UserId = x.UserId,
+                    Username = x.User?.Username ?? "Unknown",
+                    DisplayName = x.User?.GlobalDisplayName,
+                    AvatarUrl = x.User?.AvatarHash != null
+                        ? $"https://cdn.discordapp.com/avatars/{x.UserId}/{x.User.AvatarHash}.png"
+                        : null,
+                    MessageCount = x.MessageCount,
+                    UniqueChannels = x.UniqueChannels,
+                    LastActive = x.LastActive
+                })
+                .ToList();
 
-        return contributors;
+            _logger.LogInformation(
+                "Retrieved {Count} top contributors for guild {GuildId}",
+                contributors.Count, guildId);
+
+            BotActivitySource.SetSuccess(activity);
+            return contributors;
+        }
+        catch (Exception ex)
+        {
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
     }
 }

--- a/src/DiscordBot.Bot/Services/VerificationService.cs
+++ b/src/DiscordBot.Bot/Services/VerificationService.cs
@@ -1,4 +1,5 @@
 using System.Security.Cryptography;
+using DiscordBot.Bot.Tracing;
 using DiscordBot.Core.Configuration;
 using DiscordBot.Core.DTOs;
 using DiscordBot.Core.Entities;
@@ -37,105 +38,132 @@ public class VerificationService : IVerificationService
         string? ipAddress = null,
         CancellationToken cancellationToken = default)
     {
-        _logger.LogDebug("Initiating verification for user {UserId}", applicationUserId);
+        using var activity = BotActivitySource.StartServiceActivity(
+            "verification",
+            "initiate_verification");
 
-        // Check if user exists and doesn't already have Discord linked
-        var user = await _userManager.FindByIdAsync(applicationUserId);
-        if (user == null)
+        try
         {
-            return VerificationInitiationResult.Failure(
-                VerificationInitiationResult.UserNotFound,
-                "User not found.");
+            _logger.LogDebug("Initiating verification for user {UserId}", applicationUserId);
+
+            // Check if user exists and doesn't already have Discord linked
+            var user = await _userManager.FindByIdAsync(applicationUserId);
+            if (user == null)
+            {
+                return VerificationInitiationResult.Failure(
+                    VerificationInitiationResult.UserNotFound,
+                    "User not found.");
+            }
+
+            if (user.DiscordUserId.HasValue)
+            {
+                return VerificationInitiationResult.Failure(
+                    VerificationInitiationResult.AlreadyLinked,
+                    "Discord account is already linked.");
+            }
+
+            // Cancel any existing pending verifications
+            await CancelPendingVerificationAsync(applicationUserId, cancellationToken);
+
+            // Create new pending verification
+            var verification = new VerificationCode
+            {
+                Id = Guid.NewGuid(),
+                ApplicationUserId = applicationUserId,
+                Code = string.Empty, // Code generated when Discord user runs command
+                Status = VerificationStatus.Pending,
+                CreatedAt = DateTime.UtcNow,
+                ExpiresAt = DateTime.UtcNow.Add(TimeSpan.FromMinutes(_verificationOptions.CodeExpiryMinutes)),
+                IpAddress = ipAddress
+            };
+
+            _context.VerificationCodes.Add(verification);
+            await _context.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation(
+                "Verification initiated for user {UserId}, verification ID: {VerificationId}",
+                applicationUserId, verification.Id);
+
+            BotActivitySource.SetSuccess(activity);
+            return VerificationInitiationResult.Success(verification.Id);
         }
-
-        if (user.DiscordUserId.HasValue)
+        catch (Exception ex)
         {
-            return VerificationInitiationResult.Failure(
-                VerificationInitiationResult.AlreadyLinked,
-                "Discord account is already linked.");
+            BotActivitySource.RecordException(activity, ex);
+            throw;
         }
-
-        // Cancel any existing pending verifications
-        await CancelPendingVerificationAsync(applicationUserId, cancellationToken);
-
-        // Create new pending verification
-        var verification = new VerificationCode
-        {
-            Id = Guid.NewGuid(),
-            ApplicationUserId = applicationUserId,
-            Code = string.Empty, // Code generated when Discord user runs command
-            Status = VerificationStatus.Pending,
-            CreatedAt = DateTime.UtcNow,
-            ExpiresAt = DateTime.UtcNow.Add(TimeSpan.FromMinutes(_verificationOptions.CodeExpiryMinutes)),
-            IpAddress = ipAddress
-        };
-
-        _context.VerificationCodes.Add(verification);
-        await _context.SaveChangesAsync(cancellationToken);
-
-        _logger.LogInformation(
-            "Verification initiated for user {UserId}, verification ID: {VerificationId}",
-            applicationUserId, verification.Id);
-
-        return VerificationInitiationResult.Success(verification.Id);
     }
 
     public async Task<CodeGenerationResult> GenerateCodeForDiscordUserAsync(
         ulong discordUserId,
         CancellationToken cancellationToken = default)
     {
-        _logger.LogDebug("Generating verification code for Discord user {DiscordUserId}", discordUserId);
+        using var activity = BotActivitySource.StartServiceActivity(
+            "verification",
+            "generate_code",
+            userId: discordUserId);
 
-        // Check if Discord user is already linked to an account
-        var existingUser = await _userManager.Users
-            .FirstOrDefaultAsync(u => u.DiscordUserId == discordUserId, cancellationToken);
-
-        if (existingUser != null)
+        try
         {
-            return CodeGenerationResult.Failure(
-                CodeGenerationResult.AlreadyLinked,
-                "This Discord account is already linked to a user account.");
-        }
+            _logger.LogDebug("Generating verification code for Discord user {DiscordUserId}", discordUserId);
 
-        // Check rate limit
-        if (await IsRateLimitedAsync(discordUserId, cancellationToken))
+            // Check if Discord user is already linked to an account
+            var existingUser = await _userManager.Users
+                .FirstOrDefaultAsync(u => u.DiscordUserId == discordUserId, cancellationToken);
+
+            if (existingUser != null)
+            {
+                return CodeGenerationResult.Failure(
+                    CodeGenerationResult.AlreadyLinked,
+                    "This Discord account is already linked to a user account.");
+            }
+
+            // Check rate limit
+            if (await IsRateLimitedAsync(discordUserId, cancellationToken))
+            {
+                return CodeGenerationResult.Failure(
+                    CodeGenerationResult.RateLimited,
+                    "Rate limit exceeded. You can request a maximum of 3 codes per hour.");
+            }
+
+            // Find any pending verification that hasn't been claimed yet
+            // (no DiscordUserId assigned means waiting for Discord command)
+            var pendingVerification = await _context.VerificationCodes
+                .Where(v => v.Status == VerificationStatus.Pending)
+                .Where(v => v.DiscordUserId == null)
+                .Where(v => v.ExpiresAt > DateTime.UtcNow)
+                .OrderBy(v => v.CreatedAt)
+                .FirstOrDefaultAsync(cancellationToken);
+
+            if (pendingVerification == null)
+            {
+                return CodeGenerationResult.Failure(
+                    CodeGenerationResult.NoPendingVerification,
+                    "No pending verification found. Please initiate verification from the web interface first.");
+            }
+
+            // Generate unique code
+            var code = GenerateUniqueCode();
+
+            // Update the verification with Discord user and code
+            pendingVerification.DiscordUserId = discordUserId;
+            pendingVerification.Code = code;
+            pendingVerification.ExpiresAt = DateTime.UtcNow.Add(TimeSpan.FromMinutes(_verificationOptions.CodeExpiryMinutes));
+
+            await _context.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation(
+                "Verification code generated for Discord user {DiscordUserId}, verification {VerificationId}",
+                discordUserId, pendingVerification.Id);
+
+            BotActivitySource.SetSuccess(activity);
+            return CodeGenerationResult.Success(code, pendingVerification.ExpiresAt);
+        }
+        catch (Exception ex)
         {
-            return CodeGenerationResult.Failure(
-                CodeGenerationResult.RateLimited,
-                "Rate limit exceeded. You can request a maximum of 3 codes per hour.");
+            BotActivitySource.RecordException(activity, ex);
+            throw;
         }
-
-        // Find any pending verification that hasn't been claimed yet
-        // (no DiscordUserId assigned means waiting for Discord command)
-        var pendingVerification = await _context.VerificationCodes
-            .Where(v => v.Status == VerificationStatus.Pending)
-            .Where(v => v.DiscordUserId == null)
-            .Where(v => v.ExpiresAt > DateTime.UtcNow)
-            .OrderBy(v => v.CreatedAt)
-            .FirstOrDefaultAsync(cancellationToken);
-
-        if (pendingVerification == null)
-        {
-            return CodeGenerationResult.Failure(
-                CodeGenerationResult.NoPendingVerification,
-                "No pending verification found. Please initiate verification from the web interface first.");
-        }
-
-        // Generate unique code
-        var code = GenerateUniqueCode();
-
-        // Update the verification with Discord user and code
-        pendingVerification.DiscordUserId = discordUserId;
-        pendingVerification.Code = code;
-        pendingVerification.ExpiresAt = DateTime.UtcNow.Add(TimeSpan.FromMinutes(_verificationOptions.CodeExpiryMinutes));
-
-        await _context.SaveChangesAsync(cancellationToken);
-
-        _logger.LogInformation(
-            "Verification code generated for Discord user {DiscordUserId}, verification {VerificationId}",
-            discordUserId, pendingVerification.Id);
-
-        return CodeGenerationResult.Success(code, pendingVerification.ExpiresAt);
     }
 
     public async Task<CodeValidationResult> ValidateCodeAsync(
@@ -143,123 +171,150 @@ public class VerificationService : IVerificationService
         string code,
         CancellationToken cancellationToken = default)
     {
-        // Normalize code (remove dashes, uppercase)
-        code = code.Replace("-", "").Replace(" ", "").ToUpperInvariant();
+        using var activity = BotActivitySource.StartServiceActivity(
+            "verification",
+            "validate_code");
 
-        _logger.LogDebug("Validating code for user {UserId}", applicationUserId);
-
-        // Check if user already has Discord linked
-        var user = await _userManager.FindByIdAsync(applicationUserId);
-        if (user == null)
+        try
         {
-            return CodeValidationResult.Failure(
-                CodeValidationResult.InvalidCode,
-                "User not found.");
-        }
+            // Normalize code (remove dashes, uppercase)
+            code = code.Replace("-", "").Replace(" ", "").ToUpperInvariant();
 
-        if (user.DiscordUserId.HasValue)
-        {
-            return CodeValidationResult.Failure(
-                CodeValidationResult.AlreadyLinked,
-                "Discord account is already linked.");
-        }
+            _logger.LogDebug("Validating code for user {UserId}", applicationUserId);
 
-        // Find the verification by code
-        var verification = await _context.VerificationCodes
-            .Where(v => v.Code == code)
-            .Where(v => v.ApplicationUserId == applicationUserId)
-            .FirstOrDefaultAsync(cancellationToken);
+            // Check if user already has Discord linked
+            var user = await _userManager.FindByIdAsync(applicationUserId);
+            if (user == null)
+            {
+                return CodeValidationResult.Failure(
+                    CodeValidationResult.InvalidCode,
+                    "User not found.");
+            }
 
-        if (verification == null)
-        {
-            _logger.LogWarning("Invalid verification code attempt for user {UserId}", applicationUserId);
-            return CodeValidationResult.Failure(
-                CodeValidationResult.InvalidCode,
-                "Invalid verification code.");
-        }
+            if (user.DiscordUserId.HasValue)
+            {
+                return CodeValidationResult.Failure(
+                    CodeValidationResult.AlreadyLinked,
+                    "Discord account is already linked.");
+            }
 
-        if (verification.Status == VerificationStatus.Completed)
-        {
-            return CodeValidationResult.Failure(
-                CodeValidationResult.CodeAlreadyUsed,
-                "This code has already been used.");
-        }
+            // Find the verification by code
+            var verification = await _context.VerificationCodes
+                .Where(v => v.Code == code)
+                .Where(v => v.ApplicationUserId == applicationUserId)
+                .FirstOrDefaultAsync(cancellationToken);
 
-        if (verification.Status == VerificationStatus.Expired || verification.ExpiresAt <= DateTime.UtcNow)
-        {
-            verification.Status = VerificationStatus.Expired;
+            if (verification == null)
+            {
+                _logger.LogWarning("Invalid verification code attempt for user {UserId}", applicationUserId);
+                return CodeValidationResult.Failure(
+                    CodeValidationResult.InvalidCode,
+                    "Invalid verification code.");
+            }
+
+            if (verification.Status == VerificationStatus.Completed)
+            {
+                return CodeValidationResult.Failure(
+                    CodeValidationResult.CodeAlreadyUsed,
+                    "This code has already been used.");
+            }
+
+            if (verification.Status == VerificationStatus.Expired || verification.ExpiresAt <= DateTime.UtcNow)
+            {
+                verification.Status = VerificationStatus.Expired;
+                await _context.SaveChangesAsync(cancellationToken);
+
+                return CodeValidationResult.Failure(
+                    CodeValidationResult.CodeExpired,
+                    "Verification code has expired. Please request a new code.");
+            }
+
+            if (!verification.DiscordUserId.HasValue)
+            {
+                return CodeValidationResult.Failure(
+                    CodeValidationResult.InvalidCode,
+                    "Verification code not yet activated. Please run /verify-account in Discord first.");
+            }
+
+            // Check if the Discord user is already linked to another account
+            var existingDiscordUser = await _userManager.Users
+                .FirstOrDefaultAsync(u => u.DiscordUserId == verification.DiscordUserId, cancellationToken);
+
+            if (existingDiscordUser != null)
+            {
+                return CodeValidationResult.Failure(
+                    CodeValidationResult.DiscordAlreadyLinked,
+                    "This Discord account is already linked to another user.");
+            }
+
+            // Success! Link the accounts
+            user.DiscordUserId = verification.DiscordUserId;
+            var updateResult = await _userManager.UpdateAsync(user);
+
+            if (!updateResult.Succeeded)
+            {
+                _logger.LogError(
+                    "Failed to update user {UserId} with Discord ID: {Errors}",
+                    applicationUserId,
+                    string.Join(", ", updateResult.Errors.Select(e => e.Description)));
+
+                return CodeValidationResult.Failure(
+                    CodeValidationResult.InvalidCode,
+                    "Failed to link accounts. Please try again.");
+            }
+
+            // Mark verification as completed
+            verification.Status = VerificationStatus.Completed;
+            verification.CompletedAt = DateTime.UtcNow;
             await _context.SaveChangesAsync(cancellationToken);
 
-            return CodeValidationResult.Failure(
-                CodeValidationResult.CodeExpired,
-                "Verification code has expired. Please request a new code.");
-        }
+            _logger.LogInformation(
+                "Successfully linked Discord user {DiscordUserId} to user {UserId}",
+                verification.DiscordUserId, applicationUserId);
 
-        if (!verification.DiscordUserId.HasValue)
+            BotActivitySource.SetSuccess(activity);
+            return CodeValidationResult.Success(verification.DiscordUserId.Value);
+        }
+        catch (Exception ex)
         {
-            return CodeValidationResult.Failure(
-                CodeValidationResult.InvalidCode,
-                "Verification code not yet activated. Please run /verify-account in Discord first.");
+            BotActivitySource.RecordException(activity, ex);
+            throw;
         }
-
-        // Check if the Discord user is already linked to another account
-        var existingDiscordUser = await _userManager.Users
-            .FirstOrDefaultAsync(u => u.DiscordUserId == verification.DiscordUserId, cancellationToken);
-
-        if (existingDiscordUser != null)
-        {
-            return CodeValidationResult.Failure(
-                CodeValidationResult.DiscordAlreadyLinked,
-                "This Discord account is already linked to another user.");
-        }
-
-        // Success! Link the accounts
-        user.DiscordUserId = verification.DiscordUserId;
-        var updateResult = await _userManager.UpdateAsync(user);
-
-        if (!updateResult.Succeeded)
-        {
-            _logger.LogError(
-                "Failed to update user {UserId} with Discord ID: {Errors}",
-                applicationUserId,
-                string.Join(", ", updateResult.Errors.Select(e => e.Description)));
-
-            return CodeValidationResult.Failure(
-                CodeValidationResult.InvalidCode,
-                "Failed to link accounts. Please try again.");
-        }
-
-        // Mark verification as completed
-        verification.Status = VerificationStatus.Completed;
-        verification.CompletedAt = DateTime.UtcNow;
-        await _context.SaveChangesAsync(cancellationToken);
-
-        _logger.LogInformation(
-            "Successfully linked Discord user {DiscordUserId} to user {UserId}",
-            verification.DiscordUserId, applicationUserId);
-
-        return CodeValidationResult.Success(verification.DiscordUserId.Value);
     }
 
     public async Task CancelPendingVerificationAsync(
         string applicationUserId,
         CancellationToken cancellationToken = default)
     {
-        var pendingVerifications = await _context.VerificationCodes
-            .Where(v => v.ApplicationUserId == applicationUserId)
-            .Where(v => v.Status == VerificationStatus.Pending)
-            .ToListAsync(cancellationToken);
+        using var activity = BotActivitySource.StartServiceActivity(
+            "verification",
+            "cancel_pending_verification");
 
-        foreach (var verification in pendingVerifications)
+        try
         {
-            verification.Status = VerificationStatus.Cancelled;
+            var pendingVerifications = await _context.VerificationCodes
+                .Where(v => v.ApplicationUserId == applicationUserId)
+                .Where(v => v.Status == VerificationStatus.Pending)
+                .ToListAsync(cancellationToken);
+
+            foreach (var verification in pendingVerifications)
+            {
+                verification.Status = VerificationStatus.Cancelled;
+            }
+
+            if (pendingVerifications.Any())
+            {
+                await _context.SaveChangesAsync(cancellationToken);
+                _logger.LogDebug("Cancelled {Count} pending verifications for user {UserId}",
+                    pendingVerifications.Count, applicationUserId);
+            }
+
+            BotActivitySource.SetSuccess(activity);
         }
-
-        if (pendingVerifications.Any())
+        catch (Exception ex)
         {
-            await _context.SaveChangesAsync(cancellationToken);
-            _logger.LogDebug("Cancelled {Count} pending verifications for user {UserId}",
-                pendingVerifications.Count, applicationUserId);
+            BotActivitySource.RecordException(activity, ex);
+            throw;
         }
     }
 
@@ -267,60 +322,106 @@ public class VerificationService : IVerificationService
         ulong discordUserId,
         CancellationToken cancellationToken = default)
     {
-        var oneHourAgo = DateTime.UtcNow.AddHours(-1);
+        using var activity = BotActivitySource.StartServiceActivity(
+            "verification",
+            "check_rate_limit",
+            userId: discordUserId);
 
-        var recentCodeCount = await _context.VerificationCodes
-            .Where(v => v.DiscordUserId == discordUserId)
-            .Where(v => v.CreatedAt >= oneHourAgo)
-            .CountAsync(cancellationToken);
+        try
+        {
+            var oneHourAgo = DateTime.UtcNow.AddHours(-1);
 
-        return recentCodeCount >= _verificationOptions.MaxCodesPerHour;
+            var recentCodeCount = await _context.VerificationCodes
+                .Where(v => v.DiscordUserId == discordUserId)
+                .Where(v => v.CreatedAt >= oneHourAgo)
+                .CountAsync(cancellationToken);
+
+            var isRateLimited = recentCodeCount >= _verificationOptions.MaxCodesPerHour;
+
+            BotActivitySource.SetSuccess(activity);
+            return isRateLimited;
+        }
+        catch (Exception ex)
+        {
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
     }
 
     public async Task<VerificationCode?> GetPendingVerificationAsync(
         string applicationUserId,
         CancellationToken cancellationToken = default)
     {
-        return await _context.VerificationCodes
-            .Where(v => v.ApplicationUserId == applicationUserId)
-            .Where(v => v.Status == VerificationStatus.Pending)
-            .Where(v => v.ExpiresAt > DateTime.UtcNow)
-            .FirstOrDefaultAsync(cancellationToken);
+        using var activity = BotActivitySource.StartServiceActivity(
+            "verification",
+            "get_pending_verification");
+
+        try
+        {
+            var result = await _context.VerificationCodes
+                .Where(v => v.ApplicationUserId == applicationUserId)
+                .Where(v => v.Status == VerificationStatus.Pending)
+                .Where(v => v.ExpiresAt > DateTime.UtcNow)
+                .FirstOrDefaultAsync(cancellationToken);
+
+            BotActivitySource.SetSuccess(activity);
+            return result;
+        }
+        catch (Exception ex)
+        {
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
     }
 
     public async Task<int> CleanupExpiredCodesAsync(CancellationToken cancellationToken = default)
     {
-        var expiredCodes = await _context.VerificationCodes
-            .Where(v => v.Status == VerificationStatus.Pending)
-            .Where(v => v.ExpiresAt <= DateTime.UtcNow)
-            .ToListAsync(cancellationToken);
+        using var activity = BotActivitySource.StartServiceActivity(
+            "verification",
+            "cleanup_expired_codes");
 
-        foreach (var code in expiredCodes)
+        try
         {
-            code.Status = VerificationStatus.Expired;
-        }
+            var expiredCodes = await _context.VerificationCodes
+                .Where(v => v.Status == VerificationStatus.Pending)
+                .Where(v => v.ExpiresAt <= DateTime.UtcNow)
+                .ToListAsync(cancellationToken);
 
-        if (expiredCodes.Any())
+            foreach (var code in expiredCodes)
+            {
+                code.Status = VerificationStatus.Expired;
+            }
+
+            if (expiredCodes.Any())
+            {
+                await _context.SaveChangesAsync(cancellationToken);
+                _logger.LogDebug("Marked {Count} verification codes as expired", expiredCodes.Count);
+            }
+
+            // Delete old completed/expired/cancelled codes (older than configured threshold)
+            var oldCutoff = DateTime.UtcNow.AddHours(-_verificationOptions.OldCodeCleanupHours);
+            var oldCodes = await _context.VerificationCodes
+                .Where(v => v.Status != VerificationStatus.Pending)
+                .Where(v => v.CreatedAt <= oldCutoff)
+                .ToListAsync(cancellationToken);
+
+            if (oldCodes.Any())
+            {
+                _context.VerificationCodes.RemoveRange(oldCodes);
+                await _context.SaveChangesAsync(cancellationToken);
+                _logger.LogDebug("Deleted {Count} old verification codes", oldCodes.Count);
+            }
+
+            var totalCleaned = expiredCodes.Count + oldCodes.Count;
+
+            BotActivitySource.SetSuccess(activity);
+            return totalCleaned;
+        }
+        catch (Exception ex)
         {
-            await _context.SaveChangesAsync(cancellationToken);
-            _logger.LogDebug("Marked {Count} verification codes as expired", expiredCodes.Count);
+            BotActivitySource.RecordException(activity, ex);
+            throw;
         }
-
-        // Delete old completed/expired/cancelled codes (older than configured threshold)
-        var oldCutoff = DateTime.UtcNow.AddHours(-_verificationOptions.OldCodeCleanupHours);
-        var oldCodes = await _context.VerificationCodes
-            .Where(v => v.Status != VerificationStatus.Pending)
-            .Where(v => v.CreatedAt <= oldCutoff)
-            .ToListAsync(cancellationToken);
-
-        if (oldCodes.Any())
-        {
-            _context.VerificationCodes.RemoveRange(oldCodes);
-            await _context.SaveChangesAsync(cancellationToken);
-            _logger.LogDebug("Deleted {Count} old verification codes", oldCodes.Count);
-        }
-
-        return expiredCodes.Count + oldCodes.Count;
     }
 
     private string GenerateUniqueCode()

--- a/src/DiscordBot.Bot/Tracing/BotActivitySource.cs
+++ b/src/DiscordBot.Bot/Tracing/BotActivitySource.cs
@@ -309,6 +309,62 @@ public static class BotActivitySource
     }
 
     /// <summary>
+    /// Starts an activity for a service layer operation.
+    /// </summary>
+    /// <param name="serviceName">The name of the service (e.g., "guild", "rat_watch").</param>
+    /// <param name="operation">The operation being performed (e.g., "get_by_id", "create").</param>
+    /// <param name="guildId">Optional guild ID for the operation.</param>
+    /// <param name="userId">Optional user ID for the operation.</param>
+    /// <param name="entityId">Optional entity ID being operated on.</param>
+    /// <returns>The started activity, or null if not sampled.</returns>
+    public static Activity? StartServiceActivity(
+        string serviceName,
+        string operation,
+        ulong? guildId = null,
+        ulong? userId = null,
+        string? entityId = null)
+    {
+        var spanName = string.Format(TracingConstants.Spans.ServiceOperation, serviceName, operation);
+
+        var activity = Source.StartActivity(
+            name: spanName,
+            kind: ActivityKind.Internal);
+
+        if (activity is null)
+            return null;
+
+        activity.SetTag(TracingConstants.Attributes.ServiceName, serviceName);
+        activity.SetTag(TracingConstants.Attributes.ServiceOperation, operation);
+
+        if (guildId.HasValue)
+        {
+            activity.SetTag(TracingConstants.Attributes.GuildId, guildId.Value.ToString());
+        }
+
+        if (userId.HasValue)
+        {
+            activity.SetTag(TracingConstants.Attributes.UserId, userId.Value.ToString());
+        }
+
+        if (!string.IsNullOrEmpty(entityId))
+        {
+            activity.SetTag(TracingConstants.Attributes.ServiceEntityId, entityId);
+        }
+
+        return activity;
+    }
+
+    /// <summary>
+    /// Sets the number of records returned from a service operation.
+    /// </summary>
+    /// <param name="activity">The activity to record on.</param>
+    /// <param name="count">The number of records returned.</param>
+    public static void SetRecordsReturned(Activity? activity, int count)
+    {
+        activity?.SetTag(TracingConstants.Attributes.ServiceRecordsReturned, count);
+    }
+
+    /// <summary>
     /// Records the number of items processed on an activity.
     /// </summary>
     /// <param name="activity">The activity to record on.</param>

--- a/src/DiscordBot.Bot/Tracing/TracingConstants.cs
+++ b/src/DiscordBot.Bot/Tracing/TracingConstants.cs
@@ -79,6 +79,14 @@ public static class TracingConstants
         public const string BackgroundInterval = "background.interval";
         public const string BackgroundItemId = "background.item.id";
         public const string BackgroundItemType = "background.item.type";
+
+        // Service layer attributes
+        public const string ServiceName = "service.name";
+        public const string ServiceOperation = "service.operation";
+        public const string ServiceEntityType = "service.entity.type";
+        public const string ServiceEntityId = "service.entity.id";
+        public const string ServiceRecordsReturned = "service.records.returned";
+        public const string ServiceOperationSuccess = "service.operation.success";
     }
 
     /// <summary>
@@ -120,6 +128,10 @@ public static class TracingConstants
         public const string BackgroundServiceItem = "background.{0}.item";
         public const string BackgroundServiceCleanup = "background.{0}.cleanup";
         public const string BackgroundServiceAggregation = "background.{0}.aggregation";
+
+        // Service operation span template
+        // Format: service.{service_name}.{operation} e.g. service.guild.get_by_id
+        public const string ServiceOperation = "service.{0}.{1}";
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- Instruments 23 business services with OpenTelemetry tracing spans for end-to-end visibility
- Adds `StartServiceActivity` helper to `BotActivitySource` for consistent span creation
- Uses span naming convention: `service.{service_name}.{operation}`
- Includes business context attributes (guild ID, user ID, entity IDs)
- Records exceptions on failures and tracks success status

### Services Instrumented

**Core Services (5):**
- AuditLogService, BotService, CommandLogService, GuildService, WelcomeService

**Feature Services (6):**
- ConsentService, MessageLogService, RatWatchService, ReminderService, ScheduledMessageService, VerificationService

**Moderation Services (9):**
- ContentFilterService, GuildModerationConfigService, InvestigationService, ModNoteService, ModTagService, ModerationService, RaidDetectionService, SpamDetectionService, WatchlistService

**Analytics Services (3):**
- EngagementAnalyticsService, ModerationAnalyticsService, ServerAnalyticsService

### Span Attributes Added

```csharp
service.name        // Service name (e.g., "guild", "rat_watch")
service.operation   // Operation name (e.g., "get_by_id", "create")
discord.guild.id    // Guild context when applicable
discord.user.id     // User context when applicable
service.entity.id   // Entity ID being operated on
service.records.returned  // Count of records returned
```

### Notes

- CommandAnalyticsService (Infrastructure layer) not instrumented due to architecture constraints - Infrastructure layer cannot depend on Bot layer where tracing utilities reside
- All 1037 service tests pass

## Test plan

- [x] Build succeeds without errors
- [x] All service tests pass (1037 passed)
- [ ] Manual verification with Jaeger to confirm spans appear correctly
- [ ] Verify service spans correctly parent under command spans

Closes #665

🤖 Generated with [Claude Code](https://claude.com/claude-code)