### PR TITLE
feat(ui): Create PerformanceTabViewModels for partial view data

### DIFF
--- a/src/DiscordBot.Bot/ViewModels/Pages/Performance/AlertsTabViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Pages/Performance/AlertsTabViewModel.cs
@@ -1,0 +1,19 @@
+namespace DiscordBot.Bot.ViewModels.Pages.Performance;
+
+/// <summary>
+/// View model for the Alerts tab, wrapping AlertsPageViewModel.
+/// Provides a consistent interface for partial view rendering with time range filtering.
+/// </summary>
+public record AlertsTabViewModel : IPerformanceTabViewModel
+{
+    /// <inheritdoc />
+    public string TabId => "alerts";
+
+    /// <inheritdoc />
+    public int Hours { get; init; } = 24;
+
+    /// <summary>
+    /// Gets the underlying alerts page data including active incidents and alert configurations.
+    /// </summary>
+    public required AlertsPageViewModel Data { get; init; }
+}

--- a/src/DiscordBot.Bot/ViewModels/Pages/Performance/ApiMetricsTabViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Pages/Performance/ApiMetricsTabViewModel.cs
@@ -1,0 +1,19 @@
+namespace DiscordBot.Bot.ViewModels.Pages.Performance;
+
+/// <summary>
+/// View model for the API Metrics tab, wrapping ApiRateLimitsViewModel.
+/// Provides a consistent interface for partial view rendering with time range filtering.
+/// </summary>
+public record ApiMetricsTabViewModel : IPerformanceTabViewModel
+{
+    /// <inheritdoc />
+    public string TabId => "api-metrics";
+
+    /// <inheritdoc />
+    public int Hours { get; init; } = 24;
+
+    /// <summary>
+    /// Gets the underlying API rate limits and metrics data.
+    /// </summary>
+    public required ApiRateLimitsViewModel Data { get; init; }
+}

--- a/src/DiscordBot.Bot/ViewModels/Pages/Performance/CommandsTabViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Pages/Performance/CommandsTabViewModel.cs
@@ -1,0 +1,19 @@
+namespace DiscordBot.Bot.ViewModels.Pages.Performance;
+
+/// <summary>
+/// View model for the Commands tab, wrapping CommandPerformanceViewModel.
+/// Provides a consistent interface for partial view rendering with time range filtering.
+/// </summary>
+public record CommandsTabViewModel : IPerformanceTabViewModel
+{
+    /// <inheritdoc />
+    public string TabId => "commands";
+
+    /// <inheritdoc />
+    public int Hours { get; init; } = 24;
+
+    /// <summary>
+    /// Gets the underlying command performance data.
+    /// </summary>
+    public required CommandPerformanceViewModel Data { get; init; }
+}

--- a/src/DiscordBot.Bot/ViewModels/Pages/Performance/HealthMetricsTabViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Pages/Performance/HealthMetricsTabViewModel.cs
@@ -1,0 +1,19 @@
+namespace DiscordBot.Bot.ViewModels.Pages.Performance;
+
+/// <summary>
+/// View model for the Health Metrics tab, wrapping HealthMetricsViewModel.
+/// Provides a consistent interface for partial view rendering with time range filtering.
+/// </summary>
+public record HealthMetricsTabViewModel : IPerformanceTabViewModel
+{
+    /// <inheritdoc />
+    public string TabId => "health-metrics";
+
+    /// <inheritdoc />
+    public int Hours { get; init; } = 24;
+
+    /// <summary>
+    /// Gets the underlying health metrics data.
+    /// </summary>
+    public required HealthMetricsViewModel Data { get; init; }
+}

--- a/src/DiscordBot.Bot/ViewModels/Pages/Performance/IPerformanceTabViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Pages/Performance/IPerformanceTabViewModel.cs
@@ -1,0 +1,18 @@
+namespace DiscordBot.Bot.ViewModels.Pages.Performance;
+
+/// <summary>
+/// Marker interface for Performance Dashboard tab view models.
+/// Enables consistent partial view rendering and time range filtering.
+/// </summary>
+public interface IPerformanceTabViewModel
+{
+    /// <summary>
+    /// Gets the tab identifier used for routing and active tab detection.
+    /// </summary>
+    string TabId { get; }
+
+    /// <summary>
+    /// Gets the time range in hours for data filtering (default: 24).
+    /// </summary>
+    int Hours { get; }
+}

--- a/src/DiscordBot.Bot/ViewModels/Pages/Performance/OverviewTabViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Pages/Performance/OverviewTabViewModel.cs
@@ -1,0 +1,19 @@
+namespace DiscordBot.Bot.ViewModels.Pages.Performance;
+
+/// <summary>
+/// View model for the Overview tab, wrapping PerformanceOverviewViewModel.
+/// Provides a consistent interface for partial view rendering with time range filtering.
+/// </summary>
+public record OverviewTabViewModel : IPerformanceTabViewModel
+{
+    /// <inheritdoc />
+    public string TabId => "overview";
+
+    /// <inheritdoc />
+    public int Hours { get; init; } = 24;
+
+    /// <summary>
+    /// Gets the underlying performance overview data.
+    /// </summary>
+    public required PerformanceOverviewViewModel Data { get; init; }
+}

--- a/src/DiscordBot.Bot/ViewModels/Pages/Performance/PerformanceTabType.cs
+++ b/src/DiscordBot.Bot/ViewModels/Pages/Performance/PerformanceTabType.cs
@@ -1,0 +1,37 @@
+namespace DiscordBot.Bot.ViewModels.Pages.Performance;
+
+/// <summary>
+/// Identifies the type of Performance Dashboard tab for routing and display.
+/// </summary>
+public enum PerformanceTabType
+{
+    /// <summary>
+    /// Overview tab showing aggregated performance metrics.
+    /// </summary>
+    Overview,
+
+    /// <summary>
+    /// Health Metrics tab showing bot health, uptime, and connection status.
+    /// </summary>
+    HealthMetrics,
+
+    /// <summary>
+    /// Commands tab showing command response times, throughput, and errors.
+    /// </summary>
+    Commands,
+
+    /// <summary>
+    /// API Metrics tab showing API usage, rate limits, and latency.
+    /// </summary>
+    ApiMetrics,
+
+    /// <summary>
+    /// System Health tab showing database, cache, and background services.
+    /// </summary>
+    SystemHealth,
+
+    /// <summary>
+    /// Alerts tab showing active alerts, incident history, and configuration.
+    /// </summary>
+    Alerts
+}

--- a/src/DiscordBot.Bot/ViewModels/Pages/Performance/SystemHealthTabViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Pages/Performance/SystemHealthTabViewModel.cs
@@ -1,0 +1,19 @@
+namespace DiscordBot.Bot.ViewModels.Pages.Performance;
+
+/// <summary>
+/// View model for the System Health tab, wrapping SystemHealthViewModel.
+/// Provides a consistent interface for partial view rendering with time range filtering.
+/// </summary>
+public record SystemHealthTabViewModel : IPerformanceTabViewModel
+{
+    /// <inheritdoc />
+    public string TabId => "system-health";
+
+    /// <inheritdoc />
+    public int Hours { get; init; } = 24;
+
+    /// <summary>
+    /// Gets the underlying system health data including database, cache, and service metrics.
+    /// </summary>
+    public required SystemHealthViewModel Data { get; init; }
+}


### PR DESCRIPTION
## Summary

- Adds IPerformanceTabViewModel interface defining TabId and Hours properties
- Creates PerformanceTabType enum for type-safe tab identification
- Implements 6 tab-specific wrapper view models that wrap existing view models
- All wrappers are immutable records with required Data property and default 24h time range

## Implementation Details

| Tab | Wrapper | Wraps |
|-----|---------|-------|
| Overview | OverviewTabViewModel | PerformanceOverviewViewModel |
| Health Metrics | HealthMetricsTabViewModel | HealthMetricsViewModel |
| Commands | CommandsTabViewModel | CommandPerformanceViewModel |
| API Metrics | ApiMetricsTabViewModel | ApiRateLimitsViewModel |
| System Health | SystemHealthTabViewModel | SystemHealthViewModel |
| Alerts | AlertsTabViewModel | AlertsPageViewModel |

## Test plan

- [x] Solution builds successfully
- [x] Existing tests pass (2590 passed, 1 unrelated pre-existing failure)
- [ ] Will be validated when partial view conversion issues (#759-#764) use these view models

Closes #758

🤖 Generated with [Claude Code](https://claude.com/claude-code)