### PR TITLE
Add hover previews to usernames and guild names on Message Logs pages

### DIFF
--- a/src/DiscordBot.Bot/Pages/Admin/MessageLogs/Details.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/MessageLogs/Details.cshtml
@@ -84,7 +84,7 @@
                         </div>
                         <div>
                             <div class="text-base font-medium text-text-primary">
-                                @(Model.ViewModel.Message.AuthorUsername ?? "(Unknown)")
+                                <span class="preview-trigger" data-preview-type="user" data-user-id="@Model.ViewModel.Message.AuthorId" @(Model.ViewModel.Message.GuildId.HasValue ? $"data-context-guild-id=\"{Model.ViewModel.Message.GuildId}\"" : "")>@(Model.ViewModel.Message.AuthorUsername ?? "(Unknown)")</span>
                             </div>
                             <div class="text-sm text-text-secondary">Discord User</div>
                         </div>
@@ -144,7 +144,7 @@
                         {
                             <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
                                 <span class="text-sm text-text-secondary">Guild Name</span>
-                                <span class="text-sm text-text-primary">@Model.ViewModel.Message.GuildName</span>
+                                <span class="text-sm text-text-primary preview-trigger" data-preview-type="guild" data-guild-id="@Model.ViewModel.Message.GuildId">@Model.ViewModel.Message.GuildName</span>
                             </div>
                         }
                         <!-- Channel ID -->

--- a/src/DiscordBot.Bot/Pages/Admin/MessageLogs/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/MessageLogs/Index.cshtml
@@ -203,7 +203,7 @@
                                         </div>
                                         <div class="ml-3">
                                             <div class="text-sm font-medium text-text-primary">
-                                                @(message.AuthorUsername ?? "(Unknown)")
+                                                <span class="preview-trigger" data-preview-type="user" data-user-id="@message.AuthorId" @(message.GuildId.HasValue ? $"data-context-guild-id=\"{message.GuildId}\"" : "")>@(message.AuthorUsername ?? "(Unknown)")</span>
                                             </div>
                                             <div class="text-xs text-text-tertiary font-mono">@message.AuthorId</div>
                                         </div>
@@ -212,7 +212,7 @@
                                 <td class="px-6 py-4 whitespace-nowrap text-sm text-text-primary">
                                     @if (message.GuildId.HasValue)
                                     {
-                                        @(message.GuildName ?? message.GuildId.ToString())
+                                        <span class="preview-trigger" data-preview-type="guild" data-guild-id="@message.GuildId">@(message.GuildName ?? message.GuildId.ToString())</span>
                                     }
                                     else
                                     {


### PR DESCRIPTION
## Summary

- Add user hover preview popups to author usernames on Index and Details pages
- Add guild hover preview popups to guild names on Index and Details pages
- Uses existing `preview-trigger` pattern from Command Logs and Audit Logs pages

## Test plan

- [ ] Navigate to Message Logs page (`/Admin/MessageLogs`)
- [ ] Hover over author username in table row - verify user preview popup appears
- [ ] Hover over guild name in table row - verify guild preview popup appears
- [ ] Click on a message to view Details page
- [ ] Hover over author username in Author section - verify user preview popup appears
- [ ] Hover over guild name in Location section - verify guild preview popup appears
- [ ] For server messages, verify user preview includes guild context (role info)
- [ ] For DM messages, verify user preview works without guild context

Closes #773

🤖 Generated with [Claude Code](https://claude.com/claude-code)