### PR TITLE
feat(soundboard): Add Audio Settings admin page

### DIFF
--- a/src/DiscordBot.Bot/Pages/Guilds/AudioSettings/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/AudioSettings/Index.cshtml
@@ -1,0 +1,922 @@
+@page "{guildId:long}"
+@model DiscordBot.Bot.Pages.Guilds.AudioSettings.IndexModel
+@using DiscordBot.Bot.ViewModels.Components
+@{
+    ViewData["Title"] = "Audio Settings";
+}
+
+<!-- Breadcrumb Navigation -->
+<nav class="text-sm text-text-secondary mb-6" aria-label="Breadcrumb">
+    <ol class="flex items-center gap-2">
+        <li><a asp-page="/Index" class="hover:text-text-primary transition-colors">Home</a></li>
+        <li aria-hidden="true">
+            <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+        </li>
+        <li><a asp-page="/Guilds/Index" class="hover:text-text-primary transition-colors">Servers</a></li>
+        <li aria-hidden="true">
+            <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+        </li>
+        <li><a asp-page="/Guilds/Details" asp-route-id="@Model.GuildId" class="hover:text-text-primary transition-colors">@Model.GuildName</a></li>
+        <li aria-hidden="true">
+            <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+        </li>
+        <li class="text-text-primary font-medium" aria-current="page">Audio Settings</li>
+    </ol>
+</nav>
+
+<!-- Page Header -->
+<div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
+    <div>
+        <h1 class="text-2xl font-bold text-text-primary">Audio Settings</h1>
+        <p class="text-sm text-text-secondary mt-1">Configure audio and soundboard features for this server</p>
+    </div>
+    <a asp-page="/Guilds/Soundboard/Index" asp-route-guildId="@Model.GuildId" class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-text-primary bg-bg-secondary border border-border-primary rounded-lg hover:bg-bg-hover transition-colors">
+        <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
+        </svg>
+        Manage Sounds
+    </a>
+</div>
+
+<div class="max-w-4xl">
+    <!-- General Settings Section -->
+    <section class="settings-section mb-6">
+        <div class="settings-section-header">
+            <div class="settings-section-title">
+                <div class="settings-section-icon">
+                    <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                    </svg>
+                </div>
+                <div>
+                    <h2 class="text-lg font-semibold text-text-primary">General Settings</h2>
+                    <p class="text-xs text-text-tertiary">Core audio feature configuration</p>
+                </div>
+            </div>
+        </div>
+        <div class="settings-section-body">
+            <!-- Audio Enabled -->
+            <div class="settings-row">
+                <div class="settings-row-content">
+                    <div class="settings-row-title">Audio Features Enabled</div>
+                    <div class="settings-row-description">Enable or disable all audio and soundboard features for this server</div>
+                </div>
+                <label class="toggle-switch">
+                    <input type="checkbox" id="audioEnabled" @(Model.Settings.AudioEnabled ? "checked" : "") />
+                    <span class="toggle-switch-track"></span>
+                    <span class="toggle-switch-thumb"></span>
+                </label>
+            </div>
+
+            <!-- Auto-leave Timeout -->
+            <div class="settings-row">
+                <div class="settings-row-content">
+                    <div class="settings-row-title">Auto-leave Timeout</div>
+                    <div class="settings-row-description">Minutes of inactivity before the bot automatically leaves the voice channel. Set to 0 to stay indefinitely.</div>
+                </div>
+                <div class="input-with-unit">
+                    <input type="number" id="autoLeaveTimeout" value="@Model.Settings.AutoLeaveTimeoutMinutes" min="0" max="60" class="settings-input" />
+                    <span class="input-unit">minutes</span>
+                </div>
+            </div>
+
+            <!-- Queue Enabled -->
+            <div class="settings-row">
+                <div class="settings-row-content">
+                    <div class="settings-row-title">Queue Mode</div>
+                    <div class="settings-row-description">When enabled, sounds queue up and play in order. When disabled, new sounds replace the currently playing sound.</div>
+                </div>
+                <label class="toggle-switch">
+                    <input type="checkbox" id="queueEnabled" @(Model.Settings.QueueEnabled ? "checked" : "") />
+                    <span class="toggle-switch-track"></span>
+                    <span class="toggle-switch-thumb"></span>
+                </label>
+            </div>
+
+            <!-- Sound Storage Path (Read-only) -->
+            <div class="settings-row">
+                <div class="settings-row-content">
+                    <div class="settings-row-title">Sound Storage Path</div>
+                    <div class="settings-row-description">The folder where audio files for this server are stored</div>
+                </div>
+                <div class="readonly-field">
+                    <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+                    </svg>
+                    <code>@Model.SoundFolderPath</code>
+                </div>
+            </div>
+
+            <!-- Save General Settings Button -->
+            <div class="mt-6 pt-4 border-t border-border-secondary flex justify-end">
+                <button type="button" onclick="window.audioSettings.saveGeneralSettings()" class="btn btn-primary">
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+                    </svg>
+                    Save General Settings
+                </button>
+            </div>
+        </div>
+    </section>
+
+    <!-- Limits Section -->
+    <section class="settings-section mb-6">
+        <div class="settings-section-header">
+            <div class="settings-section-title">
+                <div class="settings-section-icon" style="background: var(--color-warning-bg); color: var(--color-warning);">
+                    <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                    </svg>
+                </div>
+                <div>
+                    <h2 class="text-lg font-semibold text-text-primary">Limits</h2>
+                    <p class="text-xs text-text-tertiary">Resource limits for audio files and storage</p>
+                </div>
+            </div>
+        </div>
+        <div class="settings-section-body">
+            <!-- Max Duration -->
+            <div class="settings-row">
+                <div class="settings-row-content">
+                    <div class="settings-row-title">Maximum Sound Duration</div>
+                    <div class="settings-row-description">The maximum length allowed for uploaded sound files (1-300 seconds)</div>
+                </div>
+                <div class="input-with-unit">
+                    <input type="number" id="maxDuration" value="@Model.Settings.MaxDurationSeconds" min="1" max="300" class="settings-input" />
+                    <span class="input-unit">seconds</span>
+                </div>
+            </div>
+
+            <!-- Max File Size -->
+            <div class="settings-row">
+                <div class="settings-row-content">
+                    <div class="settings-row-title">Maximum File Size</div>
+                    <div class="settings-row-description">The maximum file size allowed for uploaded audio files (1-50 MB)</div>
+                </div>
+                <div class="input-with-unit">
+                    <input type="number" id="maxFileSize" value="@(Model.Settings.MaxFileSizeBytes / (1024 * 1024))" min="1" max="50" class="settings-input" />
+                    <span class="input-unit">MB</span>
+                </div>
+            </div>
+
+            <!-- Max Sounds Per Guild -->
+            <div class="settings-row">
+                <div class="settings-row-content">
+                    <div class="settings-row-title">Maximum Sounds</div>
+                    <div class="settings-row-description">The maximum number of sounds this server can store (1-500)</div>
+                </div>
+                <div class="input-with-unit">
+                    <input type="number" id="maxSounds" value="@Model.Settings.MaxSoundsPerGuild" min="1" max="500" class="settings-input" />
+                    <span class="input-unit">sounds</span>
+                </div>
+            </div>
+
+            <!-- Save Limits Button -->
+            <div class="mt-6 pt-4 border-t border-border-secondary flex justify-end">
+                <button type="button" onclick="window.audioSettings.saveLimitSettings()" class="btn btn-primary">
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+                    </svg>
+                    Save Limit Settings
+                </button>
+            </div>
+        </div>
+    </section>
+
+    <!-- Command Permissions Section -->
+    <section class="settings-section mb-6">
+        <div class="settings-section-header">
+            <div class="settings-section-title">
+                <div class="settings-section-icon" style="background: var(--color-success-bg); color: var(--color-success);">
+                    <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+                    </svg>
+                </div>
+                <div>
+                    <h2 class="text-lg font-semibold text-text-primary">Command Permissions</h2>
+                    <p class="text-xs text-text-tertiary">Restrict audio commands to specific roles. Leave empty to allow everyone.</p>
+                </div>
+            </div>
+        </div>
+        <div class="settings-section-body">
+            @foreach (var command in IndexModel.SoundboardCommands)
+            {
+                var restriction = Model.Settings.CommandRoleRestrictions
+                    .FirstOrDefault(r => r.CommandName.Equals(command, StringComparison.OrdinalIgnoreCase));
+                var allowedRoleIds = restriction?.AllowedRoleIds ?? new List<ulong>();
+
+                <div class="command-permission-card" data-command="@command">
+                    <div class="command-name">
+                        @GetCommandIcon(command)
+                        /@command
+                    </div>
+                    <p class="text-xs text-text-tertiary mb-3">@GetCommandDescription(command)</p>
+                    <div class="role-select" data-command="@command">
+                        <div class="role-select-trigger" tabindex="0" onclick="window.audioSettings.toggleRoleDropdown('@command')">
+                            <div class="role-tags" id="@(command)-tags">
+                                @if (allowedRoleIds.Count == 0)
+                                {
+                                    <span class="role-select-placeholder">Everyone can use this command</span>
+                                }
+                                else
+                                {
+                                    @foreach (var roleId in allowedRoleIds)
+                                    {
+                                        var role = Model.AvailableRoles.FirstOrDefault(r => r.Id == roleId);
+                                        if (role != null)
+                                        {
+                                            <div class="role-tag" data-role-id="@roleId">
+                                                @role.Name
+                                                <span class="role-tag-remove" onclick="window.audioSettings.removeRole(event, '@command', '@roleId')">
+                                                    <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                                                    </svg>
+                                                </span>
+                                            </div>
+                                        }
+                                    }
+                                }
+                            </div>
+                            <svg class="w-4 h-4 text-text-tertiary flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                            </svg>
+                        </div>
+                        <div class="role-select-dropdown" id="@(command)-dropdown">
+                            @foreach (var role in Model.AvailableRoles)
+                            {
+                                var isSelected = allowedRoleIds.Contains(role.Id);
+                                <div class="role-select-option @(isSelected ? "selected" : "")"
+                                     data-role-id="@role.Id"
+                                     data-role-name="@role.Name"
+                                     onclick="window.audioSettings.toggleRole('@command', '@role.Id', '@role.Name')">
+                                    <span class="role-color" style="background: @(string.IsNullOrEmpty(role.Color) || role.Color == "0" ? "#99AAB5" : "#" + role.Color.TrimStart('#'));"></span>
+                                    <span class="text-sm text-text-primary">@role.Name</span>
+                                </div>
+                            }
+                            @if (Model.AvailableRoles.Count == 0)
+                            {
+                                <div class="px-4 py-2 text-sm text-text-tertiary">No roles available</div>
+                            }
+                        </div>
+                    </div>
+                </div>
+            }
+        </div>
+    </section>
+
+    <!-- Action Buttons -->
+    <div class="flex items-center justify-between pt-4">
+        <button type="button" class="btn btn-secondary" onclick="window.audioSettings.resetToDefaults()">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+            </svg>
+            Reset to Defaults
+        </button>
+    </div>
+</div>
+
+<!-- Hidden form with anti-forgery token -->
+<form method="post" id="audioSettingsForm">
+    @Html.AntiForgeryToken()
+    <input type="hidden" name="guildId" value="@Model.GuildId" />
+</form>
+
+<!-- Success Toast -->
+<div class="toast toast-success" id="successToast">
+    <div class="toast-icon">
+        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+        </svg>
+    </div>
+    <div>
+        <p class="text-sm font-medium text-text-primary" id="toastTitle">Settings saved</p>
+        <p class="text-xs text-text-tertiary" id="toastMessage">Audio settings have been updated successfully.</p>
+    </div>
+</div>
+
+@functions {
+    private static string GetCommandDescription(string command)
+    {
+        return command.ToLower() switch
+        {
+            "join" => "Join a voice channel",
+            "leave" => "Leave the current voice channel",
+            "play" => "Play a sound from the soundboard",
+            "sounds" => "List available sounds in the soundboard",
+            "stop" => "Stop the currently playing sound and clear the queue",
+            _ => "Execute this command"
+        };
+    }
+
+    private static Microsoft.AspNetCore.Html.IHtmlContent GetCommandIcon(string command)
+    {
+        var iconPath = command.ToLower() switch
+        {
+            "join" => "<path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M15.536 8.464a5 5 0 010 7.072m2.828-9.9a9 9 0 010 12.728M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z\" />",
+            "leave" => "<path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z\" /><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M17 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2\" />",
+            "play" => "<path d=\"M8 5v14l11-7z\" fill=\"currentColor\" />",
+            "sounds" => "<path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M4 6h16M4 10h16M4 14h16M4 18h16\" />",
+            "stop" => "<path d=\"M5 3h14a2 2 0 012 2v14a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2z\" fill=\"currentColor\" />",
+            _ => "<path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M13 10V3L4 14h7v7l9-11h-7z\" />"
+        };
+        return new Microsoft.AspNetCore.Html.HtmlString($"<svg class=\"w-3.5 h-3.5\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\">{iconPath}</svg>");
+    }
+}
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/moderation.css" asp-append-version="true" />
+    <style>
+        /* Settings Section Styles */
+        .settings-section {
+            background: var(--color-bg-secondary);
+            border: 1px solid var(--color-border-primary);
+            border-radius: 0.5rem;
+        }
+
+        .settings-section-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 1rem 1.5rem;
+            border-bottom: 1px solid var(--color-border-primary);
+        }
+
+        .settings-section-title {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+        }
+
+        .settings-section-icon {
+            width: 2rem;
+            height: 2rem;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: var(--color-accent-blue-muted);
+            color: var(--color-accent-blue);
+            border-radius: 0.5rem;
+        }
+
+        .settings-section-body {
+            padding: 1.5rem;
+        }
+
+        /* Settings Row */
+        .settings-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            padding: 1rem 0;
+            border-bottom: 1px solid var(--color-border-secondary);
+        }
+
+        .settings-row:first-child {
+            padding-top: 0;
+        }
+
+        .settings-row:last-of-type {
+            border-bottom: none;
+            padding-bottom: 0;
+        }
+
+        .settings-row-content {
+            flex: 1;
+            padding-right: 1rem;
+        }
+
+        .settings-row-title {
+            font-size: 0.875rem;
+            font-weight: 500;
+            color: var(--color-text-primary);
+            margin-bottom: 0.25rem;
+        }
+
+        .settings-row-description {
+            font-size: 0.75rem;
+            color: var(--color-text-tertiary);
+        }
+
+        /* Input Styles */
+        .settings-input {
+            width: 6rem;
+            padding: 0.5rem 0.75rem;
+            font-size: 0.875rem;
+            background: var(--color-bg-primary);
+            border: 1px solid var(--color-border-primary);
+            border-radius: 0.5rem;
+            color: var(--color-text-primary);
+            transition: border-color 0.2s, box-shadow 0.2s;
+        }
+
+        .settings-input:focus {
+            outline: none;
+            border-color: var(--color-border-focus);
+            box-shadow: 0 0 0 2px var(--color-accent-blue-muted);
+        }
+
+        .input-with-unit {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .input-unit {
+            font-size: 0.75rem;
+            color: var(--color-text-tertiary);
+        }
+
+        /* Read-only field */
+        .readonly-field {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 0.5rem 0.75rem;
+            background: var(--color-bg-tertiary);
+            border: 1px solid var(--color-border-secondary);
+            border-radius: 0.5rem;
+            font-size: 0.875rem;
+            color: var(--color-text-secondary);
+        }
+
+        .readonly-field code {
+            font-family: ui-monospace, monospace;
+            color: var(--color-text-primary);
+        }
+
+        /* Command Permission Card */
+        .command-permission-card {
+            background: var(--color-bg-tertiary);
+            border: 1px solid var(--color-border-secondary);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 0.75rem;
+        }
+
+        .command-permission-card:last-child {
+            margin-bottom: 0;
+        }
+
+        .command-name {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.25rem;
+            padding: 0.25rem 0.5rem;
+            background: var(--color-bg-hover);
+            border-radius: 0.375rem;
+            font-family: ui-monospace, monospace;
+            font-size: 0.8125rem;
+            font-weight: 500;
+            color: var(--color-accent-blue);
+            margin-bottom: 0.75rem;
+        }
+
+        /* Role Select Styles */
+        .role-select {
+            position: relative;
+            width: 100%;
+        }
+
+        .role-select-trigger {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            width: 100%;
+            min-height: 2.5rem;
+            padding: 0.5rem 0.75rem;
+            background: var(--color-bg-primary);
+            border: 1px solid var(--color-border-primary);
+            border-radius: 0.5rem;
+            cursor: pointer;
+            transition: border-color 0.2s;
+        }
+
+        .role-select-trigger:hover {
+            border-color: var(--color-border-focus);
+        }
+
+        .role-select-trigger:focus {
+            outline: none;
+            border-color: var(--color-border-focus);
+            box-shadow: 0 0 0 2px var(--color-accent-blue-muted);
+        }
+
+        .role-tags {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.375rem;
+        }
+
+        .role-tag {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.25rem;
+            padding: 0.125rem 0.5rem;
+            background: var(--color-accent-blue-muted);
+            color: var(--color-accent-blue);
+            border-radius: 9999px;
+            font-size: 0.75rem;
+            font-weight: 500;
+        }
+
+        .role-tag-remove {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 1rem;
+            height: 1rem;
+            border-radius: 50%;
+            background: transparent;
+            color: var(--color-accent-blue);
+            cursor: pointer;
+            transition: background 0.15s;
+        }
+
+        .role-tag-remove:hover {
+            background: var(--color-accent-blue);
+            color: white;
+        }
+
+        .role-select-placeholder {
+            color: var(--color-text-tertiary);
+            font-size: 0.875rem;
+        }
+
+        .role-select-dropdown {
+            position: absolute;
+            top: calc(100% + 0.25rem);
+            left: 0;
+            right: 0;
+            background: var(--color-bg-secondary);
+            border: 1px solid var(--color-border-primary);
+            border-radius: 0.5rem;
+            box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
+            z-index: 50;
+            max-height: 12rem;
+            overflow-y: auto;
+            display: none;
+        }
+
+        .role-select-dropdown.open {
+            display: block;
+        }
+
+        .role-select-option {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 0.625rem 0.75rem;
+            cursor: pointer;
+            transition: background 0.15s;
+        }
+
+        .role-select-option:hover {
+            background: var(--color-bg-hover);
+        }
+
+        .role-select-option.selected {
+            background: var(--color-accent-blue-muted);
+        }
+
+        .role-color {
+            width: 0.75rem;
+            height: 0.75rem;
+            border-radius: 50%;
+            flex-shrink: 0;
+        }
+
+        /* Toast Styles */
+        .toast {
+            position: fixed;
+            bottom: 1.5rem;
+            right: 1.5rem;
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            padding: 1rem 1.25rem;
+            background: var(--color-bg-secondary);
+            border: 1px solid var(--color-border-primary);
+            border-radius: 0.5rem;
+            box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
+            z-index: 100;
+            transform: translateY(100%);
+            opacity: 0;
+            transition: transform 0.3s, opacity 0.3s;
+        }
+
+        .toast.show {
+            transform: translateY(0);
+            opacity: 1;
+        }
+
+        .toast-success {
+            border-left: 3px solid var(--color-success);
+        }
+
+        .toast-error {
+            border-left: 3px solid var(--color-error);
+        }
+
+        .toast-icon {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 1.5rem;
+            height: 1.5rem;
+            background: var(--color-success-bg);
+            color: var(--color-success);
+            border-radius: 50%;
+        }
+
+        .toast-error .toast-icon {
+            background: var(--color-error-bg);
+            color: var(--color-error);
+        }
+
+        /* Validation error styles */
+        .input-error {
+            border-color: var(--color-error) !important;
+        }
+    </style>
+}
+
+@section Scripts {
+    <script>
+        // Guild ID for API calls (as string to preserve precision)
+        window.guildId = '@Model.GuildId';
+
+        // Initialize audio settings module
+        window.audioSettings = {
+            // Toggle role dropdown
+            toggleRoleDropdown: function(command) {
+                const dropdown = document.getElementById(command + '-dropdown');
+                const isOpen = dropdown.classList.contains('open');
+
+                // Close all dropdowns first
+                document.querySelectorAll('.role-select-dropdown').forEach(d => d.classList.remove('open'));
+
+                if (!isOpen) {
+                    dropdown.classList.add('open');
+                }
+            },
+
+            // Toggle role selection
+            toggleRole: function(command, roleId, roleName) {
+                const option = document.querySelector(`[data-command="${command}"] .role-select-option[data-role-id="${roleId}"]`);
+                const tagsContainer = document.getElementById(command + '-tags');
+                const isSelected = option.classList.contains('selected');
+
+                if (isSelected) {
+                    // Remove role
+                    option.classList.remove('selected');
+                    const tag = tagsContainer.querySelector(`[data-role-id="${roleId}"]`);
+                    if (tag) tag.remove();
+                } else {
+                    // Add role
+                    option.classList.add('selected');
+                    // Remove placeholder if present
+                    const placeholder = tagsContainer.querySelector('.role-select-placeholder');
+                    if (placeholder) placeholder.remove();
+
+                    const tag = document.createElement('div');
+                    tag.className = 'role-tag';
+                    tag.setAttribute('data-role-id', roleId);
+                    tag.innerHTML = `${roleName}
+                        <span class="role-tag-remove" onclick="window.audioSettings.removeRole(event, '${command}', '${roleId}')">
+                            <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                        </span>`;
+                    tagsContainer.appendChild(tag);
+                }
+
+                // Check if tags container is empty
+                if (tagsContainer.children.length === 0) {
+                    const placeholder = document.createElement('span');
+                    placeholder.className = 'role-select-placeholder';
+                    placeholder.textContent = 'Everyone can use this command';
+                    tagsContainer.appendChild(placeholder);
+                }
+
+                // Save the command permissions
+                this.saveCommandPermissions(command);
+            },
+
+            // Remove role
+            removeRole: function(event, command, roleId) {
+                event.stopPropagation();
+                const option = document.querySelector(`[data-command="${command}"] .role-select-option[data-role-id="${roleId}"]`);
+                if (option) option.classList.remove('selected');
+
+                const tagsContainer = document.getElementById(command + '-tags');
+                const tag = tagsContainer.querySelector(`[data-role-id="${roleId}"]`);
+                if (tag) tag.remove();
+
+                // Check if tags container is empty
+                if (tagsContainer.children.length === 0) {
+                    const placeholder = document.createElement('span');
+                    placeholder.className = 'role-select-placeholder';
+                    placeholder.textContent = 'Everyone can use this command';
+                    tagsContainer.appendChild(placeholder);
+                }
+
+                // Save the command permissions
+                this.saveCommandPermissions(command);
+            },
+
+            // Get anti-forgery token
+            getAntiForgeryToken: function() {
+                return document.querySelector('input[name="__RequestVerificationToken"]').value;
+            },
+
+            // Show toast notification
+            showToast: function(title, message, isError = false) {
+                const toast = document.getElementById('successToast');
+                document.getElementById('toastTitle').textContent = title;
+                document.getElementById('toastMessage').textContent = message;
+
+                toast.classList.remove('toast-success', 'toast-error');
+                toast.classList.add(isError ? 'toast-error' : 'toast-success');
+                toast.classList.add('show');
+
+                setTimeout(() => {
+                    toast.classList.remove('show');
+                }, 3000);
+            },
+
+            // Save general settings
+            saveGeneralSettings: async function() {
+                const data = {
+                    audioEnabled: document.getElementById('audioEnabled').checked,
+                    autoLeaveTimeoutMinutes: parseInt(document.getElementById('autoLeaveTimeout').value) || 0,
+                    queueEnabled: document.getElementById('queueEnabled').checked
+                };
+
+                // Validate auto-leave timeout
+                if (data.autoLeaveTimeoutMinutes < 0 || data.autoLeaveTimeoutMinutes > 60) {
+                    document.getElementById('autoLeaveTimeout').classList.add('input-error');
+                    this.showToast('Validation Error', 'Auto-leave timeout must be between 0 and 60 minutes.', true);
+                    return;
+                }
+                document.getElementById('autoLeaveTimeout').classList.remove('input-error');
+
+                try {
+                    const response = await fetch(`?handler=SaveGeneral&guildId=${window.guildId}`, {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'RequestVerificationToken': this.getAntiForgeryToken()
+                        },
+                        body: JSON.stringify(data)
+                    });
+
+                    const result = await response.json();
+                    this.showToast(result.success ? 'Settings saved' : 'Error', result.message, !result.success);
+                } catch (error) {
+                    console.error('Error saving general settings:', error);
+                    this.showToast('Error', 'Failed to save settings. Please try again.', true);
+                }
+            },
+
+            // Save limit settings
+            saveLimitSettings: async function() {
+                const data = {
+                    maxDurationSeconds: parseInt(document.getElementById('maxDuration').value) || 30,
+                    maxFileSizeMB: parseInt(document.getElementById('maxFileSize').value) || 5,
+                    maxSoundsPerGuild: parseInt(document.getElementById('maxSounds').value) || 50
+                };
+
+                let hasErrors = false;
+
+                // Validate max duration
+                if (data.maxDurationSeconds < 1 || data.maxDurationSeconds > 300) {
+                    document.getElementById('maxDuration').classList.add('input-error');
+                    hasErrors = true;
+                } else {
+                    document.getElementById('maxDuration').classList.remove('input-error');
+                }
+
+                // Validate max file size
+                if (data.maxFileSizeMB < 1 || data.maxFileSizeMB > 50) {
+                    document.getElementById('maxFileSize').classList.add('input-error');
+                    hasErrors = true;
+                } else {
+                    document.getElementById('maxFileSize').classList.remove('input-error');
+                }
+
+                // Validate max sounds
+                if (data.maxSoundsPerGuild < 1 || data.maxSoundsPerGuild > 500) {
+                    document.getElementById('maxSounds').classList.add('input-error');
+                    hasErrors = true;
+                } else {
+                    document.getElementById('maxSounds').classList.remove('input-error');
+                }
+
+                if (hasErrors) {
+                    this.showToast('Validation Error', 'Please fix the validation errors before saving.', true);
+                    return;
+                }
+
+                try {
+                    const response = await fetch(`?handler=SaveLimits&guildId=${window.guildId}`, {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'RequestVerificationToken': this.getAntiForgeryToken()
+                        },
+                        body: JSON.stringify(data)
+                    });
+
+                    const result = await response.json();
+                    this.showToast(result.success ? 'Settings saved' : 'Error', result.message, !result.success);
+                } catch (error) {
+                    console.error('Error saving limit settings:', error);
+                    this.showToast('Error', 'Failed to save settings. Please try again.', true);
+                }
+            },
+
+            // Save command permissions
+            saveCommandPermissions: async function(command) {
+                const tagsContainer = document.getElementById(command + '-tags');
+                const tags = tagsContainer.querySelectorAll('.role-tag[data-role-id]');
+                const roleIds = Array.from(tags).map(tag => tag.getAttribute('data-role-id'));
+
+                const data = {
+                    commandName: command,
+                    roleIds: roleIds
+                };
+
+                try {
+                    const response = await fetch(`?handler=UpdateCommandRoles&guildId=${window.guildId}`, {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'RequestVerificationToken': this.getAntiForgeryToken()
+                        },
+                        body: JSON.stringify(data)
+                    });
+
+                    const result = await response.json();
+                    if (result.success) {
+                        this.showToast('Permissions updated', `/${command} permissions saved.`);
+                    } else {
+                        this.showToast('Error', result.message, true);
+                    }
+                } catch (error) {
+                    console.error('Error saving command permissions:', error);
+                    this.showToast('Error', 'Failed to save permissions. Please try again.', true);
+                }
+            },
+
+            // Reset to defaults
+            resetToDefaults: async function() {
+                if (!confirm('Are you sure you want to reset all audio settings to their default values? This cannot be undone.')) {
+                    return;
+                }
+
+                try {
+                    const response = await fetch(`?handler=ResetToDefaults&guildId=${window.guildId}`, {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'RequestVerificationToken': this.getAntiForgeryToken()
+                        }
+                    });
+
+                    const result = await response.json();
+                    if (result.success) {
+                        this.showToast('Settings reset', 'Audio settings have been reset to defaults.');
+                        // Reload the page to show updated values
+                        setTimeout(() => location.reload(), 1000);
+                    } else {
+                        this.showToast('Error', result.message, true);
+                    }
+                } catch (error) {
+                    console.error('Error resetting settings:', error);
+                    this.showToast('Error', 'Failed to reset settings. Please try again.', true);
+                }
+            }
+        };
+
+        // Close dropdowns when clicking outside
+        document.addEventListener('click', function(e) {
+            if (!e.target.closest('.role-select')) {
+                document.querySelectorAll('.role-select-dropdown').forEach(d => d.classList.remove('open'));
+            }
+        });
+
+        // Escape key to close dropdowns
+        document.addEventListener('keydown', function(e) {
+            if (e.key === 'Escape') {
+                document.querySelectorAll('.role-select-dropdown').forEach(d => d.classList.remove('open'));
+            }
+        });
+    </script>
+}

--- a/src/DiscordBot.Bot/Pages/Guilds/AudioSettings/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/AudioSettings/Index.cshtml.cs
@@ -1,0 +1,299 @@
+using Discord.WebSocket;
+using DiscordBot.Core.Entities;
+using DiscordBot.Core.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace DiscordBot.Bot.Pages.Guilds.AudioSettings;
+
+/// <summary>
+/// Page model for the Guild Audio Settings page.
+/// Allows administrators to configure audio and soundboard settings for a guild.
+/// </summary>
+[Authorize(Policy = "RequireAdmin")]
+public class IndexModel : PageModel
+{
+    private readonly IGuildAudioSettingsService _audioSettingsService;
+    private readonly IGuildService _guildService;
+    private readonly DiscordSocketClient _discordClient;
+    private readonly ILogger<IndexModel> _logger;
+
+    public IndexModel(
+        IGuildAudioSettingsService audioSettingsService,
+        IGuildService guildService,
+        DiscordSocketClient discordClient,
+        ILogger<IndexModel> logger)
+    {
+        _audioSettingsService = audioSettingsService;
+        _guildService = guildService;
+        _discordClient = discordClient;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Gets or sets the guild ID from the route.
+    /// </summary>
+    [BindProperty(SupportsGet = true)]
+    public ulong GuildId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the guild name for display.
+    /// </summary>
+    public string GuildName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the current audio settings.
+    /// </summary>
+    public GuildAudioSettings Settings { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the available roles in the guild.
+    /// </summary>
+    public List<RoleInfo> AvailableRoles { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the sound folder path for display.
+    /// </summary>
+    public string SoundFolderPath { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The soundboard commands that can have role restrictions.
+    /// </summary>
+    public static readonly string[] SoundboardCommands = { "join", "leave", "play", "sounds", "stop" };
+
+    /// <summary>
+    /// Handles GET requests for the Audio Settings page.
+    /// </summary>
+    public async Task<IActionResult> OnGetAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("Audio settings page accessed for guild {GuildId} by user {UserId}",
+            GuildId, User.Identity?.Name);
+
+        // Load guild information
+        var guild = await _guildService.GetGuildByIdAsync(GuildId, cancellationToken);
+        if (guild == null)
+        {
+            _logger.LogWarning("Guild {GuildId} not found", GuildId);
+            return NotFound();
+        }
+
+        GuildName = guild.Name;
+
+        // Load audio settings
+        Settings = await _audioSettingsService.GetSettingsAsync(GuildId, cancellationToken);
+
+        // Load guild roles from Discord
+        var discordGuild = _discordClient.GetGuild(GuildId);
+        if (discordGuild != null)
+        {
+            AvailableRoles = discordGuild.Roles
+                .Where(r => !r.IsEveryone && !r.IsManaged)
+                .OrderByDescending(r => r.Position)
+                .Select(r => new RoleInfo
+                {
+                    Id = r.Id,
+                    Name = r.Name,
+                    Color = r.Color.ToString()
+                })
+                .ToList();
+        }
+
+        // Set the sound folder path for display
+        SoundFolderPath = $"/data/sounds/{GuildId}";
+
+        return Page();
+    }
+
+    /// <summary>
+    /// Handles POST requests to save general settings.
+    /// </summary>
+    public async Task<IActionResult> OnPostSaveGeneralAsync(
+        [FromBody] GeneralSettingsDto request,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Saving general audio settings for guild {GuildId}", GuildId);
+
+        try
+        {
+            await _audioSettingsService.UpdateSettingsAsync(GuildId, settings =>
+            {
+                settings.AudioEnabled = request.AudioEnabled;
+                settings.AutoLeaveTimeoutMinutes = request.AutoLeaveTimeoutMinutes;
+                settings.QueueEnabled = request.QueueEnabled;
+            }, cancellationToken);
+
+            _logger.LogInformation("General audio settings saved for guild {GuildId}", GuildId);
+            return new JsonResult(new { success = true, message = "General settings saved successfully." });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to save general audio settings for guild {GuildId}", GuildId);
+            return new JsonResult(new { success = false, message = "Failed to save settings." }) { StatusCode = 500 };
+        }
+    }
+
+    /// <summary>
+    /// Handles POST requests to save limit settings.
+    /// </summary>
+    public async Task<IActionResult> OnPostSaveLimitsAsync(
+        [FromBody] LimitSettingsDto request,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Saving limit settings for guild {GuildId}", GuildId);
+
+        try
+        {
+            // Validate inputs
+            if (request.MaxDurationSeconds < 1 || request.MaxDurationSeconds > 300)
+            {
+                return new JsonResult(new { success = false, message = "Max duration must be between 1 and 300 seconds." }) { StatusCode = 400 };
+            }
+            if (request.MaxFileSizeMB < 1 || request.MaxFileSizeMB > 50)
+            {
+                return new JsonResult(new { success = false, message = "Max file size must be between 1 and 50 MB." }) { StatusCode = 400 };
+            }
+            if (request.MaxSoundsPerGuild < 1 || request.MaxSoundsPerGuild > 500)
+            {
+                return new JsonResult(new { success = false, message = "Max sounds must be between 1 and 500." }) { StatusCode = 400 };
+            }
+
+            await _audioSettingsService.UpdateSettingsAsync(GuildId, settings =>
+            {
+                settings.MaxDurationSeconds = request.MaxDurationSeconds;
+                settings.MaxFileSizeBytes = request.MaxFileSizeMB * 1024 * 1024; // Convert MB to bytes
+                settings.MaxSoundsPerGuild = request.MaxSoundsPerGuild;
+            }, cancellationToken);
+
+            _logger.LogInformation("Limit settings saved for guild {GuildId}", GuildId);
+            return new JsonResult(new { success = true, message = "Limit settings saved successfully." });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to save limit settings for guild {GuildId}", GuildId);
+            return new JsonResult(new { success = false, message = "Failed to save settings." }) { StatusCode = 500 };
+        }
+    }
+
+    /// <summary>
+    /// Handles POST requests to update command role restrictions.
+    /// </summary>
+    public async Task<IActionResult> OnPostUpdateCommandRolesAsync(
+        [FromBody] CommandRolesDto request,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Updating command roles for '{CommandName}' in guild {GuildId}",
+            request.CommandName, GuildId);
+
+        try
+        {
+            // Validate command name
+            if (!SoundboardCommands.Contains(request.CommandName, StringComparer.OrdinalIgnoreCase))
+            {
+                return new JsonResult(new { success = false, message = "Invalid command name." }) { StatusCode = 400 };
+            }
+
+            // Get current settings to update restrictions
+            var settings = await _audioSettingsService.GetSettingsAsync(GuildId, cancellationToken);
+
+            // Find existing restriction or create new one
+            var restriction = settings.CommandRoleRestrictions
+                .FirstOrDefault(r => r.CommandName.Equals(request.CommandName, StringComparison.OrdinalIgnoreCase));
+
+            if (restriction != null)
+            {
+                // Clear existing roles first by removing all
+                foreach (var roleId in restriction.AllowedRoleIds.ToList())
+                {
+                    await _audioSettingsService.RemoveCommandRestrictionAsync(GuildId, request.CommandName, roleId, cancellationToken);
+                }
+            }
+
+            // Add new roles
+            foreach (var roleId in request.RoleIds)
+            {
+                await _audioSettingsService.AddCommandRestrictionAsync(GuildId, request.CommandName, roleId, cancellationToken);
+            }
+
+            _logger.LogInformation("Command roles updated for '{CommandName}' in guild {GuildId}: {RoleCount} roles",
+                request.CommandName, GuildId, request.RoleIds.Count);
+
+            return new JsonResult(new { success = true, message = "Command permissions updated successfully." });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to update command roles for '{CommandName}' in guild {GuildId}",
+                request.CommandName, GuildId);
+            return new JsonResult(new { success = false, message = "Failed to update command permissions." }) { StatusCode = 500 };
+        }
+    }
+
+    /// <summary>
+    /// Handles POST requests to reset all settings to defaults.
+    /// </summary>
+    public async Task<IActionResult> OnPostResetToDefaultsAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Resetting audio settings to defaults for guild {GuildId}", GuildId);
+
+        try
+        {
+            await _audioSettingsService.UpdateSettingsAsync(GuildId, settings =>
+            {
+                settings.AudioEnabled = true;
+                settings.AutoLeaveTimeoutMinutes = 5;
+                settings.QueueEnabled = true;
+                settings.MaxDurationSeconds = 30;
+                settings.MaxFileSizeBytes = 5_242_880; // 5 MB
+                settings.MaxSoundsPerGuild = 50;
+                settings.CommandRoleRestrictions.Clear();
+            }, cancellationToken);
+
+            _logger.LogInformation("Audio settings reset to defaults for guild {GuildId}", GuildId);
+            return new JsonResult(new { success = true, message = "Settings reset to defaults." });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to reset audio settings for guild {GuildId}", GuildId);
+            return new JsonResult(new { success = false, message = "Failed to reset settings." }) { StatusCode = 500 };
+        }
+    }
+
+    /// <summary>
+    /// DTO for general settings update.
+    /// </summary>
+    public class GeneralSettingsDto
+    {
+        public bool AudioEnabled { get; set; }
+        public int AutoLeaveTimeoutMinutes { get; set; }
+        public bool QueueEnabled { get; set; }
+    }
+
+    /// <summary>
+    /// DTO for limit settings update.
+    /// </summary>
+    public class LimitSettingsDto
+    {
+        public int MaxDurationSeconds { get; set; }
+        public int MaxFileSizeMB { get; set; }
+        public int MaxSoundsPerGuild { get; set; }
+    }
+
+    /// <summary>
+    /// DTO for command role restrictions update.
+    /// </summary>
+    public class CommandRolesDto
+    {
+        public string CommandName { get; set; } = string.Empty;
+        public List<ulong> RoleIds { get; set; } = new();
+    }
+
+    /// <summary>
+    /// Represents a Discord role for display.
+    /// </summary>
+    public class RoleInfo
+    {
+        public ulong Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Color { get; set; } = string.Empty;
+    }
+}

--- a/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml
@@ -168,6 +168,15 @@
                                     Soundboard
                                 </a>
 
+                                <a asp-page="AudioSettings/Index" asp-route-guildId="@guild.Id"
+                                   class="flex items-center gap-3 px-4 py-2.5 text-sm text-text-primary hover:bg-bg-hover transition-colors">
+                                    <svg class="w-5 h-5 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                                    </svg>
+                                    Audio Settings
+                                </a>
+
                                 <div class="border-t border-border-primary my-1"></div>
 
                                 <a asp-page="Analytics/Index" asp-route-guildId="@guild.Id"


### PR DESCRIPTION
## Summary
- Implements Audio Settings page at `/Guilds/{guildId}/AudioSettings` for guild-level soundboard configuration
- Adds three configuration sections: General Settings, Limits, and Command Permissions
- Each section saves independently via AJAX with toast notification feedback
- Adds navigation link to Guild Details dropdown menu

## Changes
| File | Change |
|------|--------|
| `Pages/Guilds/AudioSettings/Index.cshtml` | New Razor Page view with toggle switches, numeric inputs, and role selectors |
| `Pages/Guilds/AudioSettings/Index.cshtml.cs` | PageModel with OnPost handlers for each settings section |
| `Pages/Guilds/Details.cshtml` | Added "Audio Settings" link to More dropdown |

## Features Implemented
- **General Settings**: Audio enabled toggle, auto-leave timeout (0-60 min), queue mode toggle, read-only storage path display
- **Limits**: Max sound duration (1-300s), max file size (1-50MB), max sounds per guild (1-500)
- **Command Permissions**: Role-based access control for `/join`, `/leave`, `/play`, `/sounds`, `/stop` with multi-select role picker
- **Reset to Defaults**: Single button to restore all settings to defaults
- Client-side validation with visual error states
- Toast notifications for save success/failure

## Test plan
- [ ] Navigate to Guild Details and verify "Audio Settings" appears in More dropdown
- [ ] Access Audio Settings page and verify all three sections load correctly
- [ ] Toggle "Audio Features Enabled" and save - verify toast appears
- [ ] Change auto-leave timeout and save
- [ ] Modify limit values and save
- [ ] Add/remove roles from command permissions
- [ ] Click "Reset to Defaults" and verify all settings reset
- [ ] Verify role dropdowns close when clicking outside

Closes #754

🤖 Generated with [Claude Code](https://claude.com/claude-code)