### PR TITLE
Fix memory leak: Replace unbounded collections with bounded alternatives

### DIFF
--- a/src/DiscordBot.Bot/Collections/BoundedTimestampQueue.cs
+++ b/src/DiscordBot.Bot/Collections/BoundedTimestampQueue.cs
@@ -1,0 +1,201 @@
+namespace DiscordBot.Bot.Collections;
+
+/// <summary>
+/// Interface for items that have a timestamp for time-based filtering.
+/// </summary>
+public interface ITimestamped
+{
+    /// <summary>
+    /// Gets the timestamp of this item.
+    /// </summary>
+    DateTime Timestamp { get; }
+}
+
+/// <summary>
+/// Thread-safe bounded queue optimized for time-based records.
+/// Uses a circular buffer to prevent memory growth beyond the specified capacity.
+/// </summary>
+/// <remarks>
+/// This collection is designed for high-throughput scenarios where memory bounds
+/// must be enforced. When capacity is exceeded, the oldest items are automatically
+/// overwritten (FIFO eviction).
+/// </remarks>
+/// <typeparam name="T">Record type that must implement <see cref="ITimestamped"/>.</typeparam>
+public class BoundedTimestampQueue<T> where T : ITimestamped
+{
+    private readonly T[] _buffer;
+    private readonly object _lock = new();
+    private int _head;      // Next write position
+    private int _count;     // Current item count
+    private readonly int _capacity;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BoundedTimestampQueue{T}"/> class.
+    /// </summary>
+    /// <param name="capacity">The maximum number of items the queue can hold.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when capacity is less than or equal to zero.</exception>
+    public BoundedTimestampQueue(int capacity)
+    {
+        if (capacity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(capacity), "Capacity must be greater than zero.");
+        }
+
+        _capacity = capacity;
+        _buffer = new T[capacity];
+    }
+
+    /// <summary>
+    /// Gets the current number of items in the queue.
+    /// </summary>
+    public int Count
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _count;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the maximum capacity of the queue.
+    /// </summary>
+    public int Capacity => _capacity;
+
+    /// <summary>
+    /// Gets a value indicating whether the queue is at capacity.
+    /// </summary>
+    public bool IsAtCapacity
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _count >= _capacity;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Adds an item to the queue. If the queue is at capacity, the oldest item is overwritten.
+    /// </summary>
+    /// <param name="item">The item to add.</param>
+    public void Enqueue(T item)
+    {
+        lock (_lock)
+        {
+            _buffer[_head] = item;
+            _head = (_head + 1) % _capacity;
+
+            if (_count < _capacity)
+            {
+                _count++;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets all items with a timestamp on or after the specified cutoff time.
+    /// </summary>
+    /// <param name="cutoff">The minimum timestamp (inclusive).</param>
+    /// <returns>A read-only list of items matching the time criteria, in chronological order.</returns>
+    public IReadOnlyList<T> GetItemsAfter(DateTime cutoff)
+    {
+        lock (_lock)
+        {
+            var result = new List<T>(_count);
+            var start = (_head - _count + _capacity) % _capacity;
+
+            for (int i = 0; i < _count; i++)
+            {
+                var index = (start + i) % _capacity;
+                if (_buffer[index].Timestamp >= cutoff)
+                {
+                    result.Add(_buffer[index]);
+                }
+            }
+
+            return result;
+        }
+    }
+
+    /// <summary>
+    /// Counts items with a timestamp on or after the specified cutoff time.
+    /// </summary>
+    /// <param name="cutoff">The minimum timestamp (inclusive).</param>
+    /// <returns>The number of items matching the time criteria.</returns>
+    public int CountAfter(DateTime cutoff)
+    {
+        lock (_lock)
+        {
+            var count = 0;
+            var start = (_head - _count + _capacity) % _capacity;
+
+            for (int i = 0; i < _count; i++)
+            {
+                var index = (start + i) % _capacity;
+                if (_buffer[index].Timestamp >= cutoff)
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+    }
+
+    /// <summary>
+    /// Counts items matching both the time cutoff and a custom predicate.
+    /// </summary>
+    /// <param name="cutoff">The minimum timestamp (inclusive).</param>
+    /// <param name="predicate">Additional filter criteria.</param>
+    /// <returns>The number of items matching both criteria.</returns>
+    public int CountAfterWithPredicate(DateTime cutoff, Func<T, bool> predicate)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+
+        lock (_lock)
+        {
+            var count = 0;
+            var start = (_head - _count + _capacity) % _capacity;
+
+            for (int i = 0; i < _count; i++)
+            {
+                var index = (start + i) % _capacity;
+                var item = _buffer[index];
+                if (item.Timestamp >= cutoff && predicate(item))
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+    }
+
+    /// <summary>
+    /// Calculates the estimated memory usage of this queue in bytes.
+    /// </summary>
+    /// <param name="bytesPerItem">The estimated size of each item in bytes.</param>
+    /// <returns>The estimated total memory usage in bytes.</returns>
+    public long EstimatedBytes(int bytesPerItem)
+    {
+        // Buffer capacity * item size + object overhead (lock, fields, array reference)
+        return (_capacity * bytesPerItem) + 64;
+    }
+
+    /// <summary>
+    /// Clears all items from the queue.
+    /// </summary>
+    public void Clear()
+    {
+        lock (_lock)
+        {
+            Array.Clear(_buffer, 0, _capacity);
+            _head = 0;
+            _count = 0;
+        }
+    }
+}

--- a/src/DiscordBot.Bot/Collections/LruConcurrentDictionary.cs
+++ b/src/DiscordBot.Bot/Collections/LruConcurrentDictionary.cs
@@ -1,0 +1,244 @@
+namespace DiscordBot.Bot.Collections;
+
+/// <summary>
+/// Thread-safe dictionary with LRU (Least Recently Used) eviction when capacity is exceeded.
+/// </summary>
+/// <remarks>
+/// This collection is designed for scenarios where you need bounded memory usage
+/// with automatic eviction of the least recently accessed items. Access order is
+/// tracked and updated on both reads and writes.
+/// </remarks>
+/// <typeparam name="TKey">The type of keys in the dictionary.</typeparam>
+/// <typeparam name="TValue">The type of values in the dictionary.</typeparam>
+public class LruConcurrentDictionary<TKey, TValue> where TKey : notnull
+{
+    private readonly Dictionary<TKey, LinkedListNode<(TKey Key, TValue Value)>> _cache;
+    private readonly LinkedList<(TKey Key, TValue Value)> _lruList;
+    private readonly int _capacity;
+    private readonly object _lock = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LruConcurrentDictionary{TKey, TValue}"/> class.
+    /// </summary>
+    /// <param name="capacity">The maximum number of items the dictionary can hold before eviction occurs.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when capacity is less than or equal to zero.</exception>
+    public LruConcurrentDictionary(int capacity)
+    {
+        if (capacity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(capacity), "Capacity must be greater than zero.");
+        }
+
+        _capacity = capacity;
+        _cache = new Dictionary<TKey, LinkedListNode<(TKey, TValue)>>(capacity);
+        _lruList = new LinkedList<(TKey, TValue)>();
+    }
+
+    /// <summary>
+    /// Gets the current number of items in the dictionary.
+    /// </summary>
+    public int Count
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _cache.Count;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the maximum capacity of the dictionary.
+    /// </summary>
+    public int Capacity => _capacity;
+
+    /// <summary>
+    /// Gets or adds a value to the dictionary. If the key exists, moves it to the front (most recently used).
+    /// If adding a new key would exceed capacity, the least recently used item is evicted.
+    /// </summary>
+    /// <param name="key">The key to look up or add.</param>
+    /// <param name="valueFactory">A factory function to create the value if the key is not present.</param>
+    /// <returns>The existing or newly created value.</returns>
+    public TValue GetOrAdd(TKey key, Func<TKey, TValue> valueFactory)
+    {
+        ArgumentNullException.ThrowIfNull(valueFactory);
+
+        lock (_lock)
+        {
+            if (_cache.TryGetValue(key, out var existingNode))
+            {
+                // Move to front (most recently used)
+                _lruList.Remove(existingNode);
+                _lruList.AddFirst(existingNode);
+                return existingNode.Value.Value;
+            }
+
+            // Create new entry
+            var value = valueFactory(key);
+            var newNode = _lruList.AddFirst((key, value));
+            _cache[key] = newNode;
+
+            // Evict LRU entries if over capacity
+            while (_cache.Count > _capacity)
+            {
+                var lruNode = _lruList.Last!;
+                _lruList.RemoveLast();
+                _cache.Remove(lruNode.Value.Key);
+            }
+
+            return value;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to get the value associated with the specified key.
+    /// If found, the item is moved to the front (most recently used).
+    /// </summary>
+    /// <param name="key">The key to look up.</param>
+    /// <param name="value">When this method returns, contains the value if found; otherwise, the default value.</param>
+    /// <returns>true if the key was found; otherwise, false.</returns>
+    public bool TryGetValue(TKey key, out TValue? value)
+    {
+        lock (_lock)
+        {
+            if (_cache.TryGetValue(key, out var node))
+            {
+                // Move to front (most recently used)
+                _lruList.Remove(node);
+                _lruList.AddFirst(node);
+                value = node.Value.Value;
+                return true;
+            }
+
+            value = default;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Adds or updates a value in the dictionary.
+    /// If the key exists, updates the value and moves to front.
+    /// If adding a new key would exceed capacity, the least recently used item is evicted.
+    /// </summary>
+    /// <param name="key">The key to add or update.</param>
+    /// <param name="value">The value to set.</param>
+    public void AddOrUpdate(TKey key, TValue value)
+    {
+        lock (_lock)
+        {
+            if (_cache.TryGetValue(key, out var existingNode))
+            {
+                // Remove old node
+                _lruList.Remove(existingNode);
+            }
+
+            // Add new node at front
+            var newNode = _lruList.AddFirst((key, value));
+            _cache[key] = newNode;
+
+            // Evict LRU entries if over capacity
+            while (_cache.Count > _capacity)
+            {
+                var lruNode = _lruList.Last!;
+                _lruList.RemoveLast();
+                _cache.Remove(lruNode.Value.Key);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Removes the item with the specified key from the dictionary.
+    /// </summary>
+    /// <param name="key">The key to remove.</param>
+    /// <returns>true if the item was found and removed; otherwise, false.</returns>
+    public bool Remove(TKey key)
+    {
+        lock (_lock)
+        {
+            if (_cache.TryGetValue(key, out var node))
+            {
+                _lruList.Remove(node);
+                _cache.Remove(key);
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Checks if the dictionary contains the specified key.
+    /// Note: This does NOT update the LRU order.
+    /// </summary>
+    /// <param name="key">The key to check.</param>
+    /// <returns>true if the key exists; otherwise, false.</returns>
+    public bool ContainsKey(TKey key)
+    {
+        lock (_lock)
+        {
+            return _cache.ContainsKey(key);
+        }
+    }
+
+    /// <summary>
+    /// Gets all entries in the dictionary in LRU order (most recently used first).
+    /// </summary>
+    /// <returns>A list of key-value pairs in LRU order.</returns>
+    public IReadOnlyList<KeyValuePair<TKey, TValue>> GetAll()
+    {
+        lock (_lock)
+        {
+            return _lruList
+                .Select(x => new KeyValuePair<TKey, TValue>(x.Key, x.Value))
+                .ToList();
+        }
+    }
+
+    /// <summary>
+    /// Gets all keys in the dictionary.
+    /// </summary>
+    /// <returns>A collection of all keys.</returns>
+    public IReadOnlyCollection<TKey> Keys
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _cache.Keys.ToList();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Clears all items from the dictionary.
+    /// </summary>
+    public void Clear()
+    {
+        lock (_lock)
+        {
+            _cache.Clear();
+            _lruList.Clear();
+        }
+    }
+
+    /// <summary>
+    /// Calculates the estimated memory usage of this dictionary in bytes.
+    /// </summary>
+    /// <param name="bytesPerKey">The estimated size of each key in bytes.</param>
+    /// <param name="bytesPerValue">The estimated size of each value in bytes.</param>
+    /// <returns>The estimated total memory usage in bytes.</returns>
+    public long EstimatedBytes(int bytesPerKey, int bytesPerValue)
+    {
+        lock (_lock)
+        {
+            // LinkedListNode overhead: ~40 bytes per node (prev, next, list references + value tuple)
+            // Dictionary entry overhead: ~24 bytes per entry (key hash, bucket index, value reference)
+            const int nodeOverhead = 40;
+            const int dictEntryOverhead = 24;
+
+            var perEntryBytes = bytesPerKey + bytesPerValue + nodeOverhead + dictEntryOverhead;
+            return (_cache.Count * perEntryBytes) + 64; // +64 for object overhead
+        }
+    }
+}

--- a/src/DiscordBot.Bot/Extensions/ModerationServiceExtensions.cs
+++ b/src/DiscordBot.Bot/Extensions/ModerationServiceExtensions.cs
@@ -34,9 +34,16 @@ public static class ModerationServiceExtensions
         services.AddScoped<IInvestigationService, InvestigationService>();
 
         // Detection services (singleton for in-memory caching)
-        services.AddSingleton<ISpamDetectionService, SpamDetectionService>();
+        // Register concrete types first, then add interface mappings (including IMemoryReportable)
+        services.AddSingleton<SpamDetectionService>();
+        services.AddSingleton<ISpamDetectionService>(sp => sp.GetRequiredService<SpamDetectionService>());
+        services.AddSingleton<IMemoryReportable>(sp => sp.GetRequiredService<SpamDetectionService>());
+
         services.AddSingleton<IContentFilterService, ContentFilterService>();
-        services.AddSingleton<IRaidDetectionService, RaidDetectionService>();
+
+        services.AddSingleton<RaidDetectionService>();
+        services.AddSingleton<IRaidDetectionService>(sp => sp.GetRequiredService<RaidDetectionService>());
+        services.AddSingleton<IMemoryReportable>(sp => sp.GetRequiredService<RaidDetectionService>());
 
         // Handlers (singleton)
         services.AddSingleton<AutoModerationHandler>();

--- a/src/DiscordBot.Bot/appsettings.json
+++ b/src/DiscordBot.Bot/appsettings.json
@@ -150,7 +150,9 @@
     "DetectionCacheExpiryMinutes": 5,
     "MaxCachedGuilds": 1000,
     "FlaggedEventRetentionDays": 90,
-    "EnableDebugLogging": false
+    "EnableDebugLogging": false,
+    "MaxMessagesPerUser": 200,
+    "MaxJoinsPerGuild": 500
   },
   "PerformanceMetrics": {
     "LatencySampleIntervalSeconds": 30,
@@ -160,7 +162,8 @@
     "SlowQueryThresholdMs": 100,
     "SlowQueryMaxStored": 100,
     "CacheStatisticsEnabled": true,
-    "CommandAggregationCacheTtlMinutes": 5
+    "CommandAggregationCacheTtlMinutes": 5,
+    "MaxApiCategories": 100
   },
   "Serilog": {
     "MinimumLevel": {

--- a/src/DiscordBot.Core/Configuration/AutoModerationOptions.cs
+++ b/src/DiscordBot.Core/Configuration/AutoModerationOptions.cs
@@ -33,4 +33,18 @@ public class AutoModerationOptions
     /// Default: false
     /// </summary>
     public bool EnableDebugLogging { get; set; } = false;
+
+    /// <summary>
+    /// Maximum messages to track per user for spam detection.
+    /// Higher values use more memory but can catch more sophisticated spam patterns.
+    /// Default: 200 (covers ~5 minutes at 40 messages/minute rate)
+    /// </summary>
+    public int MaxMessagesPerUser { get; set; } = 200;
+
+    /// <summary>
+    /// Maximum joins to track per guild for raid detection.
+    /// Higher values use more memory but can detect longer-duration raids.
+    /// Default: 500 (covers 15 minutes at ~33 joins/minute)
+    /// </summary>
+    public int MaxJoinsPerGuild { get; set; } = 500;
 }

--- a/src/DiscordBot.Core/Configuration/PerformanceMetricsOptions.cs
+++ b/src/DiscordBot.Core/Configuration/PerformanceMetricsOptions.cs
@@ -59,4 +59,11 @@ public class PerformanceMetricsOptions
     /// Default is 5 minutes.
     /// </summary>
     public int CommandAggregationCacheTtlMinutes { get; set; } = 5;
+
+    /// <summary>
+    /// Gets or sets the maximum number of API categories to track.
+    /// When exceeded, least-recently-used categories are evicted.
+    /// Default is 100.
+    /// </summary>
+    public int MaxApiCategories { get; set; } = 100;
 }

--- a/tests/DiscordBot.Tests/Bot/Collections/BoundedTimestampQueueTests.cs
+++ b/tests/DiscordBot.Tests/Bot/Collections/BoundedTimestampQueueTests.cs
@@ -1,0 +1,655 @@
+using DiscordBot.Bot.Collections;
+using FluentAssertions;
+
+namespace DiscordBot.Tests.Bot.Collections;
+
+/// <summary>
+/// Unit tests for <see cref="BoundedTimestampQueue{T}"/>.
+/// Tests cover FIFO eviction, time-based filtering, thread safety, and memory estimation.
+/// </summary>
+public class BoundedTimestampQueueTests
+{
+    /// <summary>
+    /// Test record implementing ITimestamped for testing purposes.
+    /// </summary>
+    private record TestRecord(DateTime Timestamp, string Data) : ITimestamped;
+
+    #region Constructor Tests
+
+    [Fact]
+    public void Constructor_ZeroCapacity_ThrowsException()
+    {
+        // Arrange & Act
+        var act = () => new BoundedTimestampQueue<TestRecord>(0);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithMessage("*Capacity must be greater than zero*")
+            .And.ParamName.Should().Be("capacity");
+    }
+
+    [Fact]
+    public void Constructor_NegativeCapacity_ThrowsException()
+    {
+        // Arrange & Act
+        var act = () => new BoundedTimestampQueue<TestRecord>(-1);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithMessage("*Capacity must be greater than zero*")
+            .And.ParamName.Should().Be("capacity");
+    }
+
+    [Fact]
+    public void Constructor_ValidCapacity_CreatesQueue()
+    {
+        // Arrange & Act
+        var queue = new BoundedTimestampQueue<TestRecord>(10);
+
+        // Assert
+        queue.Capacity.Should().Be(10);
+        queue.Count.Should().Be(0);
+        queue.IsAtCapacity.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region Enqueue Tests
+
+    [Fact]
+    public void Enqueue_BelowCapacity_AddsItem()
+    {
+        // Arrange
+        var queue = new BoundedTimestampQueue<TestRecord>(5);
+        var timestamp = DateTime.UtcNow;
+        var item = new TestRecord(timestamp, "test-data");
+
+        // Act
+        queue.Enqueue(item);
+
+        // Assert
+        queue.Count.Should().Be(1, "item should be added to queue");
+        queue.IsAtCapacity.Should().BeFalse("queue should not be at capacity");
+
+        var items = queue.GetItemsAfter(DateTime.MinValue);
+        items.Should().ContainSingle()
+            .Which.Should().Be(item);
+    }
+
+    [Fact]
+    public void Enqueue_MultipleItems_MaintainsOrder()
+    {
+        // Arrange
+        var queue = new BoundedTimestampQueue<TestRecord>(5);
+        var baseTime = DateTime.UtcNow;
+        var items = new[]
+        {
+            new TestRecord(baseTime, "first"),
+            new TestRecord(baseTime.AddSeconds(1), "second"),
+            new TestRecord(baseTime.AddSeconds(2), "third")
+        };
+
+        // Act
+        foreach (var item in items)
+        {
+            queue.Enqueue(item);
+        }
+
+        // Assert
+        queue.Count.Should().Be(3);
+        var retrieved = queue.GetItemsAfter(DateTime.MinValue);
+        retrieved.Should().ContainInOrder(items);
+    }
+
+    [Fact]
+    public void Enqueue_WhenAtCapacity_RemovesOldestItem()
+    {
+        // Arrange
+        var queue = new BoundedTimestampQueue<TestRecord>(3);
+        var baseTime = DateTime.UtcNow;
+
+        var firstItem = new TestRecord(baseTime, "first");
+        var secondItem = new TestRecord(baseTime.AddSeconds(1), "second");
+        var thirdItem = new TestRecord(baseTime.AddSeconds(2), "third");
+        var fourthItem = new TestRecord(baseTime.AddSeconds(3), "fourth");
+
+        // Act - Fill to capacity
+        queue.Enqueue(firstItem);
+        queue.Enqueue(secondItem);
+        queue.Enqueue(thirdItem);
+
+        // Verify at capacity
+        queue.IsAtCapacity.Should().BeTrue("queue should be at capacity");
+        queue.Count.Should().Be(3);
+
+        // Act - Add one more to trigger eviction
+        queue.Enqueue(fourthItem);
+
+        // Assert
+        queue.Count.Should().Be(3, "count should remain at capacity");
+        queue.IsAtCapacity.Should().BeTrue("queue should still be at capacity");
+
+        var items = queue.GetItemsAfter(DateTime.MinValue);
+        items.Should().HaveCount(3);
+        items.Should().NotContain(firstItem, "oldest item should be evicted (FIFO)");
+        items.Should().ContainInOrder(secondItem, thirdItem, fourthItem);
+    }
+
+    [Fact]
+    public void Enqueue_ContinuouslyBeyondCapacity_MaintainsFifoEviction()
+    {
+        // Arrange
+        var queue = new BoundedTimestampQueue<TestRecord>(3);
+        var baseTime = DateTime.UtcNow;
+
+        // Act - Add 6 items (double the capacity)
+        for (int i = 0; i < 6; i++)
+        {
+            queue.Enqueue(new TestRecord(baseTime.AddSeconds(i), $"item-{i}"));
+        }
+
+        // Assert
+        queue.Count.Should().Be(3, "queue should maintain capacity limit");
+
+        var items = queue.GetItemsAfter(DateTime.MinValue);
+        items.Should().HaveCount(3);
+        items[0].Data.Should().Be("item-3", "should have 4th item (index 3)");
+        items[1].Data.Should().Be("item-4", "should have 5th item (index 4)");
+        items[2].Data.Should().Be("item-5", "should have 6th item (index 5)");
+    }
+
+    #endregion
+
+    #region CountAfter Tests
+
+    [Fact]
+    public void CountAfter_ReturnsOnlyItemsInTimeWindow()
+    {
+        // Arrange
+        var queue = new BoundedTimestampQueue<TestRecord>(10);
+        var baseTime = DateTime.UtcNow;
+
+        queue.Enqueue(new TestRecord(baseTime.AddMinutes(-10), "old-1"));
+        queue.Enqueue(new TestRecord(baseTime.AddMinutes(-5), "recent-1"));
+        queue.Enqueue(new TestRecord(baseTime.AddMinutes(-4), "recent-2"));
+        queue.Enqueue(new TestRecord(baseTime.AddMinutes(-3), "recent-3"));
+        queue.Enqueue(new TestRecord(baseTime.AddMinutes(-1), "recent-4"));
+
+        // Act
+        var countLastFiveMinutes = queue.CountAfter(baseTime.AddMinutes(-5));
+
+        // Assert
+        countLastFiveMinutes.Should().Be(4, "should count only items from last 5 minutes (inclusive)");
+    }
+
+    [Fact]
+    public void CountAfter_EmptyQueue_ReturnsZero()
+    {
+        // Arrange
+        var queue = new BoundedTimestampQueue<TestRecord>(10);
+
+        // Act
+        var count = queue.CountAfter(DateTime.UtcNow.AddMinutes(-5));
+
+        // Assert
+        count.Should().Be(0);
+    }
+
+    [Fact]
+    public void CountAfter_NoItemsInWindow_ReturnsZero()
+    {
+        // Arrange
+        var queue = new BoundedTimestampQueue<TestRecord>(10);
+        var baseTime = DateTime.UtcNow;
+
+        queue.Enqueue(new TestRecord(baseTime.AddMinutes(-20), "old-1"));
+        queue.Enqueue(new TestRecord(baseTime.AddMinutes(-15), "old-2"));
+
+        // Act
+        var count = queue.CountAfter(baseTime.AddMinutes(-5));
+
+        // Assert
+        count.Should().Be(0, "no items should fall within the time window");
+    }
+
+    [Fact]
+    public void CountAfter_AllItemsInWindow_ReturnsTotal()
+    {
+        // Arrange
+        var queue = new BoundedTimestampQueue<TestRecord>(5);
+        var baseTime = DateTime.UtcNow;
+
+        for (int i = 0; i < 5; i++)
+        {
+            queue.Enqueue(new TestRecord(baseTime.AddMinutes(i), $"item-{i}"));
+        }
+
+        // Act
+        var count = queue.CountAfter(baseTime);
+
+        // Assert
+        count.Should().Be(5, "all items should fall within the time window");
+    }
+
+    [Fact]
+    public void CountAfter_CutoffInclusiveBoundary_IncludesExactMatch()
+    {
+        // Arrange
+        var queue = new BoundedTimestampQueue<TestRecord>(5);
+        var exactTime = DateTime.UtcNow;
+
+        queue.Enqueue(new TestRecord(exactTime.AddSeconds(-1), "before"));
+        queue.Enqueue(new TestRecord(exactTime, "exact"));
+        queue.Enqueue(new TestRecord(exactTime.AddSeconds(1), "after"));
+
+        // Act
+        var count = queue.CountAfter(exactTime);
+
+        // Assert
+        count.Should().Be(2, "cutoff should be inclusive (>= cutoff)");
+    }
+
+    #endregion
+
+    #region CountAfterWithPredicate Tests
+
+    [Fact]
+    public void CountAfterWithPredicate_FiltersCorrectly()
+    {
+        // Arrange
+        var queue = new BoundedTimestampQueue<TestRecord>(10);
+        var baseTime = DateTime.UtcNow;
+
+        queue.Enqueue(new TestRecord(baseTime.AddMinutes(-5), "apple"));
+        queue.Enqueue(new TestRecord(baseTime.AddMinutes(-4), "banana"));
+        queue.Enqueue(new TestRecord(baseTime.AddMinutes(-3), "apricot"));
+        queue.Enqueue(new TestRecord(baseTime.AddMinutes(-2), "avocado"));
+        queue.Enqueue(new TestRecord(baseTime.AddMinutes(-10), "artichoke")); // Outside time window
+
+        // Act - Count items starting with 'a' in last 5 minutes
+        var count = queue.CountAfterWithPredicate(
+            baseTime.AddMinutes(-5),
+            item => item.Data.StartsWith('a'));
+
+        // Assert
+        count.Should().Be(3, "should match apple, apricot, and avocado (artichoke is outside time window)");
+    }
+
+    [Fact]
+    public void CountAfterWithPredicate_NullPredicate_ThrowsException()
+    {
+        // Arrange
+        var queue = new BoundedTimestampQueue<TestRecord>(10);
+        queue.Enqueue(new TestRecord(DateTime.UtcNow, "test"));
+
+        // Act
+        var act = () => queue.CountAfterWithPredicate(DateTime.UtcNow, null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>()
+            .WithParameterName("predicate");
+    }
+
+    [Fact]
+    public void CountAfterWithPredicate_NoMatches_ReturnsZero()
+    {
+        // Arrange
+        var queue = new BoundedTimestampQueue<TestRecord>(10);
+        var baseTime = DateTime.UtcNow;
+
+        queue.Enqueue(new TestRecord(baseTime, "apple"));
+        queue.Enqueue(new TestRecord(baseTime.AddSeconds(1), "banana"));
+
+        // Act
+        var count = queue.CountAfterWithPredicate(
+            baseTime,
+            item => item.Data.StartsWith('z'));
+
+        // Assert
+        count.Should().Be(0);
+    }
+
+    [Fact]
+    public void CountAfterWithPredicate_AllMatch_ReturnsTotal()
+    {
+        // Arrange
+        var queue = new BoundedTimestampQueue<TestRecord>(5);
+        var baseTime = DateTime.UtcNow;
+
+        for (int i = 0; i < 5; i++)
+        {
+            queue.Enqueue(new TestRecord(baseTime.AddSeconds(i), $"item-{i}"));
+        }
+
+        // Act
+        var count = queue.CountAfterWithPredicate(
+            baseTime,
+            item => item.Data.StartsWith("item"));
+
+        // Assert
+        count.Should().Be(5);
+    }
+
+    #endregion
+
+    #region GetItemsAfter Tests
+
+    [Fact]
+    public void GetItemsAfter_ReturnsItemsInTimeWindow()
+    {
+        // Arrange
+        var queue = new BoundedTimestampQueue<TestRecord>(10);
+        var baseTime = DateTime.UtcNow;
+
+        var oldItem = new TestRecord(baseTime.AddMinutes(-10), "old");
+        var recent1 = new TestRecord(baseTime.AddMinutes(-5), "recent-1");
+        var recent2 = new TestRecord(baseTime.AddMinutes(-3), "recent-2");
+
+        queue.Enqueue(oldItem);
+        queue.Enqueue(recent1);
+        queue.Enqueue(recent2);
+
+        // Act
+        var items = queue.GetItemsAfter(baseTime.AddMinutes(-5));
+
+        // Assert
+        items.Should().HaveCount(2);
+        items.Should().ContainInOrder(recent1, recent2);
+        items.Should().NotContain(oldItem);
+    }
+
+    [Fact]
+    public void GetItemsAfter_EmptyQueue_ReturnsEmptyList()
+    {
+        // Arrange
+        var queue = new BoundedTimestampQueue<TestRecord>(10);
+
+        // Act
+        var items = queue.GetItemsAfter(DateTime.UtcNow);
+
+        // Assert
+        items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetItemsAfter_ReturnsReadOnlyList()
+    {
+        // Arrange
+        var queue = new BoundedTimestampQueue<TestRecord>(10);
+        queue.Enqueue(new TestRecord(DateTime.UtcNow, "test"));
+
+        // Act
+        var items = queue.GetItemsAfter(DateTime.MinValue);
+
+        // Assert
+        items.Should().BeAssignableTo<IReadOnlyList<TestRecord>>();
+    }
+
+    [Fact]
+    public void GetItemsAfter_MaintainsChronologicalOrder()
+    {
+        // Arrange
+        var queue = new BoundedTimestampQueue<TestRecord>(5);
+        var baseTime = DateTime.UtcNow;
+
+        var items = new[]
+        {
+            new TestRecord(baseTime.AddSeconds(10), "third"),
+            new TestRecord(baseTime.AddSeconds(0), "first"),
+            new TestRecord(baseTime.AddSeconds(5), "second"),
+            new TestRecord(baseTime.AddSeconds(15), "fourth")
+        };
+
+        // Enqueue in non-chronological order
+        foreach (var item in items)
+        {
+            queue.Enqueue(item);
+        }
+
+        // Act
+        var retrieved = queue.GetItemsAfter(DateTime.MinValue);
+
+        // Assert - Should maintain insertion order (not sorted)
+        retrieved.Should().HaveCount(4);
+        retrieved.Should().ContainInOrder(items); // FIFO order preserved
+    }
+
+    #endregion
+
+    #region EstimatedBytes Tests
+
+    [Fact]
+    public void EstimatedBytes_ReturnsCorrectCalculation()
+    {
+        // Arrange
+        var queue = new BoundedTimestampQueue<TestRecord>(100);
+        const int bytesPerItem = 50;
+
+        // Act
+        var estimatedBytes = queue.EstimatedBytes(bytesPerItem);
+
+        // Assert
+        // Expected: (100 capacity * 50 bytes per item) + 64 overhead = 5064
+        estimatedBytes.Should().Be(5064);
+    }
+
+    [Fact]
+    public void EstimatedBytes_WithDifferentCapacity_ScalesCorrectly()
+    {
+        // Arrange
+        var smallQueue = new BoundedTimestampQueue<TestRecord>(10);
+        var largeQueue = new BoundedTimestampQueue<TestRecord>(100);
+        const int bytesPerItem = 100;
+
+        // Act
+        var smallEstimate = smallQueue.EstimatedBytes(bytesPerItem);
+        var largeEstimate = largeQueue.EstimatedBytes(bytesPerItem);
+
+        // Assert
+        smallEstimate.Should().Be(1064); // (10 * 100) + 64
+        largeEstimate.Should().Be(10064); // (100 * 100) + 64
+        largeEstimate.Should().BeGreaterThan(smallEstimate);
+    }
+
+    #endregion
+
+    #region Clear Tests
+
+    [Fact]
+    public void Clear_EmptiesQueue()
+    {
+        // Arrange
+        var queue = new BoundedTimestampQueue<TestRecord>(5);
+        var baseTime = DateTime.UtcNow;
+
+        for (int i = 0; i < 5; i++)
+        {
+            queue.Enqueue(new TestRecord(baseTime.AddSeconds(i), $"item-{i}"));
+        }
+
+        queue.Count.Should().Be(5, "precondition: queue should have items");
+
+        // Act
+        queue.Clear();
+
+        // Assert
+        queue.Count.Should().Be(0);
+        queue.IsAtCapacity.Should().BeFalse();
+        queue.GetItemsAfter(DateTime.MinValue).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Clear_AllowsReuse()
+    {
+        // Arrange
+        var queue = new BoundedTimestampQueue<TestRecord>(3);
+        var baseTime = DateTime.UtcNow;
+
+        queue.Enqueue(new TestRecord(baseTime, "first"));
+        queue.Clear();
+
+        // Act - Reuse after clear
+        var newItem = new TestRecord(baseTime.AddSeconds(10), "second");
+        queue.Enqueue(newItem);
+
+        // Assert
+        queue.Count.Should().Be(1);
+        queue.GetItemsAfter(DateTime.MinValue).Should().ContainSingle()
+            .Which.Should().Be(newItem);
+    }
+
+    #endregion
+
+    #region Thread Safety Tests
+
+    [Fact]
+    public void ThreadSafety_ConcurrentEnqueues_NoDataCorruption()
+    {
+        // Arrange
+        var queue = new BoundedTimestampQueue<TestRecord>(1000);
+        var baseTime = DateTime.UtcNow;
+        const int threadCount = 10;
+        const int itemsPerThread = 100;
+        var barrier = new System.Threading.Barrier(threadCount);
+
+        // Act - Multiple threads enqueuing concurrently
+        Parallel.For(0, threadCount, threadIndex =>
+        {
+            barrier.SignalAndWait(); // Ensure all threads start at roughly the same time
+
+            for (int i = 0; i < itemsPerThread; i++)
+            {
+                var timestamp = baseTime.AddMilliseconds(threadIndex * itemsPerThread + i);
+                queue.Enqueue(new TestRecord(timestamp, $"thread-{threadIndex}-item-{i}"));
+            }
+        });
+
+        // Assert
+        queue.Count.Should().Be(1000, "queue should be at capacity with no data loss");
+
+        var items = queue.GetItemsAfter(DateTime.MinValue);
+        items.Should().HaveCount(1000);
+        items.Should().OnlyHaveUniqueItems(item => item.Data);
+    }
+
+    [Fact]
+    public void ThreadSafety_ConcurrentEnqueuesAndReads_ConsistentState()
+    {
+        // Arrange
+        var queue = new BoundedTimestampQueue<TestRecord>(500);
+        var baseTime = DateTime.UtcNow;
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var testDuration = TimeSpan.FromMilliseconds(500);
+
+        // Act - Concurrent writes and reads
+        var writeTask = Task.Run(() =>
+        {
+            int counter = 0;
+            while (stopwatch.Elapsed < testDuration)
+            {
+                queue.Enqueue(new TestRecord(baseTime.AddMilliseconds(counter), $"item-{counter}"));
+                counter++;
+                Thread.Sleep(1); // Small delay to allow interleaving
+            }
+        });
+
+        var readTask = Task.Run(() =>
+        {
+            while (stopwatch.Elapsed < testDuration)
+            {
+                var count = queue.Count;
+                var items = queue.GetItemsAfter(baseTime);
+                var countAfter = queue.CountAfter(baseTime);
+
+                // Sanity checks - no exceptions should occur
+                count.Should().BeGreaterThanOrEqualTo(0);
+                count.Should().BeLessThanOrEqualTo(queue.Capacity);
+                items.Should().NotBeNull();
+                countAfter.Should().BeGreaterThanOrEqualTo(0);
+
+                Thread.Sleep(1);
+            }
+        });
+
+        // Assert - No exceptions or deadlocks
+        Task.WaitAll(writeTask, readTask);
+        queue.Count.Should().BeLessThanOrEqualTo(queue.Capacity);
+    }
+
+    [Fact]
+    public void ThreadSafety_ConcurrentCountAfterCalls_NoExceptions()
+    {
+        // Arrange
+        var queue = new BoundedTimestampQueue<TestRecord>(100);
+        var baseTime = DateTime.UtcNow;
+
+        for (int i = 0; i < 100; i++)
+        {
+            queue.Enqueue(new TestRecord(baseTime.AddSeconds(i), $"item-{i}"));
+        }
+
+        // Act - Multiple threads calling CountAfter concurrently
+        Parallel.For(0, 20, i =>
+        {
+            var cutoff = baseTime.AddSeconds(i * 5);
+            var count = queue.CountAfter(cutoff);
+
+            // Assert - Should not throw and should return valid count
+            count.Should().BeGreaterThanOrEqualTo(0);
+            count.Should().BeLessThanOrEqualTo(100);
+        });
+    }
+
+    #endregion
+
+    #region Capacity Boundary Tests
+
+    [Fact]
+    public void Capacity_SingleItemQueue_WorksCorrectly()
+    {
+        // Arrange
+        var queue = new BoundedTimestampQueue<TestRecord>(1);
+        var baseTime = DateTime.UtcNow;
+
+        // Act
+        queue.Enqueue(new TestRecord(baseTime, "first"));
+        queue.Enqueue(new TestRecord(baseTime.AddSeconds(1), "second"));
+        queue.Enqueue(new TestRecord(baseTime.AddSeconds(2), "third"));
+
+        // Assert
+        queue.Count.Should().Be(1);
+        queue.IsAtCapacity.Should().BeTrue();
+
+        var items = queue.GetItemsAfter(DateTime.MinValue);
+        items.Should().ContainSingle()
+            .Which.Data.Should().Be("third", "last item should remain");
+    }
+
+    [Fact]
+    public void Capacity_LargeCapacity_HandlesCorrectly()
+    {
+        // Arrange
+        var queue = new BoundedTimestampQueue<TestRecord>(10000);
+        var baseTime = DateTime.UtcNow;
+
+        // Act - Fill to capacity
+        for (int i = 0; i < 10000; i++)
+        {
+            queue.Enqueue(new TestRecord(baseTime.AddSeconds(i), $"item-{i}"));
+        }
+
+        // Assert
+        queue.Count.Should().Be(10000);
+        queue.IsAtCapacity.Should().BeTrue();
+
+        // Add one more to test eviction
+        queue.Enqueue(new TestRecord(baseTime.AddSeconds(10000), "item-10000"));
+        queue.Count.Should().Be(10000, "count should remain at capacity");
+
+        var items = queue.GetItemsAfter(DateTime.MinValue);
+        items[0].Data.Should().Be("item-1", "first item should be evicted");
+        items[9999].Data.Should().Be("item-10000", "last item should be present");
+    }
+
+    #endregion
+}

--- a/tests/DiscordBot.Tests/Bot/Collections/LruConcurrentDictionaryTests.cs
+++ b/tests/DiscordBot.Tests/Bot/Collections/LruConcurrentDictionaryTests.cs
@@ -1,0 +1,912 @@
+using DiscordBot.Bot.Collections;
+using FluentAssertions;
+
+namespace DiscordBot.Tests.Bot.Collections;
+
+/// <summary>
+/// Unit tests for <see cref="LruConcurrentDictionary{TKey, TValue}"/>.
+/// Tests cover LRU eviction, concurrent access, and dictionary operations.
+/// </summary>
+public class LruConcurrentDictionaryTests
+{
+    #region Constructor Tests
+
+    [Fact]
+    public void Constructor_ZeroCapacity_ThrowsException()
+    {
+        // Arrange & Act
+        var act = () => new LruConcurrentDictionary<string, int>(0);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithMessage("*Capacity must be greater than zero*")
+            .And.ParamName.Should().Be("capacity");
+    }
+
+    [Fact]
+    public void Constructor_NegativeCapacity_ThrowsException()
+    {
+        // Arrange & Act
+        var act = () => new LruConcurrentDictionary<string, int>(-1);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithMessage("*Capacity must be greater than zero*")
+            .And.ParamName.Should().Be("capacity");
+    }
+
+    [Fact]
+    public void Constructor_ValidCapacity_CreatesDictionary()
+    {
+        // Arrange & Act
+        var dict = new LruConcurrentDictionary<string, int>(10);
+
+        // Assert
+        dict.Capacity.Should().Be(10);
+        dict.Count.Should().Be(0);
+    }
+
+    #endregion
+
+    #region GetOrAdd Tests
+
+    [Fact]
+    public void GetOrAdd_NewKey_AddsToFront()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(5);
+
+        // Act
+        var value = dict.GetOrAdd("key1", k => 100);
+
+        // Assert
+        value.Should().Be(100);
+        dict.Count.Should().Be(1);
+        dict.ContainsKey("key1").Should().BeTrue();
+
+        var all = dict.GetAll();
+        all[0].Key.Should().Be("key1", "new item should be at front (MRU)");
+    }
+
+    [Fact]
+    public void GetOrAdd_ExistingKey_MovesToFront()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(5);
+        dict.GetOrAdd("key1", k => 1);
+        dict.GetOrAdd("key2", k => 2);
+        dict.GetOrAdd("key3", k => 3);
+
+        // Key2 is now in the middle of LRU order: [key3, key2, key1]
+
+        // Act - Access key1, should move to front
+        var value = dict.GetOrAdd("key1", k => 999);
+
+        // Assert
+        value.Should().Be(1, "should return existing value, not call factory");
+        dict.Count.Should().Be(3);
+
+        var all = dict.GetAll();
+        all[0].Key.Should().Be("key1", "accessed key should move to front (MRU)");
+        all[1].Key.Should().Be("key3");
+        all[2].Key.Should().Be("key2");
+    }
+
+    [Fact]
+    public void GetOrAdd_WhenAtCapacity_EvictsLeastRecentlyUsed()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(3);
+
+        dict.GetOrAdd("key1", k => 1);
+        dict.GetOrAdd("key2", k => 2);
+        dict.GetOrAdd("key3", k => 3);
+
+        // Current LRU order: [key3, key2, key1] (key1 is least recently used)
+
+        // Act - Add key4, should evict key1
+        dict.GetOrAdd("key4", k => 4);
+
+        // Assert
+        dict.Count.Should().Be(3, "count should remain at capacity");
+        dict.ContainsKey("key1").Should().BeFalse("least recently used item (key1) should be evicted");
+        dict.ContainsKey("key2").Should().BeTrue();
+        dict.ContainsKey("key3").Should().BeTrue();
+        dict.ContainsKey("key4").Should().BeTrue();
+
+        var all = dict.GetAll();
+        all[0].Key.Should().Be("key4", "newly added item should be at front");
+    }
+
+    [Fact]
+    public void GetOrAdd_EvictionWithAccessPattern_EvictsCorrectItem()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(3);
+
+        dict.GetOrAdd("key1", k => 1);
+        dict.GetOrAdd("key2", k => 2);
+        dict.GetOrAdd("key3", k => 3);
+
+        // Access key1 to make it most recently used
+        dict.GetOrAdd("key1", k => 999);
+
+        // Current LRU order: [key1, key3, key2] (key2 is least recently used)
+
+        // Act - Add key4, should evict key2
+        dict.GetOrAdd("key4", k => 4);
+
+        // Assert
+        dict.ContainsKey("key2").Should().BeFalse("key2 should be evicted as LRU");
+        dict.ContainsKey("key1").Should().BeTrue("key1 was accessed recently");
+        dict.ContainsKey("key3").Should().BeTrue();
+        dict.ContainsKey("key4").Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetOrAdd_NullValueFactory_ThrowsException()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(5);
+
+        // Act
+        var act = () => dict.GetOrAdd("key1", null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>()
+            .WithParameterName("valueFactory");
+    }
+
+    [Fact]
+    public void GetOrAdd_FactoryIsCalledOnlyForNewKeys()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(5);
+        var factoryCalls = 0;
+
+        // Act
+        var value1 = dict.GetOrAdd("key1", k =>
+        {
+            factoryCalls++;
+            return 100;
+        });
+
+        var value2 = dict.GetOrAdd("key1", k =>
+        {
+            factoryCalls++;
+            return 200;
+        });
+
+        // Assert
+        factoryCalls.Should().Be(1, "factory should only be called once for new key");
+        value1.Should().Be(100);
+        value2.Should().Be(100, "should return cached value without calling factory");
+    }
+
+    #endregion
+
+    #region TryGetValue Tests
+
+    [Fact]
+    public void TryGetValue_ExistingKey_ReturnsTrue()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, string>(5);
+        dict.GetOrAdd("key1", k => "value1");
+
+        // Act
+        var found = dict.TryGetValue("key1", out var value);
+
+        // Assert
+        found.Should().BeTrue();
+        value.Should().Be("value1");
+    }
+
+    [Fact]
+    public void TryGetValue_NonExistingKey_ReturnsFalse()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, string>(5);
+
+        // Act
+        var found = dict.TryGetValue("nonexistent", out var value);
+
+        // Assert
+        found.Should().BeFalse();
+        value.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryGetValue_UpdatesLruOrder()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(5);
+        dict.GetOrAdd("key1", k => 1);
+        dict.GetOrAdd("key2", k => 2);
+        dict.GetOrAdd("key3", k => 3);
+
+        // LRU order: [key3, key2, key1]
+
+        // Act - Access key1 via TryGetValue
+        dict.TryGetValue("key1", out _);
+
+        // Assert
+        var all = dict.GetAll();
+        all[0].Key.Should().Be("key1", "TryGetValue should move key to front (MRU)");
+    }
+
+    [Fact]
+    public void TryGetValue_WithValueType_DefaultIsReturnedOnMiss()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(5);
+
+        // Act
+        var found = dict.TryGetValue("nonexistent", out var value);
+
+        // Assert
+        found.Should().BeFalse();
+        value.Should().Be(0, "default value for int should be returned");
+    }
+
+    #endregion
+
+    #region AddOrUpdate Tests
+
+    [Fact]
+    public void AddOrUpdate_NewKey_AddsEntry()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(5);
+
+        // Act
+        dict.AddOrUpdate("key1", 100);
+
+        // Assert
+        dict.Count.Should().Be(1);
+        dict.TryGetValue("key1", out var value).Should().BeTrue();
+        value.Should().Be(100);
+    }
+
+    [Fact]
+    public void AddOrUpdate_ExistingKey_UpdatesValue()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(5);
+        dict.AddOrUpdate("key1", 100);
+
+        // Act
+        dict.AddOrUpdate("key1", 200);
+
+        // Assert
+        dict.Count.Should().Be(1, "count should not increase");
+        dict.TryGetValue("key1", out var value).Should().BeTrue();
+        value.Should().Be(200, "value should be updated");
+    }
+
+    [Fact]
+    public void AddOrUpdate_ExistingKey_MovesToFront()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(5);
+        dict.AddOrUpdate("key1", 1);
+        dict.AddOrUpdate("key2", 2);
+        dict.AddOrUpdate("key3", 3);
+
+        // LRU order: [key3, key2, key1]
+
+        // Act - Update key1
+        dict.AddOrUpdate("key1", 999);
+
+        // Assert
+        var all = dict.GetAll();
+        all[0].Key.Should().Be("key1", "updated key should move to front");
+        all[0].Value.Should().Be(999);
+    }
+
+    [Fact]
+    public void AddOrUpdate_AtCapacity_EvictsLru()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(3);
+        dict.AddOrUpdate("key1", 1);
+        dict.AddOrUpdate("key2", 2);
+        dict.AddOrUpdate("key3", 3);
+
+        // Act - Add key4, should evict key1
+        dict.AddOrUpdate("key4", 4);
+
+        // Assert
+        dict.Count.Should().Be(3);
+        dict.ContainsKey("key1").Should().BeFalse("LRU item should be evicted");
+        dict.ContainsKey("key4").Should().BeTrue();
+    }
+
+    #endregion
+
+    #region Remove Tests
+
+    [Fact]
+    public void Remove_ExistingKey_RemovesEntry()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(5);
+        dict.AddOrUpdate("key1", 1);
+        dict.AddOrUpdate("key2", 2);
+
+        // Act
+        var removed = dict.Remove("key1");
+
+        // Assert
+        removed.Should().BeTrue();
+        dict.Count.Should().Be(1);
+        dict.ContainsKey("key1").Should().BeFalse();
+        dict.ContainsKey("key2").Should().BeTrue();
+    }
+
+    [Fact]
+    public void Remove_NonExistingKey_ReturnsFalse()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(5);
+
+        // Act
+        var removed = dict.Remove("nonexistent");
+
+        // Assert
+        removed.Should().BeFalse();
+        dict.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void Remove_LastItem_LeavesEmptyDictionary()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(5);
+        dict.AddOrUpdate("key1", 1);
+
+        // Act
+        var removed = dict.Remove("key1");
+
+        // Assert
+        removed.Should().BeTrue();
+        dict.Count.Should().Be(0);
+        dict.GetAll().Should().BeEmpty();
+    }
+
+    #endregion
+
+    #region ContainsKey Tests
+
+    [Fact]
+    public void ContainsKey_ExistingKey_ReturnsTrue()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(5);
+        dict.AddOrUpdate("key1", 1);
+
+        // Act
+        var contains = dict.ContainsKey("key1");
+
+        // Assert
+        contains.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ContainsKey_NonExistingKey_ReturnsFalse()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(5);
+
+        // Act
+        var contains = dict.ContainsKey("nonexistent");
+
+        // Assert
+        contains.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ContainsKey_DoesNotUpdateLruOrder()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(5);
+        dict.AddOrUpdate("key1", 1);
+        dict.AddOrUpdate("key2", 2);
+
+        // Get initial order
+        var orderBefore = dict.GetAll().Select(kv => kv.Key).ToList();
+
+        // Act - ContainsKey should not change LRU order
+        dict.ContainsKey("key1");
+
+        // Assert
+        var orderAfter = dict.GetAll().Select(kv => kv.Key).ToList();
+        orderAfter.Should().Equal(orderBefore, "ContainsKey should not modify LRU order");
+    }
+
+    #endregion
+
+    #region GetAll Tests
+
+    [Fact]
+    public void GetAll_ReturnsAllEntries()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(5);
+        dict.AddOrUpdate("key1", 1);
+        dict.AddOrUpdate("key2", 2);
+        dict.AddOrUpdate("key3", 3);
+
+        // Act
+        var all = dict.GetAll();
+
+        // Assert
+        all.Should().HaveCount(3);
+        all.Should().Contain(kv => kv.Key == "key1" && kv.Value == 1);
+        all.Should().Contain(kv => kv.Key == "key2" && kv.Value == 2);
+        all.Should().Contain(kv => kv.Key == "key3" && kv.Value == 3);
+    }
+
+    [Fact]
+    public void GetAll_EmptyDictionary_ReturnsEmptyList()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(5);
+
+        // Act
+        var all = dict.GetAll();
+
+        // Assert
+        all.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetAll_ReturnsInLruOrder()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(5);
+        dict.AddOrUpdate("key1", 1);
+        dict.AddOrUpdate("key2", 2);
+        dict.AddOrUpdate("key3", 3);
+
+        // Access key1 to make it MRU
+        dict.GetOrAdd("key1", k => 999);
+
+        // Act
+        var all = dict.GetAll();
+
+        // Assert - Should be in MRU order: [key1, key3, key2]
+        all[0].Key.Should().Be("key1", "most recently used should be first");
+        all[1].Key.Should().Be("key3");
+        all[2].Key.Should().Be("key2", "least recently used should be last");
+    }
+
+    [Fact]
+    public void GetAll_ReturnsReadOnlyList()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(5);
+        dict.AddOrUpdate("key1", 1);
+
+        // Act
+        var all = dict.GetAll();
+
+        // Assert
+        all.Should().BeAssignableTo<IReadOnlyList<KeyValuePair<string, int>>>();
+    }
+
+    #endregion
+
+    #region Keys Tests
+
+    [Fact]
+    public void Keys_ReturnsAllKeys()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(5);
+        dict.AddOrUpdate("key1", 1);
+        dict.AddOrUpdate("key2", 2);
+        dict.AddOrUpdate("key3", 3);
+
+        // Act
+        var keys = dict.Keys;
+
+        // Assert
+        keys.Should().HaveCount(3);
+        keys.Should().Contain("key1");
+        keys.Should().Contain("key2");
+        keys.Should().Contain("key3");
+    }
+
+    [Fact]
+    public void Keys_EmptyDictionary_ReturnsEmptyCollection()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(5);
+
+        // Act
+        var keys = dict.Keys;
+
+        // Assert
+        keys.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Keys_ReturnsReadOnlyCollection()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(5);
+        dict.AddOrUpdate("key1", 1);
+
+        // Act
+        var keys = dict.Keys;
+
+        // Assert
+        keys.Should().BeAssignableTo<IReadOnlyCollection<string>>();
+    }
+
+    #endregion
+
+    #region Clear Tests
+
+    [Fact]
+    public void Clear_EmptiesDictionary()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(5);
+        dict.AddOrUpdate("key1", 1);
+        dict.AddOrUpdate("key2", 2);
+        dict.AddOrUpdate("key3", 3);
+
+        dict.Count.Should().Be(3, "precondition: dictionary should have items");
+
+        // Act
+        dict.Clear();
+
+        // Assert
+        dict.Count.Should().Be(0);
+        dict.GetAll().Should().BeEmpty();
+        dict.Keys.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Clear_AllowsReuse()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(3);
+        dict.AddOrUpdate("key1", 1);
+        dict.Clear();
+
+        // Act - Reuse after clear
+        dict.AddOrUpdate("key2", 2);
+
+        // Assert
+        dict.Count.Should().Be(1);
+        dict.ContainsKey("key1").Should().BeFalse();
+        dict.ContainsKey("key2").Should().BeTrue();
+    }
+
+    #endregion
+
+    #region EstimatedBytes Tests
+
+    [Fact]
+    public void EstimatedBytes_ReturnsCorrectCalculation()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(5);
+        dict.AddOrUpdate("key1", 1);
+        dict.AddOrUpdate("key2", 2);
+        dict.AddOrUpdate("key3", 3);
+
+        const int bytesPerKey = 20;
+        const int bytesPerValue = 4;
+
+        // Act
+        var estimatedBytes = dict.EstimatedBytes(bytesPerKey, bytesPerValue);
+
+        // Assert
+        // Per entry: 20 (key) + 4 (value) + 40 (node overhead) + 24 (dict overhead) = 88
+        // Total: (3 entries * 88) + 64 (object overhead) = 328
+        estimatedBytes.Should().Be(328);
+    }
+
+    [Fact]
+    public void EstimatedBytes_EmptyDictionary_ReturnsBaseOverhead()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(5);
+
+        // Act
+        var estimatedBytes = dict.EstimatedBytes(20, 4);
+
+        // Assert
+        estimatedBytes.Should().Be(64, "should only include object overhead");
+    }
+
+    [Fact]
+    public void EstimatedBytes_ScalesWithEntryCount()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(10);
+
+        for (int i = 0; i < 5; i++)
+        {
+            dict.AddOrUpdate($"key{i}", i);
+        }
+
+        var bytes5 = dict.EstimatedBytes(10, 4);
+
+        for (int i = 5; i < 10; i++)
+        {
+            dict.AddOrUpdate($"key{i}", i);
+        }
+
+        var bytes10 = dict.EstimatedBytes(10, 4);
+
+        // Assert
+        bytes10.Should().BeGreaterThan(bytes5, "more entries should use more memory");
+        (bytes10 - bytes5).Should().Be(5 * (10 + 4 + 40 + 24), "difference should be 5 entries");
+    }
+
+    #endregion
+
+    #region Thread Safety Tests
+
+    [Fact]
+    public void ThreadSafety_ConcurrentOperations_NoDataCorruption()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<int, string>(1000);
+        const int threadCount = 10;
+        const int operationsPerThread = 100;
+        var barrier = new System.Threading.Barrier(threadCount);
+
+        // Act - Multiple threads performing concurrent operations
+        Parallel.For(0, threadCount, threadIndex =>
+        {
+            barrier.SignalAndWait(); // Ensure all threads start at roughly the same time
+
+            for (int i = 0; i < operationsPerThread; i++)
+            {
+                var key = threadIndex * operationsPerThread + i;
+
+                // Mix of operations
+                dict.GetOrAdd(key, k => $"value-{k}");
+                dict.TryGetValue(key, out _);
+                dict.ContainsKey(key);
+
+                if (i % 10 == 0)
+                {
+                    dict.Remove(key - 5);
+                }
+            }
+        });
+
+        // Assert
+        dict.Count.Should().BeLessThanOrEqualTo(1000, "dictionary should respect capacity limit");
+        dict.Count.Should().BeGreaterThan(0, "dictionary should have entries");
+
+        // Verify no corruption - should not throw
+        var all = dict.GetAll();
+        all.Should().NotBeNull();
+        all.Count.Should().Be(dict.Count);
+    }
+
+    [Fact]
+    public void ThreadSafety_ConcurrentGetOrAdd_SameKey_CallsFactoryOnce()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(10);
+        var factoryCalls = 0;
+        const int threadCount = 20;
+        var barrier = new System.Threading.Barrier(threadCount);
+        var results = new int[threadCount];
+
+        // Act - Multiple threads trying to add the same key
+        Parallel.For(0, threadCount, threadIndex =>
+        {
+            barrier.SignalAndWait();
+
+            results[threadIndex] = dict.GetOrAdd("shared-key", k =>
+            {
+                Interlocked.Increment(ref factoryCalls);
+                Thread.Sleep(10); // Simulate some work
+                return 42;
+            });
+        });
+
+        // Assert
+        factoryCalls.Should().Be(1, "factory should only be called once despite concurrent access");
+        results.Should().OnlyContain(x => x == 42, "all threads should get the same value");
+        dict.Count.Should().Be(1);
+    }
+
+    [Fact]
+    public void ThreadSafety_ConcurrentReadsAndWrites_ConsistentState()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<int, string>(500);
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var testDuration = TimeSpan.FromMilliseconds(500);
+
+        // Act - Concurrent writes and reads
+        var writeTask = Task.Run(() =>
+        {
+            int counter = 0;
+            while (stopwatch.Elapsed < testDuration)
+            {
+                dict.AddOrUpdate(counter % 100, $"value-{counter}");
+                counter++;
+                Thread.Sleep(1);
+            }
+        });
+
+        var readTask = Task.Run(() =>
+        {
+            while (stopwatch.Elapsed < testDuration)
+            {
+                var count = dict.Count;
+                var keys = dict.Keys;
+                var all = dict.GetAll();
+
+                // Sanity checks - no exceptions should occur
+                count.Should().BeGreaterThanOrEqualTo(0);
+                count.Should().BeLessThanOrEqualTo(dict.Capacity);
+                keys.Should().NotBeNull();
+                all.Should().NotBeNull();
+
+                Thread.Sleep(1);
+            }
+        });
+
+        var removeTask = Task.Run(() =>
+        {
+            int counter = 0;
+            while (stopwatch.Elapsed < testDuration)
+            {
+                dict.Remove(counter % 100);
+                counter++;
+                Thread.Sleep(2);
+            }
+        });
+
+        // Assert - No exceptions or deadlocks
+        Task.WaitAll(writeTask, readTask, removeTask);
+        dict.Count.Should().BeLessThanOrEqualTo(dict.Capacity);
+    }
+
+    [Fact]
+    public void ThreadSafety_ConcurrentEvictions_MaintainsCapacity()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<int, int>(50);
+        const int totalItems = 500;
+
+        // Act - Fill beyond capacity from multiple threads
+        Parallel.For(0, totalItems, i =>
+        {
+            dict.GetOrAdd(i, k => k * 2);
+            Thread.Sleep(1); // Small delay to ensure interleaving
+        });
+
+        // Assert
+        dict.Count.Should().BeLessThanOrEqualTo(50, "should never exceed capacity");
+        dict.Count.Should().BeGreaterThan(0, "should have items");
+        dict.GetAll().Should().HaveCount(dict.Count);
+
+        // Verify all values are correct (no corruption)
+        var all = dict.GetAll();
+        foreach (var kvp in all)
+        {
+            kvp.Value.Should().Be(kvp.Key * 2, "values should match factory function");
+        }
+
+        // Verify keys are unique (no duplicates)
+        var keys = dict.Keys.ToList();
+        keys.Should().OnlyHaveUniqueItems("dictionary should not have duplicate keys");
+        keys.Count.Should().Be(dict.Count);
+    }
+
+    #endregion
+
+    #region Capacity Boundary Tests
+
+    [Fact]
+    public void Capacity_SingleItemDictionary_WorksCorrectly()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(1);
+
+        // Act
+        dict.AddOrUpdate("key1", 1);
+        dict.AddOrUpdate("key2", 2);
+        dict.AddOrUpdate("key3", 3);
+
+        // Assert
+        dict.Count.Should().Be(1, "single-item dictionary should only hold one item");
+        dict.ContainsKey("key3").Should().BeTrue("last added item should be present");
+        dict.ContainsKey("key1").Should().BeFalse("first item should be evicted");
+        dict.ContainsKey("key2").Should().BeFalse("second item should be evicted");
+    }
+
+    [Fact]
+    public void Capacity_LargeCapacity_HandlesCorrectly()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<int, int>(10000);
+
+        // Act - Fill to capacity
+        for (int i = 0; i < 10000; i++)
+        {
+            dict.AddOrUpdate(i, i * 2);
+        }
+
+        // Assert
+        dict.Count.Should().Be(10000);
+
+        // Add one more to test eviction
+        dict.AddOrUpdate(10000, 20000);
+        dict.Count.Should().Be(10000, "count should remain at capacity");
+        dict.ContainsKey(0).Should().BeFalse("first item (LRU) should be evicted");
+        dict.ContainsKey(10000).Should().BeTrue("newly added item should be present");
+    }
+
+    #endregion
+
+    #region Complex LRU Scenarios
+
+    [Fact]
+    public void LruEviction_ComplexAccessPattern_EvictsCorrectly()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(4);
+
+        // Build initial state
+        dict.AddOrUpdate("A", 1);
+        dict.AddOrUpdate("B", 2);
+        dict.AddOrUpdate("C", 3);
+        dict.AddOrUpdate("D", 4);
+
+        // Access pattern: access A and C
+        dict.TryGetValue("A", out _);
+        dict.TryGetValue("C", out _);
+
+        // Current LRU order: [C, A, D, B] (B is LRU)
+
+        // Act - Add E, should evict B
+        dict.AddOrUpdate("E", 5);
+
+        // Assert
+        dict.ContainsKey("B").Should().BeFalse("B should be evicted as LRU");
+        dict.ContainsKey("A").Should().BeTrue("A was accessed");
+        dict.ContainsKey("C").Should().BeTrue("C was accessed");
+        dict.ContainsKey("D").Should().BeTrue("D was not accessed but newer than B");
+        dict.ContainsKey("E").Should().BeTrue("E is newly added");
+
+        var order = dict.GetAll().Select(kv => kv.Key).ToList();
+        order[0].Should().Be("E", "E should be MRU");
+        order[3].Should().Be("D", "D should be LRU");
+    }
+
+    [Fact]
+    public void LruEviction_UpdateExistingKey_DoesNotChangeCount()
+    {
+        // Arrange
+        var dict = new LruConcurrentDictionary<string, int>(3);
+
+        dict.AddOrUpdate("A", 1);
+        dict.AddOrUpdate("B", 2);
+        dict.AddOrUpdate("C", 3);
+
+        // Act - Update existing key
+        dict.AddOrUpdate("B", 999);
+
+        // Assert
+        dict.Count.Should().Be(3, "updating existing key should not change count");
+        dict.TryGetValue("B", out var value).Should().BeTrue();
+        value.Should().Be(999);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Fixes #808 - Memory leak: Working set growing to ~1GB over time
- Replaces unbounded `ConcurrentBag<T>` and `ConcurrentDictionary<K,V>` with bounded alternatives
- Adds comprehensive unit tests for new bounded collections (72 tests)
- Implements `IMemoryReportable` on SpamDetectionService and RaidDetectionService for dashboard visibility

## Problem
The bot's working set was growing from ~400MB to ~800MB+ over time due to:
- `ConcurrentBag<T>.Clear()` not releasing internal thread-local array capacity
- Cleanup only triggering when count > 100, allowing gradual accumulation  
- No global limits on tracked users/guilds
- Unbounded `ConcurrentDictionary` for API categories

## Solution

### New Bounded Collections
- **BoundedTimestampQueue<T>**: Thread-safe circular buffer with fixed capacity for time-based records (FIFO eviction)
- **LruConcurrentDictionary<TKey, TValue>**: Thread-safe dictionary with LRU eviction when capacity exceeded

### Service Refactoring
- **SpamDetectionService**: Now uses `BoundedTimestampQueue` (max 200 messages per user)
- **RaidDetectionService**: Now uses `BoundedTimestampQueue` (max 500 joins per guild)
- **ApiRequestTracker**: Now uses `LruConcurrentDictionary` (max 100 categories)

### Memory Budget After Fix
| Service | Maximum Memory | Previous (Unbounded) |
|---------|---------------|----------------------|
| SpamDetectionService | ~46.4 MB | Hundreds of MB |
| RaidDetectionService | ~15.3 MB | Tens of MB |
| ApiRequestTracker | ~20 KB | Unbounded |
| **Total Maximum** | **~62 MB** | **400+ MB and growing** |

## Configuration
New options added (all with sensible defaults):
- `AutoModeration:MaxMessagesPerUser` (default: 200)
- `AutoModeration:MaxJoinsPerGuild` (default: 500)  
- `PerformanceMetrics:MaxApiCategories` (default: 100)

## Test plan
- [x] Build succeeds
- [x] 72 new unit tests for bounded collections pass
- [x] 2704 existing tests pass (3 pre-existing flaky tests unrelated to this change)
- [ ] Deploy to staging and monitor memory for 48+ hours
- [ ] Verify spam detection still triggers correctly
- [ ] Verify raid detection still triggers correctly
- [ ] Check memory diagnostics dashboard shows all services

🤖 Generated with [Claude Code](https://claude.com/claude-code)