### PR TITLE
feat(ui): Add Voice Channel Control Panel component

### DIFF
--- a/src/DiscordBot.Bot/Pages/Guilds/Soundboard/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Soundboard/Index.cshtml
@@ -282,6 +282,9 @@
         <!-- Right Sidebar (30%) -->
         <div class="lg:col-span-3 space-y-6">
 
+            <!-- Voice Channel Control Panel -->
+            <partial name="Shared/Components/_VoiceChannelPanel" model="Model.VoiceChannelPanel" />
+
             <!-- Upload Sounds Section -->
             <div class="bg-bg-secondary border border-border-primary rounded-lg p-6">
                 <h3 class="text-sm font-semibold text-text-primary mb-1">Upload Sounds</h3>
@@ -419,6 +422,11 @@
 </div>
 
 @section Scripts {
+    <!-- SignalR and Voice Channel Panel scripts -->
+    <script src="~/lib/signalr/dist/browser/signalr.min.js"></script>
+    <script src="~/js/dashboard-hub.js"></script>
+    <script src="~/js/voice-channel-panel.js"></script>
+
     <style>
         .sound-row .row-actions {
             opacity: 0;
@@ -532,5 +540,15 @@
                 document.querySelectorAll('[id^="menu-"]').forEach(m => m.classList.add('hidden'));
             }
         });
+
+        // Initialize SignalR connection for real-time updates
+        (async function initializeRealtime() {
+            try {
+                await DashboardHub.connect();
+                console.log('[Soundboard] SignalR connected');
+            } catch (error) {
+                console.error('[Soundboard] Failed to connect SignalR:', error);
+            }
+        })();
     </script>
 }

--- a/src/DiscordBot.Bot/Pages/Shared/Components/_VoiceChannelPanel.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/Components/_VoiceChannelPanel.cshtml
@@ -1,0 +1,194 @@
+@model DiscordBot.Bot.ViewModels.Components.VoiceChannelPanelViewModel
+@{
+    var statusClass = Model.IsConnected ? "text-success" : "text-text-tertiary";
+    var statusText = Model.IsConnected ? "Connected" : "Disconnected";
+    var statusBgClass = Model.IsConnected ? "bg-success/20" : "bg-bg-tertiary";
+}
+
+<div id="voice-channel-panel"
+     class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden"
+     data-guild-id="@Model.GuildId"
+     data-connected="@Model.IsConnected.ToString().ToLower()"
+     data-channel-id="@Model.ConnectedChannelId">
+
+    <!-- Voice Channel Status Section -->
+    <div class="px-4 py-3 border-b border-border-primary">
+        <div class="flex items-center justify-between mb-2">
+            <h3 class="text-sm font-semibold text-text-primary">Voice Channel</h3>
+            <span id="connection-status-badge"
+                  class="inline-flex items-center gap-1.5 px-2 py-0.5 text-xs font-medium rounded-full @statusBgClass @statusClass">
+                <span id="connection-status-dot" class="w-1.5 h-1.5 rounded-full @(Model.IsConnected ? "bg-success" : "bg-text-tertiary")"></span>
+                <span id="connection-status-text">@statusText</span>
+            </span>
+        </div>
+        @if (Model.IsConnected && !string.IsNullOrEmpty(Model.ConnectedChannelName))
+        {
+            <p id="connected-channel-info" class="text-sm text-text-secondary flex items-center gap-2">
+                <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z" />
+                </svg>
+                <span id="connected-channel-name">@Model.ConnectedChannelName</span>
+                @if (Model.ChannelMemberCount.HasValue)
+                {
+                    <span class="text-text-tertiary">(<span id="channel-member-count">@Model.ChannelMemberCount</span> members)</span>
+                }
+            </p>
+        }
+        else
+        {
+            <p id="connected-channel-info" class="hidden text-sm text-text-secondary flex items-center gap-2">
+                <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z" />
+                </svg>
+                <span id="connected-channel-name"></span>
+                <span class="text-text-tertiary">(<span id="channel-member-count">0</span> members)</span>
+            </p>
+        }
+    </div>
+
+    <!-- Channel Control Section -->
+    <div class="px-4 py-3 border-b border-border-primary">
+        <label for="channel-selector" class="block text-xs font-medium text-text-secondary mb-1.5">
+            Select Channel
+        </label>
+        <div class="flex items-center gap-2">
+            <select id="channel-selector"
+                    class="flex-1 bg-bg-tertiary border border-border-primary rounded-md px-3 py-1.5 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-accent-blue focus:border-transparent">
+                <option value="">-- Select a channel --</option>
+                @foreach (var channel in Model.AvailableChannels)
+                {
+                    if (channel.Id == Model.ConnectedChannelId)
+                    {
+                        <option value="@channel.Id" selected>
+                            @channel.Name (@channel.MemberCount)
+                        </option>
+                    }
+                    else
+                    {
+                        <option value="@channel.Id">
+                            @channel.Name (@channel.MemberCount)
+                        </option>
+                    }
+                }
+            </select>
+            @if (Model.IsConnected)
+            {
+                <button id="leave-channel-btn"
+                        type="button"
+                        class="px-3 py-1.5 bg-error hover:bg-red-600 text-white text-sm font-medium rounded-md transition-colors flex items-center gap-1.5"
+                        title="Leave voice channel">
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+                    </svg>
+                    Leave
+                </button>
+            }
+            else
+            {
+                <button id="leave-channel-btn"
+                        type="button"
+                        class="hidden px-3 py-1.5 bg-error hover:bg-red-600 text-white text-sm font-medium rounded-md transition-colors flex items-center gap-1.5"
+                        title="Leave voice channel">
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+                    </svg>
+                    Leave
+                </button>
+            }
+        </div>
+    </div>
+
+    <!-- Now Playing Section -->
+    <div id="now-playing-section" class="px-4 py-3 border-b border-border-primary @(Model.NowPlaying == null ? "hidden" : "")">
+        <div class="flex items-center justify-between mb-2">
+            <h4 class="text-xs font-medium text-text-secondary uppercase tracking-wider">Now Playing</h4>
+            <button id="stop-playback-btn"
+                    type="button"
+                    class="p-1 text-error hover:bg-error/10 rounded transition-colors"
+                    title="Stop playback">
+                <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M6 6h12v12H6z"/>
+                </svg>
+            </button>
+        </div>
+        <div class="flex items-center gap-3">
+            <div class="w-10 h-10 bg-accent-blue/20 rounded-lg flex items-center justify-center text-accent-blue flex-shrink-0">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z"/>
+                </svg>
+            </div>
+            <div class="flex-1 min-w-0">
+                <p id="now-playing-name" class="text-sm font-medium text-text-primary truncate">
+                    @(Model.NowPlaying?.Name ?? "Nothing playing")
+                </p>
+                <div class="mt-1.5">
+                    <div class="w-full bg-bg-tertiary rounded-full h-1.5">
+                        <div id="now-playing-progress"
+                             class="bg-accent-blue h-1.5 rounded-full transition-all duration-300"
+                             style="width: @(Model.NowPlaying?.ProgressPercent ?? 0)%"></div>
+                    </div>
+                    <div class="flex justify-between mt-1 text-xs text-text-tertiary">
+                        <span id="now-playing-position">@FormatDuration(Model.NowPlaying?.PositionSeconds ?? 0)</span>
+                        <span id="now-playing-duration">@FormatDuration(Model.NowPlaying?.DurationSeconds ?? 0)</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Queue Section -->
+    <div class="px-4 py-3">
+        <div class="flex items-center justify-between mb-3">
+            <h4 class="text-xs font-medium text-text-secondary uppercase tracking-wider">Queue</h4>
+            <span id="queue-count-badge" class="text-xs text-text-tertiary">
+                @(Model.QueueCount > 0 ? $"{Model.QueueCount} sound{(Model.QueueCount == 1 ? "" : "s")}" : "Empty")
+            </span>
+        </div>
+
+        @if (Model.Queue.Any())
+        {
+            <ul id="queue-list" class="space-y-2">
+                @foreach (var item in Model.Queue)
+                {
+                    <li class="flex items-center gap-3 p-2 bg-bg-tertiary rounded-lg group" data-queue-position="@item.Position">
+                        <span class="w-5 h-5 flex items-center justify-center text-xs text-text-tertiary font-medium">
+                            @item.Position
+                        </span>
+                        <div class="flex-1 min-w-0">
+                            <p class="text-sm text-text-primary truncate">@item.Name</p>
+                            <p class="text-xs text-text-tertiary">@item.DurationFormatted</p>
+                        </div>
+                        <button type="button"
+                                class="skip-queue-btn p-1 text-text-tertiary hover:text-accent-blue opacity-0 group-hover:opacity-100 transition-all"
+                                data-position="@item.Position"
+                                title="Skip to next">
+                            <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                                <path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z"/>
+                            </svg>
+                        </button>
+                    </li>
+                }
+            </ul>
+        }
+        else
+        {
+            <div id="queue-empty-state" class="text-center py-4">
+                <svg class="w-8 h-8 text-text-tertiary mx-auto mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
+                </svg>
+                <p class="text-sm text-text-tertiary">No sounds in queue</p>
+            </div>
+            <ul id="queue-list" class="hidden space-y-2"></ul>
+        }
+    </div>
+</div>
+
+@functions {
+    private static string FormatDuration(double seconds)
+    {
+        var ts = TimeSpan.FromSeconds(seconds);
+        return ts.TotalHours >= 1
+            ? $"{(int)ts.TotalHours}:{ts.Minutes:D2}:{ts.Seconds:D2}"
+            : $"{ts.Minutes}:{ts.Seconds:D2}";
+    }
+}

--- a/src/DiscordBot.Bot/ViewModels/Components/VoiceChannelPanelViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Components/VoiceChannelPanelViewModel.cs
@@ -1,0 +1,147 @@
+namespace DiscordBot.Bot.ViewModels.Components;
+
+/// <summary>
+/// ViewModel for the Voice Channel Control Panel component.
+/// Displays voice connection status, playback state, and queue management.
+/// </summary>
+public record VoiceChannelPanelViewModel
+{
+    /// <summary>
+    /// The Discord guild ID this panel is for.
+    /// </summary>
+    public required ulong GuildId { get; init; }
+
+    /// <summary>
+    /// Whether the bot is currently connected to a voice channel.
+    /// </summary>
+    public bool IsConnected { get; init; }
+
+    /// <summary>
+    /// The name of the currently connected channel, if any.
+    /// </summary>
+    public string? ConnectedChannelName { get; init; }
+
+    /// <summary>
+    /// The ID of the currently connected channel, if any.
+    /// </summary>
+    public ulong? ConnectedChannelId { get; init; }
+
+    /// <summary>
+    /// Number of members in the currently connected channel.
+    /// </summary>
+    public int? ChannelMemberCount { get; init; }
+
+    /// <summary>
+    /// List of available voice channels in the guild.
+    /// </summary>
+    public IReadOnlyList<VoiceChannelInfo> AvailableChannels { get; init; } = [];
+
+    /// <summary>
+    /// Information about the currently playing audio, if any.
+    /// </summary>
+    public NowPlayingInfo? NowPlaying { get; init; }
+
+    /// <summary>
+    /// List of queued audio items.
+    /// </summary>
+    public IReadOnlyList<QueueItemInfo> Queue { get; init; } = [];
+
+    /// <summary>
+    /// Total number of items in the queue.
+    /// </summary>
+    public int QueueCount => Queue.Count;
+}
+
+/// <summary>
+/// Information about a voice channel available for the bot to join.
+/// </summary>
+public record VoiceChannelInfo
+{
+    /// <summary>
+    /// The Discord voice channel ID.
+    /// </summary>
+    public required ulong Id { get; init; }
+
+    /// <summary>
+    /// The display name of the voice channel.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Number of members currently in the channel.
+    /// </summary>
+    public int MemberCount { get; init; }
+}
+
+/// <summary>
+/// Information about the currently playing audio.
+/// </summary>
+public record NowPlayingInfo
+{
+    /// <summary>
+    /// The ID of the sound or message being played.
+    /// </summary>
+    public string? Id { get; init; }
+
+    /// <summary>
+    /// The display name of what's playing.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Total duration in seconds.
+    /// </summary>
+    public double DurationSeconds { get; init; }
+
+    /// <summary>
+    /// Current playback position in seconds.
+    /// </summary>
+    public double PositionSeconds { get; init; }
+
+    /// <summary>
+    /// Progress percentage (0-100).
+    /// </summary>
+    public int ProgressPercent => DurationSeconds > 0
+        ? (int)Math.Round(PositionSeconds / DurationSeconds * 100)
+        : 0;
+}
+
+/// <summary>
+/// Information about an item in the playback queue.
+/// </summary>
+public record QueueItemInfo
+{
+    /// <summary>
+    /// Position in the queue (1-based).
+    /// </summary>
+    public int Position { get; init; }
+
+    /// <summary>
+    /// The ID of the queued item.
+    /// </summary>
+    public string? Id { get; init; }
+
+    /// <summary>
+    /// The display name of the queued item.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Duration in seconds.
+    /// </summary>
+    public double DurationSeconds { get; init; }
+
+    /// <summary>
+    /// Formatted duration string (e.g., "0:30").
+    /// </summary>
+    public string DurationFormatted
+    {
+        get
+        {
+            var ts = TimeSpan.FromSeconds(DurationSeconds);
+            return ts.TotalHours >= 1
+                ? $"{(int)ts.TotalHours}:{ts.Minutes:D2}:{ts.Seconds:D2}"
+                : $"{ts.Minutes}:{ts.Seconds:D2}";
+        }
+    }
+}

--- a/src/DiscordBot.Bot/wwwroot/js/voice-channel-panel.js
+++ b/src/DiscordBot.Bot/wwwroot/js/voice-channel-panel.js
@@ -1,0 +1,611 @@
+/**
+ * Voice Channel Panel Module
+ * Handles real-time voice connection status, playback, and queue management.
+ * Integrates with DashboardHub SignalR for live updates.
+ */
+const VoiceChannelPanel = (function() {
+    'use strict';
+
+    // DOM element references
+    let panelElement = null;
+    let channelSelector = null;
+    let leaveButton = null;
+    let stopButton = null;
+    let connectionStatusBadge = null;
+    let connectionStatusDot = null;
+    let connectionStatusText = null;
+    let connectedChannelInfo = null;
+    let connectedChannelName = null;
+    let channelMemberCount = null;
+    let nowPlayingSection = null;
+    let nowPlayingName = null;
+    let nowPlayingProgress = null;
+    let nowPlayingPosition = null;
+    let nowPlayingDuration = null;
+    let queueList = null;
+    let queueEmptyState = null;
+    let queueCountBadge = null;
+
+    // State
+    let guildId = null;
+    let isConnected = false;
+    let connectedChannelId = null;
+    let isHubConnected = false;
+
+    /**
+     * Initializes the Voice Channel Panel module.
+     * Call this after the DOM is ready and DashboardHub is connected.
+     */
+    function init() {
+        panelElement = document.getElementById('voice-channel-panel');
+        if (!panelElement) {
+            console.log('[VoiceChannelPanel] Panel element not found, skipping initialization');
+            return;
+        }
+
+        // Get guild ID from data attribute
+        guildId = panelElement.dataset.guildId;
+        isConnected = panelElement.dataset.connected === 'true';
+        connectedChannelId = panelElement.dataset.channelId || null;
+
+        // Cache DOM elements
+        channelSelector = document.getElementById('channel-selector');
+        leaveButton = document.getElementById('leave-channel-btn');
+        stopButton = document.getElementById('stop-playback-btn');
+        connectionStatusBadge = document.getElementById('connection-status-badge');
+        connectionStatusDot = document.getElementById('connection-status-dot');
+        connectionStatusText = document.getElementById('connection-status-text');
+        connectedChannelInfo = document.getElementById('connected-channel-info');
+        connectedChannelName = document.getElementById('connected-channel-name');
+        channelMemberCount = document.getElementById('channel-member-count');
+        nowPlayingSection = document.getElementById('now-playing-section');
+        nowPlayingName = document.getElementById('now-playing-name');
+        nowPlayingProgress = document.getElementById('now-playing-progress');
+        nowPlayingPosition = document.getElementById('now-playing-position');
+        nowPlayingDuration = document.getElementById('now-playing-duration');
+        queueList = document.getElementById('queue-list');
+        queueEmptyState = document.getElementById('queue-empty-state');
+        queueCountBadge = document.getElementById('queue-count-badge');
+
+        // Set up event listeners
+        setupEventListeners();
+
+        // Connect to SignalR if DashboardHub is available
+        if (typeof DashboardHub !== 'undefined') {
+            setupSignalRHandlers();
+        }
+
+        console.log('[VoiceChannelPanel] Initialized for guild:', guildId);
+    }
+
+    /**
+     * Sets up DOM event listeners for user interactions.
+     */
+    function setupEventListeners() {
+        // Channel selector change
+        if (channelSelector) {
+            channelSelector.addEventListener('change', handleChannelSelect);
+        }
+
+        // Leave button click
+        if (leaveButton) {
+            leaveButton.addEventListener('click', handleLeaveChannel);
+        }
+
+        // Stop button click
+        if (stopButton) {
+            stopButton.addEventListener('click', handleStopPlayback);
+        }
+
+        // Queue skip buttons (delegated)
+        if (queueList) {
+            queueList.addEventListener('click', function(e) {
+                const skipBtn = e.target.closest('.skip-queue-btn');
+                if (skipBtn) {
+                    const position = parseInt(skipBtn.dataset.position, 10);
+                    handleSkipQueueItem(position);
+                }
+            });
+        }
+    }
+
+    /**
+     * Sets up SignalR event handlers for real-time updates.
+     */
+    function setupSignalRHandlers() {
+        // Connection state handlers
+        DashboardHub.on('connected', function() {
+            isHubConnected = true;
+            joinGuildAudioGroup();
+        });
+
+        DashboardHub.on('reconnected', function() {
+            isHubConnected = true;
+            joinGuildAudioGroup();
+        });
+
+        DashboardHub.on('disconnected', function() {
+            isHubConnected = false;
+        });
+
+        // Audio event handlers
+        DashboardHub.on('AudioConnected', handleAudioConnected);
+        DashboardHub.on('AudioDisconnected', handleAudioDisconnected);
+        DashboardHub.on('PlaybackStarted', handlePlaybackStarted);
+        DashboardHub.on('PlaybackProgress', handlePlaybackProgress);
+        DashboardHub.on('PlaybackFinished', handlePlaybackFinished);
+        DashboardHub.on('QueueUpdated', handleQueueUpdated);
+
+        // If already connected, join the guild audio group
+        if (DashboardHub.isConnected()) {
+            isHubConnected = true;
+            joinGuildAudioGroup();
+        }
+    }
+
+    /**
+     * Joins the guild-specific audio group for SignalR events.
+     */
+    async function joinGuildAudioGroup() {
+        if (!isHubConnected || !guildId) return;
+
+        try {
+            await DashboardHub.joinGuildGroup(guildId);
+            console.log('[VoiceChannelPanel] Joined guild audio group:', guildId);
+        } catch (error) {
+            console.error('[VoiceChannelPanel] Failed to join guild audio group:', error);
+        }
+    }
+
+    /**
+     * Handles channel selection change.
+     */
+    async function handleChannelSelect(e) {
+        const selectedChannelId = e.target.value;
+        if (!selectedChannelId || !guildId) return;
+
+        try {
+            setChannelSelectorLoading(true);
+
+            const response = await fetch(`/api/guilds/${guildId}/audio/join/${selectedChannelId}`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            });
+
+            if (!response.ok) {
+                const error = await response.json();
+                showToast(error.message || 'Failed to join channel', 'error');
+                // Reset selector to previous value
+                channelSelector.value = connectedChannelId || '';
+            }
+            // Success will be handled by AudioConnected SignalR event
+        } catch (error) {
+            console.error('[VoiceChannelPanel] Error joining channel:', error);
+            showToast('Failed to join channel', 'error');
+            channelSelector.value = connectedChannelId || '';
+        } finally {
+            setChannelSelectorLoading(false);
+        }
+    }
+
+    /**
+     * Handles leave channel button click.
+     */
+    async function handleLeaveChannel() {
+        if (!guildId) return;
+
+        try {
+            setLeaveButtonLoading(true);
+
+            const response = await fetch(`/api/guilds/${guildId}/audio/leave`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            });
+
+            if (!response.ok) {
+                const error = await response.json();
+                showToast(error.message || 'Failed to leave channel', 'error');
+            }
+            // Success will be handled by AudioDisconnected SignalR event
+        } catch (error) {
+            console.error('[VoiceChannelPanel] Error leaving channel:', error);
+            showToast('Failed to leave channel', 'error');
+        } finally {
+            setLeaveButtonLoading(false);
+        }
+    }
+
+    /**
+     * Handles stop playback button click.
+     */
+    async function handleStopPlayback() {
+        if (!guildId) return;
+
+        try {
+            const response = await fetch(`/api/guilds/${guildId}/audio/stop`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            });
+
+            if (!response.ok) {
+                const error = await response.json();
+                showToast(error.message || 'Failed to stop playback', 'error');
+            }
+            // Success will be handled by PlaybackFinished SignalR event
+        } catch (error) {
+            console.error('[VoiceChannelPanel] Error stopping playback:', error);
+            showToast('Failed to stop playback', 'error');
+        }
+    }
+
+    /**
+     * Handles skip queue item button click.
+     * @param {number} position - The queue position to skip.
+     */
+    async function handleSkipQueueItem(position) {
+        if (!guildId) return;
+
+        try {
+            const response = await fetch(`/api/guilds/${guildId}/audio/queue/${position}`, {
+                method: 'DELETE',
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            });
+
+            if (!response.ok) {
+                const error = await response.json();
+                showToast(error.message || 'Failed to skip item', 'error');
+            }
+            // Success will be handled by QueueUpdated SignalR event
+        } catch (error) {
+            console.error('[VoiceChannelPanel] Error skipping queue item:', error);
+            showToast('Failed to skip item', 'error');
+        }
+    }
+
+    /**
+     * Handles AudioConnected SignalR event.
+     * @param {object} data - Event data with guildId, channelId, channelName.
+     */
+    function handleAudioConnected(data) {
+        if (data.guildId !== guildId) return;
+
+        console.log('[VoiceChannelPanel] Audio connected:', data);
+
+        isConnected = true;
+        connectedChannelId = data.channelId;
+
+        // Update connection status
+        updateConnectionStatus(true, data.channelName, data.memberCount);
+
+        // Update channel selector
+        if (channelSelector) {
+            channelSelector.value = data.channelId;
+        }
+
+        // Show leave button
+        if (leaveButton) {
+            leaveButton.classList.remove('hidden');
+        }
+    }
+
+    /**
+     * Handles AudioDisconnected SignalR event.
+     * @param {object} data - Event data with guildId, reason.
+     */
+    function handleAudioDisconnected(data) {
+        if (data.guildId !== guildId) return;
+
+        console.log('[VoiceChannelPanel] Audio disconnected:', data);
+
+        isConnected = false;
+        connectedChannelId = null;
+
+        // Update connection status
+        updateConnectionStatus(false);
+
+        // Reset channel selector
+        if (channelSelector) {
+            channelSelector.value = '';
+        }
+
+        // Hide leave button
+        if (leaveButton) {
+            leaveButton.classList.add('hidden');
+        }
+
+        // Clear now playing
+        updateNowPlaying(null);
+
+        // Clear queue
+        updateQueue([]);
+    }
+
+    /**
+     * Handles PlaybackStarted SignalR event.
+     * @param {object} data - Event data with guildId, soundId, name, durationSeconds.
+     */
+    function handlePlaybackStarted(data) {
+        if (data.guildId !== guildId) return;
+
+        console.log('[VoiceChannelPanel] Playback started:', data);
+
+        updateNowPlaying({
+            id: data.soundId,
+            name: data.name,
+            durationSeconds: data.durationSeconds,
+            positionSeconds: 0
+        });
+    }
+
+    /**
+     * Handles PlaybackProgress SignalR event.
+     * @param {object} data - Event data with guildId, soundId, positionSeconds, durationSeconds.
+     */
+    function handlePlaybackProgress(data) {
+        if (data.guildId !== guildId) return;
+
+        updatePlaybackProgress(data.positionSeconds, data.durationSeconds);
+    }
+
+    /**
+     * Handles PlaybackFinished SignalR event.
+     * @param {object} data - Event data with guildId, soundId.
+     */
+    function handlePlaybackFinished(data) {
+        if (data.guildId !== guildId) return;
+
+        console.log('[VoiceChannelPanel] Playback finished:', data);
+
+        updateNowPlaying(null);
+    }
+
+    /**
+     * Handles QueueUpdated SignalR event.
+     * @param {object} data - Event data with guildId, queue array.
+     */
+    function handleQueueUpdated(data) {
+        if (data.guildId !== guildId) return;
+
+        console.log('[VoiceChannelPanel] Queue updated:', data);
+
+        updateQueue(data.queue || []);
+    }
+
+    /**
+     * Updates the connection status display.
+     * @param {boolean} connected - Whether connected.
+     * @param {string} channelName - Connected channel name.
+     * @param {number} memberCount - Member count in channel.
+     */
+    function updateConnectionStatus(connected, channelName, memberCount) {
+        if (connectionStatusDot) {
+            connectionStatusDot.className = connected
+                ? 'w-1.5 h-1.5 rounded-full bg-success'
+                : 'w-1.5 h-1.5 rounded-full bg-text-tertiary';
+        }
+
+        if (connectionStatusText) {
+            connectionStatusText.textContent = connected ? 'Connected' : 'Disconnected';
+        }
+
+        if (connectionStatusBadge) {
+            connectionStatusBadge.className = connected
+                ? 'inline-flex items-center gap-1.5 px-2 py-0.5 text-xs font-medium rounded-full bg-success/20 text-success'
+                : 'inline-flex items-center gap-1.5 px-2 py-0.5 text-xs font-medium rounded-full bg-bg-tertiary text-text-tertiary';
+        }
+
+        if (connectedChannelInfo) {
+            if (connected && channelName) {
+                connectedChannelInfo.classList.remove('hidden');
+                if (connectedChannelName) {
+                    connectedChannelName.textContent = channelName;
+                }
+                if (channelMemberCount && memberCount !== undefined) {
+                    channelMemberCount.textContent = memberCount;
+                }
+            } else {
+                connectedChannelInfo.classList.add('hidden');
+            }
+        }
+
+        // Update panel data attribute
+        if (panelElement) {
+            panelElement.dataset.connected = connected.toString();
+            panelElement.dataset.channelId = connected ? connectedChannelId : '';
+        }
+    }
+
+    /**
+     * Updates the now playing display.
+     * @param {object|null} nowPlaying - Now playing info or null.
+     */
+    function updateNowPlaying(nowPlaying) {
+        if (!nowPlayingSection) return;
+
+        if (nowPlaying) {
+            nowPlayingSection.classList.remove('hidden');
+
+            if (nowPlayingName) {
+                nowPlayingName.textContent = nowPlaying.name;
+            }
+
+            updatePlaybackProgress(nowPlaying.positionSeconds || 0, nowPlaying.durationSeconds || 0);
+        } else {
+            nowPlayingSection.classList.add('hidden');
+        }
+    }
+
+    /**
+     * Updates the playback progress bar and time display.
+     * @param {number} position - Current position in seconds.
+     * @param {number} duration - Total duration in seconds.
+     */
+    function updatePlaybackProgress(position, duration) {
+        const percent = duration > 0 ? Math.round((position / duration) * 100) : 0;
+
+        if (nowPlayingProgress) {
+            nowPlayingProgress.style.width = `${percent}%`;
+        }
+
+        if (nowPlayingPosition) {
+            nowPlayingPosition.textContent = formatDuration(position);
+        }
+
+        if (nowPlayingDuration) {
+            nowPlayingDuration.textContent = formatDuration(duration);
+        }
+    }
+
+    /**
+     * Updates the queue display.
+     * @param {Array} queue - Array of queue items.
+     */
+    function updateQueue(queue) {
+        if (!queueList || !queueEmptyState || !queueCountBadge) return;
+
+        // Update count badge
+        const count = queue.length;
+        queueCountBadge.textContent = count > 0
+            ? `${count} sound${count === 1 ? '' : 's'}`
+            : 'Empty';
+
+        if (count === 0) {
+            queueList.classList.add('hidden');
+            queueList.innerHTML = '';
+            queueEmptyState.classList.remove('hidden');
+            return;
+        }
+
+        queueEmptyState.classList.add('hidden');
+        queueList.classList.remove('hidden');
+
+        // Build queue HTML
+        let html = '';
+        queue.forEach((item, index) => {
+            const position = index + 1;
+            const duration = formatDuration(item.durationSeconds || 0);
+            html += `
+                <li class="flex items-center gap-3 p-2 bg-bg-tertiary rounded-lg group" data-queue-position="${position}">
+                    <span class="w-5 h-5 flex items-center justify-center text-xs text-text-tertiary font-medium">
+                        ${position}
+                    </span>
+                    <div class="flex-1 min-w-0">
+                        <p class="text-sm text-text-primary truncate">${escapeHtml(item.name)}</p>
+                        <p class="text-xs text-text-tertiary">${duration}</p>
+                    </div>
+                    <button type="button"
+                            class="skip-queue-btn p-1 text-text-tertiary hover:text-accent-blue opacity-0 group-hover:opacity-100 transition-all"
+                            data-position="${position}"
+                            title="Skip to next">
+                        <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                            <path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z"/>
+                        </svg>
+                    </button>
+                </li>
+            `;
+        });
+
+        queueList.innerHTML = html;
+    }
+
+    /**
+     * Formats a duration in seconds to a display string.
+     * @param {number} seconds - Duration in seconds.
+     * @returns {string} Formatted string (e.g., "1:30" or "1:02:30").
+     */
+    function formatDuration(seconds) {
+        const totalSeconds = Math.floor(seconds);
+        const hours = Math.floor(totalSeconds / 3600);
+        const minutes = Math.floor((totalSeconds % 3600) / 60);
+        const secs = totalSeconds % 60;
+
+        if (hours > 0) {
+            return `${hours}:${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+        }
+        return `${minutes}:${secs.toString().padStart(2, '0')}`;
+    }
+
+    /**
+     * Escapes HTML characters to prevent XSS.
+     * @param {string} text - Text to escape.
+     * @returns {string} Escaped text.
+     */
+    function escapeHtml(text) {
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+
+    /**
+     * Sets the channel selector loading state.
+     * @param {boolean} loading - Whether loading.
+     */
+    function setChannelSelectorLoading(loading) {
+        if (channelSelector) {
+            channelSelector.disabled = loading;
+        }
+    }
+
+    /**
+     * Sets the leave button loading state.
+     * @param {boolean} loading - Whether loading.
+     */
+    function setLeaveButtonLoading(loading) {
+        if (leaveButton) {
+            leaveButton.disabled = loading;
+            if (loading) {
+                leaveButton.innerHTML = `
+                    <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                    </svg>
+                    Leaving...
+                `;
+            } else {
+                leaveButton.innerHTML = `
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+                    </svg>
+                    Leave
+                `;
+            }
+        }
+    }
+
+    /**
+     * Shows a toast notification.
+     * @param {string} message - Toast message.
+     * @param {string} type - Toast type (success, error, info, warning).
+     */
+    function showToast(message, type) {
+        // Use global Toast if available
+        if (typeof Toast !== 'undefined' && Toast.show) {
+            Toast.show(message, type);
+        } else {
+            console.log(`[VoiceChannelPanel] Toast (${type}):`, message);
+        }
+    }
+
+    // Public API
+    return {
+        init: init,
+        updateConnectionStatus: updateConnectionStatus,
+        updateNowPlaying: updateNowPlaying,
+        updateQueue: updateQueue
+    };
+})();
+
+// Initialize when DOM is ready
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', VoiceChannelPanel.init);
+} else {
+    VoiceChannelPanel.init();
+}


### PR DESCRIPTION
## Summary

- Add reusable Voice Channel Control Panel component for the admin UI
- Create VoiceChannelPanelViewModel with voice channel, playback, and queue models
- Implement Razor partial view with connection status, channel selector, now playing, and queue sections
- Add JavaScript module for SignalR integration and real-time UI updates
- Integrate component into Soundboard page

## Changes

### New Files
- `VoiceChannelPanelViewModel.cs` - ViewModel with `VoiceChannelInfo`, `NowPlayingInfo`, and `QueueItemInfo` records
- `_VoiceChannelPanel.cshtml` - Razor partial view component with:
  - Connection status badge (Connected/Disconnected)
  - Channel selector dropdown with member count
  - Leave Channel button
  - Now Playing section with progress bar
  - Queue list with skip buttons
- `voice-channel-panel.js` - JavaScript module for:
  - SignalR event handlers (AudioConnected, AudioDisconnected, PlaybackStarted, PlaybackProgress, PlaybackFinished, QueueUpdated)
  - Channel join/leave API calls
  - Stop playback and skip queue functionality
  - Real-time UI updates

### Modified Files
- `Soundboard/Index.cshtml` - Added partial view and SignalR scripts
- `Soundboard/Index.cshtml.cs` - Added IAudioService and DiscordSocketClient injection, VoiceChannelPanel property

## Test plan

- [ ] Verify component renders on Soundboard page
- [ ] Verify channel selector populates with voice channels
- [ ] Verify connection status updates via SignalR (requires #893 implementation)
- [ ] Verify leave button appears when connected
- [ ] Verify Now Playing and Queue sections update in real-time (requires #893 implementation)

## Dependencies

This component is ready for use but full real-time functionality depends on:
- #893 - SignalR Real-time Audio Status (for AudioConnected/AudioDisconnected/Playback* events)

Closes #892

🤖 Generated with [Claude Code](https://claude.com/claude-code)