### PR TITLE
fix: Add service.name enricher for Elastic Observability log identification

### DIFF
--- a/docs/articles/log-aggregation.md
+++ b/docs/articles/log-aggregation.md
@@ -1,7 +1,7 @@
 # Centralized Log Aggregation
 
 **Version:** 2.1
-**Last Updated:** 2026-01-05
+**Last Updated:** 2026-01-06
 **Target Framework:** .NET 8 with Serilog, Elasticsearch, Seq, and Elastic APM
 **Status:** Phase 2 Implementation (Elasticsearch primary with APM tracing, Seq optional)
 
@@ -307,6 +307,33 @@ The base configuration file defines Elasticsearch endpoints and index format:
 | `ApmServerUrl` | string | null | Elastic APM server URL for distributed tracing integration. |
 | `ApmSecretToken` | string | null | APM secret token for authentication. |
 | `Environment` | string | development | Environment name to distinguish logs by deployment stage. |
+
+### Elastic Observability Integration
+
+Elastic Observability's log events widget requires the `service.name` field to identify and group logs by service. Without this field, logs appear as "unknown" in the overview.
+
+The Discord bot automatically enriches all log events with `service.name` using the value from `ElasticApm:ServiceName` configuration:
+
+```csharp
+// In Program.cs - service.name is added to all log events
+.Enrich.WithProperty("service.name", serviceName)
+```
+
+This ensures logs correlate properly with APM traces and appear under the correct service name in Kibana.
+
+**Configuration:**
+
+The service name is configured via `ElasticApm:ServiceName` in `appsettings.json`:
+
+```json
+{
+  "ElasticApm": {
+    "ServiceName": "discordbot"
+  }
+}
+```
+
+This single configuration value is used for both APM traces and log enrichment, ensuring consistent service identification across all observability data.
 
 ### Environment-Specific Configuration
 

--- a/src/DiscordBot.Bot/Program.cs
+++ b/src/DiscordBot.Bot/Program.cs
@@ -42,11 +42,15 @@ try
     // Configure Serilog from appsettings.json with programmatic Elasticsearch sink
     builder.Host.UseSerilog((context, services, configuration) =>
     {
+        // Get service name from config (used by Elastic Observability to identify log source)
+        var serviceName = context.Configuration["ElasticApm:ServiceName"] ?? "discordbot";
+
         configuration
             .ReadFrom.Configuration(context.Configuration)
             .ReadFrom.Services(services)
             .Enrich.FromLogContext()
-            .Enrich.WithElasticApmCorrelationInfo();
+            .Enrich.WithElasticApmCorrelationInfo()
+            .Enrich.WithProperty("service.name", serviceName);
 
         // Add Elasticsearch sink programmatically if configured
         var elasticUrl = context.Configuration["ElasticSearch:Url"];


### PR DESCRIPTION
## Summary

- Added `service.name` Serilog enricher to include service identification in all log events
- Service name is read from `ElasticApm:ServiceName` configuration (defaults to "discordbot")
- Updated log-aggregation.md documentation with new Elastic Observability Integration section

## Root Cause

Logs were appearing as "unknown" in Elastic Observability's log events widget because the Serilog Elasticsearch sink was sending logs without the `service.name` field that Elastic expects to identify and group logs by service.

## Changes

**Program.cs:**
- Added `.Enrich.WithProperty("service.name", serviceName)` to Serilog configuration
- Service name sourced from `ElasticApm:ServiceName` config for consistency with APM tracing

**log-aggregation.md:**
- Added new "Elastic Observability Integration" section explaining the service.name requirement
- Documented how service name is configured and shared between logs and APM

## Test Plan

- [ ] Verify logs appear under "discordbot" in Elastic Observability overview (not "unknown")
- [ ] Confirm service.name field is present in Elasticsearch log documents
- [ ] Verify APM traces and logs show consistent service name in Kibana

Closes #813

🤖 Generated with [Claude Code](https://claude.com/claude-code)