### PR TITLE
Remove uptime display from sidebar navigation

### DIFF
--- a/src/DiscordBot.Bot/Pages/Shared/_Sidebar.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/_Sidebar.cshtml
@@ -228,7 +228,7 @@
           </div>
           <div class="bot-status-text flex-1 min-w-0">
             <p class="text-sm font-medium text-text-primary">Bot Online</p>
-            <p class="text-xs text-text-tertiary">@VersionService.GetVersion() - Uptime: 2h</p>
+            <p class="text-xs text-text-tertiary">@VersionService.GetVersion()</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Removes hardcoded "Uptime: 2h" text from sidebar navigation that didn't reflect actual bot uptime
- Version number continues to display correctly

## Changes

Single line change in `src/DiscordBot.Bot/Pages/Shared/_Sidebar.cshtml`:
- Before: `@VersionService.GetVersion() - Uptime: 2h`
- After: `@VersionService.GetVersion()`

## Test plan

- [ ] Verify sidebar displays version without uptime text
- [ ] Verify no visual layout issues after removal

Closes #789

🤖 Generated with [Claude Code](https://claude.com/claude-code)