### PR TITLE
fix: Move Task.Delay outside APM activity scope in background services

### DIFF
--- a/src/DiscordBot.Bot/Services/ChannelActivityAggregationService.cs
+++ b/src/DiscordBot.Bot/Services/ChannelActivityAggregationService.cs
@@ -78,31 +78,32 @@ public class ChannelActivityAggregationService : MonitoredBackgroundService
             executionCycle++;
             var correlationId = Guid.NewGuid().ToString("N")[..16];
 
-            using var activity = BotActivitySource.StartBackgroundServiceActivity(
+            using (var activity = BotActivitySource.StartBackgroundServiceActivity(
                 TracingServiceName,
                 executionCycle,
-                correlationId);
-
-            UpdateHeartbeat();
-
-            try
+                correlationId))
             {
-                var snapshotsProcessed = await AggregateHourlyAsync(stoppingToken);
+                UpdateHeartbeat();
 
-                BotActivitySource.SetRecordsProcessed(activity, snapshotsProcessed);
-                BotActivitySource.SetSuccess(activity);
-                ClearError();
-            }
-            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
-            {
-                // Normal shutdown
-                break;
-            }
-            catch (Exception ex)
-            {
-                BotActivitySource.RecordException(activity, ex);
-                _logger.LogError(ex, "Error during channel activity aggregation");
-                RecordError(ex);
+                try
+                {
+                    var snapshotsProcessed = await AggregateHourlyAsync(stoppingToken);
+
+                    BotActivitySource.SetRecordsProcessed(activity, snapshotsProcessed);
+                    BotActivitySource.SetSuccess(activity);
+                    ClearError();
+                }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    // Normal shutdown
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    BotActivitySource.RecordException(activity, ex);
+                    _logger.LogError(ex, "Error during channel activity aggregation");
+                    RecordError(ex);
+                }
             }
 
             // Wait for next aggregation interval


### PR DESCRIPTION
## Summary

- Fixed background service APM transactions showing incorrect 30-60 minute latency values
- Moved `Task.Delay` calls outside the OpenTelemetry activity scope so transactions only measure actual work execution time
- Affected services: ChannelActivityAggregationService, MemberActivityAggregationService, DiscordTokenRefreshService

## Test plan

- [x] Build passes
- [x] All tests pass (2708 passed, 18 skipped)
- [ ] Deploy and verify APM shows actual transaction times (seconds instead of minutes)

Fixes #849

🤖 Generated with [Claude Code](https://claude.com/claude-code)