### PR TITLE
feat: Add preview ViewModels and API endpoints for user/guild popups

### DIFF
--- a/src/DiscordBot.Bot/Controllers/PreviewController.cs
+++ b/src/DiscordBot.Bot/Controllers/PreviewController.cs
@@ -1,0 +1,320 @@
+using Discord.WebSocket;
+using DiscordBot.Bot.Extensions;
+using DiscordBot.Bot.ViewModels.Pages;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Entities;
+using DiscordBot.Core.Interfaces;
+using DiscordBot.Infrastructure.Data;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace DiscordBot.Bot.Controllers;
+
+/// <summary>
+/// Controller for lightweight preview data for user and guild popups.
+/// </summary>
+[ApiController]
+[Route("api/preview")]
+[Authorize(Policy = "RequireViewer")]
+public class PreviewController : ControllerBase
+{
+    private readonly DiscordSocketClient _client;
+    private readonly BotDbContext _dbContext;
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly ILogger<PreviewController> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PreviewController"/> class.
+    /// </summary>
+    public PreviewController(
+        DiscordSocketClient client,
+        BotDbContext dbContext,
+        UserManager<ApplicationUser> userManager,
+        ILogger<PreviewController> logger)
+    {
+        _client = client;
+        _dbContext = dbContext;
+        _userManager = userManager;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Gets preview data for a user (without guild context).
+    /// </summary>
+    /// <param name="userId">The Discord user ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>User preview data.</returns>
+    [HttpGet("users/{userId}")]
+    [ProducesResponseType(typeof(UserPreviewDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<UserPreviewDto>> GetUserPreview(
+        ulong userId,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("User preview requested for user {UserId}", userId);
+
+        // Try to get user from Discord cache
+        var discordUser = _client.GetUser(userId);
+        if (discordUser == null)
+        {
+            _logger.LogDebug("User {UserId} not found in Discord cache", userId);
+            return NotFound(new ApiErrorDto
+            {
+                Message = "User not found",
+                Detail = $"No user with ID {userId} found in Discord cache.",
+                StatusCode = StatusCodes.Status404NotFound,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+
+        var preview = await BuildUserPreviewAsync(discordUser, null, cancellationToken);
+
+        _logger.LogDebug("User preview retrieved for {Username}", discordUser.Username);
+        return Ok(preview);
+    }
+
+    /// <summary>
+    /// Gets preview data for a user with guild context.
+    /// </summary>
+    /// <param name="userId">The Discord user ID.</param>
+    /// <param name="guildId">The guild ID for context.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>User preview data with guild-specific information.</returns>
+    [HttpGet("users/{userId}/guild/{guildId}")]
+    [ProducesResponseType(typeof(UserPreviewDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<UserPreviewDto>> GetUserPreviewWithGuild(
+        ulong userId,
+        ulong guildId,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("User preview requested for user {UserId} in guild {GuildId}", userId, guildId);
+
+        // Try to get guild from Discord cache
+        var discordGuild = _client.GetGuild(guildId);
+        if (discordGuild == null)
+        {
+            _logger.LogDebug("Guild {GuildId} not found in Discord cache", guildId);
+            return NotFound(new ApiErrorDto
+            {
+                Message = "Guild not found",
+                Detail = $"No guild with ID {guildId} found in Discord cache.",
+                StatusCode = StatusCodes.Status404NotFound,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+
+        // Try to get user as guild member
+        var guildUser = discordGuild.GetUser(userId);
+        if (guildUser == null)
+        {
+            // Fall back to regular user without guild context
+            var regularUser = _client.GetUser(userId);
+            if (regularUser == null)
+            {
+                _logger.LogDebug("User {UserId} not found in Discord cache", userId);
+                return NotFound(new ApiErrorDto
+                {
+                    Message = "User not found",
+                    Detail = $"No user with ID {userId} found in Discord cache.",
+                    StatusCode = StatusCodes.Status404NotFound,
+                    TraceId = HttpContext.GetCorrelationId()
+                });
+            }
+
+            var preview = await BuildUserPreviewAsync(regularUser, guildId, cancellationToken);
+            return Ok(preview);
+        }
+
+        var previewWithGuild = await BuildGuildUserPreviewAsync(guildUser, guildId, cancellationToken);
+
+        _logger.LogDebug("User preview with guild context retrieved for {Username} in {GuildName}",
+            guildUser.Username, discordGuild.Name);
+        return Ok(previewWithGuild);
+    }
+
+    /// <summary>
+    /// Gets preview data for a guild.
+    /// </summary>
+    /// <param name="guildId">The Discord guild ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Guild preview data.</returns>
+    [HttpGet("guilds/{guildId}")]
+    [ProducesResponseType(typeof(GuildPreviewDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<GuildPreviewDto>> GetGuildPreview(
+        ulong guildId,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("Guild preview requested for guild {GuildId}", guildId);
+
+        // Try to get guild from Discord cache first
+        var discordGuild = _client.GetGuild(guildId);
+        if (discordGuild == null)
+        {
+            _logger.LogDebug("Guild {GuildId} not found in Discord cache", guildId);
+            return NotFound(new ApiErrorDto
+            {
+                Message = "Guild not found",
+                Detail = $"No guild with ID {guildId} found in Discord cache.",
+                StatusCode = StatusCodes.Status404NotFound,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+
+        var preview = await BuildGuildPreviewAsync(discordGuild, cancellationToken);
+
+        _logger.LogDebug("Guild preview retrieved for {GuildName}", discordGuild.Name);
+        return Ok(preview);
+    }
+
+    /// <summary>
+    /// Builds a user preview DTO from a Discord user.
+    /// </summary>
+    private async Task<UserPreviewDto> BuildUserPreviewAsync(
+        SocketUser discordUser,
+        ulong? guildId,
+        CancellationToken cancellationToken)
+    {
+        // Get last activity from command logs
+        var lastActive = await _dbContext.CommandLogs
+            .Where(c => c.UserId == discordUser.Id)
+            .OrderByDescending(c => c.ExecutedAt)
+            .Select(c => (DateTime?)c.ExecutedAt)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        // Check if user is verified (has a linked application user account)
+        var isVerified = await _userManager.Users
+            .AnyAsync(u => u.DiscordUserId == discordUser.Id, cancellationToken);
+
+        // Check for active moderation cases
+        var hasActiveModeration = guildId.HasValue && await HasActiveModerationAsync(guildId.Value, discordUser.Id, cancellationToken);
+
+        return new UserPreviewDto
+        {
+            UserId = discordUser.Id,
+            Username = discordUser.Username,
+            DisplayName = discordUser.GlobalName,
+            AvatarUrl = discordUser.GetAvatarUrl() ?? discordUser.GetDefaultAvatarUrl(),
+            LastActive = lastActive,
+            IsVerified = isVerified,
+            HasActiveModeration = hasActiveModeration,
+            Roles = [],
+            MemberSince = null
+        };
+    }
+
+    /// <summary>
+    /// Builds a user preview DTO from a guild member.
+    /// </summary>
+    private async Task<UserPreviewDto> BuildGuildUserPreviewAsync(
+        SocketGuildUser guildUser,
+        ulong guildId,
+        CancellationToken cancellationToken)
+    {
+        // Get last activity from command logs
+        var lastActive = await _dbContext.CommandLogs
+            .Where(c => c.UserId == guildUser.Id)
+            .OrderByDescending(c => c.ExecutedAt)
+            .Select(c => (DateTime?)c.ExecutedAt)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        // Check if user is verified (has a linked application user account)
+        var isVerified = await _userManager.Users
+            .AnyAsync(u => u.DiscordUserId == guildUser.Id, cancellationToken);
+
+        // Check for active moderation cases
+        var hasActiveModeration = await HasActiveModerationAsync(guildId, guildUser.Id, cancellationToken);
+
+        // Get top roles (excluding @everyone, limit to 5)
+        var roles = guildUser.Roles
+            .Where(r => !r.IsEveryone)
+            .OrderByDescending(r => r.Position)
+            .Take(5)
+            .Select(r => r.Name)
+            .ToList();
+
+        return new UserPreviewDto
+        {
+            UserId = guildUser.Id,
+            Username = guildUser.Username,
+            DisplayName = guildUser.DisplayName,
+            AvatarUrl = guildUser.GetGuildAvatarUrl() ?? guildUser.GetAvatarUrl() ?? guildUser.GetDefaultAvatarUrl(),
+            MemberSince = guildUser.JoinedAt?.UtcDateTime,
+            Roles = roles,
+            LastActive = lastActive,
+            IsVerified = isVerified,
+            HasActiveModeration = hasActiveModeration
+        };
+    }
+
+    /// <summary>
+    /// Builds a guild preview DTO from a Discord guild.
+    /// </summary>
+    private async Task<GuildPreviewDto> BuildGuildPreviewAsync(
+        SocketGuild discordGuild,
+        CancellationToken cancellationToken)
+    {
+        // Get database guild for bot joined date and settings
+        var dbGuild = await _dbContext.Guilds
+            .AsNoTracking()
+            .FirstOrDefaultAsync(g => g.Id == discordGuild.Id, cancellationToken);
+
+        // Get owner username
+        var owner = discordGuild.Owner;
+        var ownerUsername = owner?.Username ?? "Unknown";
+
+        // Determine active features from guild settings
+        var activeFeatures = new List<string>();
+        if (dbGuild?.Settings != null)
+        {
+            var settings = GuildSettingsViewModel.Parse(dbGuild.Settings);
+            if (settings.WelcomeMessagesEnabled) activeFeatures.Add("Welcome");
+            if (settings.AutoModEnabled) activeFeatures.Add("AutoMod");
+            if (settings.ModerationAlertsEnabled) activeFeatures.Add("Moderation");
+            if (settings.CommandLoggingEnabled) activeFeatures.Add("Logging");
+        }
+
+        // Check for additional features in database tables
+        var hasRatWatch = await _dbContext.GuildRatWatchSettings
+            .AnyAsync(r => r.GuildId == discordGuild.Id && r.IsEnabled, cancellationToken);
+        if (hasRatWatch) activeFeatures.Add("RatWatch");
+
+        var hasScheduledMessages = await _dbContext.ScheduledMessages
+            .AnyAsync(s => s.GuildId == discordGuild.Id && s.IsEnabled, cancellationToken);
+        if (hasScheduledMessages) activeFeatures.Add("Scheduled Messages");
+
+        return new GuildPreviewDto
+        {
+            GuildId = discordGuild.Id,
+            Name = discordGuild.Name,
+            IconUrl = discordGuild.IconUrl,
+            MemberCount = discordGuild.MemberCount,
+            OnlineMemberCount = discordGuild.Users.Count(u => u.Status != Discord.UserStatus.Offline),
+            OwnerUsername = ownerUsername,
+            BotJoinedAt = dbGuild?.JoinedAt ?? discordGuild.CurrentUser?.JoinedAt?.UtcDateTime ?? DateTime.UtcNow,
+            ActiveFeatures = activeFeatures,
+            IsActive = dbGuild?.IsActive ?? true
+        };
+    }
+
+    /// <summary>
+    /// Checks if a user has any active (non-expired) moderation cases.
+    /// </summary>
+    private async Task<bool> HasActiveModerationAsync(
+        ulong guildId,
+        ulong userId,
+        CancellationToken cancellationToken)
+    {
+        // Check for active moderation cases (mutes, temp bans that haven't expired)
+        // A case is active if it has no expiry (permanent) or hasn't expired yet
+        return await _dbContext.ModerationCases
+            .AnyAsync(c =>
+                c.GuildId == guildId &&
+                c.TargetUserId == userId &&
+                (c.ExpiresAt == null || c.ExpiresAt > DateTime.UtcNow),
+                cancellationToken);
+    }
+}

--- a/src/DiscordBot.Bot/ViewModels/Components/GuildPreviewViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Components/GuildPreviewViewModel.cs
@@ -1,0 +1,62 @@
+namespace DiscordBot.Bot.ViewModels.Components;
+
+/// <summary>
+/// ViewModel for displaying guild preview popup data.
+/// </summary>
+public record GuildPreviewViewModel
+{
+    /// <summary>
+    /// Discord guild snowflake ID.
+    /// </summary>
+    public ulong GuildId { get; init; }
+
+    /// <summary>
+    /// Guild name.
+    /// </summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Guild icon URL (Discord CDN).
+    /// </summary>
+    public string? IconUrl { get; init; }
+
+    /// <summary>
+    /// Total member count.
+    /// </summary>
+    public int MemberCount { get; init; }
+
+    /// <summary>
+    /// Online member count (if available).
+    /// </summary>
+    public int? OnlineMemberCount { get; init; }
+
+    /// <summary>
+    /// Guild owner username.
+    /// </summary>
+    public string OwnerUsername { get; init; } = string.Empty;
+
+    /// <summary>
+    /// When the bot joined this guild.
+    /// </summary>
+    public DateTime BotJoinedAt { get; init; }
+
+    /// <summary>
+    /// Active features (e.g., "Moderation", "RatWatch", "Welcome").
+    /// </summary>
+    public IReadOnlyList<string> ActiveFeatures { get; init; } = [];
+
+    /// <summary>
+    /// Whether the guild is currently active (bot connected).
+    /// </summary>
+    public bool IsActive { get; init; }
+
+    /// <summary>
+    /// URL to guild details page.
+    /// </summary>
+    public string DetailsUrl { get; init; } = string.Empty;
+
+    /// <summary>
+    /// URL to guild settings page.
+    /// </summary>
+    public string SettingsUrl { get; init; } = string.Empty;
+}

--- a/src/DiscordBot.Bot/ViewModels/Components/UserPreviewViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Components/UserPreviewViewModel.cs
@@ -1,0 +1,67 @@
+namespace DiscordBot.Bot.ViewModels.Components;
+
+/// <summary>
+/// ViewModel for displaying user preview popup data.
+/// </summary>
+public record UserPreviewViewModel
+{
+    /// <summary>
+    /// Discord user snowflake ID.
+    /// </summary>
+    public ulong UserId { get; init; }
+
+    /// <summary>
+    /// Discord username (e.g., "username" or "username#0000" for legacy).
+    /// </summary>
+    public string Username { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Display name (nickname or global display name).
+    /// </summary>
+    public string? DisplayName { get; init; }
+
+    /// <summary>
+    /// Avatar URL (Discord CDN).
+    /// </summary>
+    public string? AvatarUrl { get; init; }
+
+    /// <summary>
+    /// When user joined the guild (null if no guild context).
+    /// </summary>
+    public DateTime? MemberSince { get; init; }
+
+    /// <summary>
+    /// Top roles (limit to 3-5 for display).
+    /// </summary>
+    public IReadOnlyList<string> Roles { get; init; } = [];
+
+    /// <summary>
+    /// Last activity timestamp from command logs or events.
+    /// </summary>
+    public DateTime? LastActive { get; init; }
+
+    /// <summary>
+    /// Whether user is verified in the system.
+    /// </summary>
+    public bool IsVerified { get; init; }
+
+    /// <summary>
+    /// Whether user has an active moderation case.
+    /// </summary>
+    public bool HasActiveModeration { get; init; }
+
+    /// <summary>
+    /// Guild context for the preview (optional).
+    /// </summary>
+    public ulong? GuildId { get; init; }
+
+    /// <summary>
+    /// URL to full profile page.
+    /// </summary>
+    public string ProfileUrl { get; init; } = string.Empty;
+
+    /// <summary>
+    /// URL to moderation history page (null if not available).
+    /// </summary>
+    public string? ModerationHistoryUrl { get; init; }
+}

--- a/src/DiscordBot.Core/DTOs/PreviewDtos.cs
+++ b/src/DiscordBot.Core/DTOs/PreviewDtos.cs
@@ -1,0 +1,103 @@
+namespace DiscordBot.Core.DTOs;
+
+/// <summary>
+/// Data transfer object for user preview popup data.
+/// </summary>
+public record UserPreviewDto
+{
+    /// <summary>
+    /// Discord user snowflake ID.
+    /// </summary>
+    public ulong UserId { get; init; }
+
+    /// <summary>
+    /// Discord username.
+    /// </summary>
+    public string Username { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Display name (nickname or global display name).
+    /// </summary>
+    public string? DisplayName { get; init; }
+
+    /// <summary>
+    /// Avatar URL (Discord CDN).
+    /// </summary>
+    public string? AvatarUrl { get; init; }
+
+    /// <summary>
+    /// When user joined the guild (null if no guild context).
+    /// </summary>
+    public DateTime? MemberSince { get; init; }
+
+    /// <summary>
+    /// Top roles (limit to 3-5 for display).
+    /// </summary>
+    public List<string> Roles { get; init; } = [];
+
+    /// <summary>
+    /// Last activity timestamp from command logs or events.
+    /// </summary>
+    public DateTime? LastActive { get; init; }
+
+    /// <summary>
+    /// Whether user is verified in the system.
+    /// </summary>
+    public bool IsVerified { get; init; }
+
+    /// <summary>
+    /// Whether user has an active moderation case.
+    /// </summary>
+    public bool HasActiveModeration { get; init; }
+}
+
+/// <summary>
+/// Data transfer object for guild preview popup data.
+/// </summary>
+public record GuildPreviewDto
+{
+    /// <summary>
+    /// Discord guild snowflake ID.
+    /// </summary>
+    public ulong GuildId { get; init; }
+
+    /// <summary>
+    /// Guild name.
+    /// </summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Guild icon URL (Discord CDN).
+    /// </summary>
+    public string? IconUrl { get; init; }
+
+    /// <summary>
+    /// Total member count.
+    /// </summary>
+    public int MemberCount { get; init; }
+
+    /// <summary>
+    /// Online member count (if available).
+    /// </summary>
+    public int? OnlineMemberCount { get; init; }
+
+    /// <summary>
+    /// Guild owner username.
+    /// </summary>
+    public string OwnerUsername { get; init; } = string.Empty;
+
+    /// <summary>
+    /// When the bot joined this guild.
+    /// </summary>
+    public DateTime BotJoinedAt { get; init; }
+
+    /// <summary>
+    /// Active features (e.g., "Moderation", "RatWatch", "Welcome").
+    /// </summary>
+    public List<string> ActiveFeatures { get; init; } = [];
+
+    /// <summary>
+    /// Whether the guild is currently active (bot connected).
+    /// </summary>
+    public bool IsActive { get; init; }
+}


### PR DESCRIPTION
## Summary
- Add `UserPreviewViewModel` and `GuildPreviewViewModel` for preview popup displays
- Add `UserPreviewDto` and `GuildPreviewDto` for API responses
- Add `PreviewController` with three endpoints for user and guild preview data

## Changes

### ViewModels (Issue #698)
- `UserPreviewViewModel`: Contains user ID, username, display name, avatar, roles, last active, verification status, moderation status, and profile URLs
- `GuildPreviewViewModel`: Contains guild ID, name, icon, member counts, owner, bot joined date, active features, and page URLs

### API Endpoints (Issue #699)
- `GET /api/preview/users/{userId}` - Returns user preview data without guild context
- `GET /api/preview/users/{userId}/guild/{guildId}` - Returns user preview with guild-specific data (roles, join date)
- `GET /api/preview/guilds/{guildId}` - Returns guild preview data

### Data Sources
- Discord client cache for live user/guild data
- Command logs for last activity timestamps
- Application users for verification status
- Moderation cases for active moderation flags
- Guild settings for active features detection

## Test plan
- [ ] Build succeeds with no errors
- [ ] API endpoints respond correctly when Discord cache has data
- [ ] 404 returned when user/guild not found in cache
- [ ] Authorization requires Viewer role
- [ ] Swagger documentation shows new endpoints

Closes #698
Closes #699

🤖 Generated with [Claude Code](https://claude.com/claude-code)