### PR TITLE
style: Add custom scrollbar styling for sidebar navigation

### DIFF
--- a/src/DiscordBot.Bot/wwwroot/css/site.css
+++ b/src/DiscordBot.Bot/wwwroot/css/site.css
@@ -970,6 +970,31 @@
     transition: width 0.2s ease-out, transform 0.2s ease-out;
   }
 
+  /* Custom Scrollbar for Sidebar - Issue #801 */
+  /* Webkit browsers (Chrome, Safari, Edge) */
+  #sidebar::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  #sidebar::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  #sidebar::-webkit-scrollbar-thumb {
+    background: var(--color-bg-hover);
+    border-radius: 3px;
+  }
+
+  #sidebar::-webkit-scrollbar-thumb:hover {
+    background: var(--color-text-tertiary);
+  }
+
+  /* Firefox scrollbar support */
+  #sidebar {
+    scrollbar-width: thin;
+    scrollbar-color: var(--color-bg-hover) transparent;
+  }
+
   .sidebar-redesign.collapsed {
     width: var(--sidebar-collapsed-width);
   }


### PR DESCRIPTION
## Summary
- Add custom scrollbar CSS for the sidebar navigation to match the dark theme
- Uses design system color tokens (`--color-bg-hover` for thumb, `--color-text-tertiary` for hover state)
- Supports Webkit browsers (Chrome, Safari, Edge) and Firefox

## Implementation Details
- 6px thin scrollbar width for unobtrusive appearance
- Transparent track to blend with sidebar background
- Rounded corners on thumb (3px border-radius)
- Hover state on thumb provides visual feedback (Webkit only - Firefox limitation)

## Browser Support
| Browser | Feature Support |
|---------|----------------|
| Chrome/Edge/Safari | Full (including hover state) |
| Firefox | Basic (thin scrollbar, colors - no hover state) |

## Test plan
- [ ] Resize browser viewport to make sidebar content overflow
- [ ] Verify scrollbar appears with dark theme styling in Chrome/Edge
- [ ] Verify scrollbar thumb changes color on hover (Webkit only)
- [ ] Verify Firefox shows thin scrollbar with matching colors

Closes #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)