### PR TITLE
feat: Add per-service memory breakdown diagnostics

### DIFF
--- a/src/DiscordBot.Bot/Extensions/PerformanceMetricsServiceExtensions.cs
+++ b/src/DiscordBot.Bot/Extensions/PerformanceMetricsServiceExtensions.cs
@@ -42,6 +42,9 @@ public static class PerformanceMetricsServiceExtensions
         // Instrumented cache wrapper (singleton)
         services.AddSingleton<IInstrumentedCache, InstrumentedMemoryCache>();
 
+        // Memory diagnostics service (singleton - aggregates IMemoryReportable services)
+        services.AddSingleton<IMemoryDiagnosticsService, MemoryDiagnosticsService>();
+
         // Command performance aggregator as background service
         services.AddHostedService<CommandPerformanceAggregator>();
 

--- a/src/DiscordBot.Bot/Pages/Admin/Performance/HealthMetrics.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/HealthMetrics.cshtml
@@ -1,5 +1,6 @@
 @page
 @model DiscordBot.Bot.Pages.Admin.Performance.HealthMetricsModel
+@using DiscordBot.Bot.ViewModels.Pages
 @{
     ViewData["Title"] = "Health Metrics";
     ViewData["Breadcrumbs"] = new List<(string Text, string? Url)>
@@ -202,6 +203,121 @@
         </div>
     </div>
 </div>
+
+<!-- Memory Breakdown Section -->
+@if (Model.ViewModel.MemoryDiagnostics != null)
+{
+    <div class="chart-card mb-6">
+        <div class="chart-card-header">
+            <div>
+                <h2 class="chart-card-title">Memory Breakdown</h2>
+                <p class="chart-card-subtitle">GC heap details and per-service memory usage</p>
+            </div>
+        </div>
+        <div class="chart-card-body">
+            <!-- GC Generation Sizes -->
+            <div class="mb-6">
+                <h3 class="text-sm font-medium text-text-primary mb-3">GC Heap Generations</h3>
+                <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3">
+                    <div class="text-center p-3 bg-bg-tertiary rounded-lg">
+                        <div class="text-lg font-bold text-text-primary">
+                            @HealthMetricsViewModel.FormatBytes(Model.ViewModel.MemoryDiagnostics.GcGenerations.Gen0SizeBytes)
+                        </div>
+                        <div class="text-xs text-text-tertiary">Gen 0</div>
+                    </div>
+                    <div class="text-center p-3 bg-bg-tertiary rounded-lg">
+                        <div class="text-lg font-bold text-text-primary">
+                            @HealthMetricsViewModel.FormatBytes(Model.ViewModel.MemoryDiagnostics.GcGenerations.Gen1SizeBytes)
+                        </div>
+                        <div class="text-xs text-text-tertiary">Gen 1</div>
+                    </div>
+                    <div class="text-center p-3 bg-bg-tertiary rounded-lg">
+                        <div class="text-lg font-bold text-text-primary">
+                            @HealthMetricsViewModel.FormatBytes(Model.ViewModel.MemoryDiagnostics.GcGenerations.Gen2SizeBytes)
+                        </div>
+                        <div class="text-xs text-text-tertiary">Gen 2</div>
+                    </div>
+                    <div class="text-center p-3 bg-bg-tertiary rounded-lg">
+                        <div class="text-lg font-bold text-text-primary">
+                            @HealthMetricsViewModel.FormatBytes(Model.ViewModel.MemoryDiagnostics.GcGenerations.LohSizeBytes)
+                        </div>
+                        <div class="text-xs text-text-tertiary">LOH</div>
+                    </div>
+                    <div class="text-center p-3 bg-bg-tertiary rounded-lg">
+                        <div class="text-lg font-bold text-text-primary">
+                            @HealthMetricsViewModel.FormatBytes(Model.ViewModel.MemoryDiagnostics.GcGenerations.PohSizeBytes)
+                        </div>
+                        <div class="text-xs text-text-tertiary">POH</div>
+                    </div>
+                    <div class="text-center p-3 bg-bg-tertiary rounded-lg">
+                        <div class="text-lg font-bold @HealthMetricsViewModel.GetFragmentationClass(Model.ViewModel.MemoryDiagnostics.GcGenerations.FragmentationPercent)">
+                            @Model.ViewModel.MemoryDiagnostics.GcGenerations.FragmentationPercent.ToString("F1")%
+                        </div>
+                        <div class="text-xs text-text-tertiary">Fragmentation</div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Service Memory Breakdown -->
+            @if (Model.ViewModel.MemoryDiagnostics.ServiceReports.Any())
+            {
+                <div class="mb-6">
+                    <h3 class="text-sm font-medium text-text-primary mb-3">Service Memory Usage</h3>
+                    <div class="space-y-3">
+                        @foreach (var service in Model.ViewModel.MemoryDiagnostics.ServiceReports)
+                        {
+                            var percentOfTotal = Model.ViewModel.MemoryDiagnostics.TotalAccountedBytes > 0
+                                ? (double)service.EstimatedBytes / Model.ViewModel.MemoryDiagnostics.TotalAccountedBytes * 100
+                                : 0;
+
+                            <div class="bg-bg-tertiary rounded-lg p-3">
+                                <div class="flex items-center justify-between mb-2">
+                                    <span class="text-sm font-medium text-text-primary">@service.ServiceName</span>
+                                    <span class="text-sm text-text-secondary">@HealthMetricsViewModel.FormatBytes(service.EstimatedBytes)</span>
+                                </div>
+                                <div class="progress-bar-container progress-bar-sm">
+                                    <div class="progress-bar-fill progress-bar-healthy" style="width: @percentOfTotal.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)%;"></div>
+                                </div>
+                                @if (!string.IsNullOrEmpty(service.Details))
+                                {
+                                    <div class="text-xs text-text-tertiary mt-1">@service.Details</div>
+                                }
+                            </div>
+                        }
+                    </div>
+                </div>
+            }
+
+            <!-- Memory Summary -->
+            <div class="grid grid-cols-2 md:grid-cols-4 gap-4 pt-4 border-t border-border-primary">
+                <div class="text-center">
+                    <div class="text-xl font-bold text-text-primary">
+                        @HealthMetricsViewModel.FormatBytes(Model.ViewModel.MemoryDiagnostics.TotalAccountedBytes)
+                    </div>
+                    <div class="text-xs text-text-tertiary">Accounted</div>
+                </div>
+                <div class="text-center">
+                    <div class="text-xl font-bold text-warning">
+                        @HealthMetricsViewModel.FormatBytes(Model.ViewModel.MemoryDiagnostics.UnaccountedBytes)
+                    </div>
+                    <div class="text-xs text-text-tertiary">Unaccounted</div>
+                </div>
+                <div class="text-center">
+                    <div class="text-xl font-bold text-text-primary">
+                        @HealthMetricsViewModel.FormatBytes(Model.ViewModel.MemoryDiagnostics.ManagedHeapBytes)
+                    </div>
+                    <div class="text-xs text-text-tertiary">Managed Heap</div>
+                </div>
+                <div class="text-center">
+                    <div class="text-xl font-bold text-text-primary">
+                        @HealthMetricsViewModel.FormatBytes(Model.ViewModel.MemoryDiagnostics.GcGenerations.TotalCommittedBytes)
+                    </div>
+                    <div class="text-xs text-text-tertiary">Committed</div>
+                </div>
+            </div>
+        </div>
+    </div>
+}
 
 <!-- Latency History Chart -->
 <div class="chart-card mb-6">

--- a/src/DiscordBot.Bot/Pages/Admin/Performance/HealthMetrics.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/HealthMetrics.cshtml.cs
@@ -15,6 +15,7 @@ public class HealthMetricsModel : PageModel
 {
     private readonly IConnectionStateService _connectionStateService;
     private readonly ILatencyHistoryService _latencyHistoryService;
+    private readonly IMemoryDiagnosticsService _memoryDiagnosticsService;
     private readonly ILogger<HealthMetricsModel> _logger;
 
     /// <summary>
@@ -27,14 +28,17 @@ public class HealthMetricsModel : PageModel
     /// </summary>
     /// <param name="connectionStateService">The connection state service.</param>
     /// <param name="latencyHistoryService">The latency history service.</param>
+    /// <param name="memoryDiagnosticsService">The memory diagnostics service.</param>
     /// <param name="logger">The logger.</param>
     public HealthMetricsModel(
         IConnectionStateService connectionStateService,
         ILatencyHistoryService latencyHistoryService,
+        IMemoryDiagnosticsService memoryDiagnosticsService,
         ILogger<HealthMetricsModel> logger)
     {
         _connectionStateService = connectionStateService;
         _latencyHistoryService = latencyHistoryService;
+        _memoryDiagnosticsService = memoryDiagnosticsService;
         _logger = logger;
     }
 
@@ -78,6 +82,9 @@ public class HealthMetricsModel : PageModel
             var gen2Collections = GC.CollectionCount(2);
             var threadCount = process.Threads.Count;
 
+            // Get detailed memory diagnostics
+            var memoryDiagnostics = _memoryDiagnosticsService.GetDiagnostics();
+
             // Format session start time (UTC for client-side conversion)
             var sessionStart = _connectionStateService.GetLastConnectedTime();
             var sessionStartFormatted = sessionStart?.ToString("MMM dd, yyyy 'at' HH:mm") + " UTC" ?? "Unknown";
@@ -113,7 +120,8 @@ public class HealthMetricsModel : PageModel
                 MemoryUtilizationPercent = memoryUtilizationPercent,
                 Gen2Collections = gen2Collections,
                 CpuUsagePercent = 0, // TODO: CPU calculation requires time delta, will be handled via JavaScript/SignalR
-                ThreadCount = threadCount
+                ThreadCount = threadCount,
+                MemoryDiagnostics = memoryDiagnostics
             };
 
             _logger.LogDebug(

--- a/src/DiscordBot.Bot/Services/MemoryDiagnosticsService.cs
+++ b/src/DiscordBot.Bot/Services/MemoryDiagnosticsService.cs
@@ -1,0 +1,124 @@
+using System.Diagnostics;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace DiscordBot.Bot.Services;
+
+/// <summary>
+/// Service for aggregating memory diagnostics from all IMemoryReportable services.
+/// Caches results to avoid expensive repeated GC calls.
+/// </summary>
+public class MemoryDiagnosticsService : IMemoryDiagnosticsService
+{
+    private readonly IEnumerable<IMemoryReportable> _memoryReportableServices;
+    private readonly ILogger<MemoryDiagnosticsService> _logger;
+
+    private MemoryDiagnosticsDto? _cachedReport;
+    private DateTime _cacheExpiry = DateTime.MinValue;
+    private readonly TimeSpan _cacheDuration = TimeSpan.FromSeconds(5);
+    private readonly object _lock = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MemoryDiagnosticsService"/> class.
+    /// </summary>
+    /// <param name="memoryReportableServices">All services implementing IMemoryReportable.</param>
+    /// <param name="logger">The logger.</param>
+    public MemoryDiagnosticsService(
+        IEnumerable<IMemoryReportable> memoryReportableServices,
+        ILogger<MemoryDiagnosticsService> logger)
+    {
+        _memoryReportableServices = memoryReportableServices;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public MemoryDiagnosticsDto GetDiagnostics()
+    {
+        lock (_lock)
+        {
+            if (_cachedReport != null && DateTime.UtcNow < _cacheExpiry)
+            {
+                return _cachedReport;
+            }
+
+            var gcInfo = GetGcGenerationSizes();
+            var serviceReports = _memoryReportableServices
+                .Select(s =>
+                {
+                    try
+                    {
+                        return s.GetMemoryReport();
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Failed to get memory report from {ServiceName}", s.ServiceName);
+                        return new ServiceMemoryReportDto
+                        {
+                            ServiceName = s.ServiceName,
+                            EstimatedBytes = 0,
+                            ItemCount = 0,
+                            Details = "Error collecting memory report"
+                        };
+                    }
+                })
+                .OrderByDescending(r => r.EstimatedBytes)
+                .ToList();
+
+            var totalAccounted = serviceReports.Sum(r => r.EstimatedBytes);
+            var process = Process.GetCurrentProcess();
+
+            // Unaccounted is the difference between total committed and what we've tracked
+            // This includes framework overhead, native memory, and services not yet instrumented
+            var unaccounted = Math.Max(0, gcInfo.TotalCommittedBytes - totalAccounted);
+
+            _cachedReport = new MemoryDiagnosticsDto
+            {
+                Timestamp = DateTime.UtcNow,
+                GcGenerations = gcInfo,
+                ServiceReports = serviceReports,
+                TotalAccountedBytes = totalAccounted,
+                UnaccountedBytes = unaccounted,
+                WorkingSetBytes = process.WorkingSet64,
+                ManagedHeapBytes = GC.GetTotalMemory(false)
+            };
+
+            _cacheExpiry = DateTime.UtcNow.Add(_cacheDuration);
+
+            _logger.LogDebug(
+                "Memory diagnostics collected: {ServiceCount} services, {AccountedKB:F1} KB accounted, {UnaccountedMB:F2} MB unaccounted",
+                serviceReports.Count,
+                totalAccounted / 1024.0,
+                unaccounted / (1024.0 * 1024.0));
+
+            return _cachedReport;
+        }
+    }
+
+    /// <inheritdoc/>
+    public GcGenerationSizesDto GetGcGenerationSizes()
+    {
+        var gcInfo = GC.GetGCMemoryInfo();
+
+        // Calculate fragmentation: fragmented / heap size * 100
+        var totalHeap = gcInfo.HeapSizeBytes;
+        var fragmentedBytes = gcInfo.FragmentedBytes;
+        var fragmentationPercent = totalHeap > 0
+            ? (double)fragmentedBytes / totalHeap * 100.0
+            : 0.0;
+
+        return new GcGenerationSizesDto
+        {
+            Gen0SizeBytes = gcInfo.GenerationInfo[0].SizeAfterBytes,
+            Gen1SizeBytes = gcInfo.GenerationInfo[1].SizeAfterBytes,
+            Gen2SizeBytes = gcInfo.GenerationInfo[2].SizeAfterBytes,
+            LohSizeBytes = gcInfo.GenerationInfo[3].SizeAfterBytes,
+            // POH is index 4, available in .NET 5+
+            PohSizeBytes = gcInfo.GenerationInfo.Length > 4
+                ? gcInfo.GenerationInfo[4].SizeAfterBytes
+                : 0,
+            TotalCommittedBytes = gcInfo.TotalCommittedBytes,
+            FragmentationPercent = fragmentationPercent
+        };
+    }
+}

--- a/src/DiscordBot.Bot/ViewModels/Pages/HealthMetricsViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Pages/HealthMetricsViewModel.cs
@@ -8,6 +8,11 @@ namespace DiscordBot.Bot.ViewModels.Pages;
 public record HealthMetricsViewModel
 {
     /// <summary>
+    /// Gets the detailed memory diagnostics including GC and service breakdown.
+    /// </summary>
+    public MemoryDiagnosticsDto? MemoryDiagnostics { get; init; }
+
+    /// <summary>
     /// Gets the current health status of the bot.
     /// </summary>
     public PerformanceHealthDto Health { get; init; } = new();
@@ -148,6 +153,37 @@ public record HealthMetricsViewModel
             < 100 => "gauge-fill-healthy",
             < 200 => "gauge-fill-warning",
             _ => "gauge-fill-error"
+        };
+    }
+
+    /// <summary>
+    /// Formats bytes to a human-readable string with appropriate unit.
+    /// </summary>
+    /// <param name="bytes">The number of bytes to format.</param>
+    /// <returns>A formatted string like "1.5 GB", "256.3 MB", "64.0 KB", or "512 B".</returns>
+    public static string FormatBytes(long bytes)
+    {
+        if (bytes >= 1024L * 1024L * 1024L)
+            return $"{bytes / (1024.0 * 1024.0 * 1024.0):F1} GB";
+        if (bytes >= 1024L * 1024L)
+            return $"{bytes / (1024.0 * 1024.0):F1} MB";
+        if (bytes >= 1024L)
+            return $"{bytes / 1024.0:F1} KB";
+        return $"{bytes} B";
+    }
+
+    /// <summary>
+    /// Gets the CSS class for fragmentation percentage styling.
+    /// </summary>
+    /// <param name="fragmentationPercent">The fragmentation percentage (0-100).</param>
+    /// <returns>A CSS class name for text coloring.</returns>
+    public static string GetFragmentationClass(double fragmentationPercent)
+    {
+        return fragmentationPercent switch
+        {
+            < 10 => "text-success",
+            < 25 => "text-warning",
+            _ => "text-error"
         };
     }
 }

--- a/src/DiscordBot.Core/DTOs/MemoryDiagnosticsDtos.cs
+++ b/src/DiscordBot.Core/DTOs/MemoryDiagnosticsDtos.cs
@@ -1,0 +1,110 @@
+namespace DiscordBot.Core.DTOs;
+
+/// <summary>
+/// Memory usage report for a single service.
+/// </summary>
+public record ServiceMemoryReportDto
+{
+    /// <summary>
+    /// Gets the display name of the service.
+    /// </summary>
+    public string ServiceName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the estimated memory usage in bytes.
+    /// </summary>
+    public long EstimatedBytes { get; init; }
+
+    /// <summary>
+    /// Gets the number of items/entries being tracked by this service.
+    /// </summary>
+    public int ItemCount { get; init; }
+
+    /// <summary>
+    /// Gets additional details about memory usage (e.g., buffer occupancy, configuration).
+    /// </summary>
+    public string? Details { get; init; }
+}
+
+/// <summary>
+/// GC heap generation sizes and fragmentation information.
+/// </summary>
+public record GcGenerationSizesDto
+{
+    /// <summary>
+    /// Gets the Generation 0 heap size in bytes.
+    /// </summary>
+    public long Gen0SizeBytes { get; init; }
+
+    /// <summary>
+    /// Gets the Generation 1 heap size in bytes.
+    /// </summary>
+    public long Gen1SizeBytes { get; init; }
+
+    /// <summary>
+    /// Gets the Generation 2 heap size in bytes.
+    /// </summary>
+    public long Gen2SizeBytes { get; init; }
+
+    /// <summary>
+    /// Gets the Large Object Heap (LOH) size in bytes.
+    /// </summary>
+    public long LohSizeBytes { get; init; }
+
+    /// <summary>
+    /// Gets the Pinned Object Heap (POH) size in bytes (.NET 5+).
+    /// </summary>
+    public long PohSizeBytes { get; init; }
+
+    /// <summary>
+    /// Gets the total committed memory in bytes.
+    /// </summary>
+    public long TotalCommittedBytes { get; init; }
+
+    /// <summary>
+    /// Gets the heap fragmentation percentage (0-100).
+    /// </summary>
+    public double FragmentationPercent { get; init; }
+}
+
+/// <summary>
+/// Complete memory diagnostics including GC info and service breakdown.
+/// </summary>
+public record MemoryDiagnosticsDto
+{
+    /// <summary>
+    /// Gets the timestamp when this report was generated (UTC).
+    /// </summary>
+    public DateTime Timestamp { get; init; }
+
+    /// <summary>
+    /// Gets the GC generation sizes and fragmentation info.
+    /// </summary>
+    public GcGenerationSizesDto GcGenerations { get; init; } = new();
+
+    /// <summary>
+    /// Gets the collection of service memory reports, ordered by size descending.
+    /// </summary>
+    public IReadOnlyList<ServiceMemoryReportDto> ServiceReports { get; init; } = Array.Empty<ServiceMemoryReportDto>();
+
+    /// <summary>
+    /// Gets the total accounted memory from all services in bytes.
+    /// </summary>
+    public long TotalAccountedBytes { get; init; }
+
+    /// <summary>
+    /// Gets the unaccounted memory in bytes (committed - accounted).
+    /// This includes framework overhead, native memory, and services not yet instrumented.
+    /// </summary>
+    public long UnaccountedBytes { get; init; }
+
+    /// <summary>
+    /// Gets the working set memory in bytes (total physical memory used).
+    /// </summary>
+    public long WorkingSetBytes { get; init; }
+
+    /// <summary>
+    /// Gets the managed heap size in bytes (via GC.GetTotalMemory).
+    /// </summary>
+    public long ManagedHeapBytes { get; init; }
+}

--- a/src/DiscordBot.Core/Interfaces/IMemoryDiagnosticsService.cs
+++ b/src/DiscordBot.Core/Interfaces/IMemoryDiagnosticsService.cs
@@ -1,0 +1,22 @@
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Core.Interfaces;
+
+/// <summary>
+/// Service for aggregating and reporting memory diagnostics across all services.
+/// </summary>
+public interface IMemoryDiagnosticsService
+{
+    /// <summary>
+    /// Gets the complete memory diagnostics report including GC info and service breakdown.
+    /// Results are cached for a short duration to avoid expensive GC calls.
+    /// </summary>
+    /// <returns>Complete memory diagnostics report.</returns>
+    MemoryDiagnosticsDto GetDiagnostics();
+
+    /// <summary>
+    /// Gets just the GC generation sizes (useful for lightweight polling).
+    /// </summary>
+    /// <returns>GC generation size information.</returns>
+    GcGenerationSizesDto GetGcGenerationSizes();
+}

--- a/src/DiscordBot.Core/Interfaces/IMemoryReportable.cs
+++ b/src/DiscordBot.Core/Interfaces/IMemoryReportable.cs
@@ -1,0 +1,21 @@
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Core.Interfaces;
+
+/// <summary>
+/// Interface for services that can report their memory consumption.
+/// Implementing services should calculate their approximate in-memory footprint.
+/// </summary>
+public interface IMemoryReportable
+{
+    /// <summary>
+    /// Gets the display name for this service in memory reports.
+    /// </summary>
+    string ServiceName { get; }
+
+    /// <summary>
+    /// Gets the estimated memory usage of this service.
+    /// </summary>
+    /// <returns>Memory report containing usage details.</returns>
+    ServiceMemoryReportDto GetMemoryReport();
+}


### PR DESCRIPTION
## Summary

- Adds granular memory diagnostics to the Health Metrics page displaying GC heap generation sizes (Gen 0, 1, 2, LOH, POH), heap fragmentation percentage, and per-service memory usage estimates
- Implements `IMemoryReportable` interface that services can use to report their memory consumption, with three services now reporting: `LatencyHistoryService`, `ApiRequestTracker`, and `InteractionStateService`
- Creates `MemoryDiagnosticsService` to aggregate all memory reports and provide GC memory info with 5-second caching to avoid expensive repeated GC calls

## Changes

### New Files
- `IMemoryReportable.cs` - Interface for memory-reporting services
- `IMemoryDiagnosticsService.cs` - Aggregation service interface
- `MemoryDiagnosticsDtos.cs` - DTOs for memory reports (ServiceMemoryReportDto, GcGenerationSizesDto, MemoryDiagnosticsDto)
- `MemoryDiagnosticsService.cs` - Aggregation service implementation

### Modified Files
- `LatencyHistoryService.cs` - Implements IMemoryReportable (~46 KB circular buffer)
- `ApiRequestTracker.cs` - Implements IMemoryReportable (~90-110 KB tracking data)
- `InteractionStateService.cs` - Implements IMemoryReportable (~320 bytes per active state)
- `PerformanceMetricsServiceExtensions.cs` - Registers MemoryDiagnosticsService
- `HealthMetricsViewModel.cs` - Adds MemoryDiagnostics property and FormatBytes/GetFragmentationClass helpers
- `HealthMetrics.cshtml.cs` - Injects and uses IMemoryDiagnosticsService
- `HealthMetrics.cshtml` - Adds Memory Breakdown UI section

## Test plan

- [x] Build succeeds with no new errors
- [x] Existing tests for LatencyHistoryService, ApiRequestTracker, and InteractionStateService pass
- [ ] Navigate to `/Admin/Performance/HealthMetrics` and verify Memory Breakdown section displays
- [ ] Verify GC generation sizes show non-zero values
- [ ] Verify fragmentation percentage is in 0-100% range with appropriate color coding
- [ ] Verify service memory reports show accurate details strings
- [ ] Verify unaccounted memory is reasonable (not negative)

Closes #609

🤖 Generated with [Claude Code](https://claude.com/claude-code)