### PR TITLE
fix(ui): Merge class attributes in _Button component to fix acknowledge buttons

### DIFF
--- a/src/DiscordBot.Bot/Pages/Shared/Components/_Button.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/Components/_Button.cshtml
@@ -1,4 +1,5 @@
 @model DiscordBot.Bot.ViewModels.Components.ButtonViewModel
+@using System.Linq
 @{
     var sizeClasses = Model.Size switch
     {
@@ -20,13 +21,17 @@
         ? "p-2.5 text-text-secondary hover:text-text-primary hover:bg-bg-hover rounded-md transition-colors"
         : $"inline-flex items-center justify-center gap-2 {sizeClasses} font-semibold {variantClasses} rounded-md transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-blue disabled:opacity-50 disabled:cursor-not-allowed";
 
+    // Extract and merge additional classes to avoid duplicate class attributes
+    var additionalClass = Model.AdditionalAttributes?.GetValueOrDefault("class");
+    var finalClasses = string.IsNullOrEmpty(additionalClass) ? baseClasses : $"{baseClasses} {additionalClass}";
+
     var isDisabled = Model.IsDisabled || Model.IsLoading;
     var ariaLabel = Model.AriaLabel ?? (Model.IsIconOnly ? Model.Text : null);
 }
 
 <button
     type="@Model.Type"
-    class="@baseClasses"
+    class="@finalClasses"
     @(isDisabled ? "disabled" : "")
     @if (Model.IsLoading)
     {
@@ -42,7 +47,7 @@
     }
     @if (Model.AdditionalAttributes != null)
     {
-        foreach (var attr in Model.AdditionalAttributes)
+        foreach (var attr in Model.AdditionalAttributes.Where(a => a.Key != "class"))
         {
             @($" {attr.Key}=\"{attr.Value}\"")
         }


### PR DESCRIPTION
## Summary

- Fixed `_Button.cshtml` component rendering duplicate `class` attributes when `AdditionalAttributes` contained a "class" key
- HTML parsers only use the first class attribute, so additional classes like "acknowledge-btn" were silently ignored
- This caused the Acknowledge buttons on the Alerts page to not work after the AJAX migration (commit 775ef71)

## Root Cause

The `_Button` component had:
1. Line 29: `class="@baseClasses"` - the main class attribute
2. Lines 43-48: A loop that could add another `class` attribute from `AdditionalAttributes`

When `AdditionalAttributes = new Dictionary<string, string> { { "class", "acknowledge-btn" } }` was passed, the rendered HTML became:
```html
<button class="inline-flex items-center..." ... class="acknowledge-btn">
```

The duplicate `class` attribute is invalid HTML, and browsers ignore the second one. The JavaScript at line 679 of `alerts-realtime.js` couldn't find `.acknowledge-btn`, preventing the acknowledge functionality from working.

## Changes

- Extract "class" from `AdditionalAttributes` and merge it with `baseClasses` into `finalClasses`
- Filter out "class" when rendering other `AdditionalAttributes`
- Add `System.Linq` using directive for the `Where()` extension method

## Test Plan

- [x] Build succeeds with no errors
- [x] All relevant tests pass (15 Button/Alert related tests)
- [ ] Manual test: Navigate to `/Admin/Performance/Alerts` with active incidents
- [ ] Manual test: Click "Acknowledge" button - should update UI and show success toast
- [ ] Manual test: Click "Acknowledge All" button - should acknowledge all incidents
- [ ] Manual test: Verify no JavaScript console errors on the page

Closes #871

🤖 Generated with [Claude Code](https://claude.com/claude-code)