### PR TITLE
fix(performance): Bound RateLimitAttribute cache to prevent memory leak

### DIFF
--- a/src/DiscordBot.Bot/Preconditions/RateLimitAttribute.cs
+++ b/src/DiscordBot.Bot/Preconditions/RateLimitAttribute.cs
@@ -1,6 +1,6 @@
-using System.Collections.Concurrent;
 using Discord;
 using Discord.Interactions;
+using DiscordBot.Bot.Collections;
 using DiscordBot.Bot.Metrics;
 using DiscordBot.Core.Enums;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,7 +13,13 @@ namespace DiscordBot.Bot.Preconditions;
 /// </summary>
 public class RateLimitAttribute : PreconditionAttribute
 {
-    private static readonly ConcurrentDictionary<string, List<DateTime>> _invocations = new();
+    /// <summary>
+    /// Maximum number of unique rate limit keys to track before evicting least recently used entries.
+    /// This prevents unbounded memory growth when many unique users invoke rate-limited commands.
+    /// </summary>
+    internal const int MaxTrackedKeys = 10000;
+
+    private static readonly LruConcurrentDictionary<string, List<DateTime>> _invocations = new(MaxTrackedKeys);
 
     private readonly int _times;
     private readonly double _periodSeconds;


### PR DESCRIPTION
## Summary

- Replace unbounded `ConcurrentDictionary` with `LruConcurrentDictionary` in `RateLimitAttribute`
- Set capacity to 10,000 entries to prevent unbounded memory growth
- Add unit tests verifying LRU eviction behavior and cache bounding

Closes #854

## Problem

The `RateLimitAttribute` used a static `ConcurrentDictionary<string, List<DateTime>>` that grew without bounds. Every unique user who invoked a rate-limited command created a permanent dictionary entry, leading to gradual memory growth over time.

## Solution

Applied the same pattern used in PR #815 (bounded collections fix) by replacing the unbounded dictionary with `LruConcurrentDictionary<string, List<DateTime>>` with a capacity of 10,000. This ensures the least recently used entries are evicted when capacity is exceeded, while maintaining rate limiting functionality for active users.

## Test plan

- [x] All existing `RateLimitAttributeTests` pass (17 tests)
- [x] New tests verify:
  - `MaxTrackedKeys` constant has expected value
  - Cache is bounded and evicts LRU entries
  - LRU order updates correctly on key access
  - Cache uses correct `LruConcurrentDictionary` type

🤖 Generated with [Claude Code](https://claude.com/claude-code)