### PR TITLE
fix: Convert Discord user IDs to strings in RatWatch analytics

### DIFF
--- a/src/DiscordBot.Bot/Pages/Admin/RatWatchAnalytics.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/RatWatchAnalytics.cshtml
@@ -397,7 +397,7 @@
                 count = h.Count
             }),
             topUsers = Model.ViewModel.MostWatched.Take(5).Select(u => new {
-                userId = u.UserId,
+                userId = u.UserId.ToString(), // Pass as string to preserve Discord ID precision
                 username = u.Username,
                 watchesAgainst = u.WatchesAgainst,
                 guiltyCount = u.GuiltyCount

--- a/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Analytics.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Analytics.cshtml
@@ -681,7 +681,7 @@
                 count = h.Count
             }),
             topUsers = Model.ViewModel.MostWatched.Take(5).Select(u => new {
-                userId = u.UserId,
+                userId = u.UserId.ToString(), // Pass as string to preserve Discord ID precision
                 username = u.Username,
                 watchesAgainst = u.WatchesAgainst,
                 guiltyCount = u.GuiltyCount


### PR DESCRIPTION
## Summary

- Fixed Discord Snowflake ID precision loss in RatWatch Analytics pages
- Converted `userId` to string when serializing chart data to JSON
- Affects both global Admin RatWatch Analytics and guild-specific RatWatch Analytics pages

## Root Cause

Discord IDs are 64-bit integers that exceed JavaScript's `Number.MAX_SAFE_INTEGER` (9007199254740991). When serialized as numbers in JSON and parsed by JavaScript, precision is lost. For example, ID `140899190757654528` becomes `140899190757654530` (off by 2).

## Changes

| File | Change |
|------|--------|
| `Pages/Admin/RatWatchAnalytics.cshtml` | Convert `userId` to string in topUsers chart data |
| `Pages/Guilds/RatWatch/Analytics.cshtml` | Convert `userId` to string in topUsers chart data |

## Test plan

- [ ] Verify RatWatch Analytics pages load without JavaScript errors
- [ ] Verify top users chart displays correctly with user IDs preserved

Closes #781

🤖 Generated with [Claude Code](https://claude.ai/code)