### PR TITLE
feat: Add landing page HTML prototype

### DIFF
--- a/docs/prototypes/features/landing-page/index.html
+++ b/docs/prototypes/features/landing-page/index.html
@@ -47,9 +47,9 @@
       color: #f0f0f0;
     }
 
-    /* Hidden login button - CSS only hover reveal */
+    /* Login button - subtle but discoverable */
     .login-btn {
-      opacity: 0;
+      opacity: 0.6;
       transition: opacity 0.2s ease-in-out;
     }
     .login-btn:hover,
@@ -82,10 +82,8 @@
 
     .feature-card:hover {
       border-color: #098ecf;
-      transform: translateY(-4px) scale(1.02);
-      box-shadow:
-        0 12px 40px rgba(9, 142, 207, 0.15),
-        0 0 0 1px rgba(9, 142, 207, 0.1) inset;
+      transform: translateY(-2px);
+      box-shadow: 0 8px 24px rgba(9, 142, 207, 0.12);
     }
 
     .feature-card:hover .icon-wrapper {
@@ -140,30 +138,8 @@
 
     /* Dot pattern background */
     .dot-pattern {
-      background-image: radial-gradient(circle, rgba(203, 78, 27, 0.12) 1px, transparent 1px);
+      background-image: radial-gradient(circle, rgba(203, 78, 27, 0.18) 1px, transparent 1px);
       background-size: 20px 20px;
-    }
-
-    /* Floating geometric shapes */
-    .floating-shape {
-      position: absolute;
-      border: 1px solid rgba(203, 78, 27, 0.15);
-      pointer-events: none;
-    }
-
-    @keyframes float-slow {
-      0%, 100% { transform: translateY(0) rotate(0deg); }
-      50% { transform: translateY(-12px) rotate(2deg); }
-    }
-    @keyframes float-medium {
-      0%, 100% { transform: translateY(0) rotate(0deg); }
-      50% { transform: translateY(-18px) rotate(-1.5deg); }
-    }
-    .animate-float-slow {
-      animation: float-slow 10s ease-in-out infinite;
-    }
-    .animate-float-medium {
-      animation: float-medium 7s ease-in-out infinite;
     }
 
     /* Section divider */
@@ -220,7 +196,7 @@
         <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold text-text-primary mb-4">
           Discord Bot
         </h1>
-        <p class="text-xl sm:text-2xl text-text-secondary mb-3">
+        <p class="text-xl sm:text-2xl lg:text-3xl text-text-secondary mb-6">
           A Discord bot that does a bunch of stuff.
         </p>
         <p class="text-base text-text-tertiary mb-10">
@@ -238,12 +214,6 @@
     <div class="hero-bg absolute inset-0 -z-10 overflow-hidden">
       <!-- Dot pattern -->
       <div class="absolute inset-0 dot-pattern"></div>
-
-      <!-- Floating geometric shapes -->
-      <div class="floating-shape w-16 h-16 rounded-lg top-1/4 left-[15%] animate-float-slow"></div>
-      <div class="floating-shape w-12 h-12 rounded top-1/3 right-[20%] animate-float-medium" style="animation-delay: -2s;"></div>
-      <div class="floating-shape w-8 h-8 rounded-full bottom-1/3 left-[25%] animate-float-medium" style="border-color: rgba(9, 142, 207, 0.15);"></div>
-      <div class="floating-shape w-20 h-20 rounded-lg bottom-1/4 right-[15%] animate-float-slow" style="animation-delay: -4s;"></div>
     </div>
   </section>
 
@@ -378,7 +348,7 @@
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
 
           <!-- Audio/Soundboard -->
-          <div class="coming-soon-card feature-card bg-bg-secondary border border-border-primary rounded-lg p-6">
+          <div class="coming-soon-card feature-card bg-bg-secondary border border-border-primary rounded-lg p-6 opacity-75">
             <div class="flex items-center justify-between mb-4">
               <div class="flex items-center gap-3">
                 <div class="icon-wrapper p-2 bg-bg-tertiary rounded-lg">
@@ -403,7 +373,7 @@
           </div>
 
           <!-- TTS Support -->
-          <div class="coming-soon-card feature-card bg-bg-secondary border border-border-primary rounded-lg p-6">
+          <div class="coming-soon-card feature-card bg-bg-secondary border border-border-primary rounded-lg p-6 opacity-75">
             <div class="flex items-center justify-between mb-4">
               <div class="flex items-center gap-3">
                 <div class="icon-wrapper p-2 bg-bg-tertiary rounded-lg">
@@ -428,7 +398,7 @@
           </div>
 
           <!-- Docker -->
-          <div class="coming-soon-card feature-card bg-bg-secondary border border-border-primary rounded-lg p-6">
+          <div class="coming-soon-card feature-card bg-bg-secondary border border-border-primary rounded-lg p-6 opacity-75">
             <div class="flex items-center justify-between mb-4">
               <div class="flex items-center gap-3">
                 <div class="icon-wrapper p-2 bg-bg-tertiary rounded-lg">
@@ -466,7 +436,7 @@
     <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
       <h2 class="text-2xl sm:text-3xl font-bold text-text-primary mb-10 text-center">Built with</h2>
 
-      <div class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-4 max-w-4xl mx-auto">
+      <div class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-6 max-w-4xl mx-auto">
         <div class="tech-icon p-4 bg-bg-tertiary border border-border-primary rounded-xl text-center hover:border-accent-blue">
           <div class="w-10 h-10 mx-auto mb-2 bg-accent-blue rounded-lg flex items-center justify-center text-white font-bold text-sm">.N</div>
           <span class="text-xs text-text-secondary">.NET 8</span>


### PR DESCRIPTION
## Summary

- Create HTML prototype for the public landing page at `docs/prototypes/features/landing-page/index.html`
- Implements all page sections: sticky nav, hidden login button, hero, features, tech stack, open source, about, footer
- Uses existing design system tokens and shared CSS infrastructure
- Responsive layout (mobile-first with md/lg breakpoints)

## Test plan

- [ ] Open `docs/prototypes/features/landing-page/index.html` in browser
- [ ] Verify sticky nav works and anchor links scroll to sections
- [ ] On desktop: hover near bottom-right to see login button appear
- [ ] Resize browser to test responsive breakpoints (sm, md, lg, xl)
- [ ] Verify feature cards show 5 current features + 3 "Coming Soon" with badges
- [ ] Verify no Rat Watch feature is mentioned
- [ ] Check casual tone throughout

Closes #805

🤖 Generated with [Claude Code](https://claude.com/claude-code)