### PR TITLE
Add preview popups to additional pages

### DIFF
--- a/src/DiscordBot.Bot/Pages/Admin/Performance/Commands.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/Commands.cshtml
@@ -217,11 +217,11 @@ else
                                 <td class="text-text-secondary">
                                     @if (!string.IsNullOrEmpty(cmd.Username))
                                     {
-                                        <span title="User ID: @cmd.UserId">@cmd.Username</span>
+                                        <span class="preview-trigger" data-preview-type="user" data-user-id="@cmd.UserId" @(cmd.GuildId.HasValue ? $"data-context-guild-id=\"{cmd.GuildId}\"" : "") title="User ID: @cmd.UserId">@cmd.Username</span>
                                     }
                                     else
                                     {
-                                        <span class="text-mono">@cmd.UserId</span>
+                                        <span class="preview-trigger text-mono" data-preview-type="user" data-user-id="@cmd.UserId" @(cmd.GuildId.HasValue ? $"data-context-guild-id=\"{cmd.GuildId}\"" : "")>@cmd.UserId</span>
                                     }
                                 </td>
                                 <td class="text-text-secondary">
@@ -229,11 +229,11 @@ else
                                     {
                                         @if (!string.IsNullOrEmpty(cmd.GuildName))
                                         {
-                                            <span title="Guild ID: @cmd.GuildId.Value">@cmd.GuildName</span>
+                                            <span class="preview-trigger" data-preview-type="guild" data-guild-id="@cmd.GuildId.Value" title="Guild ID: @cmd.GuildId.Value">@cmd.GuildName</span>
                                         }
                                         else
                                         {
-                                            <span class="text-mono">@cmd.GuildId.Value</span>
+                                            <span class="preview-trigger text-mono" data-preview-type="guild" data-guild-id="@cmd.GuildId.Value">@cmd.GuildId.Value</span>
                                         }
                                     }
                                     else

--- a/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Incidents.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Incidents.cshtml
@@ -316,11 +316,11 @@
                                         @incident.StatusText
                                     </span>
                                 </td>
-                                <td class="px-6 py-4 whitespace-nowrap">
-                                    <span class="text-sm text-text-primary">@incident.AccusedUsername</span>
+                                <td class="px-6 py-4 whitespace-nowrap" onclick="event.stopPropagation()">
+                                    <span class="preview-trigger text-sm text-text-primary" data-preview-type="user" data-user-id="@incident.AccusedUserId" data-context-guild-id="@Model.ViewModel.GuildId">@incident.AccusedUsername</span>
                                 </td>
-                                <td class="px-6 py-4 whitespace-nowrap">
-                                    <span class="text-sm text-text-secondary">@incident.InitiatorUsername</span>
+                                <td class="px-6 py-4 whitespace-nowrap" onclick="event.stopPropagation()">
+                                    <span class="preview-trigger text-sm text-text-secondary" data-preview-type="user" data-user-id="@incident.InitiatorUserId" data-context-guild-id="@Model.ViewModel.GuildId">@incident.InitiatorUsername</span>
                                 </td>
                                 <td class="px-6 py-4 whitespace-nowrap">
                                     <span class="text-sm text-text-primary" data-utc="@incident.ScheduledAtUtcIso" data-format="datetime-short"></span>

--- a/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Index.cshtml
@@ -329,7 +329,7 @@
                                 <span class="w-8 h-8 flex items-center justify-center rounded-full text-sm font-bold @(entry.Rank == 1 ? "bg-yellow-500/20 text-yellow-500" : entry.Rank == 2 ? "bg-gray-400/20 text-gray-400" : entry.Rank == 3 ? "bg-orange-600/20 text-orange-600" : "bg-bg-tertiary text-text-tertiary")">
                                     @entry.Rank
                                 </span>
-                                <span class="text-sm text-text-primary">@entry.Username</span>
+                                <span class="preview-trigger text-sm text-text-primary" data-preview-type="user" data-user-id="@entry.UserId" data-context-guild-id="@Model.ViewModel.GuildId">@entry.Username</span>
                             </div>
                             <span class="text-sm font-semibold text-error">@entry.GuiltyCount guilty</span>
                         </div>
@@ -416,10 +416,10 @@
                                     </span>
                                 </td>
                                 <td class="px-6 py-4">
-                                    <span class="text-sm text-text-primary">@watch.AccusedUsername</span>
+                                    <span class="preview-trigger text-sm text-text-primary" data-preview-type="user" data-user-id="@watch.AccusedUserId" data-context-guild-id="@Model.ViewModel.GuildId">@watch.AccusedUsername</span>
                                 </td>
                                 <td class="px-6 py-4">
-                                    <span class="text-sm text-text-secondary">@watch.InitiatorUsername</span>
+                                    <span class="preview-trigger text-sm text-text-secondary" data-preview-type="user" data-user-id="@watch.InitiatorUserId" data-context-guild-id="@Model.ViewModel.GuildId">@watch.InitiatorUsername</span>
                                 </td>
                                 <td class="px-6 py-4">
                                     <span class="text-sm text-text-secondary max-w-[200px] truncate block" title="@watch.CustomMessage">

--- a/src/DiscordBot.Bot/Pages/Guilds/Reminders/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Reminders/Index.cshtml
@@ -224,7 +224,7 @@
                                                 </svg>
                                             </div>
                                         }
-                                        <span class="text-sm text-text-primary">@reminder.Username</span>
+                                        <span class="preview-trigger text-sm text-text-primary" data-preview-type="user" data-user-id="@reminder.UserId" data-context-guild-id="@Model.ViewModel.GuildId">@reminder.Username</span>
                                     </div>
                                 </td>
                                 <td class="px-6 py-4">


### PR DESCRIPTION
## Summary

- Add user/guild preview popups to Performance/Commands page (slowest commands table)
- Add user preview popups to Reminders page (user column)
- Add user preview popups to RatWatch Index page (leaderboard and watches table)
- Add user preview popups to RatWatch Incidents page (accused/initiator columns)

## Test plan

- [ ] Navigate to Performance/Commands page, verify hovering over usernames/guild names shows preview popups
- [ ] Navigate to Reminders page for a guild, verify hovering over usernames shows preview popups
- [ ] Navigate to RatWatch Index page, verify hovering over usernames in leaderboard and table shows preview popups
- [ ] Navigate to RatWatch Incidents page, verify hovering over usernames shows preview popups (click propagation is stopped to prevent opening modal)

Closes #719
Closes #720

🤖 Generated with [Claude Code](https://claude.com/claude-code)