### PR TITLE
feat: Display usernames instead of user IDs in Slowest Commands table

### DIFF
--- a/src/DiscordBot.Bot/Pages/Admin/Performance/Commands.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/Commands.cshtml
@@ -197,8 +197,8 @@ else
                             <th>Command</th>
                             <th>Duration</th>
                             <th>Executed At</th>
-                            <th>User ID</th>
-                            <th>Guild ID</th>
+                            <th>User</th>
+                            <th>Guild</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -214,8 +214,33 @@ else
                                 <td>
                                     <span data-utc-time="@cmd.ExecutedAt.ToString("o")">@cmd.ExecutedAt.ToString("MMM dd, HH:mm")</span>
                                 </td>
-                                <td class="text-text-secondary">@cmd.UserId</td>
-                                <td class="text-text-secondary">@(cmd.GuildId?.ToString() ?? "DM")</td>
+                                <td class="text-text-secondary">
+                                    @if (!string.IsNullOrEmpty(cmd.Username))
+                                    {
+                                        <span title="User ID: @cmd.UserId">@cmd.Username</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="text-mono">@cmd.UserId</span>
+                                    }
+                                </td>
+                                <td class="text-text-secondary">
+                                    @if (cmd.GuildId.HasValue)
+                                    {
+                                        @if (!string.IsNullOrEmpty(cmd.GuildName))
+                                        {
+                                            <span title="Guild ID: @cmd.GuildId.Value">@cmd.GuildName</span>
+                                        }
+                                        else
+                                        {
+                                            <span class="text-mono">@cmd.GuildId.Value</span>
+                                        }
+                                    }
+                                    else
+                                    {
+                                        <span>DM</span>
+                                    }
+                                </td>
                             </tr>
                         }
                     </tbody>

--- a/src/DiscordBot.Core/DTOs/PerformanceMetricsDtos.cs
+++ b/src/DiscordBot.Core/DTOs/PerformanceMetricsDtos.cs
@@ -245,9 +245,19 @@ public record SlowestCommandDto
     public ulong UserId { get; set; }
 
     /// <summary>
+    /// Gets or sets the Discord username who executed the command (resolved from cache).
+    /// </summary>
+    public string? Username { get; set; }
+
+    /// <summary>
     /// Gets or sets the Discord guild ID where the command was executed.
     /// </summary>
     public ulong? GuildId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Discord guild name where the command was executed (resolved from cache).
+    /// </summary>
+    public string? GuildName { get; set; }
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

- Display usernames instead of raw Discord user IDs in the Slowest Commands table on the Performance Dashboard
- Display guild names instead of raw Discord guild IDs
- User/guild IDs remain accessible via tooltips when hovering over the names
- Falls back gracefully to displaying raw IDs when the user/guild is not in Discord's cache

## Changes Made

- **PerformanceMetricsDtos.cs**: Added `Username` and `GuildName` properties to `SlowestCommandDto`
- **CommandPerformanceAggregator.cs**: Resolves usernames and guild names from Discord's cached data using `DiscordSocketClient`
- **Commands.cshtml**: Updated table to display names with ID tooltips, with fallback to raw IDs

## Test plan

- [x] Build succeeds
- [x] All tests pass (2591 passed, 15 skipped)
- [ ] Verify Slowest Commands table shows usernames for users in cache
- [ ] Verify tooltip shows user ID when hovering over username
- [ ] Verify falls back to raw ID when user not in cache
- [ ] Verify same behavior for guild names

Closes #668

🤖 Generated with [Claude Code](https://claude.com/claude-code)