### PR TITLE
feat(audio): Add cross-platform audio configuration and dependencies documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ The application uses the `IOptions<T>` pattern for strongly-typed configuration.
 | `ReminderOptions` | `Reminder` | Reminder system settings (polling, delivery, limits) |
 | `SamplingOptions` | `OpenTelemetry:Tracing:Sampling` | OpenTelemetry trace sampling rates (priority-based sampling) |
 | `ScheduledMessagesOptions` | `ScheduledMessages` | Scheduled message delivery settings |
+| `SoundboardOptions` | `Soundboard` | Audio/soundboard settings (FFmpeg path, file limits, supported formats) |
 | `VerificationOptions` | `Verification` | Verification code generation settings |
 | `ElasticApm:*` | `ElasticApm` | Elastic APM distributed tracing configuration (see appsettings.json for full options) |
 
@@ -149,6 +150,7 @@ Reference these docs for detailed specifications (build and serve locally with `
 | [identity-configuration.md](docs/articles/identity-configuration.md) | Authentication setup, troubleshooting |
 | [authorization-policies.md](docs/articles/authorization-policies.md) | Role hierarchy, guild access |
 | [api-endpoints.md](docs/articles/api-endpoints.md) | REST API documentation |
+| [audio-dependencies.md](docs/articles/audio-dependencies.md) | Audio dependencies (FFmpeg, libsodium, libopus) setup |
 | [log-aggregation.md](docs/articles/log-aggregation.md) | Elasticsearch and Seq centralized logging setup |
 | [elastic-stack-setup.md](docs/articles/elastic-stack-setup.md) | Local development setup for Elastic Stack (Elasticsearch, Kibana, APM) |
 | [kibana-dashboards.md](docs/articles/kibana-dashboards.md) | Kibana dashboards, saved searches, and alerting setup |

--- a/docs/articles/audio-dependencies.md
+++ b/docs/articles/audio-dependencies.md
@@ -1,0 +1,246 @@
+# Audio Dependencies
+
+This document describes the external dependencies required for audio features (soundboard, voice channel playback).
+
+## Overview
+
+The bot's audio features require external tools for audio processing. These are not bundled with the application and must be installed separately on the host system.
+
+## Required Dependencies
+
+### FFmpeg
+
+FFmpeg is required for audio format conversion and streaming to Discord voice channels.
+
+| Platform | Installation |
+|----------|--------------|
+| Windows | Download from [ffmpeg.org](https://ffmpeg.org/download.html) or use `winget install ffmpeg` |
+| Linux (Debian/Ubuntu) | `sudo apt install ffmpeg` |
+| Linux (RHEL/Fedora) | `sudo dnf install ffmpeg` |
+| macOS | `brew install ffmpeg` |
+| Docker | Include in Dockerfile (see below) |
+
+**Verify installation:**
+```bash
+ffmpeg -version
+ffprobe -version
+```
+
+### Native Libraries
+
+Discord.NET audio requires additional native libraries:
+
+| Library | Purpose | Notes |
+|---------|---------|-------|
+| **libsodium** | Voice encryption | Usually bundled with Discord.NET on Windows; may need explicit installation on Linux |
+| **libopus** | Opus audio encoding | Usually bundled with Discord.NET on Windows; may need explicit installation on Linux |
+
+**Linux installation:**
+```bash
+# Debian/Ubuntu
+sudo apt install libsodium23 libopus0
+
+# RHEL/Fedora
+sudo dnf install libsodium opus
+```
+
+## Configuration
+
+Audio dependencies are configured in `appsettings.json` under the `Soundboard` section:
+
+```json
+{
+  "Soundboard": {
+    "BasePath": "./sounds",
+    "FfmpegPath": null,
+    "FfprobePath": null,
+    "DefaultMaxDurationSeconds": 30,
+    "DefaultMaxFileSizeBytes": 10485760,
+    "DefaultMaxSoundsPerGuild": 100,
+    "DefaultMaxStorageBytes": 524288000,
+    "DefaultAutoLeaveTimeoutMinutes": 0,
+    "SupportedFormats": ["mp3", "wav", "ogg"]
+  }
+}
+```
+
+### Configuration Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `BasePath` | `./sounds` | Root folder for sound file storage |
+| `FfmpegPath` | `null` | Path to FFmpeg executable. `null` means use system PATH |
+| `FfprobePath` | `null` | Path to FFprobe executable. `null` means use system PATH |
+| `DefaultMaxDurationSeconds` | 30 | Maximum sound duration in seconds |
+| `DefaultMaxFileSizeBytes` | 10485760 | Maximum file size (10MB) |
+| `DefaultMaxSoundsPerGuild` | 100 | Maximum sounds per guild |
+| `DefaultMaxStorageBytes` | 524288000 | Total storage limit per guild (500MB) |
+| `DefaultAutoLeaveTimeoutMinutes` | 0 | Idle timeout (0 = stay indefinitely) |
+| `SupportedFormats` | `["mp3", "wav", "ogg"]` | Allowed audio file formats |
+
+### Platform-Specific FFmpeg Paths
+
+If FFmpeg is not in your system PATH, specify the full path:
+
+```json
+{
+  "Soundboard": {
+    "FfmpegPath": "C:/ffmpeg/bin/ffmpeg.exe",
+    "FfprobePath": "C:/ffmpeg/bin/ffprobe.exe"
+  }
+}
+```
+
+**Common paths:**
+- **Windows**: `C:/ffmpeg/bin/ffmpeg.exe` or `C:/Program Files/ffmpeg/bin/ffmpeg.exe`
+- **Linux**: `/usr/bin/ffmpeg` (usually in PATH)
+- **macOS**: `/usr/local/bin/ffmpeg` (Homebrew) or `/opt/homebrew/bin/ffmpeg` (Apple Silicon)
+- **Docker**: `/usr/bin/ffmpeg` (installed in PATH)
+
+## Docker Deployment
+
+### Dockerfile Example
+
+Add FFmpeg and native libraries to your Dockerfile:
+
+```dockerfile
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+
+# Install audio dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ffmpeg \
+    libsodium23 \
+    libopus0 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+EXPOSE 5001
+
+# ... rest of Dockerfile
+```
+
+### Docker Compose Example
+
+Mount the sounds directory as a volume:
+
+```yaml
+services:
+  discordbot:
+    build: .
+    volumes:
+      - ./sounds:/app/sounds
+    environment:
+      - Soundboard__BasePath=/app/sounds
+```
+
+## File System Considerations
+
+### Cross-Platform Path Handling
+
+The application uses `Path.Combine()` for all path operations, ensuring compatibility across Windows (`\`) and Linux (`/`).
+
+**Correct configuration:**
+```json
+{
+  "Soundboard": {
+    "BasePath": "./sounds"
+  }
+}
+```
+
+The path will be normalized at runtime:
+- Windows: `.\sounds\123456789\sound.mp3`
+- Linux: `./sounds/123456789/sound.mp3`
+
+### Directory Structure
+
+Sounds are organized by guild ID:
+
+```
+sounds/
+├── 123456789012345678/    # Guild ID
+│   ├── airhorn.mp3
+│   └── bruh.wav
+└── 987654321098765432/    # Another guild
+    └── victory.ogg
+```
+
+### Permissions (Linux/Docker)
+
+Ensure the application has read/write access to the sounds directory:
+
+```bash
+# Create directory with appropriate permissions
+mkdir -p ./sounds
+chmod 755 ./sounds
+
+# If running as non-root user in Docker
+chown -R 1000:1000 ./sounds
+```
+
+## Troubleshooting
+
+### FFmpeg Not Found
+
+**Symptoms:** Audio commands fail with "FFmpeg not found" errors.
+
+**Solutions:**
+1. Verify FFmpeg is installed: `ffmpeg -version`
+2. Add FFmpeg to system PATH
+3. Configure explicit path in `appsettings.json`:
+   ```json
+   { "Soundboard": { "FfmpegPath": "/path/to/ffmpeg" } }
+   ```
+
+### Voice Connection Issues
+
+**Symptoms:** Bot joins channel but no audio plays.
+
+**Possible causes:**
+1. Missing libsodium or libopus
+2. FFmpeg not configured correctly
+3. Bot lacks voice permissions in Discord
+
+**Linux fix:**
+```bash
+sudo apt install libsodium23 libopus0
+```
+
+### File Permission Errors
+
+**Symptoms:** Cannot upload or play sounds; permission denied errors.
+
+**Solutions:**
+1. Check directory ownership
+2. Ensure write permissions on sounds folder
+3. For Docker, verify volume mount permissions
+
+## Environment-Specific Setup
+
+### Development (Windows)
+
+1. Install FFmpeg via winget or download from ffmpeg.org
+2. Add to PATH or configure `FfmpegPath`
+3. Sounds stored in `./sounds` relative to project
+
+### Production (Linux)
+
+1. Install via package manager: `apt install ffmpeg libsodium23 libopus0`
+2. Create sounds directory with proper permissions
+3. Configure volume mounts if using containers
+
+### CI/CD
+
+For build pipelines that need audio processing:
+
+```yaml
+# GitHub Actions example
+- name: Install FFmpeg
+  run: sudo apt-get update && sudo apt-get install -y ffmpeg
+```
+
+## See Also
+
+- [Audio Support Requirements](../requirements/audio-support.md) - Full feature specification
+- [Discord.NET Audio Documentation](https://docs.discord.net/faq/voice/sending-voice.html) - Official voice guide
+- [FFmpeg Documentation](https://ffmpeg.org/documentation.html) - FFmpeg reference

--- a/src/DiscordBot.Bot/Program.cs
+++ b/src/DiscordBot.Bot/Program.cs
@@ -336,6 +336,10 @@ try
     builder.Services.Configure<HistoricalMetricsOptions>(
         builder.Configuration.GetSection(HistoricalMetricsOptions.SectionName));
 
+    // Add Soundboard configuration (audio services added when implemented)
+    builder.Services.Configure<SoundboardOptions>(
+        builder.Configuration.GetSection(SoundboardOptions.SectionName));
+
     // Add Moderation services (includes detection services and handlers)
     builder.Services.AddModerationServices(builder.Configuration);
 

--- a/src/DiscordBot.Bot/appsettings.json
+++ b/src/DiscordBot.Bot/appsettings.json
@@ -168,6 +168,17 @@
     "CommandMetricsIntervalSeconds": 30,
     "SystemMetricsIntervalSeconds": 10
   },
+  "Soundboard": {
+    "BasePath": "./sounds",
+    "FfmpegPath": null,
+    "FfprobePath": null,
+    "DefaultMaxDurationSeconds": 30,
+    "DefaultMaxFileSizeBytes": 10485760,
+    "DefaultMaxSoundsPerGuild": 100,
+    "DefaultMaxStorageBytes": 524288000,
+    "DefaultAutoLeaveTimeoutMinutes": 0,
+    "SupportedFormats": [ "mp3", "wav", "ogg" ]
+  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Information",

--- a/src/DiscordBot.Core/Configuration/SoundboardOptions.cs
+++ b/src/DiscordBot.Core/Configuration/SoundboardOptions.cs
@@ -1,0 +1,80 @@
+namespace DiscordBot.Core.Configuration;
+
+/// <summary>
+/// Configuration options for the soundboard and audio features.
+/// </summary>
+public class SoundboardOptions
+{
+    /// <summary>
+    /// The configuration section name for binding.
+    /// </summary>
+    public const string SectionName = "Soundboard";
+
+    /// <summary>
+    /// Gets or sets the base path for sound file storage.
+    /// Default is "./sounds". Use forward slashes for cross-platform compatibility;
+    /// paths are normalized at runtime using Path.Combine.
+    /// </summary>
+    /// <remarks>
+    /// Per-guild subfolders are created under this path: {BasePath}/{guildId}/
+    /// </remarks>
+    public string BasePath { get; set; } = "./sounds";
+
+    /// <summary>
+    /// Gets or sets the path to the FFmpeg executable.
+    /// Default is null, which means FFmpeg is expected to be in the system PATH.
+    /// </summary>
+    /// <remarks>
+    /// Windows: Usually "C:/ffmpeg/bin/ffmpeg.exe" or just "ffmpeg" if in PATH.
+    /// Linux: Usually "/usr/bin/ffmpeg" or just "ffmpeg" if in PATH.
+    /// Docker: Typically "ffmpeg" as it's installed in PATH.
+    /// </remarks>
+    public string? FfmpegPath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the path to the FFprobe executable (for audio metadata extraction).
+    /// Default is null, which means FFprobe is expected to be in the system PATH.
+    /// </summary>
+    /// <remarks>
+    /// FFprobe is typically installed alongside FFmpeg and is used to extract
+    /// audio duration and format information.
+    /// </remarks>
+    public string? FfprobePath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default maximum duration for sounds in seconds.
+    /// Default is 30 seconds.
+    /// </summary>
+    public int DefaultMaxDurationSeconds { get; set; } = 30;
+
+    /// <summary>
+    /// Gets or sets the default maximum file size for sounds in bytes.
+    /// Default is 10MB (10,485,760 bytes).
+    /// </summary>
+    public long DefaultMaxFileSizeBytes { get; set; } = 10_485_760;
+
+    /// <summary>
+    /// Gets or sets the default maximum number of sounds per guild.
+    /// Default is 100.
+    /// </summary>
+    public int DefaultMaxSoundsPerGuild { get; set; } = 100;
+
+    /// <summary>
+    /// Gets or sets the default total storage limit per guild in bytes.
+    /// Default is 500MB (524,288,000 bytes).
+    /// </summary>
+    public long DefaultMaxStorageBytes { get; set; } = 524_288_000;
+
+    /// <summary>
+    /// Gets or sets the default auto-leave timeout in minutes.
+    /// 0 means the bot will stay in the voice channel indefinitely.
+    /// Default is 0 (stay indefinitely).
+    /// </summary>
+    public int DefaultAutoLeaveTimeoutMinutes { get; set; } = 0;
+
+    /// <summary>
+    /// Gets or sets the supported audio file formats.
+    /// Default is mp3, wav, and ogg.
+    /// </summary>
+    public string[] SupportedFormats { get; set; } = ["mp3", "wav", "ogg"];
+}


### PR DESCRIPTION
## Summary

- Add `SoundboardOptions` configuration class with `FfmpegPath` and `FfprobePath` settings for custom FFmpeg location
- Create comprehensive audio dependencies documentation covering installation for Windows, Linux, macOS, and Docker
- Register `SoundboardOptions` in DI and add configuration section to `appsettings.json`
- Update CLAUDE.md with new options class and documentation reference

## Test plan

- [ ] Build passes without errors (`dotnet build`)
- [ ] Verify `SoundboardOptions` is available via DI injection
- [ ] Review documentation covers all platforms mentioned in issue

Closes #757

🤖 Generated with [Claude Code](https://claude.com/claude-code)