### PR TITLE
fix: Add authorization to sidebar navigation links

### DIFF
--- a/src/DiscordBot.Bot/Pages/Commands/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Commands/Index.cshtml.cs
@@ -10,7 +10,7 @@ namespace DiscordBot.Bot.Pages.Commands;
 /// <summary>
 /// Page model for displaying all registered command modules and their commands.
 /// </summary>
-[Authorize]
+[Authorize(Policy = "RequireViewer")]
 public class IndexModel : PageModel
 {
     private readonly ICommandMetadataService _commandMetadataService;

--- a/src/DiscordBot.Bot/Pages/Shared/_Sidebar.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/_Sidebar.cshtml
@@ -35,16 +35,18 @@
         </a>
       </authorize>
 
-      <!-- Commands - visible to all authenticated users -->
-      @{
-        var commandsActive = ViewContext.RouteData.Values["page"]?.ToString()?.StartsWith("/Commands") == true;
-      }
-      <a href="/Commands" class="sidebar-link-redesign @(commandsActive ? "active" : "")" @(commandsActive ? "aria-current=page" : "")>
-        <svg class="w-5 h-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-        </svg>
-        <span class="sidebar-link-text">Commands</span>
-      </a>
+      <!-- Commands - visible to Viewer+ -->
+      <authorize policy="RequireViewer">
+        @{
+          var commandsActive = ViewContext.RouteData.Values["page"]?.ToString()?.StartsWith("/Commands") == true;
+        }
+        <a href="/Commands" class="sidebar-link-redesign @(commandsActive ? "active" : "")" @(commandsActive ? "aria-current=page" : "")>
+          <svg class="w-5 h-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+          </svg>
+          <span class="sidebar-link-text">Commands</span>
+        </a>
+      </authorize>
 
       <!-- Logs - visible to Moderator+ -->
       <authorize policy="RequireModerator">


### PR DESCRIPTION
## Summary
- Wrap **Commands** sidebar link with `RequireViewer` policy (also updated page authorization)
- Wrap **Command Logs** sidebar link with `RequireModerator` policy to match page authorization
- Wrap **Bot Performance** sidebar link with `RequireViewer` policy to match page authorization
- Users now only see navigation links for pages they have access to
- Users without any role now only see the Dashboard

## Sidebar Visibility by Role

| Link | No Role | Viewer | Moderator | Admin |
|------|---------|--------|-----------|-------|
| Dashboard | ✅ | ✅ | ✅ | ✅ |
| Commands | ❌ | ✅ | ✅ | ✅ |
| Bot Performance | ❌ | ✅ | ✅ | ✅ |
| Servers | ❌ | ❌ | ✅ | ✅ |
| Logs | ❌ | ❌ | ✅ | ✅ |
| Analytics | ❌ | ❌ | ✅ | ✅ |
| Settings | ❌ | ❌ | ❌ | ✅ |
| Admin Section | ❌ | ❌ | ❌ | ✅ |

## Test plan
- [ ] Log in as user with no role - should only see Dashboard
- [ ] Log in as Viewer - should see Dashboard, Commands, Bot Performance
- [ ] Log in as Moderator - should also see Servers, Logs, Analytics
- [ ] Log in as Admin+ - should see all links including Settings and Admin section

Closes #856

🤖 Generated with [Claude Code](https://claude.com/claude-code)