### PR TITLE
fix: Align Connected Servers widget height with Activity Timeline

### DIFF
--- a/src/DiscordBot.Bot/Pages/Shared/Components/_ConnectedServersWidget.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/Components/_ConnectedServersWidget.cshtml
@@ -1,7 +1,7 @@
 @model DiscordBot.Bot.ViewModels.Components.ConnectedServersWidgetViewModel
 @using DiscordBot.Bot.ViewModels.Components.Enums
 
-<div class="xl:col-span-2 bg-bg-secondary border border-border-primary rounded-xl overflow-hidden">
+<div class="xl:col-span-2 bg-bg-secondary border border-border-primary rounded-xl overflow-hidden h-full flex flex-col">
     <!-- Card Header -->
     <div class="flex items-center justify-between px-6 py-4 border-b border-border-primary">
         <h2 class="text-lg font-semibold text-text-primary">@Model.Title</h2>
@@ -14,7 +14,7 @@
     </div>
 
     <!-- Table Container -->
-    <div class="overflow-x-auto">
+    <div class="overflow-x-auto flex-grow">
         <table class="w-full">
             <thead class="bg-bg-primary/50">
                 <tr>


### PR DESCRIPTION
## Summary

- Adds `h-full flex flex-col` to the Connected Servers widget outer container to match the Activity Timeline's flexbox behavior
- Adds `flex-grow` to the table container so it expands to fill available space

This ensures both widgets in the grid row have matching heights and the table content displays without an unnecessary vertical scrollbar.

## Test plan

- [ ] Verify the Connected Servers widget no longer shows a scrollbar when 3 or fewer servers are displayed
- [ ] Verify both widgets in the row have equal heights
- [ ] Verify the layout remains responsive across breakpoints (mobile, tablet, desktop)
- [ ] Verify the Activity Timeline widget behavior is unchanged

Closes #835

🤖 Generated with [Claude Code](https://claude.com/claude-code)