### PR TITLE
feat: Add keyboard and touch accessibility to preview popups

### DIFF
--- a/src/DiscordBot.Bot/wwwroot/css/site.css
+++ b/src/DiscordBot.Bot/wwwroot/css/site.css
@@ -2318,6 +2318,8 @@
   cursor: pointer;
   border-bottom: 1px dashed transparent;
   transition: border-color 0.15s ease-out, color 0.15s ease-out;
+  /* Ensure inline elements can receive focus */
+  display: inline-block;
 }
 
 .preview-trigger:hover,
@@ -2329,6 +2331,30 @@
   outline: 2px solid var(--color-border-focus);
   outline-offset: 2px;
   border-radius: 2px;
+}
+
+/* Touch target sizing for accessibility (WCAG 2.5.5 - minimum 44x44px) */
+@media (pointer: coarse) {
+  .preview-trigger {
+    /* Increase touch target size while keeping visual appearance compact */
+    position: relative;
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+  }
+
+  /* Extend clickable area without visual change */
+  .preview-trigger::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    min-width: 44px;
+    min-height: 44px;
+    width: 100%;
+    height: 100%;
+  }
 }
 
 /* Preview popup container - base styles */


### PR DESCRIPTION
## Summary
- Implements keyboard accessibility for preview popups (focus triggers popup, Escape closes, Enter/Space toggles)
- Adds touch device support with tap-outside-to-close functionality  
- Auto-adds required ARIA attributes (`role="button"`, `aria-haspopup="dialog"`, `aria-expanded`, `tabindex="0"`) via JavaScript
- Uses MutationObserver to handle dynamically added triggers
- Adds WCAG 2.5.5 compliant touch target sizing (44x44px minimum) for coarse pointer devices
- Implements proper focus management with focus return on Escape key

## Implementation Details

### JavaScript Changes (`preview-popup.js`)
- Added `isTouchDevice()` utility function for touch detection
- Added `ensureTriggerAccessibility()` to set required ARIA attributes
- Added `initTriggerAccessibility()` and MutationObserver for dynamic content
- Added `handleTouchStart()` event handler for tap-outside-to-close
- Updated `hidePopup()` to accept `returnFocus` parameter
- Track `lastFocusedTrigger` for proper focus return on Escape
- Exposed `isTouchDevice` and `refreshAccessibility` in public API

### CSS Changes (`site.css`)
- Added `display: inline-block` for focus accessibility
- Added `@media (pointer: coarse)` rule for touch devices
- Extended touch target using pseudo-element overlay (44x44px minimum)

## Checklist from Issue #708

### Keyboard ✅
- [x] Focus on trigger shows popup
- [x] Focus out hides popup (with delay for popup focus)
- [x] Escape key closes popup
- [x] Tab navigates through popup content
- [x] Focus returns to trigger on close
- [x] Enter/Space on trigger opens popup

### Touch ✅
- [x] Tap toggles popup on touch devices
- [x] Tap outside closes popup
- [x] Touch targets meet 44x44px minimum
- [x] Popup positions correctly on mobile

### Screen Reader ✅
- [x] Proper ARIA roles and attributes
- [x] Live region announces popup opening
- [x] Popup content is readable
- [x] Close is clearly communicated

## Test plan
- [ ] Verify keyboard navigation works (Tab to trigger, Enter to open, Escape to close)
- [ ] Test focus return after Escape key
- [ ] Test on touch device (tap to toggle, tap outside to close)
- [ ] Verify ARIA attributes are auto-added to triggers
- [ ] Test with VoiceOver/NVDA for screen reader accessibility
- [ ] Verify touch targets are 44x44px on mobile

Closes #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)