### PR TITLE
feat: Add Performance Dashboard shell layout

### DIFF
--- a/src/DiscordBot.Bot/Pages/Admin/Performance/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/Index.cshtml
@@ -11,714 +11,120 @@
 
 @section Styles {
     <link rel="stylesheet" href="~/css/performance-pages.css" />
-    <style>
-        /* Chart Card */
-        .chart-card {
-            background: rgb(35, 38, 40);
-            border: 1px solid rgb(63, 68, 71);
-            border-radius: 0.5rem;
-            overflow: hidden;
-        }
-
-        .chart-card-header {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            padding: 1.25rem;
-            border-bottom: 1px solid rgb(63, 68, 71);
-        }
-
-        .chart-card-title {
-            font-size: 1.125rem;
-            font-weight: 600;
-            color: rgb(215, 211, 208);
-            margin: 0;
-        }
-
-        .chart-card-subtitle {
-            font-size: 0.875rem;
-            color: rgb(168, 165, 163);
-            margin: 0.25rem 0 0;
-        }
-
-        .chart-card-body {
-            padding: 1.25rem;
-        }
-
-        .chart-container {
-            position: relative;
-            height: 300px;
-        }
-
-        /* Status Cards */
-        .status-cards-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-            gap: 1rem;
-            margin-bottom: 2rem;
-        }
-
-        .status-card {
-            display: flex;
-            align-items: center;
-            gap: 1rem;
-            padding: 1rem;
-            background: rgb(35, 38, 40);
-            border: 1px solid rgb(63, 68, 71);
-            border-radius: 0.5rem;
-            transition: all 0.2s;
-            text-decoration: none;
-        }
-
-        .status-card:hover {
-            border-color: rgb(9, 142, 207);
-            background: rgb(40, 43, 46);
-        }
-
-        .status-card-icon {
-            width: 3rem;
-            height: 3rem;
-            border-radius: 0.5rem;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            flex-shrink: 0;
-        }
-
-        .status-card-icon svg {
-            width: 1.5rem;
-            height: 1.5rem;
-        }
-
-        .status-card-content {
-            flex: 1;
-            min-width: 0;
-        }
-
-        .status-card-label {
-            display: block;
-            font-size: 0.75rem;
-            color: rgb(168, 165, 163);
-            margin-bottom: 0.25rem;
-        }
-
-        .status-card-value {
-            display: block;
-            font-size: 1.25rem;
-            font-weight: 600;
-            color: rgb(215, 211, 208);
-        }
-
-        /* Metric Cards */
-        .metric-card {
-            background: rgb(35, 38, 40);
-            border: 1px solid rgb(63, 68, 71);
-            border-radius: 0.5rem;
-            padding: 1.25rem;
-        }
-
-        .metric-header {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 0.75rem;
-        }
-
-        .metric-label {
-            font-size: 0.875rem;
-            color: rgb(168, 165, 163);
-        }
-
-        .metric-icon {
-            width: 1.25rem;
-            height: 1.25rem;
-            color: rgb(168, 165, 163);
-        }
-
-        .metric-value {
-            font-size: 2rem;
-            font-weight: 700;
-            color: rgb(215, 211, 208);
-            line-height: 1;
-        }
-
-        .metric-unit {
-            font-size: 1rem;
-            font-weight: 500;
-            color: rgb(168, 165, 163);
-        }
-
-        .metric-trend {
-            display: flex;
-            align-items: center;
-            gap: 0.25rem;
-            margin-top: 0.5rem;
-            font-size: 0.75rem;
-        }
-
-        .metric-trend-up {
-            color: rgb(16, 185, 129);
-        }
-
-        /* Progress Bar */
-        .progress-labeled {
-            margin-top: 1rem;
-        }
-
-        .progress-header {
-            display: flex;
-            justify-content: space-between;
-            margin-bottom: 0.5rem;
-        }
-
-        .progress-label {
-            font-size: 0.875rem;
-            color: rgb(168, 165, 163);
-        }
-
-        .progress-value {
-            font-size: 0.875rem;
-            color: rgb(215, 211, 208);
-            font-weight: 500;
-        }
-
-        .progress-bar-container {
-            width: 100%;
-            height: 0.5rem;
-            background: rgb(47, 51, 54);
-            border-radius: 9999px;
-            overflow: hidden;
-        }
-
-        .progress-bar-fill {
-            height: 100%;
-            border-radius: 9999px;
-            transition: width 0.3s ease;
-        }
-
-        .progress-bar-healthy {
-            background: rgb(16, 185, 129);
-        }
-
-        .progress-bar-warning {
-            background: rgb(245, 158, 11);
-        }
-
-        .progress-bar-error {
-            background: rgb(239, 68, 68);
-        }
-
-        /* Alert Card */
-        .alert-card {
-            display: flex;
-            gap: 1rem;
-            padding: 1rem;
-            border: 1px solid rgb(63, 68, 71);
-            border-radius: 0.5rem;
-        }
-
-        .alert-card-warning {
-            background: rgba(245, 158, 11, 0.05);
-            border-color: rgba(245, 158, 11, 0.3);
-        }
-
-        .alert-card-info {
-            background: rgba(9, 142, 207, 0.05);
-            border-color: rgba(9, 142, 207, 0.3);
-        }
-
-        .alert-icon {
-            width: 1.25rem;
-            height: 1.25rem;
-            flex-shrink: 0;
-        }
-
-        .alert-icon-warning {
-            color: rgb(245, 158, 11);
-        }
-
-        .alert-icon-info {
-            color: rgb(9, 142, 207);
-        }
-
-        .alert-content {
-            flex: 1;
-            min-width: 0;
-        }
-
-        .alert-title {
-            font-size: 0.875rem;
-            font-weight: 600;
-            color: rgb(215, 211, 208);
-            margin-bottom: 0.25rem;
-        }
-
-        .alert-description {
-            font-size: 0.875rem;
-            color: rgb(168, 165, 163);
-            margin-bottom: 0.5rem;
-        }
-
-        .alert-meta {
-            display: flex;
-            align-items: center;
-            gap: 0.75rem;
-            font-size: 0.75rem;
-            color: rgb(120, 116, 113);
-        }
-
-        .severity-badge {
-            display: inline-flex;
-            align-items: center;
-            padding: 0.125rem 0.5rem;
-            border-radius: 9999px;
-            font-size: 0.75rem;
-            font-weight: 500;
-        }
-
-        .severity-warning {
-            background: rgba(245, 158, 11, 0.2);
-            color: rgb(245, 158, 11);
-        }
-
-        .severity-info {
-            background: rgba(9, 142, 207, 0.2);
-            color: rgb(9, 142, 207);
-        }
-
-        /* Grid Layouts */
-        .performance-grid-2 {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-            gap: 1.5rem;
-        }
-
-        /* Button Styles */
-        .btn {
-            display: inline-flex;
-            align-items: center;
-            gap: 0.5rem;
-            padding: 0.5rem 1rem;
-            font-size: 0.875rem;
-            font-weight: 500;
-            border-radius: 0.375rem;
-            transition: all 0.2s;
-            text-decoration: none;
-            border: none;
-            cursor: pointer;
-        }
-
-        .btn-secondary {
-            background: rgb(47, 51, 54);
-            color: rgb(215, 211, 208);
-            border: 1px solid rgb(63, 68, 71);
-        }
-
-        .btn-secondary:hover {
-            background: rgb(55, 60, 63);
-            border-color: rgb(99, 102, 104);
-        }
-
-        .btn-svg-icon {
-            width: 1rem;
-            height: 1rem;
-        }
-    </style>
+    <link rel="stylesheet" href="~/css/performance-shell.css" />
 }
 
-<!-- Page Header -->
-<div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 mb-6">
-    <div class="flex items-center gap-3">
+<!-- Skip Link for Accessibility -->
+<a href="#tabContent" class="performance-skip-link">Skip to content</a>
+
+<div class="performance-shell">
+    <!-- Shell Header -->
+    <header class="performance-shell-header">
         <div>
-            <h1 class="text-2xl lg:text-3xl font-bold text-text-primary">Bot Performance</h1>
-            <p class="text-text-secondary mt-1">Real-time monitoring and performance metrics</p>
-        </div>
-        <div class="live-indicator" id="liveIndicator">
-            <span class="live-dot"></span>
-            <span class="live-text">Live</span>
-        </div>
-    </div>
-
-    <!-- Overall Health Status -->
-    <div class="health-status @Model.ViewModel.OverallStatusClass">
-        @{
-            var statusIcon = Model.ViewModel.OverallStatus.ToLowerInvariant() switch
-            {
-                "healthy" => @"<svg class=""w-4 h-4"" fill=""none"" viewBox=""0 0 24 24"" stroke=""currentColor""><path stroke-linecap=""round"" stroke-linejoin=""round"" stroke-width=""2"" d=""M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"" /></svg>",
-                "warning" => @"<svg class=""w-4 h-4"" fill=""none"" viewBox=""0 0 24 24"" stroke=""currentColor""><path stroke-linecap=""round"" stroke-linejoin=""round"" stroke-width=""2"" d=""M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"" /></svg>",
-                "critical" => @"<svg class=""w-4 h-4"" fill=""none"" viewBox=""0 0 24 24"" stroke=""currentColor""><path stroke-linecap=""round"" stroke-linejoin=""round"" stroke-width=""2"" d=""M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"" /></svg>",
-                _ => @"<svg class=""w-4 h-4"" fill=""none"" viewBox=""0 0 24 24"" stroke=""currentColor""><path stroke-linecap=""round"" stroke-linejoin=""round"" stroke-width=""2"" d=""M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"" /></svg>"
-            };
-        }
-        @Html.Raw(statusIcon)
-        <span>@Model.ViewModel.OverallStatusText</span>
-    </div>
-</div>
-
-<!-- Navigation Tabs -->
-@await Html.PartialAsync("Components/_PerformanceTabs", new DiscordBot.Bot.ViewModels.Components.PerformanceTabsViewModel
-{
-    ActiveTab = "overview",
-    ActiveAlertCount = Model.ViewModel.ActiveAlertCount
-})
-
-<!-- Quick Status Cards -->
-<div class="status-cards-grid mb-8">
-    <!-- Bot Health -->
-    <a href="/Admin/Performance/HealthMetrics" class="status-card group">
-        <div class="status-card-icon bg-success/10">
-            <svg class="text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
-            </svg>
-        </div>
-        <div class="status-card-content">
-            <span class="status-card-label">Bot Health</span>
-            <span class="status-card-value @Model.ViewModel.BotHealthStatusClass">@Model.ViewModel.BotHealthStatusText</span>
-        </div>
-        <svg class="w-4 h-4 text-text-tertiary group-hover:text-accent-blue transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-        </svg>
-    </a>
-
-    <!-- Command Performance -->
-    <a href="/Admin/Performance/Commands" class="status-card group">
-        <div class="status-card-icon bg-accent-blue/10">
-            <svg class="text-accent-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
-            </svg>
-        </div>
-        <div class="status-card-content">
-            <span class="status-card-label">Avg Response</span>
-            <span class="status-card-value">@Model.ViewModel.AvgCommandResponseMs.ToString("F0")ms</span>
-        </div>
-        <svg class="w-4 h-4 text-text-tertiary group-hover:text-accent-blue transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-        </svg>
-    </a>
-
-    <!-- API Health -->
-    <a href="/Admin/Performance/ApiMetrics" class="status-card group">
-        <div class="status-card-icon bg-success/10">
-            <svg class="text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-            </svg>
-        </div>
-        <div class="status-card-content">
-            <span class="status-card-label">API Status</span>
-            <span class="status-card-value text-success">@Model.ViewModel.ApiRateLimitFormatted</span>
-        </div>
-        <svg class="w-4 h-4 text-text-tertiary group-hover:text-accent-blue transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-        </svg>
-    </a>
-
-    <!-- System Health -->
-    <a href="/Admin/Performance/SystemHealth" class="status-card group">
-        <div class="status-card-icon bg-success/10">
-            <svg class="text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" />
-            </svg>
-        </div>
-        <div class="status-card-content">
-            <span class="status-card-label">System</span>
-            <span class="status-card-value text-success">Normal</span>
-        </div>
-        <svg class="w-4 h-4 text-text-tertiary group-hover:text-accent-blue transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-        </svg>
-    </a>
-
-    <!-- Active Alerts -->
-    <a href="/Admin/Performance/Alerts" class="status-card group">
-        <div class="status-card-icon @(Model.ViewModel.ActiveAlertCount > 0 ? "bg-warning/10" : "bg-success/10")">
-            <svg class="@(Model.ViewModel.ActiveAlertCount > 0 ? "text-warning" : "text-success")" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
-            </svg>
-        </div>
-        <div class="status-card-content">
-            <span class="status-card-label">Active Alerts</span>
-            <span class="status-card-value @(Model.ViewModel.ActiveAlertCount > 0 ? "text-warning" : "text-success")">@Model.ViewModel.ActiveAlertCount</span>
-        </div>
-        <svg class="w-4 h-4 text-text-tertiary group-hover:text-accent-blue transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-        </svg>
-    </a>
-</div>
-
-<!-- Key Metrics Row -->
-<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-    <!-- Uptime -->
-    <div class="metric-card">
-        <div class="metric-header">
-            <span class="metric-label">Uptime</span>
-            <svg class="metric-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-        </div>
-        <div class="metric-value">@Model.ViewModel.Uptime30DaysPercent.ToString("F1")<span class="metric-unit">%</span></div>
-        <div class="metric-trend metric-trend-up">
-            <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18" />
-            </svg>
-            Last 30 days
-        </div>
-    </div>
-
-    <!-- Latency -->
-    <div class="metric-card">
-        <div class="metric-header">
-            <span class="metric-label">Avg Latency</span>
-            <svg class="metric-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
-            </svg>
-        </div>
-        <div class="metric-value">@Model.ViewModel.AvgLatencyMs<span class="metric-unit">ms</span></div>
-        <div class="metric-trend metric-trend-up">
-            <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18" />
-            </svg>
-            Gateway heartbeat
-        </div>
-    </div>
-
-    <!-- Commands Today -->
-    <div class="metric-card">
-        <div class="metric-header">
-            <span class="metric-label">Commands Today</span>
-            <svg class="metric-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
-            </svg>
-        </div>
-        <div class="metric-value">@Model.ViewModel.CommandsToday.ToString("N0")</div>
-        <div class="metric-trend metric-trend-up">
-            <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18" />
-            </svg>
-            Last 24 hours
-        </div>
-    </div>
-
-    <!-- Error Rate -->
-    <div class="metric-card">
-        <div class="metric-header">
-            <span class="metric-label">Error Rate</span>
-            <svg class="metric-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-        </div>
-        <div class="metric-value">@Model.ViewModel.ErrorRate.ToString("F1")<span class="metric-unit">%</span></div>
-        <div class="metric-trend metric-trend-up">
-            <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18" />
-            </svg>
-            Last 24 hours
-        </div>
-    </div>
-</div>
-
-<!-- Charts Row -->
-<div class="performance-grid-2 mb-6">
-    <!-- Response Time Trend -->
-    <div class="chart-card">
-        <div class="chart-card-header">
-            <div>
-                <h2 class="chart-card-title">Response Time Trend</h2>
-                <p class="chart-card-subtitle">Average command response time (last 24 hours)</p>
-            </div>
-        </div>
-        <div class="chart-card-body">
-            <div class="chart-container">
-                <canvas id="responseTimeChart"></canvas>
-            </div>
-        </div>
-    </div>
-
-    <!-- Command Throughput -->
-    <div class="chart-card">
-        <div class="chart-card-header">
-            <div>
-                <h2 class="chart-card-title">Command Throughput</h2>
-                <p class="chart-card-subtitle">Commands per hour (last 24 hours)</p>
-            </div>
-        </div>
-        <div class="chart-card-body">
-            <div class="chart-container">
-                <canvas id="throughputChart"></canvas>
-            </div>
-        </div>
-    </div>
-</div>
-
-<!-- Resource Usage & Recent Alerts -->
-<div class="performance-grid-2 mb-6">
-    <!-- Resource Usage -->
-    <div class="chart-card">
-        <div class="chart-card-header">
-            <div>
-                <h2 class="chart-card-title">Resource Usage</h2>
-                <p class="chart-card-subtitle">Current system resource utilization</p>
-            </div>
-            <a href="/Admin/Performance/SystemHealth" class="text-sm font-medium text-accent-blue hover:text-accent-blue-hover transition-colors">
-                View Details
-            </a>
-        </div>
-        <div class="chart-card-body space-y-6">
-            <!-- Memory -->
-            <div class="progress-labeled">
-                <div class="progress-header">
-                    <span class="progress-label">Memory</span>
-                    <span class="progress-value">@Model.ViewModel.MemoryUsageFormatted</span>
-                </div>
-                <div class="progress-bar-container">
-                    <div class="progress-bar-fill @Model.ViewModel.MemoryUsageProgressClass" style="width: @Model.ViewModel.MemoryUsagePercent.ToString("F0")%;"></div>
+            <div class="performance-shell-title-group">
+                <h1 class="performance-shell-title">Bot Performance</h1>
+                <div class="live-indicator" id="liveIndicator">
+                    <span class="live-dot"></span>
+                    <span class="live-text">Live</span>
                 </div>
             </div>
-
-            <!-- CPU -->
-            <div class="progress-labeled">
-                <div class="progress-header">
-                    <span class="progress-label">CPU</span>
-                    <span class="progress-value" id="cpuUsageText">0%</span>
-                </div>
-                <div class="progress-bar-container">
-                    <div class="progress-bar-fill progress-bar-healthy" id="cpuProgressBar" style="width: 0%;"></div>
-                </div>
-            </div>
-
-            <!-- Database Connections -->
-            <div class="progress-labeled">
-                <div class="progress-header">
-                    <span class="progress-label">DB Connections</span>
-                    <span class="progress-value">@Model.ViewModel.DatabaseConnectionsFormatted</span>
-                </div>
-                <div class="progress-bar-container">
-                    <div class="progress-bar-fill progress-bar-healthy" style="width: 40%;"></div>
-                </div>
-            </div>
-
-            <!-- Discord API -->
-            <div class="progress-labeled">
-                <div class="progress-header">
-                    <span class="progress-label">API Rate Limit</span>
-                    <span class="progress-value">@Model.ViewModel.ApiRateLimitFormatted</span>
-                </div>
-                <div class="progress-bar-container">
-                    <div class="progress-bar-fill @Model.ViewModel.ApiRateLimitProgressClass" style="width: @Model.ViewModel.ApiRateLimitPercent.ToString("F0")%;"></div>
-                </div>
-            </div>
+            <p class="performance-shell-subtitle">Real-time monitoring and performance metrics</p>
         </div>
-    </div>
 
-    <!-- Recent Alerts -->
-    <div class="chart-card">
-        <div class="chart-card-header">
-            <div>
-                <h2 class="chart-card-title">Recent Alerts</h2>
-                <p class="chart-card-subtitle">Active and recent system alerts</p>
+        <div class="performance-shell-controls">
+            <!-- Time Range Selector -->
+            <div class="time-range-selector" role="group" aria-label="Time range">
+                <button type="button" class="time-range-option active" data-hours="24">24h</button>
+                <button type="button" class="time-range-option" data-hours="168">7d</button>
+                <button type="button" class="time-range-option" data-hours="720">30d</button>
             </div>
-            <a href="/Admin/Performance/Alerts" class="text-sm font-medium text-accent-blue hover:text-accent-blue-hover transition-colors">
-                View All
-            </a>
-        </div>
-        <div class="chart-card-body p-0">
-            @if (Model.ViewModel.RecentAlerts.Any())
-            {
-                <div class="divide-y divide-border-primary">
-                    @foreach (var alert in Model.ViewModel.RecentAlerts)
+
+            <!-- Overall Health Status -->
+            <div class="health-status @Model.ShellViewModel.OverallStatusClass">
+                @{
+                    var statusIcon = Model.ShellViewModel.OverallStatus.ToLowerInvariant() switch
                     {
-                        var severityStr = alert.Severity.ToString().ToLowerInvariant();
-                        var severityClass = severityStr switch
-                        {
-                            "critical" => "alert-card-warning",
-                            "warning" => "alert-card-warning",
-                            _ => "alert-card-info"
-                        };
-                        var iconClass = severityStr switch
-                        {
-                            "critical" => "alert-icon text-error",
-                            "warning" => "alert-icon alert-icon-warning",
-                            _ => "alert-icon alert-icon-info"
-                        };
-                        var severityBadgeClass = severityStr switch
-                        {
-                            "critical" => "inline-flex items-center px-2 py-0.5 text-xs font-medium bg-error/20 text-error rounded",
-                            "warning" => "severity-badge severity-warning",
-                            _ => "severity-badge severity-info"
-                        };
+                        "healthy" => @"<svg class=""w-4 h-4"" fill=""none"" viewBox=""0 0 24 24"" stroke=""currentColor""><path stroke-linecap=""round"" stroke-linejoin=""round"" stroke-width=""2"" d=""M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"" /></svg>",
+                        "warning" => @"<svg class=""w-4 h-4"" fill=""none"" viewBox=""0 0 24 24"" stroke=""currentColor""><path stroke-linecap=""round"" stroke-linejoin=""round"" stroke-width=""2"" d=""M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"" /></svg>",
+                        "critical" => @"<svg class=""w-4 h-4"" fill=""none"" viewBox=""0 0 24 24"" stroke=""currentColor""><path stroke-linecap=""round"" stroke-linejoin=""round"" stroke-width=""2"" d=""M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"" /></svg>",
+                        _ => @"<svg class=""w-4 h-4"" fill=""none"" viewBox=""0 0 24 24"" stroke=""currentColor""><path stroke-linecap=""round"" stroke-linejoin=""round"" stroke-width=""2"" d=""M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"" /></svg>"
+                    };
+                }
+                @Html.Raw(statusIcon)
+                <span>@Model.ShellViewModel.OverallStatusText</span>
+            </div>
+        </div>
+    </header>
 
-                        <div class="alert-card border-0 rounded-none @severityClass">
-                            <svg class="@iconClass" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-                            </svg>
-                            <div class="alert-content">
-                                <div class="alert-title">@alert.Message</div>
-                                @if (!string.IsNullOrEmpty(alert.Notes))
-                                {
-                                    <div class="alert-description">@alert.Notes</div>
-                                }
-                                <div class="alert-meta">
-                                    <span class="@severityBadgeClass">@alert.Severity</span>
-                                    <span data-utc-time="@alert.TriggeredAt.ToString("o")" data-format="relative">@((DateTime.UtcNow - alert.TriggeredAt).TotalMinutes < 60 ? $"{(int)(DateTime.UtcNow - alert.TriggeredAt).TotalMinutes} minutes ago" : $"{(int)(DateTime.UtcNow - alert.TriggeredAt).TotalHours} hours ago")</span>
-                                </div>
-                            </div>
-                        </div>
-                    }
-                </div>
-            }
-            else
-            {
-                <div class="text-center py-8">
-                    <svg class="w-12 h-12 mx-auto mb-3 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                    </svg>
-                    <div class="text-text-secondary font-medium">No active alerts</div>
-                    <div class="text-text-tertiary text-sm">All systems operating normally</div>
-                </div>
-            }
-        </div>
-    </div>
-</div>
+    <!-- Tab Navigation -->
+    @await Html.PartialAsync("Components/_PerformanceTabNav", Model.ShellViewModel)
 
-<!-- Quick Actions -->
-<div class="chart-card">
-    <div class="chart-card-header">
-        <div>
-            <h2 class="chart-card-title">Quick Actions</h2>
-            <p class="chart-card-subtitle">Common performance management tasks</p>
+    <!-- Tab Content Area -->
+    <main class="performance-shell-content" id="tabContent">
+        <!-- Overview Tab Panel -->
+        <div class="performance-tab-panel active" id="tabPanel-overview" role="tabpanel" aria-labelledby="tab-overview">
+            @await Html.PartialAsync("_OverviewTabContent", Model.ViewModel)
         </div>
-    </div>
-    <div class="chart-card-body">
-        <div class="flex flex-wrap gap-3">
-            <button class="btn btn-secondary" onclick="alert('Bot restart functionality would be implemented here')">
-                <svg class="btn-svg-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+
+        <!-- Health Metrics Tab Panel -->
+        <div class="performance-tab-panel" id="tabPanel-health" role="tabpanel" aria-labelledby="tab-health" hidden>
+            <div class="performance-placeholder">
+                <svg class="performance-placeholder-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
                 </svg>
-                Restart Bot
-            </button>
-            <button class="btn btn-secondary" onclick="alert('Clear cache functionality would be implemented here')">
-                <svg class="btn-svg-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                </svg>
-                Clear Cache
-            </button>
-            <button class="btn btn-secondary" onclick="alert('Export metrics functionality would be implemented here')">
-                <svg class="btn-svg-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-                </svg>
-                Export Metrics
-            </button>
-            <a href="/Admin/Performance/Alerts" class="btn btn-secondary">
-                <svg class="btn-svg-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                </svg>
-                Configure Alerts
-            </a>
+                <h3 class="performance-placeholder-title">Health Metrics</h3>
+                <p class="performance-placeholder-description">Bot health and connection status will be loaded here via AJAX.</p>
+            </div>
         </div>
-    </div>
+
+        <!-- Commands Tab Panel -->
+        <div class="performance-tab-panel" id="tabPanel-commands" role="tabpanel" aria-labelledby="tab-commands" hidden>
+            <div class="performance-placeholder">
+                <svg class="performance-placeholder-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
+                </svg>
+                <h3 class="performance-placeholder-title">Command Performance</h3>
+                <p class="performance-placeholder-description">Command execution metrics and response times will be loaded here via AJAX.</p>
+            </div>
+        </div>
+
+        <!-- API Tab Panel -->
+        <div class="performance-tab-panel" id="tabPanel-api" role="tabpanel" aria-labelledby="tab-api" hidden>
+            <div class="performance-placeholder">
+                <svg class="performance-placeholder-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                </svg>
+                <h3 class="performance-placeholder-title">API & Rate Limits</h3>
+                <p class="performance-placeholder-description">Discord API usage and rate limit metrics will be loaded here via AJAX.</p>
+            </div>
+        </div>
+
+        <!-- System Tab Panel -->
+        <div class="performance-tab-panel" id="tabPanel-system" role="tabpanel" aria-labelledby="tab-system" hidden>
+            <div class="performance-placeholder">
+                <svg class="performance-placeholder-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" />
+                </svg>
+                <h3 class="performance-placeholder-title">System Health</h3>
+                <p class="performance-placeholder-description">Database, cache, and background service status will be loaded here via AJAX.</p>
+            </div>
+        </div>
+
+        <!-- Alerts Tab Panel -->
+        <div class="performance-tab-panel" id="tabPanel-alerts" role="tabpanel" aria-labelledby="tab-alerts" hidden>
+            <div class="performance-placeholder">
+                <svg class="performance-placeholder-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+                </svg>
+                <h3 class="performance-placeholder-title">Performance Alerts</h3>
+                <p class="performance-placeholder-description">Alert thresholds and incident management will be loaded here via AJAX.</p>
+            </div>
+        </div>
+    </main>
 </div>
 
 @section Scripts {
+    <script src="~/js/performance-shell.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
     <script src="~/js/realtime-ui.js"></script>
     <script>
@@ -729,7 +135,7 @@
         let responseTimeChart;
         let throughputChart;
 
-        // Initialize charts
+        // Initialize charts for overview tab
         async function initCharts() {
             try {
                 // Fetch command performance data
@@ -741,129 +147,114 @@
                 const throughputData = await throughputResponse.json();
 
                 // Response Time Chart
-                const responseCtx = document.getElementById('responseTimeChart').getContext('2d');
-                const responseLabels = performanceData.slice(0, 12).map((_, i) => {
-                    const hour = new Date().getHours() - (12 - i);
-                    return `${(hour + 24) % 24}:00`;
-                });
-                const responseValues = performanceData.slice(0, 12).map(d => d.avgDurationMs || 0);
+                const responseCtx = document.getElementById('responseTimeChart');
+                if (responseCtx) {
+                    const responseLabels = performanceData.slice(0, 12).map((_, i) => {
+                        const hour = new Date().getHours() - (12 - i);
+                        return `${(hour + 24) % 24}:00`;
+                    });
+                    const responseValues = performanceData.slice(0, 12).map(d => d.avgDurationMs || 0);
 
-                responseTimeChart = new Chart(responseCtx, {
-                    type: 'line',
-                    data: {
-                        labels: responseLabels,
-                        datasets: [{
-                            label: 'Avg Response (ms)',
-                            data: responseValues,
-                            borderColor: '#098ecf',
-                            backgroundColor: 'rgba(9, 142, 207, 0.1)',
-                            fill: true,
-                            tension: 0.4,
-                            pointBackgroundColor: '#098ecf',
-                            pointBorderColor: '#098ecf',
-                            pointRadius: 3,
-                            pointHoverRadius: 5
-                        }]
-                    },
-                    options: {
-                        responsive: true,
-                        maintainAspectRatio: false,
-                        plugins: {
-                            legend: {
-                                display: false
-                            },
-                            tooltip: {
-                                backgroundColor: '#2f3336',
-                                titleColor: '#d7d3d0',
-                                bodyColor: '#a8a5a3',
-                                borderColor: '#3f4447',
-                                borderWidth: 1,
-                                padding: 12,
-                                displayColors: false,
-                                callbacks: {
-                                    label: function(context) {
-                                        return context.parsed.y.toFixed(0) + ' ms';
-                                    }
-                                }
-                            }
+                    responseTimeChart = new Chart(responseCtx.getContext('2d'), {
+                        type: 'line',
+                        data: {
+                            labels: responseLabels,
+                            datasets: [{
+                                label: 'Avg Response (ms)',
+                                data: responseValues,
+                                borderColor: '#098ecf',
+                                backgroundColor: 'rgba(9, 142, 207, 0.1)',
+                                fill: true,
+                                tension: 0.4,
+                                pointBackgroundColor: '#098ecf',
+                                pointBorderColor: '#098ecf',
+                                pointRadius: 3,
+                                pointHoverRadius: 5
+                            }]
                         },
-                        scales: {
-                            y: {
-                                beginAtZero: true,
-                                grid: {
-                                    color: '#2f3336'
-                                },
-                                ticks: {
-                                    callback: function(value) {
-                                        return value + ' ms';
+                        options: {
+                            responsive: true,
+                            maintainAspectRatio: false,
+                            plugins: {
+                                legend: { display: false },
+                                tooltip: {
+                                    backgroundColor: '#2f3336',
+                                    titleColor: '#d7d3d0',
+                                    bodyColor: '#a8a5a3',
+                                    borderColor: '#3f4447',
+                                    borderWidth: 1,
+                                    padding: 12,
+                                    displayColors: false,
+                                    callbacks: {
+                                        label: function(context) {
+                                            return context.parsed.y.toFixed(0) + ' ms';
+                                        }
                                     }
                                 }
                             },
-                            x: {
-                                grid: {
-                                    display: false
-                                }
+                            scales: {
+                                y: {
+                                    beginAtZero: true,
+                                    grid: { color: '#2f3336' },
+                                    ticks: {
+                                        callback: function(value) {
+                                            return value + ' ms';
+                                        }
+                                    }
+                                },
+                                x: { grid: { display: false } }
                             }
                         }
-                    }
-                });
+                    });
+                }
 
                 // Throughput Chart
-                const throughputCtx = document.getElementById('throughputChart').getContext('2d');
-                const throughputLabels = throughputData.slice(0, 12).map(d => {
-                    const date = new Date(d.timestamp);
-                    return date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' });
-                });
-                const throughputValues = throughputData.slice(0, 12).map(d => d.commandCount);
+                const throughputCtx = document.getElementById('throughputChart');
+                if (throughputCtx) {
+                    const throughputLabels = throughputData.slice(0, 12).map(d => {
+                        const date = new Date(d.timestamp);
+                        return date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' });
+                    });
+                    const throughputValues = throughputData.slice(0, 12).map(d => d.commandCount);
 
-                throughputChart = new Chart(throughputCtx, {
-                    type: 'bar',
-                    data: {
-                        labels: throughputLabels,
-                        datasets: [{
-                            label: 'Commands',
-                            data: throughputValues,
-                            backgroundColor: '#cb4e1b',
-                            borderRadius: 4
-                        }]
-                    },
-                    options: {
-                        responsive: true,
-                        maintainAspectRatio: false,
-                        plugins: {
-                            legend: {
-                                display: false
-                            },
-                            tooltip: {
-                                backgroundColor: '#2f3336',
-                                titleColor: '#d7d3d0',
-                                bodyColor: '#a8a5a3',
-                                borderColor: '#3f4447',
-                                borderWidth: 1,
-                                padding: 12,
-                                displayColors: false,
-                                callbacks: {
-                                    label: function(context) {
-                                        return context.parsed.y + ' commands';
+                    throughputChart = new Chart(throughputCtx.getContext('2d'), {
+                        type: 'bar',
+                        data: {
+                            labels: throughputLabels,
+                            datasets: [{
+                                label: 'Commands',
+                                data: throughputValues,
+                                backgroundColor: '#cb4e1b',
+                                borderRadius: 4
+                            }]
+                        },
+                        options: {
+                            responsive: true,
+                            maintainAspectRatio: false,
+                            plugins: {
+                                legend: { display: false },
+                                tooltip: {
+                                    backgroundColor: '#2f3336',
+                                    titleColor: '#d7d3d0',
+                                    bodyColor: '#a8a5a3',
+                                    borderColor: '#3f4447',
+                                    borderWidth: 1,
+                                    padding: 12,
+                                    displayColors: false,
+                                    callbacks: {
+                                        label: function(context) {
+                                            return context.parsed.y + ' commands';
+                                        }
                                     }
                                 }
-                            }
-                        },
-                        scales: {
-                            y: {
-                                beginAtZero: true,
-                                grid: {
-                                    color: '#2f3336'
-                                }
                             },
-                            x: {
-                                grid: {
-                                    display: false
-                                }
+                            scales: {
+                                y: { beginAtZero: true, grid: { color: '#2f3336' } },
+                                x: { grid: { display: false } }
                             }
                         }
-                    }
-                });
+                    });
+                }
             } catch (error) {
                 console.error('Failed to initialize charts:', error);
             }
@@ -874,73 +265,11 @@
             try {
                 const response = await fetch('/api/metrics/health');
                 const health = await response.json();
-
-                // Update any dynamic values if needed
                 console.log('Health data refreshed:', health);
             } catch (error) {
                 console.error('Failed to refresh data:', error);
             }
         }
-
-        // Smart reconnect behavior foundation
-        // Will be wired up to SignalR when DashboardHub is extended (issue #624)
-        const RealtimeUI = {
-            liveIndicatorId: 'liveIndicator',
-
-            setLive(isLive) {
-                const indicator = document.getElementById(this.liveIndicatorId);
-                if (indicator) {
-                    if (isLive) {
-                        indicator.classList.remove('paused');
-                    } else {
-                        indicator.classList.add('paused');
-                    }
-                }
-            },
-
-            animateValueChange(elementId, newValue, formatter = null) {
-                const element = document.getElementById(elementId);
-                if (!element) return;
-
-                const oldValue = element.textContent;
-                const displayValue = formatter ? formatter(newValue) : String(newValue);
-                element.textContent = displayValue;
-
-                if (oldValue !== displayValue) {
-                    element.classList.add('value-changed');
-                    setTimeout(() => element.classList.remove('value-changed'), 500);
-                }
-            },
-
-            // Called when SignalR reconnects
-            async onReconnected() {
-                this.setLive(true);
-
-                // Refresh all data
-                await refreshData();
-                await initCharts();
-
-                // Show reconnected toast
-                if (typeof ToastManager !== 'undefined') {
-                    ToastManager.show('success', 'Real-time updates restored', {
-                        title: 'Reconnected',
-                        duration: 3000
-                    });
-                }
-            },
-
-            // Called when SignalR disconnects
-            onDisconnected() {
-                this.setLive(false);
-
-                if (typeof ToastManager !== 'undefined') {
-                    ToastManager.show('warning', 'Attempting to reconnect...', {
-                        title: 'Connection Lost',
-                        duration: 5000
-                    });
-                }
-            }
-        };
 
         // Convert UTC timestamps to local timezone
         function convertTimestampsToLocal() {
@@ -953,7 +282,6 @@
                         const date = new Date(utcTime);
 
                         if (format === 'relative') {
-                            // For relative times, calculate the difference and format as "X ago"
                             const now = new Date();
                             const elapsed = now - date;
                             const minutes = Math.floor(elapsed / 60000);
@@ -972,7 +300,6 @@
                             }
                             element.textContent = relativeText;
                         } else {
-                            // For absolute times, format as local date/time
                             const formatted = date.toLocaleDateString('en-US', {
                                 month: 'short',
                                 day: '2-digit',
@@ -990,6 +317,21 @@
                 }
             });
         }
+
+        // Listen for tab changes
+        document.addEventListener('performanceTabChanged', function(e) {
+            console.log('Tab changed to:', e.detail.tabId);
+            // Re-initialize charts when switching to overview
+            if (e.detail.tabId === 'overview' && !responseTimeChart) {
+                initCharts();
+            }
+        });
+
+        // Listen for time range changes
+        document.addEventListener('timeRangeChanged', function(e) {
+            console.log('Time range changed to:', e.detail.hours, 'hours');
+            // Future: refresh data with new time range
+        });
 
         // Initialize on page load
         document.addEventListener('DOMContentLoaded', function() {

--- a/src/DiscordBot.Bot/Pages/Admin/Performance/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/Index.cshtml.cs
@@ -9,6 +9,7 @@ namespace DiscordBot.Bot.Pages.Admin.Performance;
 /// <summary>
 /// Page model for the Performance Overview dashboard.
 /// Displays aggregated performance metrics, system health, and active alerts.
+/// Uses a shell layout with client-side tab switching.
 /// </summary>
 [Authorize(Policy = "RequireViewer")]
 public class IndexModel : PageModel
@@ -22,9 +23,14 @@ public class IndexModel : PageModel
     private readonly ILogger<IndexModel> _logger;
 
     /// <summary>
-    /// Gets the view model for the performance overview page.
+    /// Gets the view model for the performance overview page content.
     /// </summary>
     public PerformanceOverviewViewModel ViewModel { get; private set; } = new();
+
+    /// <summary>
+    /// Gets the shell view model for the performance dashboard layout.
+    /// </summary>
+    public PerformanceShellViewModel ShellViewModel { get; private set; } = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="IndexModel"/> class.
@@ -114,6 +120,7 @@ public class IndexModel : PageModel
             // Determine overall status based on alerts and health
             var overallHealthStatus = DetermineOverallStatus(overallStatus, activeAlerts.Count);
 
+            // Create the overview content view model
             ViewModel = new PerformanceOverviewViewModel
             {
                 OverallStatus = overallHealthStatus,
@@ -133,6 +140,16 @@ public class IndexModel : PageModel
                 ApiRateLimitPercent = apiUsagePercent
             };
 
+            // Create the shell view model
+            ShellViewModel = new PerformanceShellViewModel
+            {
+                OverallStatus = overallHealthStatus,
+                ActiveAlertCount = activeAlerts.Count,
+                ActiveTab = "overview",
+                TimeRangeHours = 24,
+                IsLive = true
+            };
+
             _logger.LogDebug(
                 "Performance Overview ViewModel loaded: OverallStatus={OverallStatus}, Uptime={Uptime:F1}%, ActiveAlerts={ActiveAlerts}",
                 overallHealthStatus,
@@ -143,7 +160,7 @@ public class IndexModel : PageModel
         {
             _logger.LogError(ex, "Failed to load Performance Overview ViewModel");
 
-            // Create a default view model in case of error
+            // Create default view models in case of error
             ViewModel = new PerformanceOverviewViewModel
             {
                 OverallStatus = "Critical",
@@ -151,6 +168,15 @@ public class IndexModel : PageModel
                 MemoryUsageFormatted = "Unknown",
                 DatabaseConnectionsFormatted = "Unknown",
                 ApiRateLimitFormatted = "Unknown"
+            };
+
+            ShellViewModel = new PerformanceShellViewModel
+            {
+                OverallStatus = "Critical",
+                ActiveAlertCount = 0,
+                ActiveTab = "overview",
+                TimeRangeHours = 24,
+                IsLive = false
             };
         }
     }

--- a/src/DiscordBot.Bot/Pages/Admin/Performance/_OverviewTabContent.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/_OverviewTabContent.cshtml
@@ -1,0 +1,675 @@
+@using DiscordBot.Bot.ViewModels.Pages
+@model PerformanceOverviewViewModel
+@{
+    // This partial contains the Overview tab content for the Performance Dashboard shell
+}
+
+<style>
+    /* Chart Card */
+    .chart-card {
+        background: rgb(35, 38, 40);
+        border: 1px solid rgb(63, 68, 71);
+        border-radius: 0.5rem;
+        overflow: hidden;
+    }
+
+    .chart-card-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 1.25rem;
+        border-bottom: 1px solid rgb(63, 68, 71);
+    }
+
+    .chart-card-title {
+        font-size: 1.125rem;
+        font-weight: 600;
+        color: rgb(215, 211, 208);
+        margin: 0;
+    }
+
+    .chart-card-subtitle {
+        font-size: 0.875rem;
+        color: rgb(168, 165, 163);
+        margin: 0.25rem 0 0;
+    }
+
+    .chart-card-body {
+        padding: 1.25rem;
+    }
+
+    .chart-container {
+        position: relative;
+        height: 300px;
+    }
+
+    /* Status Cards */
+    .status-cards-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 1rem;
+        margin-bottom: 2rem;
+    }
+
+    .status-card {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        padding: 1rem;
+        background: rgb(35, 38, 40);
+        border: 1px solid rgb(63, 68, 71);
+        border-radius: 0.5rem;
+        transition: all 0.2s;
+        text-decoration: none;
+    }
+
+    .status-card:hover {
+        border-color: rgb(9, 142, 207);
+        background: rgb(40, 43, 46);
+    }
+
+    .status-card-icon {
+        width: 3rem;
+        height: 3rem;
+        border-radius: 0.5rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+    }
+
+    .status-card-icon svg {
+        width: 1.5rem;
+        height: 1.5rem;
+    }
+
+    .status-card-content {
+        flex: 1;
+        min-width: 0;
+    }
+
+    .status-card-label {
+        display: block;
+        font-size: 0.75rem;
+        color: rgb(168, 165, 163);
+        margin-bottom: 0.25rem;
+    }
+
+    .status-card-value {
+        display: block;
+        font-size: 1.25rem;
+        font-weight: 600;
+        color: rgb(215, 211, 208);
+    }
+
+    /* Metric Cards */
+    .metric-card {
+        background: rgb(35, 38, 40);
+        border: 1px solid rgb(63, 68, 71);
+        border-radius: 0.5rem;
+        padding: 1.25rem;
+    }
+
+    .metric-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 0.75rem;
+    }
+
+    .metric-label {
+        font-size: 0.875rem;
+        color: rgb(168, 165, 163);
+    }
+
+    .metric-icon {
+        width: 1.25rem;
+        height: 1.25rem;
+        color: rgb(168, 165, 163);
+    }
+
+    .metric-value {
+        font-size: 2rem;
+        font-weight: 700;
+        color: rgb(215, 211, 208);
+        line-height: 1;
+    }
+
+    .metric-unit {
+        font-size: 1rem;
+        font-weight: 500;
+        color: rgb(168, 165, 163);
+    }
+
+    .metric-trend {
+        display: flex;
+        align-items: center;
+        gap: 0.25rem;
+        margin-top: 0.5rem;
+        font-size: 0.75rem;
+    }
+
+    .metric-trend-up {
+        color: rgb(16, 185, 129);
+    }
+
+    /* Progress Bar */
+    .progress-labeled {
+        margin-top: 1rem;
+    }
+
+    .progress-header {
+        display: flex;
+        justify-content: space-between;
+        margin-bottom: 0.5rem;
+    }
+
+    .progress-label {
+        font-size: 0.875rem;
+        color: rgb(168, 165, 163);
+    }
+
+    .progress-value {
+        font-size: 0.875rem;
+        color: rgb(215, 211, 208);
+        font-weight: 500;
+    }
+
+    .progress-bar-container {
+        width: 100%;
+        height: 0.5rem;
+        background: rgb(47, 51, 54);
+        border-radius: 9999px;
+        overflow: hidden;
+    }
+
+    .progress-bar-fill {
+        height: 100%;
+        border-radius: 9999px;
+        transition: width 0.3s ease;
+    }
+
+    .progress-bar-healthy {
+        background: rgb(16, 185, 129);
+    }
+
+    .progress-bar-warning {
+        background: rgb(245, 158, 11);
+    }
+
+    .progress-bar-error {
+        background: rgb(239, 68, 68);
+    }
+
+    /* Alert Card */
+    .alert-card {
+        display: flex;
+        gap: 1rem;
+        padding: 1rem;
+        border: 1px solid rgb(63, 68, 71);
+        border-radius: 0.5rem;
+    }
+
+    .alert-card-warning {
+        background: rgba(245, 158, 11, 0.05);
+        border-color: rgba(245, 158, 11, 0.3);
+    }
+
+    .alert-card-info {
+        background: rgba(9, 142, 207, 0.05);
+        border-color: rgba(9, 142, 207, 0.3);
+    }
+
+    .alert-icon {
+        width: 1.25rem;
+        height: 1.25rem;
+        flex-shrink: 0;
+    }
+
+    .alert-icon-warning {
+        color: rgb(245, 158, 11);
+    }
+
+    .alert-icon-info {
+        color: rgb(9, 142, 207);
+    }
+
+    .alert-content {
+        flex: 1;
+        min-width: 0;
+    }
+
+    .alert-title {
+        font-size: 0.875rem;
+        font-weight: 600;
+        color: rgb(215, 211, 208);
+        margin-bottom: 0.25rem;
+    }
+
+    .alert-description {
+        font-size: 0.875rem;
+        color: rgb(168, 165, 163);
+        margin-bottom: 0.5rem;
+    }
+
+    .alert-meta {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        font-size: 0.75rem;
+        color: rgb(120, 116, 113);
+    }
+
+    .severity-badge {
+        display: inline-flex;
+        align-items: center;
+        padding: 0.125rem 0.5rem;
+        border-radius: 9999px;
+        font-size: 0.75rem;
+        font-weight: 500;
+    }
+
+    .severity-warning {
+        background: rgba(245, 158, 11, 0.2);
+        color: rgb(245, 158, 11);
+    }
+
+    .severity-info {
+        background: rgba(9, 142, 207, 0.2);
+        color: rgb(9, 142, 207);
+    }
+
+    /* Grid Layouts */
+    .performance-grid-2 {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+        gap: 1.5rem;
+    }
+
+    /* Button Styles */
+    .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.5rem 1rem;
+        font-size: 0.875rem;
+        font-weight: 500;
+        border-radius: 0.375rem;
+        transition: all 0.2s;
+        text-decoration: none;
+        border: none;
+        cursor: pointer;
+    }
+
+    .btn-secondary {
+        background: rgb(47, 51, 54);
+        color: rgb(215, 211, 208);
+        border: 1px solid rgb(63, 68, 71);
+    }
+
+    .btn-secondary:hover {
+        background: rgb(55, 60, 63);
+        border-color: rgb(99, 102, 104);
+    }
+
+    .btn-svg-icon {
+        width: 1rem;
+        height: 1rem;
+    }
+</style>
+
+<!-- Quick Status Cards -->
+<div class="status-cards-grid mb-8">
+    <!-- Bot Health -->
+    <button type="button" class="status-card group" onclick="PerformanceShell.switchTab('health')">
+        <div class="status-card-icon bg-success/10">
+            <svg class="text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+            </svg>
+        </div>
+        <div class="status-card-content">
+            <span class="status-card-label">Bot Health</span>
+            <span class="status-card-value @Model.BotHealthStatusClass">@Model.BotHealthStatusText</span>
+        </div>
+        <svg class="w-4 h-4 text-text-tertiary group-hover:text-accent-blue transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+        </svg>
+    </button>
+
+    <!-- Command Performance -->
+    <button type="button" class="status-card group" onclick="PerformanceShell.switchTab('commands')">
+        <div class="status-card-icon bg-accent-blue/10">
+            <svg class="text-accent-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
+            </svg>
+        </div>
+        <div class="status-card-content">
+            <span class="status-card-label">Avg Response</span>
+            <span class="status-card-value">@Model.AvgCommandResponseMs.ToString("F0")ms</span>
+        </div>
+        <svg class="w-4 h-4 text-text-tertiary group-hover:text-accent-blue transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+        </svg>
+    </button>
+
+    <!-- API Health -->
+    <button type="button" class="status-card group" onclick="PerformanceShell.switchTab('api')">
+        <div class="status-card-icon bg-success/10">
+            <svg class="text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            </svg>
+        </div>
+        <div class="status-card-content">
+            <span class="status-card-label">API Status</span>
+            <span class="status-card-value text-success">@Model.ApiRateLimitFormatted</span>
+        </div>
+        <svg class="w-4 h-4 text-text-tertiary group-hover:text-accent-blue transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+        </svg>
+    </button>
+
+    <!-- System Health -->
+    <button type="button" class="status-card group" onclick="PerformanceShell.switchTab('system')">
+        <div class="status-card-icon bg-success/10">
+            <svg class="text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" />
+            </svg>
+        </div>
+        <div class="status-card-content">
+            <span class="status-card-label">System</span>
+            <span class="status-card-value text-success">Normal</span>
+        </div>
+        <svg class="w-4 h-4 text-text-tertiary group-hover:text-accent-blue transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+        </svg>
+    </button>
+
+    <!-- Active Alerts -->
+    <button type="button" class="status-card group" onclick="PerformanceShell.switchTab('alerts')">
+        <div class="status-card-icon @(Model.ActiveAlertCount > 0 ? "bg-warning/10" : "bg-success/10")">
+            <svg class="@(Model.ActiveAlertCount > 0 ? "text-warning" : "text-success")" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+            </svg>
+        </div>
+        <div class="status-card-content">
+            <span class="status-card-label">Active Alerts</span>
+            <span class="status-card-value @(Model.ActiveAlertCount > 0 ? "text-warning" : "text-success")">@Model.ActiveAlertCount</span>
+        </div>
+        <svg class="w-4 h-4 text-text-tertiary group-hover:text-accent-blue transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+        </svg>
+    </button>
+</div>
+
+<!-- Key Metrics Row -->
+<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+    <!-- Uptime -->
+    <div class="metric-card">
+        <div class="metric-header">
+            <span class="metric-label">Uptime</span>
+            <svg class="metric-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+        </div>
+        <div class="metric-value">@Model.Uptime30DaysPercent.ToString("F1")<span class="metric-unit">%</span></div>
+        <div class="metric-trend metric-trend-up">
+            <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18" />
+            </svg>
+            Last 30 days
+        </div>
+    </div>
+
+    <!-- Latency -->
+    <div class="metric-card">
+        <div class="metric-header">
+            <span class="metric-label">Avg Latency</span>
+            <svg class="metric-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
+            </svg>
+        </div>
+        <div class="metric-value">@Model.AvgLatencyMs<span class="metric-unit">ms</span></div>
+        <div class="metric-trend metric-trend-up">
+            <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18" />
+            </svg>
+            Gateway heartbeat
+        </div>
+    </div>
+
+    <!-- Commands Today -->
+    <div class="metric-card">
+        <div class="metric-header">
+            <span class="metric-label">Commands Today</span>
+            <svg class="metric-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+            </svg>
+        </div>
+        <div class="metric-value">@Model.CommandsToday.ToString("N0")</div>
+        <div class="metric-trend metric-trend-up">
+            <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18" />
+            </svg>
+            Last 24 hours
+        </div>
+    </div>
+
+    <!-- Error Rate -->
+    <div class="metric-card">
+        <div class="metric-header">
+            <span class="metric-label">Error Rate</span>
+            <svg class="metric-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+        </div>
+        <div class="metric-value">@Model.ErrorRate.ToString("F1")<span class="metric-unit">%</span></div>
+        <div class="metric-trend metric-trend-up">
+            <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18" />
+            </svg>
+            Last 24 hours
+        </div>
+    </div>
+</div>
+
+<!-- Charts Row -->
+<div class="performance-grid-2 mb-6">
+    <!-- Response Time Trend -->
+    <div class="chart-card">
+        <div class="chart-card-header">
+            <div>
+                <h2 class="chart-card-title">Response Time Trend</h2>
+                <p class="chart-card-subtitle">Average command response time (last 24 hours)</p>
+            </div>
+        </div>
+        <div class="chart-card-body">
+            <div class="chart-container">
+                <canvas id="responseTimeChart"></canvas>
+            </div>
+        </div>
+    </div>
+
+    <!-- Command Throughput -->
+    <div class="chart-card">
+        <div class="chart-card-header">
+            <div>
+                <h2 class="chart-card-title">Command Throughput</h2>
+                <p class="chart-card-subtitle">Commands per hour (last 24 hours)</p>
+            </div>
+        </div>
+        <div class="chart-card-body">
+            <div class="chart-container">
+                <canvas id="throughputChart"></canvas>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Resource Usage & Recent Alerts -->
+<div class="performance-grid-2 mb-6">
+    <!-- Resource Usage -->
+    <div class="chart-card">
+        <div class="chart-card-header">
+            <div>
+                <h2 class="chart-card-title">Resource Usage</h2>
+                <p class="chart-card-subtitle">Current system resource utilization</p>
+            </div>
+            <button type="button" class="text-sm font-medium text-accent-blue hover:text-accent-blue-hover transition-colors" onclick="PerformanceShell.switchTab('system')">
+                View Details
+            </button>
+        </div>
+        <div class="chart-card-body space-y-6">
+            <!-- Memory -->
+            <div class="progress-labeled">
+                <div class="progress-header">
+                    <span class="progress-label">Memory</span>
+                    <span class="progress-value">@Model.MemoryUsageFormatted</span>
+                </div>
+                <div class="progress-bar-container">
+                    <div class="progress-bar-fill @Model.MemoryUsageProgressClass" style="width: @Model.MemoryUsagePercent.ToString("F0")%;"></div>
+                </div>
+            </div>
+
+            <!-- CPU -->
+            <div class="progress-labeled">
+                <div class="progress-header">
+                    <span class="progress-label">CPU</span>
+                    <span class="progress-value" id="cpuUsageText">0%</span>
+                </div>
+                <div class="progress-bar-container">
+                    <div class="progress-bar-fill progress-bar-healthy" id="cpuProgressBar" style="width: 0%;"></div>
+                </div>
+            </div>
+
+            <!-- Database Connections -->
+            <div class="progress-labeled">
+                <div class="progress-header">
+                    <span class="progress-label">DB Connections</span>
+                    <span class="progress-value">@Model.DatabaseConnectionsFormatted</span>
+                </div>
+                <div class="progress-bar-container">
+                    <div class="progress-bar-fill progress-bar-healthy" style="width: 40%;"></div>
+                </div>
+            </div>
+
+            <!-- Discord API -->
+            <div class="progress-labeled">
+                <div class="progress-header">
+                    <span class="progress-label">API Rate Limit</span>
+                    <span class="progress-value">@Model.ApiRateLimitFormatted</span>
+                </div>
+                <div class="progress-bar-container">
+                    <div class="progress-bar-fill @Model.ApiRateLimitProgressClass" style="width: @Model.ApiRateLimitPercent.ToString("F0")%;"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Recent Alerts -->
+    <div class="chart-card">
+        <div class="chart-card-header">
+            <div>
+                <h2 class="chart-card-title">Recent Alerts</h2>
+                <p class="chart-card-subtitle">Active and recent system alerts</p>
+            </div>
+            <button type="button" class="text-sm font-medium text-accent-blue hover:text-accent-blue-hover transition-colors" onclick="PerformanceShell.switchTab('alerts')">
+                View All
+            </button>
+        </div>
+        <div class="chart-card-body p-0">
+            @if (Model.RecentAlerts.Any())
+            {
+                <div class="divide-y divide-border-primary">
+                    @foreach (var alert in Model.RecentAlerts)
+                    {
+                        var severityStr = alert.Severity.ToString().ToLowerInvariant();
+                        var severityClass = severityStr switch
+                        {
+                            "critical" => "alert-card-warning",
+                            "warning" => "alert-card-warning",
+                            _ => "alert-card-info"
+                        };
+                        var iconClass = severityStr switch
+                        {
+                            "critical" => "alert-icon text-error",
+                            "warning" => "alert-icon alert-icon-warning",
+                            _ => "alert-icon alert-icon-info"
+                        };
+                        var severityBadgeClass = severityStr switch
+                        {
+                            "critical" => "inline-flex items-center px-2 py-0.5 text-xs font-medium bg-error/20 text-error rounded",
+                            "warning" => "severity-badge severity-warning",
+                            _ => "severity-badge severity-info"
+                        };
+
+                        <div class="alert-card border-0 rounded-none @severityClass">
+                            <svg class="@iconClass" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                            </svg>
+                            <div class="alert-content">
+                                <div class="alert-title">@alert.Message</div>
+                                @if (!string.IsNullOrEmpty(alert.Notes))
+                                {
+                                    <div class="alert-description">@alert.Notes</div>
+                                }
+                                <div class="alert-meta">
+                                    <span class="@severityBadgeClass">@alert.Severity</span>
+                                    <span data-utc-time="@alert.TriggeredAt.ToString("o")" data-format="relative">@((DateTime.UtcNow - alert.TriggeredAt).TotalMinutes < 60 ? $"{(int)(DateTime.UtcNow - alert.TriggeredAt).TotalMinutes} minutes ago" : $"{(int)(DateTime.UtcNow - alert.TriggeredAt).TotalHours} hours ago")</span>
+                                </div>
+                            </div>
+                        </div>
+                    }
+                </div>
+            }
+            else
+            {
+                <div class="text-center py-8">
+                    <svg class="w-12 h-12 mx-auto mb-3 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                    <div class="text-text-secondary font-medium">No active alerts</div>
+                    <div class="text-text-tertiary text-sm">All systems operating normally</div>
+                </div>
+            }
+        </div>
+    </div>
+</div>
+
+<!-- Quick Actions -->
+<div class="chart-card">
+    <div class="chart-card-header">
+        <div>
+            <h2 class="chart-card-title">Quick Actions</h2>
+            <p class="chart-card-subtitle">Common performance management tasks</p>
+        </div>
+    </div>
+    <div class="chart-card-body">
+        <div class="flex flex-wrap gap-3">
+            <button class="btn btn-secondary" onclick="alert('Bot restart functionality would be implemented here')">
+                <svg class="btn-svg-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                </svg>
+                Restart Bot
+            </button>
+            <button class="btn btn-secondary" onclick="alert('Clear cache functionality would be implemented here')">
+                <svg class="btn-svg-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                </svg>
+                Clear Cache
+            </button>
+            <button class="btn btn-secondary" onclick="alert('Export metrics functionality would be implemented here')">
+                <svg class="btn-svg-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                </svg>
+                Export Metrics
+            </button>
+            <button type="button" class="btn btn-secondary" onclick="PerformanceShell.switchTab('alerts')">
+                <svg class="btn-svg-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                </svg>
+                Configure Alerts
+            </button>
+        </div>
+    </div>
+</div>

--- a/src/DiscordBot.Bot/Pages/Shared/Components/_PerformanceTabNav.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/Components/_PerformanceTabNav.cshtml
@@ -1,0 +1,41 @@
+@using DiscordBot.Bot.ViewModels.Pages
+@model PerformanceShellViewModel
+@{
+    string GetTabClass(string tabId) => Model.ActiveTab == tabId ? "performance-shell-tab active" : "performance-shell-tab";
+    string GetAriaSelected(string tabId) => Model.ActiveTab == tabId ? "true" : "false";
+}
+
+<div class="performance-shell-tabs-container" id="performanceShellTabsContainer">
+    <nav class="performance-shell-tabs" id="performanceShellTabs" role="tablist" aria-label="Performance dashboard sections">
+        @foreach (var tab in PerformanceShellViewModel.Tabs)
+        {
+            var tabPanelId = $"tabPanel-{tab.Id}";
+            var isAlertsTab = tab.Id == "alerts";
+            <button type="button"
+                    class="@GetTabClass(tab.Id)"
+                    role="tab"
+                    id="tab-@tab.Id"
+                    aria-selected="@GetAriaSelected(tab.Id)"
+                    aria-controls="@tabPanelId"
+                    data-tab-id="@tab.Id"
+                    data-tab-hash="@tab.Hash">
+                <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@tab.IconPath" />
+                </svg>
+                @if (!string.IsNullOrEmpty(tab.ShortLabel))
+                {
+                    <span class="tab-label-long">@tab.Label</span>
+                    <span class="tab-label-short">@tab.ShortLabel</span>
+                }
+                else
+                {
+                    <span>@tab.Label</span>
+                }
+                @if (isAlertsTab && Model.ActiveAlertCount > 0)
+                {
+                    <span class="tab-alert-badge" aria-label="@Model.ActiveAlertCount active alerts">@Model.ActiveAlertCount</span>
+                }
+            </button>
+        }
+    </nav>
+</div>

--- a/src/DiscordBot.Bot/ViewModels/Pages/PerformanceShellViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Pages/PerformanceShellViewModel.cs
@@ -1,0 +1,100 @@
+namespace DiscordBot.Bot.ViewModels.Pages;
+
+/// <summary>
+/// ViewModel for the Performance Dashboard shell layout.
+/// Contains shared state for all performance tabs including header, time range, and overall health.
+/// </summary>
+public record PerformanceShellViewModel
+{
+    /// <summary>
+    /// Gets the overall health status (Healthy, Warning, Critical).
+    /// </summary>
+    public string OverallStatus { get; init; } = "Healthy";
+
+    /// <summary>
+    /// Gets the CSS class for overall health status badge.
+    /// </summary>
+    public string OverallStatusClass => OverallStatus.ToLowerInvariant() switch
+    {
+        "healthy" => "health-status-healthy",
+        "warning" => "health-status-warning",
+        "critical" => "health-status-error",
+        _ => "health-status-healthy"
+    };
+
+    /// <summary>
+    /// Gets the display text for overall health status badge.
+    /// </summary>
+    public string OverallStatusText => OverallStatus.ToLowerInvariant() switch
+    {
+        "healthy" => "Operational",
+        "warning" => "Degraded",
+        "critical" => "Critical",
+        _ => "Operational"
+    };
+
+    /// <summary>
+    /// Gets the number of active performance alerts.
+    /// </summary>
+    public int ActiveAlertCount { get; init; }
+
+    /// <summary>
+    /// Gets the currently active tab identifier.
+    /// Valid values: "overview", "health", "commands", "api", "system", "alerts"
+    /// </summary>
+    public string ActiveTab { get; init; } = "overview";
+
+    /// <summary>
+    /// Gets the selected time range in hours (24, 168, or 720).
+    /// </summary>
+    public int TimeRangeHours { get; init; } = 24;
+
+    /// <summary>
+    /// Gets the display label for the selected time range.
+    /// </summary>
+    public string TimeRangeLabel => TimeRangeHours switch
+    {
+        24 => "24h",
+        168 => "7d",
+        720 => "30d",
+        _ => "24h"
+    };
+
+    /// <summary>
+    /// Gets whether the live data connection is active.
+    /// </summary>
+    public bool IsLive { get; init; } = true;
+
+    /// <summary>
+    /// Gets the tab definitions for navigation.
+    /// </summary>
+    public static IReadOnlyList<TabDefinition> Tabs { get; } = new List<TabDefinition>
+    {
+        new("overview", "Overview", "overview", "M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"),
+        new("health", "Health Metrics", "health-metrics", "M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z", "Health"),
+        new("commands", "Commands", "commands", "M13 10V3L4 14h7v7l9-11h-7z"),
+        new("api", "API & Rate Limits", "api-metrics", "M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z", "API"),
+        new("system", "System", "system-health", "M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01"),
+        new("alerts", "Alerts", "alerts", "M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9")
+    };
+
+    /// <summary>
+    /// Gets the tab definition for the currently active tab.
+    /// </summary>
+    public TabDefinition? CurrentTab => Tabs.FirstOrDefault(t => t.Id == ActiveTab);
+}
+
+/// <summary>
+/// Represents a tab in the Performance Dashboard navigation.
+/// </summary>
+/// <param name="Id">The unique tab identifier.</param>
+/// <param name="Label">The full tab label.</param>
+/// <param name="Hash">The URL hash for this tab (without #).</param>
+/// <param name="IconPath">The SVG path for the tab icon.</param>
+/// <param name="ShortLabel">Optional short label for mobile display.</param>
+public record TabDefinition(
+    string Id,
+    string Label,
+    string Hash,
+    string IconPath,
+    string? ShortLabel = null);

--- a/src/DiscordBot.Bot/wwwroot/css/performance-shell.css
+++ b/src/DiscordBot.Bot/wwwroot/css/performance-shell.css
@@ -1,0 +1,353 @@
+/* Performance Shell Layout Styles */
+/* Specific styles for the Performance Dashboard shell (issue #721) */
+/* Works alongside performance-pages.css for shared component styles */
+
+/* ===== Shell Container ===== */
+.performance-shell {
+    display: flex;
+    flex-direction: column;
+    min-height: calc(100vh - 4rem); /* Account for main nav */
+}
+
+/* ===== Shell Header ===== */
+.performance-shell-header {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+@media (min-width: 1024px) {
+    .performance-shell-header {
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+    }
+}
+
+.performance-shell-title-group {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.performance-shell-title {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--color-text-primary);
+    margin: 0;
+}
+
+@media (min-width: 1024px) {
+    .performance-shell-title {
+        font-size: 1.875rem;
+    }
+}
+
+.performance-shell-subtitle {
+    font-size: 0.875rem;
+    color: var(--color-text-secondary);
+    margin: 0.25rem 0 0;
+}
+
+/* ===== Header Controls ===== */
+.performance-shell-controls {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+/* Time Range Selector */
+.time-range-selector {
+    display: flex;
+    gap: 0.25rem;
+    background: var(--color-bg-secondary);
+    border: 1px solid var(--color-border-primary);
+    border-radius: 0.5rem;
+    padding: 0.25rem;
+}
+
+.time-range-option {
+    padding: 0.5rem 0.875rem;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: var(--color-text-secondary);
+    background: transparent;
+    border: none;
+    border-radius: 0.375rem;
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.time-range-option:hover:not(.active) {
+    color: var(--color-text-primary);
+    background: var(--color-bg-hover);
+}
+
+.time-range-option.active {
+    color: var(--color-accent-blue);
+    background: rgba(9, 142, 207, 0.15);
+}
+
+.time-range-option:focus-visible {
+    outline: 2px solid var(--color-accent-blue);
+    outline-offset: 2px;
+}
+
+/* ===== Tab Navigation ===== */
+.performance-shell-tabs-container {
+    position: relative;
+    margin-bottom: 1.5rem;
+}
+
+/* Scroll fade indicators */
+.performance-shell-tabs-container::before,
+.performance-shell-tabs-container::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 2px;
+    width: 2rem;
+    pointer-events: none;
+    z-index: 1;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+}
+
+.performance-shell-tabs-container::before {
+    left: 0;
+    background: linear-gradient(to right, var(--color-bg-primary), transparent);
+}
+
+.performance-shell-tabs-container::after {
+    right: 0;
+    background: linear-gradient(to left, var(--color-bg-primary), transparent);
+}
+
+.performance-shell-tabs-container.can-scroll-left::before {
+    opacity: 1;
+}
+
+.performance-shell-tabs-container.can-scroll-right::after {
+    opacity: 1;
+}
+
+.performance-shell-tabs {
+    display: flex;
+    gap: 0.25rem;
+    border-bottom: 2px solid var(--color-border-primary);
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    scroll-behavior: smooth;
+    scroll-snap-type: x proximity;
+}
+
+.performance-shell-tabs::-webkit-scrollbar {
+    display: none;
+}
+
+.performance-shell-tab {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-text-secondary);
+    background: transparent;
+    border: none;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -2px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    white-space: nowrap;
+    scroll-snap-align: start;
+    flex-shrink: 0;
+}
+
+.performance-shell-tab:hover:not(.active) {
+    color: var(--color-text-primary);
+    border-bottom-color: var(--color-border-secondary);
+}
+
+.performance-shell-tab.active {
+    color: var(--color-accent-blue);
+    border-bottom-color: var(--color-accent-blue);
+}
+
+.performance-shell-tab:focus-visible {
+    outline: 2px solid var(--color-accent-blue);
+    outline-offset: -2px;
+    border-radius: 0.25rem 0.25rem 0 0;
+}
+
+.performance-shell-tab .tab-icon {
+    width: 1.25rem;
+    height: 1.25rem;
+    flex-shrink: 0;
+}
+
+/* Alert badge on Alerts tab */
+.tab-alert-badge {
+    margin-left: 0.25rem;
+    padding: 0.125rem 0.5rem;
+    font-size: 0.6875rem;
+    font-weight: 700;
+    line-height: 1;
+    color: var(--color-error);
+    background: rgba(239, 68, 68, 0.2);
+    border-radius: 9999px;
+}
+
+/* Mobile tab label switching */
+@media (max-width: 640px) {
+    .performance-shell-tab {
+        padding: 0.625rem 0.75rem;
+        font-size: 0.8125rem;
+    }
+
+    .performance-shell-tab .tab-icon {
+        width: 1rem;
+        height: 1rem;
+    }
+
+    .performance-shell-tab .tab-label-long {
+        display: none;
+    }
+
+    .performance-shell-tab .tab-label-short {
+        display: inline;
+    }
+}
+
+@media (min-width: 641px) {
+    .performance-shell-tab .tab-label-long {
+        display: inline;
+    }
+
+    .performance-shell-tab .tab-label-short {
+        display: none;
+    }
+}
+
+/* ===== Tab Content Area ===== */
+.performance-shell-content {
+    flex: 1;
+    position: relative;
+}
+
+/* Tab panels */
+.performance-tab-panel {
+    display: none;
+    animation: fadeIn 0.2s ease;
+}
+
+.performance-tab-panel.active {
+    display: block;
+}
+
+.performance-tab-panel[hidden] {
+    display: none !important;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(4px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+/* ===== Loading State ===== */
+.performance-tab-loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 300px;
+    color: var(--color-text-secondary);
+}
+
+.performance-tab-loading-spinner {
+    width: 2.5rem;
+    height: 2.5rem;
+    border: 3px solid var(--color-border-primary);
+    border-top-color: var(--color-accent-blue);
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    margin-bottom: 1rem;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+.performance-tab-loading-text {
+    font-size: 0.875rem;
+    font-weight: 500;
+}
+
+/* ===== Placeholder Content ===== */
+.performance-placeholder {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 400px;
+    padding: 2rem;
+    text-align: center;
+    background: var(--color-bg-secondary);
+    border: 1px dashed var(--color-border-secondary);
+    border-radius: 0.5rem;
+}
+
+.performance-placeholder-icon {
+    width: 3rem;
+    height: 3rem;
+    color: var(--color-text-tertiary);
+    margin-bottom: 1rem;
+}
+
+.performance-placeholder-title {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--color-text-primary);
+    margin-bottom: 0.5rem;
+}
+
+.performance-placeholder-description {
+    font-size: 0.875rem;
+    color: var(--color-text-secondary);
+    max-width: 24rem;
+}
+
+/* ===== Keyboard Navigation Focus Ring ===== */
+.performance-shell-tab:focus:not(:focus-visible) {
+    outline: none;
+}
+
+/* ===== Skip Link for Accessibility ===== */
+.performance-skip-link {
+    position: absolute;
+    left: -9999px;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+}
+
+.performance-skip-link:focus {
+    position: fixed;
+    top: 1rem;
+    left: 1rem;
+    width: auto;
+    height: auto;
+    padding: 0.75rem 1rem;
+    background: var(--color-bg-secondary);
+    color: var(--color-accent-blue);
+    border: 2px solid var(--color-accent-blue);
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    z-index: 9999;
+    outline: none;
+}

--- a/src/DiscordBot.Bot/wwwroot/js/performance-shell.js
+++ b/src/DiscordBot.Bot/wwwroot/js/performance-shell.js
@@ -1,0 +1,384 @@
+/**
+ * Performance Dashboard Shell
+ * Handles tab switching, URL hash routing, time range persistence, and scroll management.
+ * Part of issue #721 - Performance Dashboard Shell Layout.
+ */
+
+(function() {
+    'use strict';
+
+    // ===== Configuration =====
+    const STORAGE_KEYS = {
+        TIME_RANGE: 'performanceDashboard.timeRange',
+        SCROLL_POSITIONS: 'performanceDashboard.scrollPositions'
+    };
+
+    const DEFAULT_TIME_RANGE = 24; // hours
+
+    // Tab ID to hash mapping
+    const TAB_HASH_MAP = {
+        'overview': '',
+        'health': 'health-metrics',
+        'commands': 'commands',
+        'api': 'api-metrics',
+        'system': 'system-health',
+        'alerts': 'alerts'
+    };
+
+    // Reverse mapping: hash to tab ID
+    const HASH_TAB_MAP = Object.fromEntries(
+        Object.entries(TAB_HASH_MAP).map(([tab, hash]) => [hash, tab])
+    );
+    // Also map 'overview' hash to overview tab
+    HASH_TAB_MAP['overview'] = 'overview';
+
+    // ===== State =====
+    let currentTab = 'overview';
+    let currentTimeRange = DEFAULT_TIME_RANGE;
+
+    // ===== DOM Elements =====
+    function getElements() {
+        return {
+            tabsContainer: document.getElementById('performanceShellTabsContainer'),
+            tabs: document.getElementById('performanceShellTabs'),
+            tabButtons: document.querySelectorAll('.performance-shell-tab'),
+            tabPanels: document.querySelectorAll('.performance-tab-panel'),
+            timeRangeButtons: document.querySelectorAll('.time-range-option'),
+            contentArea: document.getElementById('tabContent')
+        };
+    }
+
+    // ===== Tab Management =====
+
+    /**
+     * Switch to a specific tab
+     * @param {string} tabId - The tab identifier to switch to
+     * @param {boolean} updateHash - Whether to update the URL hash
+     */
+    function switchTab(tabId, updateHash = true) {
+        const elements = getElements();
+
+        if (!TAB_HASH_MAP.hasOwnProperty(tabId)) {
+            console.warn('Unknown tab ID:', tabId);
+            return;
+        }
+
+        // Save scroll position of current tab
+        saveScrollPosition(currentTab);
+
+        // Update tab buttons
+        elements.tabButtons.forEach(button => {
+            const isActive = button.dataset.tabId === tabId;
+            button.classList.toggle('active', isActive);
+            button.setAttribute('aria-selected', isActive ? 'true' : 'false');
+            button.setAttribute('tabindex', isActive ? '0' : '-1');
+        });
+
+        // Update tab panels
+        elements.tabPanels.forEach(panel => {
+            const panelTabId = panel.id.replace('tabPanel-', '');
+            const isActive = panelTabId === tabId;
+            panel.classList.toggle('active', isActive);
+            panel.hidden = !isActive;
+        });
+
+        // Update URL hash
+        if (updateHash) {
+            const hash = TAB_HASH_MAP[tabId];
+            if (hash) {
+                history.replaceState(null, '', '#' + hash);
+            } else {
+                // For overview tab, remove hash
+                history.replaceState(null, '', window.location.pathname + window.location.search);
+            }
+        }
+
+        // Update current tab
+        currentTab = tabId;
+
+        // Restore scroll position for new tab
+        restoreScrollPosition(tabId);
+
+        // Dispatch tab change event for other components to listen
+        document.dispatchEvent(new CustomEvent('performanceTabChanged', {
+            detail: { tabId, timeRange: currentTimeRange }
+        }));
+
+        // Scroll active tab into view if needed
+        scrollActiveTabIntoView(tabId);
+    }
+
+    /**
+     * Get the tab ID from the current URL hash
+     * @returns {string} The tab ID
+     */
+    function getTabFromHash() {
+        const hash = window.location.hash.replace('#', '');
+        if (!hash) return 'overview';
+        return HASH_TAB_MAP[hash] || 'overview';
+    }
+
+    /**
+     * Scroll the active tab button into view in the tab bar
+     * @param {string} tabId - The tab ID
+     */
+    function scrollActiveTabIntoView(tabId) {
+        const elements = getElements();
+        const activeButton = elements.tabs?.querySelector(`[data-tab-id="${tabId}"]`);
+
+        if (activeButton && elements.tabs) {
+            const tabRect = activeButton.getBoundingClientRect();
+            const containerRect = elements.tabs.getBoundingClientRect();
+
+            if (tabRect.left < containerRect.left || tabRect.right > containerRect.right) {
+                activeButton.scrollIntoView({ behavior: 'smooth', inline: 'center', block: 'nearest' });
+            }
+        }
+    }
+
+    // ===== Scroll Position Management =====
+
+    /**
+     * Save the current scroll position for a tab
+     * @param {string} tabId - The tab ID
+     */
+    function saveScrollPosition(tabId) {
+        try {
+            const positions = JSON.parse(sessionStorage.getItem(STORAGE_KEYS.SCROLL_POSITIONS) || '{}');
+            positions[tabId] = window.scrollY;
+            sessionStorage.setItem(STORAGE_KEYS.SCROLL_POSITIONS, JSON.stringify(positions));
+        } catch (e) {
+            console.warn('Failed to save scroll position:', e);
+        }
+    }
+
+    /**
+     * Restore the scroll position for a tab
+     * @param {string} tabId - The tab ID
+     */
+    function restoreScrollPosition(tabId) {
+        try {
+            const positions = JSON.parse(sessionStorage.getItem(STORAGE_KEYS.SCROLL_POSITIONS) || '{}');
+            const savedPosition = positions[tabId];
+
+            if (typeof savedPosition === 'number') {
+                // Use requestAnimationFrame to ensure DOM is updated
+                requestAnimationFrame(() => {
+                    window.scrollTo(0, savedPosition);
+                });
+            }
+        } catch (e) {
+            console.warn('Failed to restore scroll position:', e);
+        }
+    }
+
+    // ===== Time Range Management =====
+
+    /**
+     * Set the time range and persist to localStorage
+     * @param {number} hours - Time range in hours (24, 168, or 720)
+     */
+    function setTimeRange(hours) {
+        if (![24, 168, 720].includes(hours)) {
+            console.warn('Invalid time range:', hours);
+            return;
+        }
+
+        currentTimeRange = hours;
+
+        // Persist to localStorage
+        try {
+            localStorage.setItem(STORAGE_KEYS.TIME_RANGE, String(hours));
+        } catch (e) {
+            console.warn('Failed to save time range:', e);
+        }
+
+        // Update UI
+        updateTimeRangeUI();
+
+        // Dispatch time range change event
+        document.dispatchEvent(new CustomEvent('timeRangeChanged', {
+            detail: { hours, tabId: currentTab }
+        }));
+    }
+
+    /**
+     * Load the saved time range from localStorage
+     * @returns {number} Time range in hours
+     */
+    function loadTimeRange() {
+        try {
+            const saved = localStorage.getItem(STORAGE_KEYS.TIME_RANGE);
+            if (saved) {
+                const hours = parseInt(saved, 10);
+                if ([24, 168, 720].includes(hours)) {
+                    return hours;
+                }
+            }
+        } catch (e) {
+            console.warn('Failed to load time range:', e);
+        }
+        return DEFAULT_TIME_RANGE;
+    }
+
+    /**
+     * Update the time range button UI
+     */
+    function updateTimeRangeUI() {
+        const elements = getElements();
+        elements.timeRangeButtons.forEach(button => {
+            const hours = parseInt(button.dataset.hours, 10);
+            button.classList.toggle('active', hours === currentTimeRange);
+        });
+    }
+
+    // ===== Scroll Indicators =====
+
+    /**
+     * Update the scroll fade indicators on the tab bar
+     */
+    function updateScrollIndicators() {
+        const elements = getElements();
+        if (!elements.tabsContainer || !elements.tabs) return;
+
+        const { scrollLeft, scrollWidth, clientWidth } = elements.tabs;
+        const isScrollable = scrollWidth > clientWidth;
+
+        if (isScrollable) {
+            elements.tabsContainer.classList.toggle('can-scroll-left', scrollLeft > 5);
+            elements.tabsContainer.classList.toggle('can-scroll-right', scrollLeft < scrollWidth - clientWidth - 5);
+        } else {
+            elements.tabsContainer.classList.remove('can-scroll-left', 'can-scroll-right');
+        }
+    }
+
+    // ===== Keyboard Navigation =====
+
+    /**
+     * Handle keyboard navigation in the tab bar
+     * @param {KeyboardEvent} event
+     */
+    function handleTabKeydown(event) {
+        const elements = getElements();
+        const tabs = Array.from(elements.tabButtons);
+        const currentIndex = tabs.findIndex(tab => tab.classList.contains('active'));
+
+        let newIndex = currentIndex;
+
+        switch (event.key) {
+            case 'ArrowLeft':
+                newIndex = currentIndex > 0 ? currentIndex - 1 : tabs.length - 1;
+                event.preventDefault();
+                break;
+            case 'ArrowRight':
+                newIndex = currentIndex < tabs.length - 1 ? currentIndex + 1 : 0;
+                event.preventDefault();
+                break;
+            case 'Home':
+                newIndex = 0;
+                event.preventDefault();
+                break;
+            case 'End':
+                newIndex = tabs.length - 1;
+                event.preventDefault();
+                break;
+            default:
+                return;
+        }
+
+        if (newIndex !== currentIndex) {
+            const newTab = tabs[newIndex];
+            const tabId = newTab.dataset.tabId;
+            switchTab(tabId);
+            newTab.focus();
+        }
+    }
+
+    // ===== Event Binding =====
+
+    /**
+     * Bind all event listeners
+     */
+    function bindEvents() {
+        const elements = getElements();
+
+        // Tab button clicks
+        elements.tabButtons.forEach(button => {
+            button.addEventListener('click', () => {
+                const tabId = button.dataset.tabId;
+                switchTab(tabId);
+            });
+
+            // Keyboard navigation
+            button.addEventListener('keydown', handleTabKeydown);
+        });
+
+        // Time range button clicks
+        elements.timeRangeButtons.forEach(button => {
+            button.addEventListener('click', () => {
+                const hours = parseInt(button.dataset.hours, 10);
+                setTimeRange(hours);
+            });
+        });
+
+        // Hash change (browser back/forward)
+        window.addEventListener('hashchange', () => {
+            const tabId = getTabFromHash();
+            if (tabId !== currentTab) {
+                switchTab(tabId, false);
+            }
+        });
+
+        // Scroll indicators
+        if (elements.tabs) {
+            elements.tabs.addEventListener('scroll', updateScrollIndicators, { passive: true });
+        }
+        window.addEventListener('resize', updateScrollIndicators, { passive: true });
+    }
+
+    // ===== Initialization =====
+
+    /**
+     * Initialize the performance shell
+     */
+    function init() {
+        // Load saved time range
+        currentTimeRange = loadTimeRange();
+        updateTimeRangeUI();
+
+        // Determine initial tab from hash or default to overview
+        const initialTab = getTabFromHash();
+        currentTab = initialTab;
+
+        // Bind all events
+        bindEvents();
+
+        // Update scroll indicators
+        updateScrollIndicators();
+
+        // Scroll active tab into view on load
+        requestAnimationFrame(() => {
+            scrollActiveTabIntoView(currentTab);
+        });
+
+        // If there's a hash, make sure we switch to the correct tab
+        if (initialTab !== 'overview') {
+            switchTab(initialTab, false);
+        }
+    }
+
+    // ===== Public API =====
+    window.PerformanceShell = {
+        switchTab,
+        setTimeRange,
+        getTimeRange: () => currentTimeRange,
+        getCurrentTab: () => currentTab
+    };
+
+    // Initialize on DOMContentLoaded
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();


### PR DESCRIPTION
## Summary
- Create shared shell layout for Performance Dashboard with header, time range selector, and tab navigation
- Implement client-side tab switching with URL hash-based routing
- Add time range persistence via localStorage
- Extract Overview tab content to separate partial view
- Add placeholder content for other tabs (AJAX loading in #723)

## Changes
- **PerformanceShellViewModel.cs**: New ViewModel for shell state (status, active tab, time range, alerts count)
- **_PerformanceTabNav.cshtml**: Button-based tab navigation with proper ARIA attributes
- **performance-shell.css**: Shell-specific styles (header, tabs, content panels)
- **performance-shell.js**: Tab switching, hash routing, time range persistence, keyboard navigation
- **_OverviewTabContent.cshtml**: Extracted Overview tab content from Index.cshtml
- **Index.cshtml**: Converted to shell layout with all 6 tab panels
- **Index.cshtml.cs**: Updated to populate ShellViewModel

## Features
- Dashboard header with title, live status indicator, and overall health status badge
- Time range selector (24h/7d/30d) stored in localStorage
- Tab navigation with 6 tabs: Overview, Health Metrics, Commands, API & Rate Limits, System, Alerts
- URL hash-based routing (e.g., `#health-metrics`, `#commands`)
- Scroll position preservation per tab (sessionStorage)
- Keyboard navigation (Arrow keys, Home, End)
- Alert count badge on Alerts tab
- Accessibility features (skip link, ARIA roles, focus management)
- Mobile-responsive with scroll fade indicators

## Test plan
- [ ] Load the Performance Dashboard and verify header renders correctly
- [ ] Click each tab and verify content switches without page reload
- [ ] Verify URL hash updates when switching tabs
- [ ] Navigate to `#commands` directly in URL and verify Commands tab is active
- [ ] Test time range selector and refresh page - selection should persist
- [ ] Test keyboard navigation (Tab, Arrow keys, Enter)
- [ ] Test on mobile viewport - tabs should scroll horizontally
- [ ] Run `dotnet build` - no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)