### PR TITLE
feat: Integrate preview popups into admin UI pages

### DIFF
--- a/src/DiscordBot.Bot/Pages/Admin/AuditLogs/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/AuditLogs/Index.cshtml
@@ -350,7 +350,14 @@
                                         <div class="h-8 w-8 rounded-full bg-accent-blue text-white flex items-center justify-center">
                                             <span class="font-medium text-xs">@log.ActorInitials</span>
                                         </div>
-                                        <span class="text-sm text-text-primary">@log.ActorDisplayName</span>
+                                        @if (!string.IsNullOrEmpty(log.ActorId) && ulong.TryParse(log.ActorId, out var actorUserId))
+                                        {
+                                            <span class="text-sm text-text-primary preview-trigger" data-preview-type="user" data-user-id="@actorUserId" @(log.GuildId.HasValue ? $"data-context-guild-id=\"{log.GuildId}\"" : "")>@log.ActorDisplayName</span>
+                                        }
+                                        else
+                                        {
+                                            <span class="text-sm text-text-primary">@log.ActorDisplayName</span>
+                                        }
                                     </div>
                                 }
                                 else if (log.IsUserActor && log.HasActorGuid)
@@ -385,7 +392,11 @@
                                 @log.TargetType
                             </td>
                             <td class="px-4 py-4 whitespace-nowrap text-sm hidden lg:table-cell">
-                                @if (!string.IsNullOrEmpty(log.GuildName))
+                                @if (!string.IsNullOrEmpty(log.GuildName) && log.GuildId.HasValue)
+                                {
+                                    <span class="text-text-primary preview-trigger" data-preview-type="guild" data-guild-id="@log.GuildId">@log.GuildName</span>
+                                }
+                                else if (!string.IsNullOrEmpty(log.GuildName))
                                 {
                                     <span class="text-text-primary">@log.GuildName</span>
                                 }
@@ -568,7 +579,14 @@
                                     <div class="h-8 w-8 rounded-full bg-accent-blue text-white flex items-center justify-center">
                                         <span class="font-medium text-xs">@log.ActorInitials</span>
                                     </div>
-                                    <span class="text-sm text-text-primary">@log.ActorDisplayName</span>
+                                    @if (!string.IsNullOrEmpty(log.ActorId) && ulong.TryParse(log.ActorId, out var actorUserIdMobile))
+                                    {
+                                        <span class="text-sm text-text-primary preview-trigger" data-preview-type="user" data-user-id="@actorUserIdMobile" @(log.GuildId.HasValue ? $"data-context-guild-id=\"{log.GuildId}\"" : "")>@log.ActorDisplayName</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="text-sm text-text-primary">@log.ActorDisplayName</span>
+                                    }
                                 </div>
                             }
                             else if (log.IsUserActor && log.HasActorGuid)
@@ -607,7 +625,11 @@
                         </div>
                         <div>
                             <span class="text-text-tertiary">Guild:</span>
-                            @if (!string.IsNullOrEmpty(log.GuildName))
+                            @if (!string.IsNullOrEmpty(log.GuildName) && log.GuildId.HasValue)
+                            {
+                                <span class="text-text-primary ml-1 preview-trigger" data-preview-type="guild" data-guild-id="@log.GuildId">@log.GuildName</span>
+                            }
+                            else if (!string.IsNullOrEmpty(log.GuildName))
                             {
                                 <span class="text-text-primary ml-1">@log.GuildName</span>
                             }

--- a/src/DiscordBot.Bot/Pages/CommandLogs/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/CommandLogs/Index.cshtml
@@ -251,11 +251,18 @@
                                 </td>
                                 <!-- Server (desktop only) -->
                                 <td class="px-6 py-4 text-text-secondary text-sm hidden lg:table-cell">
-                                    @log.GuildName
+                                    @if (log.GuildId.HasValue)
+                                    {
+                                        <span class="preview-trigger" data-preview-type="guild" data-guild-id="@log.GuildId">@log.GuildName</span>
+                                    }
+                                    else
+                                    {
+                                        @log.GuildName
+                                    }
                                 </td>
                                 <!-- User -->
                                 <td class="px-6 py-4 text-text-secondary text-sm">
-                                    @log.Username
+                                    <span class="preview-trigger" data-preview-type="user" data-user-id="@log.UserId" @(log.GuildId.HasValue ? $"data-context-guild-id=\"{log.GuildId}\"" : "")>@log.Username</span>
                                 </td>
                                 <!-- Duration (xl screens only) -->
                                 <td class="px-6 py-4 text-text-secondary text-sm hidden xl:table-cell">
@@ -351,11 +358,18 @@
                     <div class="grid grid-cols-2 gap-3 text-sm">
                         <div>
                             <span class="text-text-tertiary">Server:</span>
-                            <span class="text-text-primary ml-1">@log.GuildName</span>
+                            @if (log.GuildId.HasValue)
+                            {
+                                <span class="text-text-primary ml-1 preview-trigger" data-preview-type="guild" data-guild-id="@log.GuildId">@log.GuildName</span>
+                            }
+                            else
+                            {
+                                <span class="text-text-primary ml-1">@log.GuildName</span>
+                            }
                         </div>
                         <div>
                             <span class="text-text-tertiary">User:</span>
-                            <span class="text-text-primary ml-1">@log.Username</span>
+                            <span class="text-text-primary ml-1 preview-trigger" data-preview-type="user" data-user-id="@log.UserId" @(log.GuildId.HasValue ? $"data-context-guild-id=\"{log.GuildId}\"" : "")>@log.Username</span>
                         </div>
                         <div>
                             <span class="text-text-tertiary">Duration:</span>

--- a/src/DiscordBot.Bot/Pages/Guilds/FlaggedEvents/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/FlaggedEvents/Index.cshtml
@@ -204,7 +204,7 @@
                                 <partial name="Shared/Components/_SeverityBadge" model="evt.Severity" />
                             </td>
                             <td class="px-4 py-4 whitespace-nowrap">
-                                <div class="text-sm font-medium text-text-primary">@evt.Username</div>
+                                <div class="text-sm font-medium text-text-primary preview-trigger" data-preview-type="user" data-user-id="@evt.UserId" data-context-guild-id="@Model.GuildId">@evt.Username</div>
                             </td>
                             <td class="px-4 py-4 whitespace-nowrap">
                                 <div class="flex items-center gap-2">
@@ -260,7 +260,7 @@
                     <div class="space-y-2">
                         <div class="flex items-center gap-2">
                             <span class="text-sm font-semibold text-text-secondary">User:</span>
-                            <span class="text-sm text-text-primary">@evt.Username</span>
+                            <span class="text-sm text-text-primary preview-trigger" data-preview-type="user" data-user-id="@evt.UserId" data-context-guild-id="@Model.GuildId">@evt.Username</span>
                         </div>
                         <div class="flex items-center gap-2">
                             <partial name="Shared/Components/_RuleTypeIcon" model="evt.RuleType" />

--- a/src/DiscordBot.Bot/Pages/Guilds/Members/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Members/Index.cshtml
@@ -278,7 +278,7 @@
                                             </div>
                                         }
                                         <div class="min-w-0">
-                                            <p class="font-medium text-text-primary truncate">@member.DisplayName</p>
+                                            <p class="font-medium text-text-primary truncate preview-trigger" data-preview-type="user" data-user-id="@member.UserId" data-context-guild-id="@Model.GuildId">@member.DisplayName</p>
                                             <p class="text-xs text-text-tertiary font-mono">@@@member.Username</p>
                                         </div>
                                     </div>
@@ -385,7 +385,7 @@
                                 </div>
                             }
                             <div class="min-w-0">
-                                <p class="font-medium text-text-primary truncate">@member.DisplayName</p>
+                                <p class="font-medium text-text-primary truncate preview-trigger" data-preview-type="user" data-user-id="@member.UserId" data-context-guild-id="@Model.GuildId">@member.DisplayName</p>
                                 <p class="text-xs text-text-tertiary font-mono">@@@member.Username</p>
                             </div>
                         </div>

--- a/src/DiscordBot.Bot/Pages/Guilds/Members/Moderation.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Members/Moderation.cshtml
@@ -203,7 +203,7 @@
                                         </span>
                                     </td>
                                     <td class="px-6 py-4 text-sm text-text-secondary">@(moderationCase.Reason ?? "No reason provided")</td>
-                                    <td class="px-6 py-4 text-sm text-text-secondary">@moderationCase.ModeratorUsername</td>
+                                    <td class="px-6 py-4 text-sm text-text-secondary preview-trigger" data-preview-type="user" data-user-id="@moderationCase.ModeratorUserId" data-context-guild-id="@Model.GuildId">@moderationCase.ModeratorUsername</td>
                                     <td class="px-6 py-4 text-sm text-text-tertiary" data-utc="@moderationCase.CreatedAt.ToString("o")" data-format="date"></td>
                                 </tr>
                             }
@@ -251,7 +251,7 @@
                     {
                         <div class="note-item" data-note-id="@note.Id">
                             <div class="note-meta">
-                                <span class="font-medium text-text-secondary">@note.AuthorUsername</span>
+                                <span class="font-medium text-text-secondary preview-trigger" data-preview-type="user" data-user-id="@note.AuthorUserId" data-context-guild-id="@Model.GuildId">@note.AuthorUsername</span>
                                 <span>-</span>
                                 <span data-utc="@note.CreatedAt.ToString("o")" data-format="datetime"></span>
                                 @if (note.AuthorUserId == Model.ViewModel.CurrentUserId)

--- a/src/DiscordBot.Bot/ViewModels/Pages/AuditLogListViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Pages/AuditLogListViewModel.cs
@@ -168,6 +168,11 @@ public record AuditLogListItem
     public string TargetId { get; init; } = string.Empty;
 
     /// <summary>
+    /// Gets the Discord guild snowflake ID associated with this action.
+    /// </summary>
+    public ulong? GuildId { get; init; }
+
+    /// <summary>
     /// Gets the guild name for display.
     /// </summary>
     public string? GuildName { get; init; }
@@ -312,6 +317,7 @@ public record AuditLogListItem
             ActorAvatarClass = actorAvatarClass,
             TargetType = dto.TargetType ?? string.Empty,
             TargetId = dto.TargetId ?? string.Empty,
+            GuildId = dto.GuildId,
             GuildName = dto.GuildName,
             DetailsSummary = detailsSummary,
             Details = details,

--- a/src/DiscordBot.Bot/ViewModels/Pages/CommandLogListViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Pages/CommandLogListViewModel.cs
@@ -80,9 +80,19 @@ public record CommandLogListItem
     public Guid Id { get; init; }
 
     /// <summary>
+    /// Gets the Discord guild snowflake ID where the command was executed.
+    /// </summary>
+    public ulong? GuildId { get; init; }
+
+    /// <summary>
     /// Gets the guild name where the command was executed.
     /// </summary>
     public string GuildName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the Discord user snowflake ID who executed the command.
+    /// </summary>
+    public ulong UserId { get; init; }
 
     /// <summary>
     /// Gets the username of the user who executed the command.
@@ -129,7 +139,9 @@ public record CommandLogListItem
         return new CommandLogListItem
         {
             Id = dto.Id,
+            GuildId = dto.GuildId,
             GuildName = dto.GuildName ?? "Direct Message",
+            UserId = dto.UserId,
             Username = dto.Username ?? "Unknown",
             CommandName = dto.CommandName,
             ExecutedAt = dto.ExecutedAt,


### PR DESCRIPTION
## Summary

- Adds user and guild preview popup triggers to multiple admin UI pages
- Enables quick user/guild information previews on hover without navigating away
- Extends the preview popup infrastructure from #698-702 to additional pages

## Pages Updated

| Page | Preview Type | Context |
|------|--------------|---------|
| Command Logs | User + Guild | Shows user info with guild context; guild preview for server names |
| Audit Logs | User + Guild | Actor usernames (when available) and guild names |
| Member Directory | User | Member display names with guild context |
| Member Moderation | User | Moderator usernames and note authors |
| Flagged Events | User | Flagged user names with guild context |

## ViewModel Changes

- **CommandLogListItem**: Added `UserId` and `GuildId` properties to enable preview triggers
- **AuditLogListItem**: Added `GuildId` property to enable guild preview triggers

## Test Plan

- [x] Build succeeds with no errors
- [x] All existing tests pass (2590 passed, 15 skipped, 1 pre-existing failure unrelated to this change)
- [ ] Manually verify preview popups appear on hover for each updated page:
  - [ ] Command Logs page - user names and guild names
  - [ ] Audit Logs page - actor names and guild names
  - [ ] Member Directory page - member display names
  - [ ] Member Moderation page - moderator names and note authors
  - [ ] Flagged Events page - flagged user names

Closes #703
Closes #704
Closes #705
Closes #706
Closes #707

🤖 Generated with [Claude Code](https://claude.com/claude-code)