### PR TITLE
perf(analytics): Parallelize data retrieval in Command Analytics page

### DIFF
--- a/src/DiscordBot.Bot/Pages/CommandLogs/Analytics.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/CommandLogs/Analytics.cshtml.cs
@@ -65,11 +65,14 @@ public class AnalyticsModel : PageModel
 
         try
         {
-            // Load analytics data
-            var analytics = await _analyticsService.GetAnalyticsAsync(start, end, GuildId, cancellationToken);
+            // Load analytics data and guild list in parallel
+            var analyticsTask = _analyticsService.GetAnalyticsAsync(start, end, GuildId, cancellationToken);
+            var guildsTask = _guildService.GetAllGuildsAsync(cancellationToken);
 
-            // Load available guilds for filter dropdown
-            var guilds = await _guildService.GetAllGuildsAsync(cancellationToken);
+            await Task.WhenAll(analyticsTask, guildsTask);
+
+            var analytics = await analyticsTask;
+            var guilds = await guildsTask;
             var guildOptions = guilds.Select(g => new GuildSelectOption(g.Id, g.Name)).ToList();
 
             ViewModel = new CommandAnalyticsViewModel


### PR DESCRIPTION
## Summary
- Run analytics service and guild service queries concurrently using `Task.WhenAll` instead of sequential awaits
- Improves page load performance by parallelizing 2 independent data calls

## Related
Closes #822

Part of #826 (parent issue for analytics page parallelization)

## Test plan
- [ ] Navigate to Command Analytics page (`/CommandLogs/Analytics`)
- [ ] Verify page loads correctly with all data
- [ ] Verify filters work (date range, guild)
- [ ] Check no errors in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)