### PR TITLE
feat(privacy): Implement user data purge functionality

### DIFF
--- a/src/DiscordBot.Bot/Pages/Admin/Privacy/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Privacy/Index.cshtml
@@ -1,0 +1,424 @@
+@page
+@model DiscordBot.Bot.Pages.Admin.Privacy.IndexModel
+@using DiscordBot.Bot.ViewModels.Components
+@{
+    ViewData["Title"] = "User Data Purge";
+}
+
+<div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <!-- Header -->
+    <div class="mb-6">
+        <div class="flex items-center gap-2 text-sm text-text-secondary mb-2">
+            <a asp-page="/Index" class="hover:text-text-primary">Dashboard</a>
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+            <span class="text-text-secondary">Admin</span>
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+            <span class="text-text-primary">Privacy</span>
+        </div>
+        <div>
+            <h1 class="text-2xl font-bold text-text-primary">User Data Purge</h1>
+            <p class="mt-1 text-sm text-text-secondary">
+                Permanently delete user data for privacy compliance and "right to be forgotten" requests
+            </p>
+        </div>
+    </div>
+
+    <!-- Success Message -->
+    @if (!string.IsNullOrEmpty(Model.SuccessMessage))
+    {
+        <div class="mb-6">
+            <partial name="Shared/Components/_Alert" model="new AlertViewModel {
+                Variant = AlertVariant.Success,
+                Message = Model.SuccessMessage,
+                IsDismissible = true
+            }" />
+        </div>
+    }
+
+    <!-- Error Message -->
+    @if (!string.IsNullOrEmpty(Model.ErrorMessage))
+    {
+        <div class="mb-6">
+            <partial name="Shared/Components/_Alert" model="new AlertViewModel {
+                Variant = AlertVariant.Error,
+                Message = Model.ErrorMessage,
+                IsDismissible = true
+            }" />
+        </div>
+    }
+
+    <!-- Warning Alert -->
+    <div class="mb-6">
+        @{
+            var warningAlert = new AlertViewModel
+            {
+                Variant = AlertVariant.Warning,
+                Title = "Warning: Irreversible Operation",
+                Message = "Data purge operations permanently delete ALL user data from the system. This action cannot be undone. Only proceed with verified privacy compliance requests.",
+                ShowIcon = true
+            };
+        }
+        <partial name="Shared/Components/_Alert" model="warningAlert" />
+    </div>
+
+    <!-- Search/Preview Form -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg p-6 mb-6">
+        <h2 class="text-lg font-semibold text-text-primary mb-4">Step 1: Preview User Data</h2>
+        <p class="text-sm text-text-secondary mb-4">
+            Enter a Discord User ID to see what data would be affected by a purge operation.
+        </p>
+
+        <form method="post" asp-page-handler="Preview">
+            @Html.AntiForgeryToken()
+
+            <div class="flex gap-4 items-end">
+                <div class="flex-1">
+                    <label for="DiscordUserId" class="block text-sm font-medium text-text-secondary mb-2">
+                        Discord User ID
+                    </label>
+                    <input type="text"
+                           id="DiscordUserId"
+                           name="DiscordUserId"
+                           value="@Model.DiscordUserId"
+                           class="w-full px-3 py-2 bg-bg-tertiary border border-border-primary rounded-lg text-text-primary placeholder-text-tertiary focus:outline-none focus:ring-2 focus:ring-accent-blue focus:border-transparent"
+                           placeholder="Enter Discord User ID (e.g., 123456789012345678)"
+                           required
+                           pattern="[0-9]{17,20}"
+                           title="Discord User IDs are 17-20 digit numbers" />
+                </div>
+                <button type="submit" class="btn btn-primary">
+                    <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                    </svg>
+                    Preview Data
+                </button>
+            </div>
+        </form>
+    </div>
+
+    <!-- Data Summary (shown after preview) -->
+    @if (Model.Summary != null && Model.Summary.UserExists)
+    {
+        <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden mb-6">
+            <div class="px-6 py-4 border-b border-border-primary bg-bg-tertiary">
+                <h2 class="text-lg font-semibold text-text-primary">Data Summary for User @Model.Summary.DiscordUserId</h2>
+                <p class="text-sm text-text-secondary mt-1">
+                    The following records will be permanently deleted
+                </p>
+            </div>
+
+            <div class="p-6">
+                @if (Model.Summary.TotalRecords > 0)
+                {
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-border-primary">
+                            <thead class="bg-bg-tertiary">
+                                <tr>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
+                                        Entity Type
+                                    </th>
+                                    <th class="px-6 py-3 text-right text-xs font-medium text-text-secondary uppercase tracking-wider">
+                                        Record Count
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody class="divide-y divide-border-primary">
+                                @if (Model.Summary.Counts.Users > 0)
+                                {
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-text-primary">User Account</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-text-primary text-right font-medium">@Model.Summary.Counts.Users</td>
+                                    </tr>
+                                }
+                                @if (Model.Summary.Counts.CommandLogs > 0)
+                                {
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-text-primary">Command Logs</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-text-primary text-right font-medium">@Model.Summary.Counts.CommandLogs</td>
+                                    </tr>
+                                }
+                                @if (Model.Summary.Counts.MessageLogs > 0)
+                                {
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-text-primary">Message Logs</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-text-primary text-right font-medium">@Model.Summary.Counts.MessageLogs</td>
+                                    </tr>
+                                }
+                                @if (Model.Summary.Counts.GuildMembers > 0)
+                                {
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-text-primary">Guild Memberships</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-text-primary text-right font-medium">@Model.Summary.Counts.GuildMembers</td>
+                                    </tr>
+                                }
+                                @if (Model.Summary.Counts.UserConsents > 0)
+                                {
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-text-primary">User Consents</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-text-primary text-right font-medium">@Model.Summary.Counts.UserConsents</td>
+                                    </tr>
+                                }
+                                @if (Model.Summary.Counts.RatWatches > 0)
+                                {
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-text-primary">Rat Watch Incidents</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-text-primary text-right font-medium">@Model.Summary.Counts.RatWatches</td>
+                                    </tr>
+                                }
+                                @if (Model.Summary.Counts.RatVotes > 0)
+                                {
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-text-primary">Rat Watch Votes</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-text-primary text-right font-medium">@Model.Summary.Counts.RatVotes</td>
+                                    </tr>
+                                }
+                                @if (Model.Summary.Counts.RatRecords > 0)
+                                {
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-text-primary">Rat Records</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-text-primary text-right font-medium">@Model.Summary.Counts.RatRecords</td>
+                                    </tr>
+                                }
+                                @if (Model.Summary.Counts.Reminders > 0)
+                                {
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-text-primary">Reminders</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-text-primary text-right font-medium">@Model.Summary.Counts.Reminders</td>
+                                    </tr>
+                                }
+                                @if (Model.Summary.Counts.FlaggedEvents > 0)
+                                {
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-text-primary">Flagged Events</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-text-primary text-right font-medium">@Model.Summary.Counts.FlaggedEvents</td>
+                                    </tr>
+                                }
+                                @if (Model.Summary.Counts.ModerationCases > 0)
+                                {
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-text-primary">Moderation Cases</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-text-primary text-right font-medium">@Model.Summary.Counts.ModerationCases</td>
+                                    </tr>
+                                }
+                                @if (Model.Summary.Counts.ModNotes > 0)
+                                {
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-text-primary">Moderator Notes</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-text-primary text-right font-medium">@Model.Summary.Counts.ModNotes</td>
+                                    </tr>
+                                }
+                                @if (Model.Summary.Counts.UserModTags > 0)
+                                {
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-text-primary">Moderator Tags</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-text-primary text-right font-medium">@Model.Summary.Counts.UserModTags</td>
+                                    </tr>
+                                }
+                                @if (Model.Summary.Counts.Watchlists > 0)
+                                {
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-text-primary">Watchlist Entries</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-text-primary text-right font-medium">@Model.Summary.Counts.Watchlists</td>
+                                    </tr>
+                                }
+                                @if (Model.Summary.Counts.MemberActivitySnapshots > 0)
+                                {
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-text-primary">Activity Snapshots</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-text-primary text-right font-medium">@Model.Summary.Counts.MemberActivitySnapshots</td>
+                                    </tr>
+                                }
+                            </tbody>
+                            <tfoot class="bg-bg-tertiary font-semibold">
+                                <tr>
+                                    <td class="px-6 py-4 text-sm text-text-primary">Total Records</td>
+                                    <td class="px-6 py-4 text-sm text-text-primary text-right">@Model.Summary.TotalRecords</td>
+                                </tr>
+                            </tfoot>
+                        </table>
+                    </div>
+                }
+                else
+                {
+                    <div class="py-8">
+                        @{
+                            var emptyState = new EmptyStateViewModel
+                            {
+                                Type = EmptyStateType.NoData,
+                                Title = "No Data Found",
+                                Description = "This user has no associated data in the system."
+                            };
+                        }
+                        <partial name="Shared/Components/_EmptyState" model="emptyState" />
+                    </div>
+                }
+            </div>
+        </div>
+
+        <!-- Purge Confirmation Form -->
+        @if (Model.Summary.TotalRecords > 0)
+        {
+            <div class="bg-bg-secondary border border-border-primary rounded-lg p-6">
+                <h2 class="text-lg font-semibold text-text-primary mb-4">Step 2: Confirm Data Purge</h2>
+                <p class="text-sm text-text-secondary mb-4">
+                    This operation will permanently delete <span class="font-semibold text-warning">@Model.Summary.TotalRecords record(s)</span> associated with user @Model.Summary.DiscordUserId.
+                </p>
+
+                <form id="purgeForm">
+                    @Html.AntiForgeryToken()
+                    <input type="hidden" name="DiscordUserId" value="@Model.DiscordUserId" />
+
+                    <div class="mb-4">
+                        <label for="Reason" class="block text-sm font-medium text-text-secondary mb-2">
+                            Reason for Purge (Optional)
+                        </label>
+                        <textarea id="Reason"
+                                  name="Reason"
+                                  rows="3"
+                                  class="w-full px-3 py-2 bg-bg-tertiary border border-border-primary rounded-lg text-text-primary placeholder-text-tertiary focus:outline-none focus:ring-2 focus:ring-accent-blue focus:border-transparent"
+                                  placeholder="e.g., GDPR right to be forgotten request - Ticket #12345">@Model.Reason</textarea>
+                        <p class="mt-1 text-xs text-text-tertiary">This reason will be recorded in the audit log.</p>
+                    </div>
+
+                    <button type="button"
+                            onclick="showPurgeModal()"
+                            class="btn btn-danger">
+                        <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                        </svg>
+                        Purge User Data
+                    </button>
+                </form>
+            </div>
+        }
+    }
+</div>
+
+<!-- Confirmation Modal -->
+<div id="purge-modal" class="hidden fixed inset-0 z-50" role="alertdialog" aria-modal="true" aria-labelledby="purge-modal-title">
+    <!-- Backdrop -->
+    <div class="fixed inset-0 bg-black/70 backdrop-blur-sm" onclick="hidePurgeModal()"></div>
+
+    <!-- Dialog -->
+    <div class="fixed inset-0 flex items-center justify-center p-4">
+        <div class="bg-bg-tertiary border border-border-primary rounded-lg shadow-xl max-w-lg w-full">
+            <div class="p-6">
+                <div class="flex items-start gap-4">
+                    <div class="flex-shrink-0">
+                        <svg class="w-10 h-10 text-error" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                        </svg>
+                    </div>
+                    <div class="flex-1">
+                        <h3 id="purge-modal-title" class="text-lg font-semibold text-text-primary mb-2">
+                            Confirm Data Purge
+                        </h3>
+                        <p class="text-sm text-text-secondary mb-4">
+                            You are about to permanently delete ALL data for user <span class="font-semibold text-text-primary">@Model.Summary?.DiscordUserId</span>.
+                        </p>
+                        <p class="text-sm text-error font-medium mb-4">
+                            This action cannot be undone.
+                        </p>
+
+                        <!-- Explicit Confirmation Checkbox -->
+                        <div class="flex items-start gap-3 p-4 bg-bg-secondary border border-border-primary rounded-lg mb-4">
+                            <input type="checkbox"
+                                   id="confirmPurgeCheckbox"
+                                   class="mt-1 w-4 h-4 text-accent-orange bg-bg-tertiary border-border-primary rounded focus:ring-accent-orange focus:ring-2" />
+                            <label for="confirmPurgeCheckbox" class="text-sm text-text-primary select-none">
+                                I understand this operation is <span class="font-semibold">irreversible</span> and will permanently delete
+                                <span class="font-semibold text-warning">@Model.Summary?.TotalRecords record(s)</span> from the database.
+                            </label>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="flex justify-end gap-3 px-6 py-4 bg-bg-secondary border-t border-border-primary">
+                <button type="button" onclick="hidePurgeModal()" class="btn btn-secondary">
+                    Cancel
+                </button>
+                <button type="button"
+                        id="confirmPurgeButton"
+                        onclick="confirmPurge()"
+                        disabled
+                        class="btn btn-danger disabled:opacity-50 disabled:cursor-not-allowed">
+                    <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                    </svg>
+                    Confirm Purge
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script>
+        // Modal control functions
+        function showPurgeModal() {
+            document.getElementById('purge-modal').classList.remove('hidden');
+            document.body.style.overflow = 'hidden';
+        }
+
+        function hidePurgeModal() {
+            document.getElementById('purge-modal').classList.add('hidden');
+            document.body.style.overflow = '';
+            // Reset checkbox
+            document.getElementById('confirmPurgeCheckbox').checked = false;
+            document.getElementById('confirmPurgeButton').disabled = true;
+        }
+
+        // Enable/disable confirm button based on checkbox
+        document.getElementById('confirmPurgeCheckbox')?.addEventListener('change', function() {
+            document.getElementById('confirmPurgeButton').disabled = !this.checked;
+        });
+
+        // Handle purge confirmation
+        function confirmPurge() {
+            // Create a real form submit to the Purge handler
+            const form = document.createElement('form');
+            form.method = 'POST';
+            form.action = '?handler=Purge';
+
+            // Add anti-forgery token
+            const token = document.querySelector('input[name="__RequestVerificationToken"]');
+            if (token) {
+                const tokenInput = document.createElement('input');
+                tokenInput.type = 'hidden';
+                tokenInput.name = '__RequestVerificationToken';
+                tokenInput.value = token.value;
+                form.appendChild(tokenInput);
+            }
+
+            // Add Discord User ID
+            const userIdInput = document.createElement('input');
+            userIdInput.type = 'hidden';
+            userIdInput.name = 'DiscordUserId';
+            userIdInput.value = '@Model.DiscordUserId';
+            form.appendChild(userIdInput);
+
+            // Add Reason
+            const reasonValue = document.getElementById('Reason')?.value || '';
+            const reasonInput = document.createElement('input');
+            reasonInput.type = 'hidden';
+            reasonInput.name = 'Reason';
+            reasonInput.value = reasonValue;
+            form.appendChild(reasonInput);
+
+            document.body.appendChild(form);
+            form.submit();
+        }
+
+        // Close modal on Escape key
+        document.addEventListener('keydown', function(e) {
+            if (e.key === 'Escape' && !document.getElementById('purge-modal').classList.contains('hidden')) {
+                hidePurgeModal();
+            }
+        });
+    </script>
+}

--- a/src/DiscordBot.Bot/Pages/Admin/Privacy/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Admin/Privacy/Index.cshtml.cs
@@ -1,0 +1,189 @@
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace DiscordBot.Bot.Pages.Admin.Privacy;
+
+/// <summary>
+/// Page model for user data purge operations.
+/// Provides functionality for privacy compliance and "right to be forgotten" requests.
+/// Only accessible to SuperAdmins due to the sensitive and irreversible nature of data purges.
+/// </summary>
+[Authorize(Policy = "RequireSuperAdmin")]
+public class IndexModel : PageModel
+{
+    private readonly IUserDataPurgeService _userDataPurgeService;
+    private readonly ILogger<IndexModel> _logger;
+
+    public IndexModel(
+        IUserDataPurgeService userDataPurgeService,
+        ILogger<IndexModel> logger)
+    {
+        _userDataPurgeService = userDataPurgeService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// The Discord User ID to search for or purge.
+    /// </summary>
+    [BindProperty]
+    public ulong DiscordUserId { get; set; }
+
+    /// <summary>
+    /// Optional reason for the purge operation (for audit logging).
+    /// </summary>
+    [BindProperty]
+    public string? Reason { get; set; }
+
+    /// <summary>
+    /// Summary of user data (populated after preview).
+    /// </summary>
+    public UserDataSummary? Summary { get; set; }
+
+    /// <summary>
+    /// Success message displayed after purge operation (survives redirect via TempData).
+    /// </summary>
+    [TempData]
+    public string? SuccessMessage { get; set; }
+
+    /// <summary>
+    /// Error message displayed when operation fails.
+    /// </summary>
+    public string? ErrorMessage { get; set; }
+
+    /// <summary>
+    /// Handles GET request - displays empty search form.
+    /// </summary>
+    public void OnGet()
+    {
+        // Empty page load - user will enter Discord User ID to preview
+    }
+
+    /// <summary>
+    /// Handles POST request to preview user data before purging.
+    /// Retrieves a summary of all data associated with the Discord User ID.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Page result with populated Summary.</returns>
+    public async Task<IActionResult> OnPostPreviewAsync(CancellationToken cancellationToken)
+    {
+        if (DiscordUserId == 0)
+        {
+            ErrorMessage = "Please enter a valid Discord User ID.";
+            return Page();
+        }
+
+        try
+        {
+            _logger.LogInformation(
+                "User {CurrentUser} previewing data for Discord user ID: {DiscordUserId}",
+                User.Identity?.Name ?? "Unknown",
+                DiscordUserId);
+
+            Summary = await _userDataPurgeService.GetUserDataSummaryAsync(DiscordUserId, cancellationToken);
+
+            if (!Summary.UserExists)
+            {
+                ErrorMessage = $"No user found with Discord ID {DiscordUserId}.";
+                Summary = null;
+                return Page();
+            }
+
+            if (Summary.TotalRecords == 0)
+            {
+                ErrorMessage = $"User {DiscordUserId} exists but has no associated data to purge.";
+            }
+
+            return Page();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error previewing user data for Discord user ID: {DiscordUserId}", DiscordUserId);
+            ErrorMessage = "An error occurred while retrieving user data. Please check the logs for details.";
+            return Page();
+        }
+    }
+
+    /// <summary>
+    /// Handles POST request to permanently purge all user data.
+    /// This operation is irreversible and should only be used for privacy compliance requests.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Redirect to the same page with success message on success, or page redisplay with error on failure.</returns>
+    public async Task<IActionResult> OnPostPurgeAsync(CancellationToken cancellationToken)
+    {
+        if (DiscordUserId == 0)
+        {
+            ErrorMessage = "Please enter a valid Discord User ID.";
+            return Page();
+        }
+
+        // Get initiator from claims
+        var initiatedBy = User.Identity?.Name ?? "Unknown";
+
+        try
+        {
+            _logger.LogWarning(
+                "User {CurrentUser} initiating data purge for Discord user ID: {DiscordUserId}, reason: {Reason}",
+                initiatedBy,
+                DiscordUserId,
+                Reason ?? "Not specified");
+
+            var result = await _userDataPurgeService.PurgeUserDataAsync(
+                DiscordUserId,
+                initiatedBy,
+                Reason,
+                cancellationToken);
+
+            if (result.Succeeded)
+            {
+                _logger.LogWarning(
+                    "Successfully purged data for Discord user ID: {DiscordUserId}. Total records deleted: {TotalRecords}",
+                    DiscordUserId,
+                    result.DeletedCounts?.TotalRecords ?? 0);
+
+                SuccessMessage = $"Successfully purged all data for user {DiscordUserId}. " +
+                                $"Total records deleted: {result.DeletedCounts?.TotalRecords ?? 0}.";
+
+                // Redirect to clear form and show success message
+                return RedirectToPage();
+            }
+            else
+            {
+                _logger.LogError(
+                    "Failed to purge data for Discord user ID: {DiscordUserId}. Error: {ErrorCode} - {ErrorMessage}",
+                    DiscordUserId,
+                    result.ErrorCode,
+                    result.ErrorMessage);
+
+                ErrorMessage = result.ErrorMessage ?? "An unknown error occurred during the purge operation.";
+
+                // Reload the summary to show current state
+                try
+                {
+                    Summary = await _userDataPurgeService.GetUserDataSummaryAsync(DiscordUserId, cancellationToken);
+                }
+                catch (Exception summaryEx)
+                {
+                    _logger.LogError(summaryEx, "Error reloading summary after failed purge");
+                }
+
+                return Page();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogWarning("User data purge operation cancelled for Discord user ID: {DiscordUserId}", DiscordUserId);
+            ErrorMessage = "The purge operation was cancelled.";
+            return Page();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error during purge operation for Discord user ID: {DiscordUserId}", DiscordUserId);
+            ErrorMessage = "An unexpected error occurred during the purge operation. Please check the logs for details.";
+            return Page();
+        }
+    }
+}

--- a/src/DiscordBot.Bot/Program.cs
+++ b/src/DiscordBot.Bot/Program.cs
@@ -260,6 +260,7 @@ try
     builder.Services.AddSingleton<IPageMetadataService, PageMetadataService>();
     builder.Services.AddScoped<ICommandRegistrationService, CommandRegistrationService>();
     builder.Services.AddScoped<IUserManagementService, UserManagementService>();
+    builder.Services.AddScoped<IUserDataPurgeService, UserDataPurgeService>();
     builder.Services.AddScoped<IWelcomeService, WelcomeService>();
     builder.Services.AddScoped<ISearchService, SearchService>();
 

--- a/src/DiscordBot.Bot/Services/UserDataPurgeService.cs
+++ b/src/DiscordBot.Bot/Services/UserDataPurgeService.cs
@@ -1,0 +1,434 @@
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Enums;
+using DiscordBot.Core.Interfaces;
+using DiscordBot.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace DiscordBot.Bot.Services;
+
+/// <summary>
+/// Service for purging user data from the system.
+/// Provides methods for privacy compliance and "right to be forgotten" requests.
+/// </summary>
+public class UserDataPurgeService : IUserDataPurgeService
+{
+    private readonly BotDbContext _dbContext;
+    private readonly IAuditLogService _auditLogService;
+    private readonly ILogger<UserDataPurgeService> _logger;
+
+    public UserDataPurgeService(
+        BotDbContext dbContext,
+        IAuditLogService auditLogService,
+        ILogger<UserDataPurgeService> logger)
+    {
+        _dbContext = dbContext;
+        _auditLogService = auditLogService;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<UserDataSummary> GetUserDataSummaryAsync(
+        ulong discordUserId,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Fetching user data summary for Discord user ID: {DiscordUserId}", discordUserId);
+
+        try
+        {
+            var userExists = await _dbContext.Users
+                .AnyAsync(u => u.Id == discordUserId, cancellationToken);
+
+            var counts = await GetUserDataCountsAsync(discordUserId, cancellationToken);
+
+            _logger.LogInformation(
+                "User data summary for {DiscordUserId}: UserExists={UserExists}, TotalRecords={TotalRecords}",
+                discordUserId, userExists, counts.TotalRecords);
+
+            return new UserDataSummary
+            {
+                DiscordUserId = discordUserId,
+                UserExists = userExists,
+                Counts = counts
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error fetching user data summary for Discord user ID: {DiscordUserId}", discordUserId);
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<UserDataPurgeResult> PurgeUserDataAsync(
+        ulong discordUserId,
+        string initiatedBy,
+        string? reason = null,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogWarning(
+            "Starting user data purge operation for Discord user ID: {DiscordUserId}, initiated by: {InitiatedBy}, reason: {Reason}",
+            discordUserId, initiatedBy, reason ?? "Not specified");
+
+        try
+        {
+            // Check if user exists
+            var userExists = await _dbContext.Users
+                .AnyAsync(u => u.Id == discordUserId, cancellationToken);
+
+            if (!userExists)
+            {
+                _logger.LogWarning("Cannot purge data: User {DiscordUserId} not found", discordUserId);
+                return UserDataPurgeResult.Failure(
+                    UserDataPurgeResult.UserNotFound,
+                    $"User with Discord ID {discordUserId} not found");
+            }
+
+            // Start transaction for atomicity
+            await using var transaction = await _dbContext.Database.BeginTransactionAsync(cancellationToken);
+
+            try
+            {
+                var counts = new UserDataPurgeCounts();
+
+                // Delete and anonymize records in order (foreign key dependencies considered)
+                // Order matters: delete child records before parent records
+
+                // 1. Delete MemberActivitySnapshots
+                var memberActivitySnapshotsDeleted = await _dbContext.MemberActivitySnapshots
+                    .Where(m => m.UserId == discordUserId)
+                    .ExecuteDeleteAsync(cancellationToken);
+                counts = counts with { MemberActivitySnapshots = memberActivitySnapshotsDeleted };
+                _logger.LogDebug("Deleted {Count} MemberActivitySnapshot records", memberActivitySnapshotsDeleted);
+
+                // 2. Delete/Anonymize Watchlists
+                // Delete where user is the target, anonymize where user is the moderator
+                var watchlistsDeleted = await _dbContext.Watchlists
+                    .Where(w => w.UserId == discordUserId)
+                    .ExecuteDeleteAsync(cancellationToken);
+
+                var watchlistsAnonymized = await _dbContext.Watchlists
+                    .Where(w => w.AddedByUserId == discordUserId)
+                    .ExecuteUpdateAsync(
+                        setters => setters.SetProperty(w => w.AddedByUserId, (ulong)0),
+                        cancellationToken);
+
+                counts = counts with { Watchlists = watchlistsDeleted };
+                _logger.LogDebug("Deleted {DeletedCount} Watchlist records (target), anonymized {AnonymizedCount} (moderator)",
+                    watchlistsDeleted, watchlistsAnonymized);
+
+                // 3. Delete/Anonymize UserModTags
+                var userModTagsDeleted = await _dbContext.UserModTags
+                    .Where(t => t.UserId == discordUserId)
+                    .ExecuteDeleteAsync(cancellationToken);
+
+                var userModTagsAnonymized = await _dbContext.UserModTags
+                    .Where(t => t.AppliedByUserId == discordUserId)
+                    .ExecuteUpdateAsync(
+                        setters => setters.SetProperty(t => t.AppliedByUserId, (ulong)0),
+                        cancellationToken);
+
+                counts = counts with { UserModTags = userModTagsDeleted };
+                _logger.LogDebug("Deleted {DeletedCount} UserModTag records (target), anonymized {AnonymizedCount} (moderator)",
+                    userModTagsDeleted, userModTagsAnonymized);
+
+                // 4. Delete/Anonymize ModNotes
+                var modNotesDeleted = await _dbContext.ModNotes
+                    .Where(n => n.TargetUserId == discordUserId)
+                    .ExecuteDeleteAsync(cancellationToken);
+
+                var modNotesAnonymized = await _dbContext.ModNotes
+                    .Where(n => n.AuthorUserId == discordUserId)
+                    .ExecuteUpdateAsync(
+                        setters => setters.SetProperty(n => n.AuthorUserId, (ulong)0),
+                        cancellationToken);
+
+                counts = counts with { ModNotes = modNotesDeleted };
+                _logger.LogDebug("Deleted {DeletedCount} ModNote records (target), anonymized {AnonymizedCount} (author)",
+                    modNotesDeleted, modNotesAnonymized);
+
+                // 5. Delete/Anonymize ModerationCases
+                var moderationCasesDeleted = await _dbContext.ModerationCases
+                    .Where(c => c.TargetUserId == discordUserId)
+                    .ExecuteDeleteAsync(cancellationToken);
+
+                var moderationCasesAnonymized = await _dbContext.ModerationCases
+                    .Where(c => c.ModeratorUserId == discordUserId)
+                    .ExecuteUpdateAsync(
+                        setters => setters.SetProperty(c => c.ModeratorUserId, (ulong)0),
+                        cancellationToken);
+
+                counts = counts with { ModerationCases = moderationCasesDeleted };
+                _logger.LogDebug("Deleted {DeletedCount} ModerationCase records (target), anonymized {AnonymizedCount} (moderator)",
+                    moderationCasesDeleted, moderationCasesAnonymized);
+
+                // 6. Delete/Anonymize FlaggedEvents
+                var flaggedEventsDeleted = await _dbContext.FlaggedEvents
+                    .Where(e => e.UserId == discordUserId)
+                    .ExecuteDeleteAsync(cancellationToken);
+
+                var flaggedEventsAnonymized = await _dbContext.FlaggedEvents
+                    .Where(e => e.ReviewedByUserId == discordUserId)
+                    .ExecuteUpdateAsync(
+                        setters => setters.SetProperty(e => e.ReviewedByUserId, (ulong?)null),
+                        cancellationToken);
+
+                counts = counts with { FlaggedEvents = flaggedEventsDeleted };
+                _logger.LogDebug("Deleted {DeletedCount} FlaggedEvent records (target), anonymized {AnonymizedCount} (reviewer)",
+                    flaggedEventsDeleted, flaggedEventsAnonymized);
+
+                // 7. Delete Reminders
+                var remindersDeleted = await _dbContext.Reminders
+                    .Where(r => r.UserId == discordUserId)
+                    .ExecuteDeleteAsync(cancellationToken);
+                counts = counts with { Reminders = remindersDeleted };
+                _logger.LogDebug("Deleted {Count} Reminder records", remindersDeleted);
+
+                // 8. Delete RatRecords
+                var ratRecordsDeleted = await _dbContext.RatRecords
+                    .Where(r => r.UserId == discordUserId)
+                    .ExecuteDeleteAsync(cancellationToken);
+                counts = counts with { RatRecords = ratRecordsDeleted };
+                _logger.LogDebug("Deleted {Count} RatRecord records", ratRecordsDeleted);
+
+                // 9. Delete RatVotes
+                var ratVotesDeleted = await _dbContext.RatVotes
+                    .Where(v => v.VoterUserId == discordUserId)
+                    .ExecuteDeleteAsync(cancellationToken);
+                counts = counts with { RatVotes = ratVotesDeleted };
+                _logger.LogDebug("Deleted {Count} RatVote records", ratVotesDeleted);
+
+                // 10. Delete RatWatches (where user is either accused or initiator)
+                var ratWatchesDeleted = await _dbContext.RatWatches
+                    .Where(w => w.AccusedUserId == discordUserId || w.InitiatorUserId == discordUserId)
+                    .ExecuteDeleteAsync(cancellationToken);
+                counts = counts with { RatWatches = ratWatchesDeleted };
+                _logger.LogDebug("Deleted {Count} RatWatch records", ratWatchesDeleted);
+
+                // 11. Delete UserConsents
+                var userConsentsDeleted = await _dbContext.UserConsents
+                    .Where(c => c.DiscordUserId == discordUserId)
+                    .ExecuteDeleteAsync(cancellationToken);
+                counts = counts with { UserConsents = userConsentsDeleted };
+                _logger.LogDebug("Deleted {Count} UserConsent records", userConsentsDeleted);
+
+                // 12. Delete GuildMembers
+                var guildMembersDeleted = await _dbContext.GuildMembers
+                    .Where(m => m.UserId == discordUserId)
+                    .ExecuteDeleteAsync(cancellationToken);
+                counts = counts with { GuildMembers = guildMembersDeleted };
+                _logger.LogDebug("Deleted {Count} GuildMember records", guildMembersDeleted);
+
+                // 13. Delete MessageLogs
+                var messageLogsDeleted = await _dbContext.MessageLogs
+                    .Where(l => l.AuthorId == discordUserId)
+                    .ExecuteDeleteAsync(cancellationToken);
+                counts = counts with { MessageLogs = messageLogsDeleted };
+                _logger.LogDebug("Deleted {Count} MessageLog records", messageLogsDeleted);
+
+                // 14. Delete CommandLogs
+                var commandLogsDeleted = await _dbContext.CommandLogs
+                    .Where(l => l.UserId == discordUserId)
+                    .ExecuteDeleteAsync(cancellationToken);
+                counts = counts with { CommandLogs = commandLogsDeleted };
+                _logger.LogDebug("Deleted {Count} CommandLog records", commandLogsDeleted);
+
+                // 15. Finally, delete the User entity itself
+                var usersDeleted = await _dbContext.Users
+                    .Where(u => u.Id == discordUserId)
+                    .ExecuteDeleteAsync(cancellationToken);
+                counts = counts with { Users = usersDeleted };
+                _logger.LogDebug("Deleted {Count} User records", usersDeleted);
+
+                // Commit the transaction
+                await transaction.CommitAsync(cancellationToken);
+
+                _logger.LogWarning(
+                    "Successfully purged user data for Discord user ID: {DiscordUserId}. Total records deleted: {TotalRecords}",
+                    discordUserId, counts.TotalRecords);
+
+                // Log audit entry after successful purge
+                try
+                {
+                    _auditLogService.CreateBuilder()
+                        .ForCategory(AuditLogCategory.User)
+                        .WithAction(AuditLogAction.DataPurged)
+                        .ByUser(initiatedBy)
+                        .OnTarget("User", discordUserId.ToString())
+                        .WithDetails(new
+                        {
+                            discordUserId = discordUserId.ToString(),
+                            reason,
+                            deletedCounts = new
+                            {
+                                commandLogs = counts.CommandLogs,
+                                messageLogs = counts.MessageLogs,
+                                guildMembers = counts.GuildMembers,
+                                userConsents = counts.UserConsents,
+                                ratWatches = counts.RatWatches,
+                                ratVotes = counts.RatVotes,
+                                ratRecords = counts.RatRecords,
+                                reminders = counts.Reminders,
+                                flaggedEvents = counts.FlaggedEvents,
+                                moderationCases = counts.ModerationCases,
+                                modNotes = counts.ModNotes,
+                                userModTags = counts.UserModTags,
+                                watchlists = counts.Watchlists,
+                                memberActivitySnapshots = counts.MemberActivitySnapshots,
+                                users = counts.Users,
+                                totalRecords = counts.TotalRecords
+                            },
+                            initiatedBy
+                        })
+                        .Enqueue();
+                }
+                catch (Exception auditEx)
+                {
+                    _logger.LogError(auditEx,
+                        "Failed to log audit entry for user data purge {DiscordUserId}",
+                        discordUserId);
+                }
+
+                return UserDataPurgeResult.Success(discordUserId, counts);
+            }
+            catch (OperationCanceledException)
+            {
+                await transaction.RollbackAsync(CancellationToken.None);
+                _logger.LogWarning("User data purge operation cancelled for Discord user ID: {DiscordUserId}", discordUserId);
+                throw;
+            }
+            catch (Exception ex)
+            {
+                await transaction.RollbackAsync(CancellationToken.None);
+                _logger.LogError(ex,
+                    "Database error during user data purge for Discord user ID: {DiscordUserId}",
+                    discordUserId);
+                throw;
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            return UserDataPurgeResult.Failure(
+                UserDataPurgeResult.OperationCancelled,
+                "The purge operation was cancelled");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to purge user data for Discord user ID: {DiscordUserId}", discordUserId);
+            return UserDataPurgeResult.Failure(
+                UserDataPurgeResult.DatabaseError,
+                $"An error occurred while purging user data: {ex.Message}");
+        }
+    }
+
+    #region Private Helper Methods
+
+    /// <summary>
+    /// Gets counts of all user data entities for the specified Discord user ID.
+    /// </summary>
+    private async Task<UserDataPurgeCounts> GetUserDataCountsAsync(
+        ulong discordUserId,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("Counting user data records for Discord user ID: {DiscordUserId}", discordUserId);
+
+        // Execute all count queries in parallel for performance
+        var commandLogsTask = _dbContext.CommandLogs
+            .Where(l => l.UserId == discordUserId)
+            .CountAsync(cancellationToken);
+
+        var messageLogsTask = _dbContext.MessageLogs
+            .Where(l => l.AuthorId == discordUserId)
+            .CountAsync(cancellationToken);
+
+        var guildMembersTask = _dbContext.GuildMembers
+            .Where(m => m.UserId == discordUserId)
+            .CountAsync(cancellationToken);
+
+        var userConsentsTask = _dbContext.UserConsents
+            .Where(c => c.DiscordUserId == discordUserId)
+            .CountAsync(cancellationToken);
+
+        var ratWatchesTask = _dbContext.RatWatches
+            .Where(w => w.AccusedUserId == discordUserId || w.InitiatorUserId == discordUserId)
+            .CountAsync(cancellationToken);
+
+        var ratVotesTask = _dbContext.RatVotes
+            .Where(v => v.VoterUserId == discordUserId)
+            .CountAsync(cancellationToken);
+
+        var ratRecordsTask = _dbContext.RatRecords
+            .Where(r => r.UserId == discordUserId)
+            .CountAsync(cancellationToken);
+
+        var remindersTask = _dbContext.Reminders
+            .Where(r => r.UserId == discordUserId)
+            .CountAsync(cancellationToken);
+
+        var flaggedEventsTask = _dbContext.FlaggedEvents
+            .Where(e => e.UserId == discordUserId || e.ReviewedByUserId == discordUserId)
+            .CountAsync(cancellationToken);
+
+        var moderationCasesTask = _dbContext.ModerationCases
+            .Where(c => c.TargetUserId == discordUserId || c.ModeratorUserId == discordUserId)
+            .CountAsync(cancellationToken);
+
+        var modNotesTask = _dbContext.ModNotes
+            .Where(n => n.TargetUserId == discordUserId || n.AuthorUserId == discordUserId)
+            .CountAsync(cancellationToken);
+
+        var userModTagsTask = _dbContext.UserModTags
+            .Where(t => t.UserId == discordUserId || t.AppliedByUserId == discordUserId)
+            .CountAsync(cancellationToken);
+
+        var watchlistsTask = _dbContext.Watchlists
+            .Where(w => w.UserId == discordUserId || w.AddedByUserId == discordUserId)
+            .CountAsync(cancellationToken);
+
+        var memberActivitySnapshotsTask = _dbContext.MemberActivitySnapshots
+            .Where(m => m.UserId == discordUserId)
+            .CountAsync(cancellationToken);
+
+        var usersTask = _dbContext.Users
+            .Where(u => u.Id == discordUserId)
+            .CountAsync(cancellationToken);
+
+        // Await all tasks
+        await Task.WhenAll(
+            commandLogsTask,
+            messageLogsTask,
+            guildMembersTask,
+            userConsentsTask,
+            ratWatchesTask,
+            ratVotesTask,
+            ratRecordsTask,
+            remindersTask,
+            flaggedEventsTask,
+            moderationCasesTask,
+            modNotesTask,
+            userModTagsTask,
+            watchlistsTask,
+            memberActivitySnapshotsTask,
+            usersTask);
+
+        return new UserDataPurgeCounts
+        {
+            CommandLogs = await commandLogsTask,
+            MessageLogs = await messageLogsTask,
+            GuildMembers = await guildMembersTask,
+            UserConsents = await userConsentsTask,
+            RatWatches = await ratWatchesTask,
+            RatVotes = await ratVotesTask,
+            RatRecords = await ratRecordsTask,
+            Reminders = await remindersTask,
+            FlaggedEvents = await flaggedEventsTask,
+            ModerationCases = await moderationCasesTask,
+            ModNotes = await modNotesTask,
+            UserModTags = await userModTagsTask,
+            Watchlists = await watchlistsTask,
+            MemberActivitySnapshots = await memberActivitySnapshotsTask,
+            Users = await usersTask
+        };
+    }
+
+    #endregion
+}

--- a/src/DiscordBot.Core/DTOs/UserDataPurgeDto.cs
+++ b/src/DiscordBot.Core/DTOs/UserDataPurgeDto.cs
@@ -1,0 +1,214 @@
+namespace DiscordBot.Core.DTOs;
+
+/// <summary>
+/// Result of a user data purge operation.
+/// Contains success/failure status and detailed counts of deleted records.
+/// </summary>
+public class UserDataPurgeResult
+{
+    /// <summary>
+    /// Indicates whether the purge operation succeeded.
+    /// </summary>
+    public bool Succeeded { get; private set; }
+
+    /// <summary>
+    /// Error code if the operation failed.
+    /// </summary>
+    public string? ErrorCode { get; private set; }
+
+    /// <summary>
+    /// Error message if the operation failed.
+    /// </summary>
+    public string? ErrorMessage { get; private set; }
+
+    /// <summary>
+    /// The Discord user ID that was purged.
+    /// </summary>
+    public ulong? DiscordUserId { get; private set; }
+
+    /// <summary>
+    /// Detailed breakdown of deleted records by entity type.
+    /// </summary>
+    public UserDataPurgeCounts? DeletedCounts { get; private set; }
+
+    /// <summary>
+    /// Timestamp when the purge operation completed (UTC).
+    /// </summary>
+    public DateTime? CompletedAt { get; private set; }
+
+    /// <summary>
+    /// Creates a successful purge result.
+    /// </summary>
+    /// <param name="discordUserId">The Discord user ID that was purged.</param>
+    /// <param name="counts">Detailed counts of deleted records.</param>
+    /// <returns>A successful purge result.</returns>
+    public static UserDataPurgeResult Success(ulong discordUserId, UserDataPurgeCounts counts) => new()
+    {
+        Succeeded = true,
+        DiscordUserId = discordUserId,
+        DeletedCounts = counts,
+        CompletedAt = DateTime.UtcNow
+    };
+
+    /// <summary>
+    /// Creates a failed purge result.
+    /// </summary>
+    /// <param name="errorCode">Error code identifying the failure type.</param>
+    /// <param name="errorMessage">Human-readable error message.</param>
+    /// <returns>A failed purge result.</returns>
+    public static UserDataPurgeResult Failure(string errorCode, string errorMessage) => new()
+    {
+        Succeeded = false,
+        ErrorCode = errorCode,
+        ErrorMessage = errorMessage
+    };
+
+    // Common error codes
+    /// <summary>
+    /// Error code: User not found in the database.
+    /// </summary>
+    public const string UserNotFound = "USER_NOT_FOUND";
+
+    /// <summary>
+    /// Error code: Database error occurred during purge operation.
+    /// </summary>
+    public const string DatabaseError = "DATABASE_ERROR";
+
+    /// <summary>
+    /// Error code: Insufficient permissions to perform purge operation.
+    /// </summary>
+    public const string InsufficientPermissions = "INSUFFICIENT_PERMISSIONS";
+
+    /// <summary>
+    /// Error code: Operation was cancelled.
+    /// </summary>
+    public const string OperationCancelled = "OPERATION_CANCELLED";
+}
+
+/// <summary>
+/// Summary of user data that exists in the system.
+/// Used to preview what would be deleted in a purge operation.
+/// </summary>
+public record UserDataSummary
+{
+    /// <summary>
+    /// The Discord user ID being analyzed.
+    /// </summary>
+    public ulong DiscordUserId { get; init; }
+
+    /// <summary>
+    /// Indicates whether a User entity exists for this Discord user ID.
+    /// </summary>
+    public bool UserExists { get; init; }
+
+    /// <summary>
+    /// Breakdown of data counts by entity type.
+    /// </summary>
+    public UserDataPurgeCounts Counts { get; init; } = new();
+
+    /// <summary>
+    /// Total count of all records that would be affected by a purge.
+    /// </summary>
+    public int TotalRecords => Counts.TotalRecords;
+}
+
+/// <summary>
+/// Detailed breakdown of user data counts by entity type.
+/// </summary>
+public record UserDataPurgeCounts
+{
+    /// <summary>
+    /// Number of CommandLog records (where UserId matches).
+    /// </summary>
+    public int CommandLogs { get; init; }
+
+    /// <summary>
+    /// Number of MessageLog records (where AuthorId matches).
+    /// </summary>
+    public int MessageLogs { get; init; }
+
+    /// <summary>
+    /// Number of GuildMember records (where UserId matches).
+    /// </summary>
+    public int GuildMembers { get; init; }
+
+    /// <summary>
+    /// Number of UserConsent records (where DiscordUserId matches).
+    /// </summary>
+    public int UserConsents { get; init; }
+
+    /// <summary>
+    /// Number of RatWatch records (where AccusedUserId or InitiatorUserId matches).
+    /// </summary>
+    public int RatWatches { get; init; }
+
+    /// <summary>
+    /// Number of RatVote records (where VoterUserId matches).
+    /// </summary>
+    public int RatVotes { get; init; }
+
+    /// <summary>
+    /// Number of RatRecord records (where UserId matches).
+    /// </summary>
+    public int RatRecords { get; init; }
+
+    /// <summary>
+    /// Number of Reminder records (where UserId matches).
+    /// </summary>
+    public int Reminders { get; init; }
+
+    /// <summary>
+    /// Number of FlaggedEvent records (where UserId or ReviewedByUserId matches).
+    /// </summary>
+    public int FlaggedEvents { get; init; }
+
+    /// <summary>
+    /// Number of ModerationCase records (where TargetUserId or ModeratorUserId matches).
+    /// </summary>
+    public int ModerationCases { get; init; }
+
+    /// <summary>
+    /// Number of ModNote records (where TargetUserId or AuthorUserId matches).
+    /// </summary>
+    public int ModNotes { get; init; }
+
+    /// <summary>
+    /// Number of UserModTag records (where UserId or AppliedByUserId matches).
+    /// </summary>
+    public int UserModTags { get; init; }
+
+    /// <summary>
+    /// Number of Watchlist records (where UserId or AddedByUserId matches).
+    /// </summary>
+    public int Watchlists { get; init; }
+
+    /// <summary>
+    /// Number of MemberActivitySnapshot records (where UserId matches).
+    /// </summary>
+    public int MemberActivitySnapshots { get; init; }
+
+    /// <summary>
+    /// Number of User records (should be 0 or 1).
+    /// </summary>
+    public int Users { get; init; }
+
+    /// <summary>
+    /// Total count of all records across all entity types.
+    /// </summary>
+    public int TotalRecords =>
+        CommandLogs +
+        MessageLogs +
+        GuildMembers +
+        UserConsents +
+        RatWatches +
+        RatVotes +
+        RatRecords +
+        Reminders +
+        FlaggedEvents +
+        ModerationCases +
+        ModNotes +
+        UserModTags +
+        Watchlists +
+        MemberActivitySnapshots +
+        Users;
+}

--- a/src/DiscordBot.Core/Enums/AuditLogAction.cs
+++ b/src/DiscordBot.Core/Enums/AuditLogAction.cs
@@ -98,5 +98,10 @@ public enum AuditLogAction
     /// <summary>
     /// The Discord bot disconnected from the Discord gateway.
     /// </summary>
-    BotDisconnected = 19
+    BotDisconnected = 19,
+
+    /// <summary>
+    /// User data was purged for privacy compliance (right to be forgotten).
+    /// </summary>
+    DataPurged = 20
 }

--- a/src/DiscordBot.Core/Interfaces/IUserDataPurgeService.cs
+++ b/src/DiscordBot.Core/Interfaces/IUserDataPurgeService.cs
@@ -1,0 +1,39 @@
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Core.Interfaces;
+
+/// <summary>
+/// Service interface for purging user data from the system.
+/// Provides methods for privacy compliance and "right to be forgotten" requests.
+/// </summary>
+public interface IUserDataPurgeService
+{
+    /// <summary>
+    /// Retrieves a summary of all user data that would be affected by a purge operation.
+    /// Use this method to preview what data will be deleted before executing the purge.
+    /// </summary>
+    /// <param name="discordUserId">The Discord user ID to analyze.</param>
+    /// <param name="cancellationToken">Cancellation token to cancel the operation.</param>
+    /// <returns>A summary containing counts of all data entities associated with the user.</returns>
+    Task<UserDataSummary> GetUserDataSummaryAsync(
+        ulong discordUserId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Permanently purges all user data from the system.
+    /// This operation is irreversible and should be used for privacy compliance requests.
+    /// Deletes the User entity and all related data across CommandLog, MessageLog, GuildMember,
+    /// UserConsent, RatWatch, RatVote, RatRecord, Reminder, FlaggedEvent, ModerationCase,
+    /// ModNote, UserModTag, Watchlist, and MemberActivitySnapshot entities.
+    /// </summary>
+    /// <param name="discordUserId">The Discord user ID whose data should be purged.</param>
+    /// <param name="initiatedBy">Identifier of the actor initiating the purge (for audit logging).</param>
+    /// <param name="reason">Optional reason for the purge operation.</param>
+    /// <param name="cancellationToken">Cancellation token to cancel the operation.</param>
+    /// <returns>A result indicating success or failure, along with counts of deleted records.</returns>
+    Task<UserDataPurgeResult> PurgeUserDataAsync(
+        ulong discordUserId,
+        string initiatedBy,
+        string? reason = null,
+        CancellationToken cancellationToken = default);
+}


### PR DESCRIPTION
## Summary

- Adds complete user data purge functionality for GDPR/privacy compliance (right to be forgotten)
- Creates `IUserDataPurgeService` with preview and purge operations
- Implements admin UI at `/Admin/Privacy` with two-step confirmation workflow
- Adds `AuditLogAction.DataPurged` for audit logging purge operations

## Changes

### Core (Interface & DTOs)
- `IUserDataPurgeService` - Service interface for purge operations
- `UserDataPurgeResult` - Result class with success/failure status and deletion counts
- `UserDataSummary` - Preview of data that would be deleted
- `UserDataPurgeCounts` - Detailed breakdown by entity type (15 entity types)

### Service Implementation
- `UserDataPurgeService` - Handles deletion across all user-related entities
- Uses transactional operations for atomicity
- Deletes user-target records, anonymizes moderator references
- Comprehensive audit logging without PII

### Admin UI
- `/Admin/Privacy` page with SuperAdmin authorization
- Step 1: Enter Discord User ID and preview data summary
- Step 2: Confirm with reason and double-confirmation (modal + checkbox)

### Entity Types Handled
Users, CommandLogs, MessageLogs, GuildMembers, UserConsents, RatWatches, RatVotes, RatRecords, Reminders, FlaggedEvents, ModerationCases, ModNotes, UserModTags, Watchlists, MemberActivitySnapshots

## Test plan

- [x] Build passes with no errors
- [x] All existing tests pass (2775 passed, 0 failed)
- [ ] Manual test: Navigate to /Admin/Privacy as SuperAdmin
- [ ] Manual test: Enter test Discord User ID and verify preview data
- [ ] Manual test: Complete purge workflow with confirmation
- [ ] Verify audit log entry is created after purge

Closes #778

🤖 Generated with [Claude Code](https://claude.com/claude-code)