### PR TITLE
feat(soundboard): Add Discord slash commands for audio playback

### DIFF
--- a/src/DiscordBot.Bot/Autocomplete/SoundAutocompleteHandler.cs
+++ b/src/DiscordBot.Bot/Autocomplete/SoundAutocompleteHandler.cs
@@ -1,0 +1,56 @@
+using Discord;
+using Discord.Interactions;
+using DiscordBot.Core.Interfaces;
+
+namespace DiscordBot.Bot.Autocomplete;
+
+/// <summary>
+/// Provides autocomplete suggestions for sound names in the /play command.
+/// Filters guild sounds based on user input and returns up to 25 matching results.
+/// </summary>
+public class SoundAutocompleteHandler : AutocompleteHandler
+{
+    /// <summary>
+    /// Generates autocomplete suggestions for sound names within the current guild.
+    /// Matches sounds by name in a case-insensitive manner and returns up to 25 results.
+    /// </summary>
+    /// <param name="context">The interaction context for the current command execution.</param>
+    /// <param name="autocompleteInteraction">The autocomplete interaction data.</param>
+    /// <param name="parameter">Information about the command parameter being completed.</param>
+    /// <param name="services">Service provider for resolving dependencies.</param>
+    /// <returns>An AutocompletionResult containing matching sound names, or empty if no guild context.</returns>
+    /// <remarks>
+    /// If the interaction context has no guild (e.g., direct message), returns an empty result
+    /// as sounds are guild-specific. The handler retrieves all sounds for the guild and filters
+    /// them based on the current user input.
+    /// </remarks>
+    public override async Task<AutocompletionResult> GenerateSuggestionsAsync(
+        IInteractionContext context,
+        IAutocompleteInteraction autocompleteInteraction,
+        IParameterInfo parameter,
+        IServiceProvider services)
+    {
+        // Guard against non-guild contexts (direct messages, etc.)
+        if (context.Guild == null)
+        {
+            return AutocompletionResult.FromSuccess();
+        }
+
+        var soundService = services.GetRequiredService<ISoundService>();
+        var userInput = autocompleteInteraction.Data.Current.Value?.ToString() ?? string.Empty;
+
+        // Get all sounds for the guild
+        var sounds = await soundService.GetAllByGuildAsync(context.Guild.Id);
+
+        // Filter and format results for autocomplete
+        var results = sounds
+            .Where(s => string.IsNullOrEmpty(userInput) ||
+                       s.Name.Contains(userInput, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(s => s.Name)
+            .Take(25) // Discord autocomplete result limit
+            .Select(s => new AutocompleteResult(s.Name, s.Name))
+            .ToList();
+
+        return AutocompletionResult.FromSuccess(results);
+    }
+}

--- a/src/DiscordBot.Bot/Commands/SoundboardModule.cs
+++ b/src/DiscordBot.Bot/Commands/SoundboardModule.cs
@@ -1,0 +1,383 @@
+using Discord;
+using Discord.Interactions;
+using Discord.WebSocket;
+using DiscordBot.Bot.Autocomplete;
+using DiscordBot.Bot.Interfaces;
+using DiscordBot.Bot.Preconditions;
+using DiscordBot.Core.Interfaces;
+
+namespace DiscordBot.Bot.Commands;
+
+/// <summary>
+/// Slash command module for soundboard playback commands.
+/// Allows users to play sounds from the guild's soundboard, list available sounds, and control playback.
+/// </summary>
+[RequireGuildActive]
+[RequireAudioEnabled]
+[RateLimit(5, 10)]
+public class SoundboardModule : InteractionModuleBase<SocketInteractionContext>
+{
+    private readonly IAudioService _audioService;
+    private readonly IPlaybackService _playbackService;
+    private readonly ISoundService _soundService;
+    private readonly IGuildAudioSettingsService _audioSettingsService;
+    private readonly ILogger<SoundboardModule> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SoundboardModule"/> class.
+    /// </summary>
+    public SoundboardModule(
+        IAudioService audioService,
+        IPlaybackService playbackService,
+        ISoundService soundService,
+        IGuildAudioSettingsService audioSettingsService,
+        ILogger<SoundboardModule> logger)
+    {
+        _audioService = audioService;
+        _playbackService = playbackService;
+        _soundService = soundService;
+        _audioSettingsService = audioSettingsService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Plays a sound from the guild's soundboard.
+    /// </summary>
+    /// <param name="soundName">The name of the sound to play.</param>
+    [SlashCommand("play", "Play a sound from the soundboard")]
+    [RequireVoiceChannel]
+    public async Task PlayAsync(
+        [Summary("sound", "Name of the sound to play")]
+        [Autocomplete(typeof(SoundAutocompleteHandler))]
+        string soundName)
+    {
+        var guildId = Context.Guild.Id;
+        var userId = Context.User.Id;
+
+        _logger.LogInformation(
+            "Play command executed by {Username} (ID: {UserId}) in guild {GuildName} (ID: {GuildId}), Sound: {SoundName}",
+            Context.User.Username,
+            userId,
+            Context.Guild.Name,
+            guildId,
+            soundName);
+
+        try
+        {
+            // Get the sound by name
+            var sound = await _soundService.GetByNameAsync(soundName, guildId);
+
+            if (sound == null)
+            {
+                _logger.LogDebug(
+                    "Sound '{SoundName}' not found in guild {GuildId}",
+                    soundName,
+                    guildId);
+
+                var notFoundEmbed = new EmbedBuilder()
+                    .WithTitle("Sound Not Found")
+                    .WithDescription($"Sound '{soundName}' not found.")
+                    .WithColor(Color.Red)
+                    .AddField("Suggestion", "Use `/sounds` to see available sounds.")
+                    .WithCurrentTimestamp()
+                    .Build();
+
+                await RespondAsync(embed: notFoundEmbed, ephemeral: true);
+                return;
+            }
+
+            // Get user's voice channel
+            var guildUser = Context.User as SocketGuildUser;
+            var voiceChannel = guildUser?.VoiceChannel;
+
+            if (voiceChannel == null)
+            {
+                _logger.LogDebug(
+                    "User {UserId} not in voice channel for play command in guild {GuildId}",
+                    userId,
+                    guildId);
+
+                var noVoiceEmbed = new EmbedBuilder()
+                    .WithTitle("Not in Voice Channel")
+                    .WithDescription("You need to be in a voice channel to use this command.")
+                    .WithColor(Color.Red)
+                    .WithCurrentTimestamp()
+                    .Build();
+
+                await RespondAsync(embed: noVoiceEmbed, ephemeral: true);
+                return;
+            }
+
+            // Check if bot needs to connect or switch channels
+            var isConnected = _audioService.IsConnected(guildId);
+            if (!isConnected)
+            {
+                _logger.LogDebug(
+                    "Bot not connected to voice in guild {GuildId}, connecting to channel {ChannelId}",
+                    guildId,
+                    voiceChannel.Id);
+
+                await _audioService.JoinChannelAsync(guildId, voiceChannel.Id);
+            }
+            else
+            {
+                // Check if connected to a different channel
+                var currentChannelId = _audioService.GetConnectedChannelId(guildId);
+                if (currentChannelId.HasValue && currentChannelId.Value != voiceChannel.Id)
+                {
+                    _logger.LogDebug(
+                        "Bot connected to different channel in guild {GuildId}, switching from {CurrentChannelId} to {NewChannelId}",
+                        guildId,
+                        currentChannelId.Value,
+                        voiceChannel.Id);
+
+                    await _audioService.LeaveChannelAsync(guildId);
+                    await _audioService.JoinChannelAsync(guildId, voiceChannel.Id);
+                }
+            }
+
+            // Get audio settings to check if queueing is enabled
+            var settings = await _audioSettingsService.GetSettingsAsync(guildId);
+            var queueEnabled = settings?.QueueEnabled ?? false;
+
+            // Get current queue length before playing (to determine if sound will be queued)
+            var wasPlaying = _playbackService.IsPlaying(guildId);
+            var queueLengthBefore = _playbackService.GetQueueLength(guildId);
+
+            // Play the sound
+            await _playbackService.PlayAsync(guildId, sound, queueEnabled);
+
+            // Determine response based on whether sound was queued or playing immediately
+            if (queueEnabled && wasPlaying)
+            {
+                var queuePosition = queueLengthBefore + 1;
+                _logger.LogInformation(
+                    "Sound '{SoundName}' queued for guild {GuildId} by user {UserId} at position {QueuePosition}",
+                    soundName,
+                    guildId,
+                    userId,
+                    queuePosition);
+
+                var queuedEmbed = new EmbedBuilder()
+                    .WithTitle("Sound Queued")
+                    .WithDescription($"Queued: **{sound.Name}** (position: {queuePosition})")
+                    .WithColor(Color.Blue)
+                    .WithCurrentTimestamp()
+                    .Build();
+
+                await RespondAsync(embed: queuedEmbed, ephemeral: true);
+            }
+            else
+            {
+                _logger.LogInformation(
+                    "Sound '{SoundName}' now playing for guild {GuildId} by user {UserId}",
+                    soundName,
+                    guildId,
+                    userId);
+
+                var playingEmbed = new EmbedBuilder()
+                    .WithTitle("Now Playing")
+                    .WithDescription($"Now playing: **{sound.Name}**")
+                    .WithColor(Color.Green)
+                    .WithCurrentTimestamp()
+                    .Build();
+
+                await RespondAsync(embed: playingEmbed, ephemeral: true);
+            }
+        }
+        catch (FileNotFoundException)
+        {
+            _logger.LogError(
+                "Sound file not found for sound '{SoundName}' in guild {GuildId}",
+                soundName,
+                guildId);
+
+            var fileErrorEmbed = new EmbedBuilder()
+                .WithTitle("File Not Found")
+                .WithDescription("Sound file not found. It may have been deleted.")
+                .WithColor(Color.Red)
+                .WithCurrentTimestamp()
+                .Build();
+
+            await RespondAsync(embed: fileErrorEmbed, ephemeral: true);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            _logger.LogError(
+                "Bot lacks permissions to join voice channel in guild {GuildId}",
+                guildId);
+
+            var permissionEmbed = new EmbedBuilder()
+                .WithTitle("Permission Denied")
+                .WithDescription("I don't have permission to join that voice channel.")
+                .WithColor(Color.Red)
+                .WithCurrentTimestamp()
+                .Build();
+
+            await RespondAsync(embed: permissionEmbed, ephemeral: true);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Failed to play sound '{SoundName}' in guild {GuildId}",
+                soundName,
+                guildId);
+
+            var errorEmbed = new EmbedBuilder()
+                .WithTitle("Playback Error")
+                .WithDescription("An error occurred while trying to play the sound. Please try again later.")
+                .WithColor(Color.Red)
+                .WithCurrentTimestamp()
+                .Build();
+
+            await RespondAsync(embed: errorEmbed, ephemeral: true);
+        }
+    }
+
+    /// <summary>
+    /// Lists all available sounds for the guild.
+    /// </summary>
+    [SlashCommand("sounds", "List all available sounds")]
+    public async Task SoundsAsync()
+    {
+        var guildId = Context.Guild.Id;
+
+        _logger.LogInformation(
+            "Sounds command executed by {Username} (ID: {UserId}) in guild {GuildName} (ID: {GuildId})",
+            Context.User.Username,
+            Context.User.Id,
+            Context.Guild.Name,
+            guildId);
+
+        try
+        {
+            var sounds = await _soundService.GetAllByGuildAsync(guildId);
+
+            if (sounds == null || !sounds.Any())
+            {
+                _logger.LogDebug(
+                    "No sounds found for guild {GuildId}",
+                    guildId);
+
+                var emptyEmbed = new EmbedBuilder()
+                    .WithTitle("Available Sounds")
+                    .WithDescription("No sounds available. Sounds can be added via the admin panel.")
+                    .WithColor(Color.Blue)
+                    .WithCurrentTimestamp()
+                    .Build();
+
+                await RespondAsync(embed: emptyEmbed, ephemeral: true);
+                return;
+            }
+
+            _logger.LogDebug(
+                "Found {Count} sounds for guild {GuildId}",
+                sounds.Count(),
+                guildId);
+
+            var embed = new EmbedBuilder()
+                .WithTitle("Available Sounds")
+                .WithColor(Color.Blue)
+                .WithFooter($"Found {sounds.Count()} sounds")
+                .WithCurrentTimestamp();
+
+            // Group sounds into columns for better display
+            var soundList = sounds.Select(s => s.Name).OrderBy(n => n).ToList();
+
+            // Split into multiple fields if there are many sounds
+            const int soundsPerField = 15;
+            var fieldNumber = 1;
+
+            for (int i = 0; i < soundList.Count; i += soundsPerField)
+            {
+                var fieldSounds = soundList.Skip(i).Take(soundsPerField);
+                var fieldValue = string.Join("\n", fieldSounds.Select(s => $"• {s}"));
+
+                var fieldName = soundList.Count <= soundsPerField
+                    ? "Sounds"
+                    : $"Sounds (Part {fieldNumber})";
+
+                embed.AddField(fieldName, fieldValue, inline: false);
+                fieldNumber++;
+            }
+
+            await RespondAsync(embed: embed.Build(), ephemeral: true);
+
+            _logger.LogDebug(
+                "Sounds list response sent for guild {GuildId}: {Count} sounds",
+                guildId,
+                sounds.Count());
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Failed to retrieve sounds for guild {GuildId}",
+                guildId);
+
+            var errorEmbed = new EmbedBuilder()
+                .WithTitle("Error")
+                .WithDescription("An error occurred while retrieving the sounds list. Please try again later.")
+                .WithColor(Color.Red)
+                .WithCurrentTimestamp()
+                .Build();
+
+            await RespondAsync(embed: errorEmbed, ephemeral: true);
+        }
+    }
+
+    /// <summary>
+    /// Stops current playback and clears the queue.
+    /// </summary>
+    [SlashCommand("stop", "Stop playback and clear the queue")]
+    [RequireAdmin]
+    public async Task StopAsync()
+    {
+        var guildId = Context.Guild.Id;
+
+        _logger.LogInformation(
+            "Stop command executed by {Username} (ID: {UserId}) in guild {GuildName} (ID: {GuildId})",
+            Context.User.Username,
+            Context.User.Id,
+            Context.Guild.Name,
+            guildId);
+
+        try
+        {
+            await _playbackService.StopAsync(guildId);
+
+            _logger.LogInformation(
+                "Playback stopped and queue cleared for guild {GuildId} by user {UserId}",
+                guildId,
+                Context.User.Id);
+
+            var successEmbed = new EmbedBuilder()
+                .WithTitle("Playback Stopped")
+                .WithDescription("Playback stopped and queue cleared.")
+                .WithColor(Color.Green)
+                .WithCurrentTimestamp()
+                .Build();
+
+            await RespondAsync(embed: successEmbed, ephemeral: true);
+
+            _logger.LogDebug("Stop command completed successfully for guild {GuildId}", guildId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Failed to stop playback for guild {GuildId}",
+                guildId);
+
+            var errorEmbed = new EmbedBuilder()
+                .WithTitle("Error")
+                .WithDescription("An error occurred while stopping playback. Please try again later.")
+                .WithColor(Color.Red)
+                .WithCurrentTimestamp()
+                .Build();
+
+            await RespondAsync(embed: errorEmbed, ephemeral: true);
+        }
+    }
+}

--- a/src/DiscordBot.Bot/Commands/VoiceModule.cs
+++ b/src/DiscordBot.Bot/Commands/VoiceModule.cs
@@ -1,0 +1,300 @@
+using Discord;
+using Discord.Interactions;
+using Discord.WebSocket;
+using DiscordBot.Bot.Interfaces;
+using DiscordBot.Bot.Preconditions;
+
+namespace DiscordBot.Bot.Commands;
+
+/// <summary>
+/// Voice channel management commands for joining and leaving voice channels.
+/// Allows users to connect the bot to their current voice channel or a specific voice channel,
+/// and disconnect the bot from voice channels.
+/// </summary>
+[RequireGuildActive]
+[RequireAudioEnabled]
+[RateLimit(3, 10)]
+public class VoiceModule : InteractionModuleBase<SocketInteractionContext>
+{
+    private readonly IAudioService _audioService;
+    private readonly ILogger<VoiceModule> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VoiceModule"/> class.
+    /// </summary>
+    public VoiceModule(
+        IAudioService audioService,
+        ILogger<VoiceModule> logger)
+    {
+        _audioService = audioService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Joins the user's current voice channel.
+    /// </summary>
+    [SlashCommand("join", "Join your current voice channel")]
+    [RequireVoiceChannel]
+    public async Task JoinAsync()
+    {
+        var guildId = Context.Guild.Id;
+        var guildUser = (SocketGuildUser)Context.User;
+        var voiceChannel = guildUser.VoiceChannel;
+
+        _logger.LogDebug(
+            "Join command (no parameter) executed by {Username} (ID: {UserId}) in guild {GuildName} (ID: {GuildId}) for channel {ChannelName} (ID: {ChannelId})",
+            Context.User.Username,
+            Context.User.Id,
+            Context.Guild.Name,
+            guildId,
+            voiceChannel?.Name,
+            voiceChannel?.Id);
+
+        try
+        {
+            // Check if already in this channel
+            var currentChannelId = _audioService.GetConnectedChannelId(guildId);
+            if (currentChannelId.HasValue && currentChannelId.Value == voiceChannel!.Id)
+            {
+                _logger.LogDebug(
+                    "Bot already in channel {ChannelId} for guild {GuildId}",
+                    voiceChannel.Id,
+                    guildId);
+
+                var alreadyConnectedEmbed = new EmbedBuilder()
+                    .WithTitle("Already Connected")
+                    .WithDescription($"I'm already in {voiceChannel.Name}!")
+                    .WithColor(Color.Orange)
+                    .WithCurrentTimestamp()
+                    .Build();
+
+                await RespondAsync(embed: alreadyConnectedEmbed, ephemeral: true);
+                return;
+            }
+
+            // Join the channel
+            var audioClient = await _audioService.JoinChannelAsync(guildId, voiceChannel!.Id);
+
+            if (audioClient == null)
+            {
+                _logger.LogWarning(
+                    "Failed to join voice channel {ChannelId} in guild {GuildId} - channel or guild not found",
+                    voiceChannel.Id,
+                    guildId);
+
+                var errorEmbed = new EmbedBuilder()
+                    .WithTitle("Error")
+                    .WithDescription("Failed to join the voice channel. The channel may no longer exist.")
+                    .WithColor(Color.Red)
+                    .WithCurrentTimestamp()
+                    .Build();
+
+                await RespondAsync(embed: errorEmbed, ephemeral: true);
+                return;
+            }
+
+            _logger.LogInformation(
+                "Joined voice channel {ChannelId} in guild {GuildId} via command from user {UserId}",
+                voiceChannel.Id,
+                guildId,
+                Context.User.Id);
+
+            var successEmbed = new EmbedBuilder()
+                .WithTitle("Joined Voice Channel")
+                .WithDescription($"Joined {voiceChannel.Name}")
+                .WithColor(Color.Green)
+                .WithCurrentTimestamp()
+                .Build();
+
+            await RespondAsync(embed: successEmbed, ephemeral: true);
+
+            _logger.LogDebug("Join command completed successfully for guild {GuildId}", guildId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Failed to join voice channel {ChannelId} in guild {GuildId}",
+                voiceChannel?.Id,
+                guildId);
+
+            var errorEmbed = new EmbedBuilder()
+                .WithTitle("Error")
+                .WithDescription("I don't have permission to join that voice channel.")
+                .WithColor(Color.Red)
+                .WithCurrentTimestamp()
+                .Build();
+
+            await RespondAsync(embed: errorEmbed, ephemeral: true);
+        }
+    }
+
+    /// <summary>
+    /// Joins a specified voice channel.
+    /// </summary>
+    /// <param name="channel">The voice channel to join.</param>
+    [SlashCommand("join-channel", "Join a specific voice channel")]
+    public async Task JoinChannelAsync(
+        [Summary("channel", "The voice channel to join")]
+        IVoiceChannel channel)
+    {
+        var guildId = Context.Guild.Id;
+
+        _logger.LogDebug(
+            "Join-channel command executed by {Username} (ID: {UserId}) in guild {GuildName} (ID: {GuildId}) for channel {ChannelName} (ID: {ChannelId})",
+            Context.User.Username,
+            Context.User.Id,
+            Context.Guild.Name,
+            guildId,
+            channel.Name,
+            channel.Id);
+
+        try
+        {
+            // Check if already in this channel
+            var currentChannelId = _audioService.GetConnectedChannelId(guildId);
+            if (currentChannelId.HasValue && currentChannelId.Value == channel.Id)
+            {
+                _logger.LogDebug(
+                    "Bot already in channel {ChannelId} for guild {GuildId}",
+                    channel.Id,
+                    guildId);
+
+                var alreadyConnectedEmbed = new EmbedBuilder()
+                    .WithTitle("Already Connected")
+                    .WithDescription($"I'm already in {channel.Name}!")
+                    .WithColor(Color.Orange)
+                    .WithCurrentTimestamp()
+                    .Build();
+
+                await RespondAsync(embed: alreadyConnectedEmbed, ephemeral: true);
+                return;
+            }
+
+            // Join the channel
+            var audioClient = await _audioService.JoinChannelAsync(guildId, channel.Id);
+
+            if (audioClient == null)
+            {
+                _logger.LogWarning(
+                    "Failed to join voice channel {ChannelId} in guild {GuildId} - channel or guild not found",
+                    channel.Id,
+                    guildId);
+
+                var errorEmbed = new EmbedBuilder()
+                    .WithTitle("Error")
+                    .WithDescription("Failed to join the voice channel. The channel may no longer exist.")
+                    .WithColor(Color.Red)
+                    .WithCurrentTimestamp()
+                    .Build();
+
+                await RespondAsync(embed: errorEmbed, ephemeral: true);
+                return;
+            }
+
+            _logger.LogInformation(
+                "Joined voice channel {ChannelId} in guild {GuildId} via command from user {UserId}",
+                channel.Id,
+                guildId,
+                Context.User.Id);
+
+            var successEmbed = new EmbedBuilder()
+                .WithTitle("Joined Voice Channel")
+                .WithDescription($"Joined {channel.Name}")
+                .WithColor(Color.Green)
+                .WithCurrentTimestamp()
+                .Build();
+
+            await RespondAsync(embed: successEmbed, ephemeral: true);
+
+            _logger.LogDebug("Join-channel command completed successfully for guild {GuildId}", guildId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Failed to join voice channel {ChannelId} in guild {GuildId}",
+                channel.Id,
+                guildId);
+
+            var errorEmbed = new EmbedBuilder()
+                .WithTitle("Error")
+                .WithDescription("I don't have permission to join that voice channel.")
+                .WithColor(Color.Red)
+                .WithCurrentTimestamp()
+                .Build();
+
+            await RespondAsync(embed: errorEmbed, ephemeral: true);
+        }
+    }
+
+    /// <summary>
+    /// Leaves the current voice channel.
+    /// </summary>
+    [SlashCommand("leave", "Leave the current voice channel")]
+    public async Task LeaveAsync()
+    {
+        var guildId = Context.Guild.Id;
+
+        _logger.LogDebug(
+            "Leave command executed by {Username} (ID: {UserId}) in guild {GuildName} (ID: {GuildId})",
+            Context.User.Username,
+            Context.User.Id,
+            Context.Guild.Name,
+            guildId);
+
+        try
+        {
+            var disconnected = await _audioService.LeaveChannelAsync(guildId);
+
+            if (!disconnected)
+            {
+                _logger.LogDebug(
+                    "Leave command executed but bot not connected to voice in guild {GuildId}",
+                    guildId);
+
+                var notConnectedEmbed = new EmbedBuilder()
+                    .WithTitle("Not Connected")
+                    .WithDescription("I'm not in a voice channel.")
+                    .WithColor(Color.Orange)
+                    .WithCurrentTimestamp()
+                    .Build();
+
+                await RespondAsync(embed: notConnectedEmbed, ephemeral: true);
+                return;
+            }
+
+            _logger.LogInformation(
+                "Left voice channel in guild {GuildId} via command from user {UserId}",
+                guildId,
+                Context.User.Id);
+
+            var successEmbed = new EmbedBuilder()
+                .WithTitle("Left Voice Channel")
+                .WithDescription("Left the voice channel.")
+                .WithColor(Color.Green)
+                .WithCurrentTimestamp()
+                .Build();
+
+            await RespondAsync(embed: successEmbed, ephemeral: true);
+
+            _logger.LogDebug("Leave command completed successfully for guild {GuildId}", guildId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Failed to leave voice channel in guild {GuildId}",
+                guildId);
+
+            var errorEmbed = new EmbedBuilder()
+                .WithTitle("Error")
+                .WithDescription("An error occurred while leaving the voice channel. Please try again later.")
+                .WithColor(Color.Red)
+                .WithCurrentTimestamp()
+                .Build();
+
+            await RespondAsync(embed: errorEmbed, ephemeral: true);
+        }
+    }
+}

--- a/src/DiscordBot.Bot/Interfaces/IPlaybackService.cs
+++ b/src/DiscordBot.Bot/Interfaces/IPlaybackService.cs
@@ -1,0 +1,56 @@
+using DiscordBot.Core.Entities;
+
+namespace DiscordBot.Bot.Interfaces;
+
+/// <summary>
+/// Service interface for soundboard audio playback.
+/// Handles FFmpeg-based audio streaming to Discord voice channels with queue/replace modes.
+/// </summary>
+public interface IPlaybackService
+{
+    /// <summary>
+    /// Plays a sound in the specified guild's voice channel.
+    /// Behavior depends on the queueEnabled parameter:
+    /// - If true: Sound is added to the queue and played when current playback finishes.
+    /// - If false: Current playback is stopped and the new sound plays immediately.
+    /// </summary>
+    /// <param name="guildId">Discord guild snowflake ID.</param>
+    /// <param name="sound">The sound entity to play.</param>
+    /// <param name="queueEnabled">Whether to queue the sound or replace current playback.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    /// <remarks>
+    /// Requires an active voice connection via IAudioService.JoinChannelAsync before calling.
+    /// The audio file is transcoded using FFmpeg to Opus PCM format (48kHz, stereo, 16-bit).
+    /// Updates the sound's play count and last activity timestamp on the voice connection.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">Thrown if no audio client is available for the guild.</exception>
+    /// <exception cref="FileNotFoundException">Thrown if the sound file does not exist.</exception>
+    Task PlayAsync(ulong guildId, Sound sound, bool queueEnabled, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Stops the currently playing sound in the specified guild and clears the queue.
+    /// </summary>
+    /// <param name="guildId">Discord guild snowflake ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    /// <remarks>
+    /// If no sound is currently playing, this method completes successfully without error.
+    /// </remarks>
+    Task StopAsync(ulong guildId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks if a sound is currently playing in the specified guild.
+    /// </summary>
+    /// <param name="guildId">Discord guild snowflake ID.</param>
+    /// <returns>True if a sound is currently playing, false otherwise.</returns>
+    bool IsPlaying(ulong guildId);
+
+    /// <summary>
+    /// Gets the number of sounds queued for playback in the specified guild.
+    /// Does not include the currently playing sound.
+    /// </summary>
+    /// <param name="guildId">Discord guild snowflake ID.</param>
+    /// <returns>The number of sounds in the queue.</returns>
+    int GetQueueLength(ulong guildId);
+}

--- a/src/DiscordBot.Bot/Preconditions/RequireAudioEnabledAttribute.cs
+++ b/src/DiscordBot.Bot/Preconditions/RequireAudioEnabledAttribute.cs
@@ -1,0 +1,39 @@
+using Discord;
+using Discord.Interactions;
+using DiscordBot.Core.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DiscordBot.Bot.Preconditions;
+
+/// <summary>
+/// Precondition that requires audio features to be enabled for the guild.
+/// Commands using this attribute will fail if the guild has disabled audio features.
+/// </summary>
+public class RequireAudioEnabledAttribute : PreconditionAttribute
+{
+    /// <summary>
+    /// Checks if audio features are enabled for the guild.
+    /// </summary>
+    public override async Task<PreconditionResult> CheckRequirementsAsync(
+        IInteractionContext context,
+        ICommandInfo commandInfo,
+        IServiceProvider services)
+    {
+        // Audio commands require a guild context
+        if (context.Guild == null)
+        {
+            return PreconditionResult.FromError("This command can only be used in a server.");
+        }
+
+        var audioSettingsService = services.GetRequiredService<IGuildAudioSettingsService>();
+        var settings = await audioSettingsService.GetSettingsAsync(context.Guild.Id);
+
+        if (!settings.AudioEnabled)
+        {
+            return PreconditionResult.FromError(
+                "Audio features are disabled for this server. An administrator can enable them in the admin panel.");
+        }
+
+        return PreconditionResult.FromSuccess();
+    }
+}

--- a/src/DiscordBot.Bot/Preconditions/RequireVoiceChannelAttribute.cs
+++ b/src/DiscordBot.Bot/Preconditions/RequireVoiceChannelAttribute.cs
@@ -1,0 +1,41 @@
+using Discord;
+using Discord.Interactions;
+using Discord.WebSocket;
+
+namespace DiscordBot.Bot.Preconditions;
+
+/// <summary>
+/// Precondition that requires the user to be in a voice channel.
+/// Verifies the user is a guild member with an active voice channel connection.
+/// </summary>
+public class RequireVoiceChannelAttribute : PreconditionAttribute
+{
+    /// <summary>
+    /// Checks if the user is in a voice channel.
+    /// </summary>
+    public override Task<PreconditionResult> CheckRequirementsAsync(
+        IInteractionContext context,
+        ICommandInfo commandInfo,
+        IServiceProvider services)
+    {
+        if (context.Guild == null)
+        {
+            return Task.FromResult(PreconditionResult.FromError(
+                "This command can only be used in a server."));
+        }
+
+        if (context.User is not SocketGuildUser guildUser)
+        {
+            return Task.FromResult(PreconditionResult.FromError(
+                "Could not verify user's voice state."));
+        }
+
+        if (guildUser.VoiceChannel == null)
+        {
+            return Task.FromResult(PreconditionResult.FromError(
+                "You need to be in a voice channel to use this command."));
+        }
+
+        return Task.FromResult(PreconditionResult.FromSuccess());
+    }
+}

--- a/src/DiscordBot.Bot/Program.cs
+++ b/src/DiscordBot.Bot/Program.cs
@@ -336,6 +336,7 @@ try
     builder.Services.Configure<VoiceChannelOptions>(
         builder.Configuration.GetSection(VoiceChannelOptions.SectionName));
     builder.Services.AddSingleton<IAudioService, AudioService>();
+    builder.Services.AddSingleton<IPlaybackService, PlaybackService>();
     builder.Services.AddHostedService<VoiceAutoLeaveService>();
 
     // Add Analytics Aggregation services

--- a/src/DiscordBot.Bot/Services/PlaybackService.cs
+++ b/src/DiscordBot.Bot/Services/PlaybackService.cs
@@ -1,0 +1,429 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using Discord.Audio;
+using DiscordBot.Bot.Interfaces;
+using DiscordBot.Bot.Tracing;
+using DiscordBot.Core.Configuration;
+using DiscordBot.Core.Entities;
+using DiscordBot.Core.Interfaces;
+using Microsoft.Extensions.Options;
+
+namespace DiscordBot.Bot.Services;
+
+/// <summary>
+/// Service for soundboard audio playback using FFmpeg to stream audio to Discord voice channels.
+/// Supports both queue mode (sounds queue up) and replace mode (new sound replaces current).
+/// Thread-safe using per-guild locks and concurrent dictionaries.
+/// </summary>
+public class PlaybackService : IPlaybackService
+{
+    private readonly IAudioService _audioService;
+    private readonly ISoundService _soundService;
+    private readonly ILogger<PlaybackService> _logger;
+    private readonly SoundboardOptions _options;
+
+    // Per-guild playback state
+    private readonly ConcurrentDictionary<ulong, PlaybackState> _playbackStates = new();
+
+    // Per-guild locks for thread-safe playback control
+    private readonly ConcurrentDictionary<ulong, SemaphoreSlim> _guildLocks = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PlaybackService"/> class.
+    /// </summary>
+    /// <param name="audioService">The audio service for voice connections.</param>
+    /// <param name="soundService">The sound service for play count tracking.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="options">Soundboard configuration options.</param>
+    public PlaybackService(
+        IAudioService audioService,
+        ISoundService soundService,
+        ILogger<PlaybackService> logger,
+        IOptions<SoundboardOptions> options)
+    {
+        _audioService = audioService;
+        _soundService = soundService;
+        _logger = logger;
+        _options = options.Value;
+    }
+
+    /// <inheritdoc/>
+    public async Task PlayAsync(ulong guildId, Sound sound, bool queueEnabled, CancellationToken cancellationToken = default)
+    {
+        using var activity = BotActivitySource.StartServiceActivity(
+            "playback",
+            "play",
+            guildId: guildId,
+            entityId: sound.Id.ToString());
+
+        try
+        {
+            // Validate audio client exists
+            var audioClient = _audioService.GetAudioClient(guildId);
+            if (audioClient == null)
+            {
+                var ex = new InvalidOperationException($"No audio client available for guild {guildId}. Join a voice channel first.");
+                _logger.LogError(ex, "Cannot play sound {SoundName} - not connected to voice channel in guild {GuildId}",
+                    sound.Name, guildId);
+                BotActivitySource.RecordException(activity, ex);
+                throw ex;
+            }
+
+            // Validate file exists
+            var filePath = Path.Combine(_options.BasePath, guildId.ToString(), sound.FileName);
+            if (!File.Exists(filePath))
+            {
+                var ex = new FileNotFoundException($"Sound file not found: {filePath}", filePath);
+                _logger.LogError(ex, "Sound file not found for sound {SoundId} ({SoundName}) in guild {GuildId}",
+                    sound.Id, sound.Name, guildId);
+                BotActivitySource.RecordException(activity, ex);
+                throw ex;
+            }
+
+            _logger.LogInformation("Queueing sound {SoundName} ({SoundId}) for playback in guild {GuildId} (QueueMode: {QueueEnabled})",
+                sound.Name, sound.Id, guildId, queueEnabled);
+
+            activity?.SetTag("sound.id", sound.Id.ToString());
+            activity?.SetTag("sound.name", sound.Name);
+            activity?.SetTag("sound.file_size_bytes", sound.FileSizeBytes);
+            activity?.SetTag("sound.duration_seconds", sound.DurationSeconds);
+            activity?.SetTag("playback.queue_enabled", queueEnabled);
+
+            var guildLock = _guildLocks.GetOrAdd(guildId, _ => new SemaphoreSlim(1, 1));
+            await guildLock.WaitAsync(cancellationToken);
+
+            try
+            {
+                var state = _playbackStates.GetOrAdd(guildId, _ => new PlaybackState());
+
+                if (queueEnabled)
+                {
+                    // Queue mode: Add to queue
+                    state.Queue.Enqueue(sound);
+                    _logger.LogDebug("Added sound {SoundName} to queue (position {QueuePosition}) in guild {GuildId}",
+                        sound.Name, state.Queue.Count, guildId);
+                }
+                else
+                {
+                    // Replace mode: Stop current playback and clear queue
+                    if (state.IsPlaying)
+                    {
+                        _logger.LogInformation("Stopping current playback to replace with {SoundName} in guild {GuildId}",
+                            sound.Name, guildId);
+                        state.CancellationTokenSource?.Cancel();
+                        state.Queue.Clear();
+                    }
+
+                    state.Queue.Enqueue(sound);
+                }
+
+                // Start playback loop if not already running
+                if (!state.IsPlaying)
+                {
+                    _logger.LogDebug("Starting playback loop for guild {GuildId}", guildId);
+                    _ = PlaybackLoopAsync(guildId, audioClient);
+                }
+            }
+            finally
+            {
+                guildLock.Release();
+            }
+
+            BotActivitySource.SetSuccess(activity);
+        }
+        catch (Exception ex) when (ex is not InvalidOperationException && ex is not FileNotFoundException)
+        {
+            _logger.LogError(ex, "Unexpected error queueing sound {SoundId} for playback in guild {GuildId}",
+                sound.Id, guildId);
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task StopAsync(ulong guildId, CancellationToken cancellationToken = default)
+    {
+        using var activity = BotActivitySource.StartServiceActivity(
+            "playback",
+            "stop",
+            guildId: guildId);
+
+        try
+        {
+            var guildLock = _guildLocks.GetOrAdd(guildId, _ => new SemaphoreSlim(1, 1));
+            await guildLock.WaitAsync(cancellationToken);
+
+            try
+            {
+                if (!_playbackStates.TryGetValue(guildId, out var state))
+                {
+                    _logger.LogDebug("No playback state for guild {GuildId}, nothing to stop", guildId);
+                    BotActivitySource.SetSuccess(activity);
+                    return;
+                }
+
+                if (state.IsPlaying)
+                {
+                    _logger.LogInformation("Stopping playback and clearing queue in guild {GuildId}", guildId);
+                    state.CancellationTokenSource?.Cancel();
+                }
+
+                state.Queue.Clear();
+
+                activity?.SetTag("playback.queue_cleared", true);
+            }
+            finally
+            {
+                guildLock.Release();
+            }
+
+            BotActivitySource.SetSuccess(activity);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error stopping playback in guild {GuildId}", guildId);
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
+    }
+
+    /// <inheritdoc/>
+    public bool IsPlaying(ulong guildId)
+    {
+        return _playbackStates.TryGetValue(guildId, out var state) && state.IsPlaying;
+    }
+
+    /// <inheritdoc/>
+    public int GetQueueLength(ulong guildId)
+    {
+        if (!_playbackStates.TryGetValue(guildId, out var state))
+        {
+            return 0;
+        }
+
+        // Don't count the currently playing sound
+        var queueLength = state.Queue.Count;
+        if (state.IsPlaying && queueLength > 0)
+        {
+            queueLength--;
+        }
+
+        return Math.Max(0, queueLength);
+    }
+
+    /// <summary>
+    /// Background playback loop that processes the queue for a guild.
+    /// Runs until the queue is empty, then stops.
+    /// </summary>
+    private async Task PlaybackLoopAsync(ulong guildId, IAudioClient audioClient)
+    {
+        if (!_playbackStates.TryGetValue(guildId, out var state))
+        {
+            return;
+        }
+
+        var guildLock = _guildLocks.GetOrAdd(guildId, _ => new SemaphoreSlim(1, 1));
+
+        try
+        {
+            while (true)
+            {
+                Sound? sound = null;
+
+                // Get next sound from queue
+                await guildLock.WaitAsync();
+
+                try
+                {
+                    if (state.Queue.Count == 0)
+                    {
+                        // Queue empty, stop playback loop
+                        state.IsPlaying = false;
+                        state.CancellationTokenSource?.Dispose();
+                        state.CancellationTokenSource = null;
+                        _logger.LogDebug("Playback queue empty, stopping playback loop for guild {GuildId}", guildId);
+                        return;
+                    }
+
+                    sound = state.Queue.Dequeue();
+                    state.IsPlaying = true;
+                    state.CancellationTokenSource?.Dispose();
+                    state.CancellationTokenSource = new CancellationTokenSource();
+                }
+                finally
+                {
+                    guildLock.Release();
+                }
+
+                if (sound == null)
+                {
+                    continue;
+                }
+
+                // Play the sound
+                try
+                {
+                    await PlaySoundAsync(guildId, sound, audioClient, state.CancellationTokenSource.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                    _logger.LogInformation("Playback cancelled for sound {SoundName} in guild {GuildId}",
+                        sound.Name, guildId);
+                    // Continue to next sound or exit loop
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error playing sound {SoundName} ({SoundId}) in guild {GuildId}",
+                        sound.Name, sound.Id, guildId);
+                    // Continue to next sound despite error
+                }
+            }
+        }
+        finally
+        {
+            // Clean up state when loop exits
+            await guildLock.WaitAsync();
+            try
+            {
+                state.IsPlaying = false;
+                state.CancellationTokenSource?.Dispose();
+                state.CancellationTokenSource = null;
+            }
+            finally
+            {
+                guildLock.Release();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Plays a single sound file using FFmpeg to transcode to Opus PCM.
+    /// </summary>
+    private async Task PlaySoundAsync(ulong guildId, Sound sound, IAudioClient audioClient, CancellationToken cancellationToken)
+    {
+        using var activity = BotActivitySource.StartServiceActivity(
+            "playback",
+            "play_sound",
+            guildId: guildId,
+            entityId: sound.Id.ToString());
+
+        try
+        {
+            var filePath = Path.Combine(_options.BasePath, guildId.ToString(), sound.FileName);
+
+            _logger.LogInformation("Starting playback of sound {SoundName} ({SoundId}) in guild {GuildId}",
+                sound.Name, sound.Id, guildId);
+
+            activity?.SetTag("sound.id", sound.Id.ToString());
+            activity?.SetTag("sound.name", sound.Name);
+            activity?.SetTag("sound.file_path", filePath);
+
+            // Update play count
+            await _soundService.IncrementPlayCountAsync(sound.Id, cancellationToken);
+
+            // Update last activity on voice connection
+            _audioService.UpdateLastActivity(guildId);
+
+            // Create PCM stream
+            using var pcmStream = audioClient.CreatePCMStream(AudioApplication.Music, bufferMillis: 1000);
+
+            // Determine FFmpeg executable path
+            var ffmpegPath = _options.FfmpegPath ?? "ffmpeg";
+
+            // Start FFmpeg process
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = ffmpegPath,
+                Arguments = $"-hide_banner -loglevel warning -i \"{filePath}\" -ac 2 -f s16le -ar 48000 pipe:1",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+
+            using var ffmpeg = Process.Start(startInfo);
+            if (ffmpeg == null)
+            {
+                throw new InvalidOperationException("Failed to start FFmpeg process");
+            }
+
+            _logger.LogDebug("FFmpeg process started (PID: {ProcessId}) for sound {SoundName} in guild {GuildId}",
+                ffmpeg.Id, sound.Name, guildId);
+
+            // Stream audio data from FFmpeg to Discord
+            // Buffer size: 3840 bytes = 20ms of audio at 48kHz stereo 16-bit
+            // (48000 samples/sec * 2 channels * 2 bytes/sample * 0.02 sec = 3840 bytes)
+            const int bufferSize = 3840;
+            var buffer = new byte[bufferSize];
+            int bytesRead;
+
+            try
+            {
+                while ((bytesRead = await ffmpeg.StandardOutput.BaseStream.ReadAsync(buffer, 0, bufferSize, cancellationToken)) > 0)
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        _logger.LogDebug("Playback cancelled for sound {SoundName} in guild {GuildId}",
+                            sound.Name, guildId);
+                        break;
+                    }
+
+                    await pcmStream.WriteAsync(buffer, 0, bytesRead, cancellationToken);
+                }
+
+                // Flush the stream to ensure all audio is sent
+                await pcmStream.FlushAsync(cancellationToken);
+            }
+            finally
+            {
+                // Clean up FFmpeg process
+                if (!ffmpeg.HasExited)
+                {
+                    ffmpeg.Kill();
+                }
+
+                // Log any FFmpeg errors
+                var errorOutput = await ffmpeg.StandardError.ReadToEndAsync();
+                if (!string.IsNullOrWhiteSpace(errorOutput))
+                {
+                    _logger.LogWarning("FFmpeg errors for sound {SoundName} in guild {GuildId}: {ErrorOutput}",
+                        sound.Name, guildId, errorOutput);
+                }
+            }
+
+            _logger.LogInformation("Completed playback of sound {SoundName} ({SoundId}) in guild {GuildId}",
+                sound.Name, sound.Id, guildId);
+
+            BotActivitySource.SetSuccess(activity);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error during playback of sound {SoundName} ({SoundId}) in guild {GuildId}",
+                sound.Name, sound.Id, guildId);
+            BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Represents the playback state for a guild.
+    /// </summary>
+    private class PlaybackState
+    {
+        /// <summary>
+        /// Queue of sounds to play.
+        /// </summary>
+        public Queue<Sound> Queue { get; } = new();
+
+        /// <summary>
+        /// Whether a sound is currently playing.
+        /// </summary>
+        public bool IsPlaying { get; set; }
+
+        /// <summary>
+        /// Cancellation token source for the current playback.
+        /// Used to stop playback when a new sound should replace the current one.
+        /// </summary>
+        public CancellationTokenSource? CancellationTokenSource { get; set; }
+    }
+}

--- a/tests/DiscordBot.Tests/Preconditions/RequireAudioEnabledAttributeTests.cs
+++ b/tests/DiscordBot.Tests/Preconditions/RequireAudioEnabledAttributeTests.cs
@@ -1,0 +1,169 @@
+using Discord;
+using Discord.Interactions;
+using DiscordBot.Bot.Preconditions;
+using DiscordBot.Core.Entities;
+using DiscordBot.Core.Interfaces;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace DiscordBot.Tests.Preconditions;
+
+/// <summary>
+/// Unit tests for <see cref="RequireAudioEnabledAttribute"/>.
+/// </summary>
+public class RequireAudioEnabledAttributeTests
+{
+    private readonly Mock<IInteractionContext> _mockContext;
+    private readonly Mock<ICommandInfo> _mockCommandInfo;
+    private readonly Mock<IServiceProvider> _mockServiceProvider;
+    private readonly Mock<IGuildAudioSettingsService> _mockAudioSettingsService;
+    private readonly RequireAudioEnabledAttribute _attribute;
+
+    public RequireAudioEnabledAttributeTests()
+    {
+        _mockContext = new Mock<IInteractionContext>();
+        _mockCommandInfo = new Mock<ICommandInfo>();
+        _mockServiceProvider = new Mock<IServiceProvider>();
+        _mockAudioSettingsService = new Mock<IGuildAudioSettingsService>();
+        _attribute = new RequireAudioEnabledAttribute();
+
+        // Setup default service provider behavior
+        _mockServiceProvider
+            .Setup(sp => sp.GetService(typeof(IGuildAudioSettingsService)))
+            .Returns(_mockAudioSettingsService.Object);
+    }
+
+    [Fact]
+    public async Task CheckRequirementsAsync_WhenAudioIsEnabled_ShouldReturnSuccess()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var mockGuild = new Mock<IGuild>();
+        mockGuild.Setup(g => g.Id).Returns(guildId);
+
+        var audioSettings = new GuildAudioSettings
+        {
+            GuildId = guildId,
+            AudioEnabled = true
+        };
+
+        _mockContext.Setup(c => c.Guild).Returns(mockGuild.Object);
+        _mockAudioSettingsService
+            .Setup(s => s.GetSettingsAsync(guildId, default))
+            .ReturnsAsync(audioSettings);
+
+        // Act
+        var result = await _attribute.CheckRequirementsAsync(
+            _mockContext.Object,
+            _mockCommandInfo.Object,
+            _mockServiceProvider.Object);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeTrue("audio features are enabled for the guild");
+        result.ErrorReason.Should().BeNull();
+        _mockAudioSettingsService.Verify(
+            s => s.GetSettingsAsync(guildId, default),
+            Times.Once,
+            "the service should be called once to check audio settings");
+    }
+
+    [Fact]
+    public async Task CheckRequirementsAsync_WhenAudioIsDisabled_ShouldReturnError()
+    {
+        // Arrange
+        var guildId = 123456789UL;
+        var mockGuild = new Mock<IGuild>();
+        mockGuild.Setup(g => g.Id).Returns(guildId);
+
+        var audioSettings = new GuildAudioSettings
+        {
+            GuildId = guildId,
+            AudioEnabled = false
+        };
+
+        _mockContext.Setup(c => c.Guild).Returns(mockGuild.Object);
+        _mockAudioSettingsService
+            .Setup(s => s.GetSettingsAsync(guildId, default))
+            .ReturnsAsync(audioSettings);
+
+        // Act
+        var result = await _attribute.CheckRequirementsAsync(
+            _mockContext.Object,
+            _mockCommandInfo.Object,
+            _mockServiceProvider.Object);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeFalse("audio features are disabled for the guild");
+        result.ErrorReason.Should().Contain(
+            "Audio features are disabled for this server",
+            "the error message should inform the user that audio is disabled");
+        _mockAudioSettingsService.Verify(
+            s => s.GetSettingsAsync(guildId, default),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CheckRequirementsAsync_WhenContextGuildIsNull_ShouldReturnError()
+    {
+        // Arrange
+        _mockContext.Setup(c => c.Guild).Returns((IGuild?)null);
+
+        // Act
+        var result = await _attribute.CheckRequirementsAsync(
+            _mockContext.Object,
+            _mockCommandInfo.Object,
+            _mockServiceProvider.Object);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeFalse("the command was used in a DM (no guild context)");
+        result.ErrorReason.Should().Be(
+            "This command can only be used in a server.",
+            "the error message should indicate guild context is required");
+        _mockAudioSettingsService.Verify(
+            s => s.GetSettingsAsync(It.IsAny<ulong>(), default),
+            Times.Never,
+            "the service should not be called when there is no guild context");
+    }
+
+    [Fact]
+    public async Task CheckRequirementsAsync_WhenMultipleGuilds_ShouldCheckCorrectGuild()
+    {
+        // Arrange
+        var guildId1 = 111111111UL;
+        var guildId2 = 222222222UL;
+        var mockGuild = new Mock<IGuild>();
+        mockGuild.Setup(g => g.Id).Returns(guildId1);
+
+        var audioSettings = new GuildAudioSettings
+        {
+            GuildId = guildId1,
+            AudioEnabled = true
+        };
+
+        _mockContext.Setup(c => c.Guild).Returns(mockGuild.Object);
+        _mockAudioSettingsService
+            .Setup(s => s.GetSettingsAsync(guildId1, default))
+            .ReturnsAsync(audioSettings);
+
+        // Act
+        var result = await _attribute.CheckRequirementsAsync(
+            _mockContext.Object,
+            _mockCommandInfo.Object,
+            _mockServiceProvider.Object);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        _mockAudioSettingsService.Verify(
+            s => s.GetSettingsAsync(guildId1, default),
+            Times.Once,
+            "the service should be called with the correct guild ID");
+        _mockAudioSettingsService.Verify(
+            s => s.GetSettingsAsync(guildId2, default),
+            Times.Never,
+            "the service should not be called with other guild IDs");
+    }
+}

--- a/tests/DiscordBot.Tests/Preconditions/RequireVoiceChannelAttributeTests.cs
+++ b/tests/DiscordBot.Tests/Preconditions/RequireVoiceChannelAttributeTests.cs
@@ -1,0 +1,124 @@
+using Discord;
+using Discord.Interactions;
+using DiscordBot.Bot.Preconditions;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace DiscordBot.Tests.Preconditions;
+
+/// <summary>
+/// Unit tests for <see cref="RequireVoiceChannelAttribute"/>.
+///
+/// Note: Due to Discord.NET's use of sealed types in SocketVoiceChannel and SocketGuildUser,
+/// we can only test the paths that don't require mocking their non-virtual members.
+/// This test suite focuses on:
+/// 1. Guild context validation
+/// 2. User type validation (IUser vs SocketGuildUser)
+/// 3. Error messages and success conditions
+///
+/// Full integration testing with actual SocketGuildUser objects would be needed to test
+/// voice channel presence detection.
+/// </summary>
+public class RequireVoiceChannelAttributeTests
+{
+    private readonly Mock<IInteractionContext> _mockContext;
+    private readonly Mock<ICommandInfo> _mockCommandInfo;
+    private readonly Mock<IServiceProvider> _mockServiceProvider;
+    private readonly RequireVoiceChannelAttribute _attribute;
+
+    public RequireVoiceChannelAttributeTests()
+    {
+        _mockContext = new Mock<IInteractionContext>();
+        _mockCommandInfo = new Mock<ICommandInfo>();
+        _mockServiceProvider = new Mock<IServiceProvider>();
+        _attribute = new RequireVoiceChannelAttribute();
+    }
+
+    [Fact]
+    public async Task CheckRequirementsAsync_WhenContextGuildIsNull_ShouldReturnError()
+    {
+        // Arrange
+        var mockUser = new Mock<IUser>();
+        mockUser.Setup(u => u.Id).Returns(123456789UL);
+
+        _mockContext.Setup(c => c.Guild).Returns((IGuild?)null);
+        _mockContext.Setup(c => c.User).Returns(mockUser.Object);
+
+        // Act
+        var result = await _attribute.CheckRequirementsAsync(
+            _mockContext.Object,
+            _mockCommandInfo.Object,
+            _mockServiceProvider.Object);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeFalse("the command was used in a DM (no guild context)");
+        result.ErrorReason.Should().Be(
+            "This command can only be used in a server.",
+            "the error message should indicate guild context is required");
+    }
+
+    [Fact]
+    public async Task CheckRequirementsAsync_WhenUserIsNotSocketGuildUser_ShouldReturnError()
+    {
+        // Arrange
+        var mockGuild = new Mock<IGuild>();
+        mockGuild.Setup(g => g.Id).Returns(123456789UL);
+
+        var mockUser = new Mock<IUser>(); // Not SocketGuildUser
+        mockUser.Setup(u => u.Id).Returns(123456789UL);
+
+        _mockContext.Setup(c => c.Guild).Returns(mockGuild.Object);
+        _mockContext.Setup(c => c.User).Returns(mockUser.Object);
+
+        // Act
+        var result = await _attribute.CheckRequirementsAsync(
+            _mockContext.Object,
+            _mockCommandInfo.Object,
+            _mockServiceProvider.Object);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeFalse("the user is not a SocketGuildUser");
+        result.ErrorReason.Should().Be(
+            "Could not verify user's voice state.",
+            "the error message should indicate the user's voice state cannot be verified");
+    }
+
+    [Fact]
+    public async Task CheckRequirementsAsync_WhenMultipleConditionsFail_ShouldCheckGuildFirst()
+    {
+        // Arrange - no guild, so guild user type check shouldn't occur
+        _mockContext.Setup(c => c.Guild).Returns((IGuild?)null);
+        _mockContext.Setup(c => c.User).Returns(new Mock<IUser>().Object);
+
+        // Act
+        var result = await _attribute.CheckRequirementsAsync(
+            _mockContext.Object,
+            _mockCommandInfo.Object,
+            _mockServiceProvider.Object);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorReason.Should().Be("This command can only be used in a server.",
+            "guild context check should happen before user type check");
+    }
+
+    [Fact]
+    public void CheckRequirementsAsync_Contract_DocumentsRequirements()
+    {
+        // This test documents the contract that CheckRequirementsAsync must fulfill:
+        //
+        // 1. If context.Guild is null, return error: "This command can only be used in a server."
+        // 2. If context.User is not a SocketGuildUser, return error: "Could not verify user's voice state."
+        // 3. If guildUser.VoiceChannel is null, return error: "You need to be in a voice channel to use this command."
+        // 4. If all checks pass, return success.
+        //
+        // Integration tests using actual SocketGuildUser instances would be required
+        // to verify voice channel presence detection, as SocketGuildUser is a sealed type
+        // with non-overridable members that cannot be mocked.
+
+        _attribute.Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
## Summary

Implements Discord slash commands for voice channel control and soundboard playback as specified in #752.

### Commands Added
| Command | Description | Permission |
|---------|-------------|------------|
| `/join` | Join user's voice channel | Everyone |
| `/join-channel <channel>` | Join specified voice channel | Everyone |
| `/leave` | Leave current voice channel | Everyone |
| `/play <sound>` | Play a sound with autocomplete | Everyone |
| `/sounds` | List available sounds | Everyone |
| `/stop` | Stop playback and clear queue | Admin |

### Components
- **VoiceModule**: Voice channel join/leave commands
- **SoundboardModule**: Playback and sound listing commands
- **SoundAutocompleteHandler**: Case-insensitive autocomplete for sound names
- **IPlaybackService/PlaybackService**: FFmpeg-based audio streaming with queue support
- **RequireAudioEnabledAttribute**: Precondition checking guild audio settings
- **RequireVoiceChannelAttribute**: Precondition requiring user in voice channel

### Features
- Auto-join user's voice channel when using `/play`
- Queue mode or replace mode based on guild settings
- Role restriction enforcement via CommandRoleRestriction

## Test plan
- [ ] Verify `/join` connects bot to user's voice channel
- [ ] Verify `/join-channel` connects to specified channel
- [ ] Verify `/leave` disconnects bot from voice channel
- [ ] Verify `/play` autocomplete shows matching sounds
- [ ] Verify `/play` auto-joins user's channel if needed
- [ ] Verify `/sounds` lists all guild sounds
- [ ] Verify `/stop` requires admin and stops playback
- [ ] Verify queue behavior based on guild settings
- [ ] Verify error messages for edge cases

Closes #752

🤖 Generated with [Claude Code](https://claude.com/claude-code)