### PR TITLE
feat: Add preview popup UI components for user and guild profiles

### DIFF
--- a/src/DiscordBot.Bot/Pages/Shared/Components/_GuildPreviewPopup.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/Components/_GuildPreviewPopup.cshtml
@@ -1,0 +1,91 @@
+@model DiscordBot.Bot.ViewModels.Components.GuildPreviewViewModel
+
+<div class="preview-popup preview-popup-guild" data-guild-id="@Model.GuildId">
+    <!-- Header -->
+    <div class="preview-header">
+        <div class="preview-avatar">
+            @if (!string.IsNullOrEmpty(Model.IconUrl))
+            {
+                <img src="@Model.IconUrl" alt="@Model.Name" class="w-14 h-14 rounded-lg object-cover" />
+            }
+            else
+            {
+                <div class="w-14 h-14 rounded-lg bg-accent-blue-muted flex items-center justify-center">
+                    <span class="text-xl font-semibold text-accent-blue">
+                        @(Model.Name.FirstOrDefault().ToString().ToUpperInvariant())
+                    </span>
+                </div>
+            }
+        </div>
+        <div class="preview-identity flex-1 min-w-0">
+            <span class="preview-username block text-sm font-semibold text-text-primary truncate">
+                @Model.Name
+            </span>
+            <span class="preview-displayname block text-xs text-text-secondary">
+                @Model.MemberCount.ToString("N0") members
+                @if (Model.OnlineMemberCount.HasValue)
+                {
+                    <span class="text-text-tertiary">(@Model.OnlineMemberCount.Value.ToString("N0") online)</span>
+                }
+            </span>
+        </div>
+        @if (!Model.IsActive)
+        {
+            <span class="preview-badge px-1.5 py-0.5 bg-warning-bg text-warning text-xs font-medium rounded" title="Inactive">
+                Inactive
+            </span>
+        }
+    </div>
+
+    <!-- Body -->
+    <div class="preview-body">
+        <div class="preview-meta space-y-2 text-xs">
+            <div class="preview-meta-item flex justify-between">
+                <span class="text-text-tertiary">Owner</span>
+                <span class="text-accent-blue">@Model.OwnerUsername</span>
+            </div>
+            <div class="preview-meta-item flex justify-between">
+                <span class="text-text-tertiary">Bot joined</span>
+                <span class="text-text-secondary">@Model.BotJoinedAt.ToString("MMM d, yyyy")</span>
+            </div>
+            @if (Model.ActiveFeatures.Count > 0)
+            {
+                <div class="preview-meta-item flex justify-between items-start">
+                    <span class="text-text-tertiary">Features</span>
+                    <div class="flex flex-wrap gap-1 justify-end max-w-[180px]">
+                        @foreach (var feature in Model.ActiveFeatures.Take(4))
+                        {
+                            var badgeClass = feature.ToLowerInvariant() switch
+                            {
+                                "moderation" or "automod" => "bg-accent-orange-muted text-accent-orange",
+                                "ratwatch" or "rat watch" => "bg-success-bg text-success",
+                                "welcome" => "bg-accent-blue-muted text-accent-blue",
+                                "logging" => "bg-info-bg text-info",
+                                _ => "bg-bg-hover text-text-secondary"
+                            };
+                            <span class="preview-feature-tag px-1.5 py-0.5 text-[10px] font-medium rounded @badgeClass">
+                                @feature
+                            </span>
+                        }
+                        @if (Model.ActiveFeatures.Count > 4)
+                        {
+                            <span class="preview-feature-tag px-1.5 py-0.5 text-[10px] font-medium rounded bg-bg-hover text-text-tertiary">
+                                +@(Model.ActiveFeatures.Count - 4)
+                            </span>
+                        }
+                    </div>
+                </div>
+            }
+        </div>
+    </div>
+
+    <!-- Footer -->
+    <div class="preview-footer">
+        <a href="@Model.DetailsUrl" class="flex-1 px-3 py-1.5 text-xs font-medium text-white bg-accent-blue rounded hover:bg-accent-blue-hover transition-colors text-center">
+            View Guild
+        </a>
+        <a href="@Model.SettingsUrl" class="flex-1 px-3 py-1.5 text-xs font-medium text-text-secondary bg-bg-tertiary border border-border-primary rounded hover:bg-bg-hover transition-colors text-center">
+            Settings
+        </a>
+    </div>
+</div>

--- a/src/DiscordBot.Bot/Pages/Shared/Components/_PreviewPopupError.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/Components/_PreviewPopupError.cshtml
@@ -1,0 +1,21 @@
+@* Error state for preview popups *@
+@{
+    var type = ViewData["Type"]?.ToString() ?? "user";
+    var errorTitle = type == "guild" ? "Guild Unavailable" : "User Not Found";
+    var errorDescription = type == "guild"
+        ? "The bot may have been removed from this server or the server was deleted."
+        : "This user may have been deleted or is unavailable.";
+}
+<div class="preview-popup preview-popup-error">
+    <div class="p-4">
+        <div class="text-center py-4">
+            <div class="w-12 h-12 mx-auto mb-3 rounded-full bg-error-bg flex items-center justify-center">
+                <svg class="w-6 h-6 text-error" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                </svg>
+            </div>
+            <p class="text-sm font-medium text-text-primary mb-1">@errorTitle</p>
+            <p class="text-xs text-text-tertiary">@errorDescription</p>
+        </div>
+    </div>
+</div>

--- a/src/DiscordBot.Bot/Pages/Shared/Components/_PreviewPopupLoading.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/Components/_PreviewPopupLoading.cshtml
@@ -1,0 +1,19 @@
+@* Loading skeleton for preview popups *@
+<div class="preview-popup preview-popup-loading">
+    <div class="preview-header">
+        <div class="w-12 h-12 rounded-full bg-bg-hover animate-pulse"></div>
+        <div class="flex-1 space-y-2">
+            <div class="h-4 w-24 bg-bg-hover rounded animate-pulse"></div>
+            <div class="h-3 w-16 bg-bg-hover rounded animate-pulse"></div>
+        </div>
+    </div>
+    <div class="preview-body space-y-2">
+        <div class="h-3 w-full bg-bg-hover rounded animate-pulse"></div>
+        <div class="h-3 w-3/4 bg-bg-hover rounded animate-pulse"></div>
+        <div class="h-3 w-1/2 bg-bg-hover rounded animate-pulse"></div>
+    </div>
+    <div class="preview-footer">
+        <div class="flex-1 h-7 bg-bg-hover rounded animate-pulse"></div>
+        <div class="flex-1 h-7 bg-bg-hover rounded animate-pulse"></div>
+    </div>
+</div>

--- a/src/DiscordBot.Bot/Pages/Shared/Components/_UserPreviewPopup.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/Components/_UserPreviewPopup.cshtml
@@ -1,0 +1,88 @@
+@model DiscordBot.Bot.ViewModels.Components.UserPreviewViewModel
+
+<div class="preview-popup preview-popup-user" data-user-id="@Model.UserId">
+    <!-- Header -->
+    <div class="preview-header">
+        <div class="preview-avatar">
+            @if (!string.IsNullOrEmpty(Model.AvatarUrl))
+            {
+                <img src="@Model.AvatarUrl" alt="@Model.Username" class="w-12 h-12 rounded-full object-cover" />
+            }
+            else
+            {
+                <div class="w-12 h-12 rounded-full bg-accent-blue-muted flex items-center justify-center">
+                    <span class="text-lg font-semibold text-accent-blue">
+                        @(Model.Username.FirstOrDefault().ToString().ToUpperInvariant())
+                    </span>
+                </div>
+            }
+        </div>
+        <div class="preview-identity flex-1 min-w-0">
+            <span class="preview-username block text-sm font-semibold text-text-primary truncate">
+                @Model.Username
+            </span>
+            @if (!string.IsNullOrEmpty(Model.DisplayName) && Model.DisplayName != Model.Username)
+            {
+                <span class="preview-displayname block text-xs text-text-secondary truncate">
+                    @Model.DisplayName
+                </span>
+            }
+        </div>
+        @if (Model.IsVerified)
+        {
+            <span class="preview-badge px-1.5 py-0.5 bg-success-bg text-success text-xs font-medium rounded" title="Verified">
+                <svg class="w-3.5 h-3.5 inline" fill="currentColor" viewBox="0 0 20 20">
+                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
+                </svg>
+            </span>
+        }
+    </div>
+
+    <!-- Body -->
+    <div class="preview-body">
+        <div class="preview-meta space-y-2 text-xs">
+            @if (Model.MemberSince.HasValue)
+            {
+                <div class="preview-meta-item flex justify-between">
+                    <span class="text-text-tertiary">Member since</span>
+                    <span class="text-text-secondary">@Model.MemberSince.Value.ToString("MMM yyyy")</span>
+                </div>
+            }
+            @if (Model.Roles.Count > 0)
+            {
+                <div class="preview-meta-item flex justify-between items-start">
+                    <span class="text-text-tertiary">Roles</span>
+                    <span class="text-text-secondary text-right max-w-[140px] truncate">
+                        @string.Join(", ", Model.Roles.Take(3))@(Model.Roles.Count > 3 ? $" +{Model.Roles.Count - 3}" : "")
+                    </span>
+                </div>
+            }
+            @if (Model.LastActive.HasValue)
+            {
+                <div class="preview-meta-item flex justify-between">
+                    <span class="text-text-tertiary">Last active</span>
+                    <span class="text-text-secondary" data-utc="@Model.LastActive.Value.ToString("o")">
+                        @Model.LastActive.Value.ToString("g")
+                    </span>
+                </div>
+            }
+        </div>
+    </div>
+
+    <!-- Footer -->
+    <div class="preview-footer">
+        <a href="@Model.ProfileUrl" class="flex-1 px-3 py-1.5 text-xs font-medium text-white bg-accent-blue rounded hover:bg-accent-blue-hover transition-colors text-center">
+            View Profile
+        </a>
+        @if (!string.IsNullOrEmpty(Model.ModerationHistoryUrl))
+        {
+            <a href="@Model.ModerationHistoryUrl" class="flex-1 px-3 py-1.5 text-xs font-medium text-text-secondary bg-bg-tertiary border border-border-primary rounded hover:bg-bg-hover transition-colors text-center inline-flex items-center justify-center gap-1">
+                Mod History
+                @if (Model.HasActiveModeration)
+                {
+                    <span class="w-1.5 h-1.5 bg-warning rounded-full" title="Active case"></span>
+                }
+            </a>
+        }
+    </div>
+</div>

--- a/src/DiscordBot.Bot/Pages/Shared/_Layout.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/_Layout.cshtml
@@ -71,6 +71,8 @@
     <script src="~/js/bot-status-refresh.js" asp-append-version="true"></script>
     <!-- Search Keyboard Shortcuts -->
     <script src="~/js/search.js" asp-append-version="true"></script>
+    <!-- Preview Popup Module -->
+    <script src="~/js/preview-popup.js" asp-append-version="true"></script>
 
     @await RenderSectionAsync("Scripts", required: false)
 </body>

--- a/src/DiscordBot.Bot/wwwroot/css/site.css
+++ b/src/DiscordBot.Bot/wwwroot/css/site.css
@@ -2307,3 +2307,119 @@
     background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24'%3e%3ccircle cx='12' cy='12' r='10' stroke='%23098ecf' stroke-width='2' stroke-dasharray='32' stroke-dashoffset='0'%3e%3c/circle%3e%3c/svg%3e");
   }
 }
+
+/* ==========================================================================
+   Preview Popup Component
+   Handles user and guild profile preview popups on hover
+   ========================================================================== */
+
+/* Preview trigger styling */
+.preview-trigger {
+  cursor: pointer;
+  border-bottom: 1px dashed transparent;
+  transition: border-color 0.15s ease-out, color 0.15s ease-out;
+}
+
+.preview-trigger:hover,
+.preview-trigger:focus {
+  border-bottom-color: var(--color-accent-blue);
+}
+
+.preview-trigger:focus-visible {
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/* Preview popup container - base styles */
+.preview-popup,
+.preview-popup-container {
+  /* Dimensions set via Tailwind classes in JS */
+}
+
+/* Preview popup header */
+.preview-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-bottom: 1px solid var(--color-border-secondary);
+  background-color: var(--color-bg-secondary);
+}
+
+.preview-avatar {
+  flex-shrink: 0;
+}
+
+.preview-identity {
+  flex: 1;
+  min-width: 0;
+}
+
+.preview-username {
+  display: block;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  font-size: 0.875rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.preview-displayname {
+  display: block;
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Preview popup body */
+.preview-body {
+  padding: 0.875rem 1rem;
+}
+
+.preview-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.preview-meta-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 0.8125rem;
+}
+
+/* Preview popup footer */
+.preview-footer {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background-color: var(--color-bg-secondary);
+  border-top: 1px solid var(--color-border-secondary);
+}
+
+/* Feature tags in guild previews */
+.preview-feature-tag {
+  display: inline-block;
+  font-size: 0.625rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+}
+
+/* Guild icons are square with rounded corners */
+.preview-popup-guild .preview-avatar img {
+  border-radius: 0.375rem;
+}
+
+/* Reduced motion support for preview popups */
+@media (prefers-reduced-motion: reduce) {
+  .preview-popup-container {
+    transition: opacity 0.1s ease-out !important;
+    transform: none !important;
+  }
+}

--- a/src/DiscordBot.Bot/wwwroot/js/preview-popup.js
+++ b/src/DiscordBot.Bot/wwwroot/js/preview-popup.js
@@ -1,0 +1,639 @@
+/**
+ * Preview Popup Module
+ * Handles user and guild preview popups on hover/click/focus
+ *
+ * Usage:
+ *   Add data attributes to trigger elements:
+ *   - data-preview-type="user" data-user-id="123456789"
+ *   - data-preview-type="guild" data-guild-id="987654321"
+ *   - data-context-guild-id="..." (optional, for user previews with guild context)
+ *
+ *   Add .preview-trigger class for styling
+ */
+const PreviewPopup = (() => {
+    // Configuration
+    const CONFIG = {
+        hoverDelay: 300,         // ms before showing popup on hover
+        hideDelay: 150,          // ms before hiding on mouse leave
+        cacheTtl: 5 * 60 * 1000, // 5 minute cache
+        userPopupWidth: 288,     // 18rem = 288px
+        guildPopupWidth: 320,    // 20rem = 320px
+        viewportPadding: 16      // Minimum distance from viewport edges
+    };
+
+    // State
+    let activePopup = null;
+    let activeTrigger = null;
+    let hoverTimer = null;
+    let hideTimer = null;
+    const cache = new Map();
+
+    // API endpoints
+    const API = {
+        userPreview: (userId, guildId) => guildId
+            ? `/api/preview/users/${userId}/guild/${guildId}`
+            : `/api/preview/users/${userId}`,
+        guildPreview: (guildId) => `/api/preview/guilds/${guildId}`
+    };
+
+    /**
+     * Fetch user preview data from API
+     */
+    async function fetchUserPreview(userId, guildId = null) {
+        const cacheKey = `user:${userId}:${guildId || 'global'}`;
+        const cached = cache.get(cacheKey);
+        if (cached && Date.now() - cached.timestamp < CONFIG.cacheTtl) {
+            return cached.data;
+        }
+
+        const response = await fetch(API.userPreview(userId, guildId));
+        if (!response.ok) {
+            throw new Error(response.status === 404 ? 'User not found' : 'Failed to fetch user preview');
+        }
+
+        const data = await response.json();
+        cache.set(cacheKey, { data, timestamp: Date.now() });
+        return data;
+    }
+
+    /**
+     * Fetch guild preview data from API
+     */
+    async function fetchGuildPreview(guildId) {
+        const cacheKey = `guild:${guildId}`;
+        const cached = cache.get(cacheKey);
+        if (cached && Date.now() - cached.timestamp < CONFIG.cacheTtl) {
+            return cached.data;
+        }
+
+        const response = await fetch(API.guildPreview(guildId));
+        if (!response.ok) {
+            throw new Error(response.status === 404 ? 'Guild not found' : 'Failed to fetch guild preview');
+        }
+
+        const data = await response.json();
+        cache.set(cacheKey, { data, timestamp: Date.now() });
+        return data;
+    }
+
+    /**
+     * Create the popup DOM element
+     */
+    function createPopupElement(type) {
+        const popup = document.createElement('div');
+        const width = type === 'user' ? 'w-72' : 'w-80';
+        popup.className = `preview-popup-container fixed z-[1100] bg-bg-tertiary border border-border-primary rounded-lg ${width} shadow-xl overflow-hidden opacity-0 transform -translate-y-1 scale-[0.98] transition-all duration-150 ease-out`;
+        popup.setAttribute('role', 'dialog');
+        popup.setAttribute('aria-label', type === 'user' ? 'User preview' : 'Guild preview');
+        return popup;
+    }
+
+    /**
+     * Position popup relative to trigger element
+     */
+    function positionPopup(popup, trigger) {
+        const triggerRect = trigger.getBoundingClientRect();
+        const isGuild = popup.classList.contains('w-80');
+        const popupWidth = isGuild ? CONFIG.guildPopupWidth : CONFIG.userPopupWidth;
+        const popupHeight = 220; // Approximate height
+
+        let left = triggerRect.left;
+        let top = triggerRect.bottom + 8;
+
+        // Check right edge
+        if (left + popupWidth > window.innerWidth - CONFIG.viewportPadding) {
+            left = window.innerWidth - popupWidth - CONFIG.viewportPadding;
+        }
+
+        // Check left edge
+        if (left < CONFIG.viewportPadding) {
+            left = CONFIG.viewportPadding;
+        }
+
+        // Check bottom edge - flip to top if needed
+        if (top + popupHeight > window.innerHeight - CONFIG.viewportPadding) {
+            top = triggerRect.top - popupHeight - 8;
+        }
+
+        // Ensure top isn't negative
+        if (top < CONFIG.viewportPadding) {
+            top = CONFIG.viewportPadding;
+        }
+
+        popup.style.left = `${left}px`;
+        popup.style.top = `${top}px`;
+    }
+
+    /**
+     * Render loading skeleton in popup
+     */
+    function renderLoading(popup, type) {
+        const avatarSize = type === 'guild' ? 'w-14 h-14 rounded-lg' : 'w-12 h-12 rounded-full';
+        popup.innerHTML = `
+            <div class="preview-header flex items-center gap-3 p-4 border-b border-border-secondary bg-bg-secondary">
+                <div class="${avatarSize} bg-bg-hover animate-pulse"></div>
+                <div class="flex-1 space-y-2">
+                    <div class="h-4 w-24 bg-bg-hover rounded animate-pulse"></div>
+                    <div class="h-3 w-16 bg-bg-hover rounded animate-pulse"></div>
+                </div>
+            </div>
+            <div class="preview-body p-4 space-y-2">
+                <div class="h-3 w-full bg-bg-hover rounded animate-pulse"></div>
+                <div class="h-3 w-3/4 bg-bg-hover rounded animate-pulse"></div>
+                <div class="h-3 w-1/2 bg-bg-hover rounded animate-pulse"></div>
+            </div>
+            <div class="preview-footer flex gap-2 p-3 border-t border-border-secondary bg-bg-secondary">
+                <div class="flex-1 h-7 bg-bg-hover rounded animate-pulse"></div>
+                <div class="flex-1 h-7 bg-bg-hover rounded animate-pulse"></div>
+            </div>
+        `;
+    }
+
+    /**
+     * Render user preview content
+     */
+    function renderUserContent(popup, data) {
+        const avatarHtml = data.avatarUrl
+            ? `<img src="${escapeHtml(data.avatarUrl)}" alt="${escapeHtml(data.username)}" class="w-12 h-12 rounded-full object-cover" />`
+            : `<div class="w-12 h-12 rounded-full bg-accent-blue-muted flex items-center justify-center">
+                   <span class="text-lg font-semibold text-accent-blue">${escapeHtml(data.username.charAt(0).toUpperCase())}</span>
+               </div>`;
+
+        const displayNameHtml = data.displayName && data.displayName !== data.username
+            ? `<span class="block text-xs text-text-secondary truncate">${escapeHtml(data.displayName)}</span>`
+            : '';
+
+        const verifiedBadge = data.isVerified
+            ? `<span class="px-1.5 py-0.5 bg-success-bg text-success text-xs font-medium rounded" title="Verified">
+                   <svg class="w-3.5 h-3.5 inline" fill="currentColor" viewBox="0 0 20 20">
+                       <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
+                   </svg>
+               </span>`
+            : '';
+
+        // Build meta items
+        let metaItems = '';
+        if (data.memberSince) {
+            const memberDate = new Date(data.memberSince);
+            metaItems += `
+                <div class="flex justify-between">
+                    <span class="text-text-tertiary">Member since</span>
+                    <span class="text-text-secondary">${memberDate.toLocaleDateString('en-US', { month: 'short', year: 'numeric' })}</span>
+                </div>`;
+        }
+        if (data.roles && data.roles.length > 0) {
+            const rolesDisplay = data.roles.slice(0, 3).join(', ') + (data.roles.length > 3 ? ` +${data.roles.length - 3}` : '');
+            metaItems += `
+                <div class="flex justify-between items-start">
+                    <span class="text-text-tertiary">Roles</span>
+                    <span class="text-text-secondary text-right max-w-[140px] truncate">${escapeHtml(rolesDisplay)}</span>
+                </div>`;
+        }
+        if (data.lastActive) {
+            const lastActiveDate = new Date(data.lastActive);
+            metaItems += `
+                <div class="flex justify-between">
+                    <span class="text-text-tertiary">Last active</span>
+                    <span class="text-text-secondary">${formatRelativeTime(lastActiveDate)}</span>
+                </div>`;
+        }
+
+        // Build profile URL - use current guild context if available
+        const guildId = activeTrigger?.dataset.contextGuildId;
+        const profileUrl = guildId
+            ? `/Guilds/${guildId}/Members/${data.userId}/Moderation`
+            : `/Admin/Users/Details?id=${data.userId}`;
+
+        const modHistoryUrl = guildId ? `/Guilds/${guildId}/Members/${data.userId}/Moderation` : null;
+        const modHistoryHtml = modHistoryUrl
+            ? `<a href="${modHistoryUrl}" class="flex-1 px-3 py-1.5 text-xs font-medium text-text-secondary bg-bg-tertiary border border-border-primary rounded hover:bg-bg-hover transition-colors text-center inline-flex items-center justify-center gap-1">
+                   Mod History
+                   ${data.hasActiveModeration ? '<span class="w-1.5 h-1.5 bg-warning rounded-full" title="Active case"></span>' : ''}
+               </a>`
+            : '';
+
+        popup.innerHTML = `
+            <div class="preview-header flex items-center gap-3 p-4 border-b border-border-secondary bg-bg-secondary">
+                ${avatarHtml}
+                <div class="flex-1 min-w-0">
+                    <span class="block text-sm font-semibold text-text-primary truncate">${escapeHtml(data.username)}</span>
+                    ${displayNameHtml}
+                </div>
+                ${verifiedBadge}
+            </div>
+            <div class="preview-body p-4">
+                <div class="space-y-2 text-xs">
+                    ${metaItems}
+                </div>
+            </div>
+            <div class="preview-footer flex gap-2 p-3 border-t border-border-secondary bg-bg-secondary">
+                <a href="${profileUrl}" class="flex-1 px-3 py-1.5 text-xs font-medium text-white bg-accent-blue rounded hover:bg-accent-blue-hover transition-colors text-center">
+                    View Profile
+                </a>
+                ${modHistoryHtml}
+            </div>
+        `;
+    }
+
+    /**
+     * Render guild preview content
+     */
+    function renderGuildContent(popup, data) {
+        const iconHtml = data.iconUrl
+            ? `<img src="${escapeHtml(data.iconUrl)}" alt="${escapeHtml(data.name)}" class="w-14 h-14 rounded-lg object-cover" />`
+            : `<div class="w-14 h-14 rounded-lg bg-accent-blue-muted flex items-center justify-center">
+                   <span class="text-xl font-semibold text-accent-blue">${escapeHtml(data.name.charAt(0).toUpperCase())}</span>
+               </div>`;
+
+        const onlineCount = data.onlineMemberCount
+            ? ` <span class="text-text-tertiary">(${data.onlineMemberCount.toLocaleString()} online)</span>`
+            : '';
+
+        const inactiveBadge = !data.isActive
+            ? '<span class="px-1.5 py-0.5 bg-warning-bg text-warning text-xs font-medium rounded">Inactive</span>'
+            : '';
+
+        // Build meta items
+        let metaItems = `
+            <div class="flex justify-between">
+                <span class="text-text-tertiary">Owner</span>
+                <span class="text-accent-blue">${escapeHtml(data.ownerUsername)}</span>
+            </div>
+            <div class="flex justify-between">
+                <span class="text-text-tertiary">Bot joined</span>
+                <span class="text-text-secondary">${new Date(data.botJoinedAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}</span>
+            </div>`;
+
+        if (data.activeFeatures && data.activeFeatures.length > 0) {
+            const featureBadges = data.activeFeatures.slice(0, 4).map(feature => {
+                const badgeClass = getFeatureBadgeClass(feature);
+                return `<span class="px-1.5 py-0.5 text-[10px] font-medium rounded ${badgeClass}">${escapeHtml(feature)}</span>`;
+            }).join('');
+            const extraBadge = data.activeFeatures.length > 4
+                ? `<span class="px-1.5 py-0.5 text-[10px] font-medium rounded bg-bg-hover text-text-tertiary">+${data.activeFeatures.length - 4}</span>`
+                : '';
+
+            metaItems += `
+                <div class="flex justify-between items-start">
+                    <span class="text-text-tertiary">Features</span>
+                    <div class="flex flex-wrap gap-1 justify-end max-w-[180px]">
+                        ${featureBadges}${extraBadge}
+                    </div>
+                </div>`;
+        }
+
+        popup.innerHTML = `
+            <div class="preview-header flex items-center gap-3 p-4 border-b border-border-secondary bg-bg-secondary">
+                ${iconHtml}
+                <div class="flex-1 min-w-0">
+                    <span class="block text-sm font-semibold text-text-primary truncate">${escapeHtml(data.name)}</span>
+                    <span class="block text-xs text-text-secondary">
+                        ${data.memberCount.toLocaleString()} members${onlineCount}
+                    </span>
+                </div>
+                ${inactiveBadge}
+            </div>
+            <div class="preview-body p-4">
+                <div class="space-y-2 text-xs">
+                    ${metaItems}
+                </div>
+            </div>
+            <div class="preview-footer flex gap-2 p-3 border-t border-border-secondary bg-bg-secondary">
+                <a href="/Guilds/Details?id=${data.guildId}" class="flex-1 px-3 py-1.5 text-xs font-medium text-white bg-accent-blue rounded hover:bg-accent-blue-hover transition-colors text-center">
+                    View Guild
+                </a>
+                <a href="/Guilds/Edit/${data.guildId}" class="flex-1 px-3 py-1.5 text-xs font-medium text-text-secondary bg-bg-tertiary border border-border-primary rounded hover:bg-bg-hover transition-colors text-center">
+                    Settings
+                </a>
+            </div>
+        `;
+    }
+
+    /**
+     * Render error state
+     */
+    function renderError(popup, type) {
+        const errorTitle = type === 'guild' ? 'Guild Unavailable' : 'User Not Found';
+        const errorDescription = type === 'guild'
+            ? 'The bot may have been removed from this server or the server was deleted.'
+            : 'This user may have been deleted or is unavailable.';
+
+        popup.innerHTML = `
+            <div class="p-4">
+                <div class="text-center py-4">
+                    <div class="w-12 h-12 mx-auto mb-3 rounded-full bg-error-bg flex items-center justify-center">
+                        <svg class="w-6 h-6 text-error" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                        </svg>
+                    </div>
+                    <p class="text-sm font-medium text-text-primary mb-1">${errorTitle}</p>
+                    <p class="text-xs text-text-tertiary">${errorDescription}</p>
+                </div>
+            </div>
+        `;
+    }
+
+    /**
+     * Get badge class for feature type
+     */
+    function getFeatureBadgeClass(feature) {
+        const featureLower = feature.toLowerCase();
+        if (featureLower === 'moderation' || featureLower === 'automod') {
+            return 'bg-accent-orange-muted text-accent-orange';
+        }
+        if (featureLower === 'ratwatch' || featureLower === 'rat watch') {
+            return 'bg-success-bg text-success';
+        }
+        if (featureLower === 'welcome') {
+            return 'bg-accent-blue-muted text-accent-blue';
+        }
+        if (featureLower === 'logging') {
+            return 'bg-info-bg text-info';
+        }
+        return 'bg-bg-hover text-text-secondary';
+    }
+
+    /**
+     * Format relative time (e.g., "2 hours ago")
+     */
+    function formatRelativeTime(date) {
+        const now = new Date();
+        const diffMs = now - date;
+        const diffSec = Math.floor(diffMs / 1000);
+        const diffMin = Math.floor(diffSec / 60);
+        const diffHour = Math.floor(diffMin / 60);
+        const diffDay = Math.floor(diffHour / 24);
+
+        if (diffSec < 60) return 'Just now';
+        if (diffMin < 60) return `${diffMin} minute${diffMin !== 1 ? 's' : ''} ago`;
+        if (diffHour < 24) return `${diffHour} hour${diffHour !== 1 ? 's' : ''} ago`;
+        if (diffDay < 7) return `${diffDay} day${diffDay !== 1 ? 's' : ''} ago`;
+        return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    }
+
+    /**
+     * Escape HTML to prevent XSS
+     */
+    function escapeHtml(text) {
+        if (!text) return '';
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+
+    /**
+     * Show popup for a trigger element
+     */
+    async function showPopup(trigger) {
+        // Hide any existing popup
+        hidePopup();
+
+        const type = trigger.dataset.previewType;
+        const userId = trigger.dataset.userId;
+        const guildId = trigger.dataset.guildId;
+        const contextGuildId = trigger.dataset.contextGuildId;
+
+        if (!type || (!userId && !guildId)) return;
+
+        activeTrigger = trigger;
+
+        // Create and position popup
+        const popup = createPopupElement(type);
+        document.body.appendChild(popup);
+        activePopup = popup;
+
+        positionPopup(popup, trigger);
+
+        // Show loading state
+        renderLoading(popup, type);
+
+        // Animate in
+        requestAnimationFrame(() => {
+            popup.classList.remove('opacity-0', '-translate-y-1', 'scale-[0.98]');
+            popup.classList.add('opacity-100', 'translate-y-0', 'scale-100');
+        });
+
+        // Update ARIA
+        trigger.setAttribute('aria-expanded', 'true');
+
+        // Add hover listeners to popup
+        popup.addEventListener('mouseenter', handlePopupMouseEnter);
+        popup.addEventListener('mouseleave', handlePopupMouseLeave);
+
+        // Fetch data
+        try {
+            let data;
+            if (type === 'user') {
+                data = await fetchUserPreview(userId, contextGuildId);
+                renderUserContent(popup, data);
+            } else if (type === 'guild') {
+                data = await fetchGuildPreview(guildId);
+                renderGuildContent(popup, data);
+            }
+
+            // Announce to screen readers
+            announcePopup(type, data);
+        } catch (error) {
+            console.error('Preview popup error:', error);
+            renderError(popup, type);
+        }
+    }
+
+    /**
+     * Hide the active popup
+     */
+    function hidePopup() {
+        if (activePopup) {
+            activePopup.classList.remove('opacity-100', 'translate-y-0', 'scale-100');
+            activePopup.classList.add('opacity-0', '-translate-y-1', 'scale-[0.98]');
+
+            const popup = activePopup;
+            setTimeout(() => {
+                popup.remove();
+            }, 150);
+
+            activePopup = null;
+        }
+
+        if (activeTrigger) {
+            activeTrigger.setAttribute('aria-expanded', 'false');
+            activeTrigger = null;
+        }
+    }
+
+    /**
+     * Announce popup content to screen readers
+     */
+    function announcePopup(type, data) {
+        let announcement;
+        if (type === 'user') {
+            announcement = `User preview for ${data.username}`;
+            if (data.isVerified) announcement += ', verified user';
+        } else {
+            announcement = `Guild preview for ${data.name}, ${data.memberCount} members`;
+        }
+
+        // Use existing toast live region or create temporary one
+        const liveRegion = document.getElementById('toastLiveRegion') || createLiveRegion();
+        liveRegion.textContent = announcement;
+        setTimeout(() => { liveRegion.textContent = ''; }, 1000);
+    }
+
+    /**
+     * Create a live region for announcements if one doesn't exist
+     */
+    function createLiveRegion() {
+        const region = document.createElement('div');
+        region.id = 'previewPopupLiveRegion';
+        region.setAttribute('aria-live', 'polite');
+        region.setAttribute('aria-atomic', 'true');
+        region.className = 'sr-only';
+        document.body.appendChild(region);
+        return region;
+    }
+
+    // Event handlers
+    function handleMouseEnter(e) {
+        const trigger = e.target.closest('[data-preview-type]');
+        if (!trigger) return;
+
+        clearTimeout(hideTimer);
+        hoverTimer = setTimeout(() => showPopup(trigger), CONFIG.hoverDelay);
+    }
+
+    function handleMouseLeave(e) {
+        clearTimeout(hoverTimer);
+        hideTimer = setTimeout(() => {
+            // Only hide if not hovering over popup
+            if (activePopup && !activePopup.matches(':hover')) {
+                hidePopup();
+            }
+        }, CONFIG.hideDelay);
+    }
+
+    function handlePopupMouseEnter() {
+        clearTimeout(hideTimer);
+    }
+
+    function handlePopupMouseLeave() {
+        hideTimer = setTimeout(() => hidePopup(), CONFIG.hideDelay);
+    }
+
+    function handleClick(e) {
+        const trigger = e.target.closest('[data-preview-type]');
+        if (!trigger) return;
+
+        e.preventDefault();
+        e.stopPropagation();
+
+        if (activeTrigger === trigger && activePopup) {
+            hidePopup();
+        } else {
+            clearTimeout(hoverTimer);
+            showPopup(trigger);
+        }
+    }
+
+    function handleFocusIn(e) {
+        const trigger = e.target.closest('[data-preview-type]');
+        if (!trigger) return;
+
+        clearTimeout(hideTimer);
+        hoverTimer = setTimeout(() => showPopup(trigger), CONFIG.hoverDelay);
+    }
+
+    function handleFocusOut(e) {
+        clearTimeout(hoverTimer);
+        // Delay to allow focus to move to popup buttons
+        hideTimer = setTimeout(() => {
+            if (!activePopup?.contains(document.activeElement)) {
+                hidePopup();
+            }
+        }, 150);
+    }
+
+    function handleKeyDown(e) {
+        if (e.key === 'Escape' && activePopup) {
+            hidePopup();
+            activeTrigger?.focus();
+        }
+
+        if ((e.key === 'Enter' || e.key === ' ') && e.target.closest('[data-preview-type]')) {
+            e.preventDefault();
+            handleClick(e);
+        }
+    }
+
+    function handleClickOutside(e) {
+        if (activePopup && !activePopup.contains(e.target) && !e.target.closest('[data-preview-type]')) {
+            hidePopup();
+        }
+    }
+
+    /**
+     * Initialize the preview popup system
+     */
+    function init() {
+        // Use event delegation for dynamic content
+        document.addEventListener('mouseenter', handleMouseEnter, true);
+        document.addEventListener('mouseleave', handleMouseLeave, true);
+        document.addEventListener('click', handleClick);
+        document.addEventListener('click', handleClickOutside);
+        document.addEventListener('focusin', handleFocusIn);
+        document.addEventListener('focusout', handleFocusOut);
+        document.addEventListener('keydown', handleKeyDown);
+    }
+
+    /**
+     * Destroy the preview popup system
+     */
+    function destroy() {
+        document.removeEventListener('mouseenter', handleMouseEnter, true);
+        document.removeEventListener('mouseleave', handleMouseLeave, true);
+        document.removeEventListener('click', handleClick);
+        document.removeEventListener('click', handleClickOutside);
+        document.removeEventListener('focusin', handleFocusIn);
+        document.removeEventListener('focusout', handleFocusOut);
+        document.removeEventListener('keydown', handleKeyDown);
+        hidePopup();
+        cache.clear();
+    }
+
+    // Public API
+    return {
+        init,
+        destroy,
+        showUserPreview: (userId, anchor, guildId) => {
+            activeTrigger = anchor;
+            return showPopup({
+                dataset: { previewType: 'user', userId, contextGuildId: guildId },
+                getAttribute: () => null,
+                setAttribute: () => {},
+                getBoundingClientRect: () => anchor.getBoundingClientRect()
+            });
+        },
+        showGuildPreview: (guildId, anchor) => {
+            activeTrigger = anchor;
+            return showPopup({
+                dataset: { previewType: 'guild', guildId },
+                getAttribute: () => null,
+                setAttribute: () => {},
+                getBoundingClientRect: () => anchor.getBoundingClientRect()
+            });
+        },
+        hide: hidePopup,
+        clearCache: () => cache.clear()
+    };
+})();
+
+// Auto-initialize on DOMContentLoaded
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', PreviewPopup.init);
+} else {
+    PreviewPopup.init();
+}
+
+// Export for use in other scripts
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = PreviewPopup;
+}


### PR DESCRIPTION
## Summary
- Create `_UserPreviewPopup.cshtml` partial view with avatar, roles, verification badge
- Create `_GuildPreviewPopup.cshtml` partial view with icon, features, member count
- Create `_PreviewPopupLoading.cshtml` skeleton loading state
- Create `_PreviewPopupError.cshtml` error state component
- Create `preview-popup.js` module with hover/click/keyboard triggers
- Add preview trigger CSS styling to site.css

## Features
- 300ms hover delay before showing popup, 150ms delay before hiding
- Client-side caching with 5-minute TTL for API responses
- Viewport edge detection for popup positioning (flips when near edges)
- Accessibility: ARIA labels, focus management, Escape key dismissal, screen reader announcements
- Support for touch devices with click-to-toggle behavior

## Files Added
- `src/DiscordBot.Bot/Pages/Shared/Components/_UserPreviewPopup.cshtml`
- `src/DiscordBot.Bot/Pages/Shared/Components/_GuildPreviewPopup.cshtml`
- `src/DiscordBot.Bot/Pages/Shared/Components/_PreviewPopupLoading.cshtml`
- `src/DiscordBot.Bot/Pages/Shared/Components/_PreviewPopupError.cshtml`
- `src/DiscordBot.Bot/wwwroot/js/preview-popup.js`

## Files Modified
- `src/DiscordBot.Bot/Pages/Shared/_Layout.cshtml` - Include preview-popup.js
- `src/DiscordBot.Bot/wwwroot/css/site.css` - Add preview popup styles

## Test Plan
- [ ] Build succeeds with no errors
- [ ] All existing tests pass
- [ ] Hover over username shows user preview popup after 300ms
- [ ] Hover over guild name shows guild preview popup after 300ms
- [ ] Popup disappears when mouse leaves (with grace period)
- [ ] Click/tap toggles popup on touch devices
- [ ] Keyboard focus triggers popup
- [ ] Escape key closes popup
- [ ] Popup positions correctly near viewport edges
- [ ] Loading skeleton shows while fetching data
- [ ] Error state shows for missing users/guilds

Closes #700
Closes #701
Closes #702

🤖 Generated with [Claude Code](https://claude.com/claude-code)