### PR TITLE
Fix: Single guild sync button returns JSON parse error

### DIFF
--- a/src/DiscordBot.Bot/wwwroot/js/guild-sync.js
+++ b/src/DiscordBot.Bot/wwwroot/js/guild-sync.js
@@ -34,7 +34,7 @@ async function syncGuild(guildId, buttonElement) {
     const token = document.querySelector('input[name="__RequestVerificationToken"]').value;
 
     // Make AJAX request
-    const response = await fetch(`?handler=Sync&id=${guildId}`, {
+    const response = await fetch(`?handler=SyncGuild&id=${guildId}`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',


### PR DESCRIPTION
## Summary
- Fixed handler name mismatch in guild-sync.js AJAX call
- Changed `?handler=Sync` to `?handler=SyncGuild` to match actual Razor Pages handler `OnPostSyncGuildAsync`

## Root Cause
ASP.NET Core Razor Pages handler naming convention removes `OnPost` prefix and `Async` suffix, so `OnPostSyncGuildAsync` maps to `?handler=SyncGuild`, not `?handler=Sync`.

## Test plan
- [ ] Click sync button on individual guild row
- [ ] Verify toast shows "Guild synced successfully"
- [ ] Verify page reloads with updated guild data
- [ ] Verify "Sync All" still works correctly

Closes #775

🤖 Generated with [Claude Code](https://claude.com/claude-code)