### PR TITLE
docs: Add comprehensive audio support documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,8 @@ Discord bot management system built with .NET 8 and Discord.NET. Combines a Disc
 
 - .NET 8 SDK
 - Node.js (for Tailwind CSS build - runs automatically on `dotnet build`)
+- FFmpeg (for audio features) - see [audio-dependencies.md](docs/articles/audio-dependencies.md)
+- libsodium and libopus (for Discord voice encryption/encoding)
 
 ## Build & Run Commands
 
@@ -151,7 +153,8 @@ Reference these docs for detailed specifications (build and serve locally with `
 | [identity-configuration.md](docs/articles/identity-configuration.md) | Authentication setup, troubleshooting |
 | [authorization-policies.md](docs/articles/authorization-policies.md) | Role hierarchy, guild access |
 | [api-endpoints.md](docs/articles/api-endpoints.md) | REST API documentation |
-| [audio-dependencies.md](docs/articles/audio-dependencies.md) | Audio dependencies (FFmpeg, libsodium, libopus) setup |
+| [audio-dependencies.md](docs/articles/audio-dependencies.md) | Audio dependencies (FFmpeg, libsodium, libopus) setup for Windows/Linux |
+| [soundboard.md](docs/articles/soundboard.md) | Soundboard feature, commands, and admin UI |
 | [log-aggregation.md](docs/articles/log-aggregation.md) | Elasticsearch and Seq centralized logging setup |
 | [elastic-stack-setup.md](docs/articles/elastic-stack-setup.md) | Local development setup for Elastic Stack (Elasticsearch, Kibana, APM) |
 | [kibana-dashboards.md](docs/articles/kibana-dashboards.md) | Kibana dashboards, saved searches, and alerting setup |
@@ -199,7 +202,7 @@ All HTML prototypes are located in `docs/prototypes/`. Open them directly in a b
 - Slash commands only (no prefix commands)
 - `InteractionHandler` discovers and registers command modules from assembly
 - Command modules inherit from `InteractionModuleBase<SocketInteractionContext>`
-- Precondition attributes for permission checks: `RequireAdminAttribute`, `RequireOwnerAttribute`, `RateLimitAttribute`, `RequireRatWatchEnabledAttribute`, `RequireGuildActive`, `RequireModerationEnabled`, `RequireModerator`
+- Precondition attributes for permission checks: `RequireAdminAttribute`, `RequireOwnerAttribute`, `RateLimitAttribute`, `RequireRatWatchEnabledAttribute`, `RequireGuildActive`, `RequireModerationEnabled`, `RequireModerator`, `RequireAudioEnabled`, `RequireVoiceChannel`
 
 **Command Modules:**
 | Module | Commands |
@@ -220,6 +223,8 @@ All HTML prototypes are located in `docs/prototypes/`. Open them directly in a b
 | `WatchlistModule` | `/watchlist add/remove/list` |
 | `InvestigateModule` | `/investigate` |
 | `ConsentModule` | `/consent`, `/privacy` |
+| `SoundboardModule` | `/play <sound>`, `/sounds`, `/stop` |
+| `VoiceModule` | `/join`, `/join-channel <channel>`, `/leave` |
 
 **Interactive Components Pattern:**
 - Use `ComponentIdBuilder` to create custom IDs: `{handler}:{action}:{userId}:{correlationId}:{data}`
@@ -302,6 +307,8 @@ The `preview-popup.js` module is loaded globally via `_Layout.cshtml`. See exist
 | Flagged Events | `/Guilds/{guildId:long}/FlaggedEvents` | Auto-moderation flagged events |
 | Flagged Event Details | `/Guilds/{guildId:long}/FlaggedEvents/{id:guid}` | Single flagged event |
 | Reminders | `/Guilds/{guildId:long}/Reminders` | Guild reminders management |
+| Soundboard | `/Guilds/Soundboard/{guildId:long}` | Guild soundboard management |
+| Audio Settings | `/Guilds/AudioSettings/{guildId:long}` | Guild audio configuration |
 | Public Leaderboard | `/Guilds/{guildId:long}/Leaderboard` | Public Rat Watch leaderboard (no auth) |
 | Global Rat Watch Analytics | `/Admin/RatWatchAnalytics` | Cross-guild Rat Watch metrics (Admin+) |
 | Performance Dashboard | `/Admin/Performance` | Performance overview dashboard |
@@ -350,6 +357,7 @@ When running locally (`dotnet run --project src/DiscordBot.Bot`):
 - **Commands not appearing**: Without `TestGuildId` configured, global commands take up to 1 hour to propagate
 - **Bot doesn't connect**: Check bot token in user secrets and that gateway intents are enabled in Discord Developer Portal
 - **OAuth fails**: Verify redirect URIs in Discord Developer Portal match your environment
+- **Audio not playing**: Ensure FFmpeg is installed and in PATH (or configure `Soundboard:FfmpegPath`). On Windows, ensure `libsodium.dll` and `opus.dll` are in the build output directory. See [audio-dependencies.md](docs/articles/audio-dependencies.md)
 
 ## JavaScript and Discord Snowflake IDs
 

--- a/docs/articles/soundboard.md
+++ b/docs/articles/soundboard.md
@@ -1,0 +1,263 @@
+# Soundboard Feature
+
+This document describes the Soundboard feature, which allows Discord users to play audio clips in voice channels and administrators to manage the sound library.
+
+## Overview
+
+The Soundboard feature provides:
+- Voice channel audio playback via slash commands
+- Per-guild sound libraries with upload/delete management
+- Admin UI for sound management and configuration
+- Configurable storage limits and audio settings per guild
+- Real-time playback status via SignalR
+
+## Prerequisites
+
+Before using audio features, ensure the following dependencies are installed:
+- **FFmpeg** - for audio transcoding
+- **libsodium** - for voice encryption
+- **libopus** - for Opus audio encoding
+
+See [Audio Dependencies](audio-dependencies.md) for detailed installation instructions.
+
+## Slash Commands
+
+### SoundboardModule
+
+| Command | Description | Preconditions |
+|---------|-------------|---------------|
+| `/play <sound>` | Play a sound from the soundboard | `RequireGuildActive`, `RequireAudioEnabled` |
+| `/sounds` | List all available sounds for the guild | `RequireGuildActive`, `RequireAudioEnabled` |
+| `/stop` | Stop playback and clear queue (Admin only) | `RequireGuildActive`, `RequireAudioEnabled`, `RequireAdmin` |
+
+**Autocomplete:** The `/play` command supports autocomplete for sound names, filtering available sounds as the user types.
+
+### VoiceModule
+
+| Command | Description | Preconditions |
+|---------|-------------|---------------|
+| `/join` | Join the user's current voice channel | `RequireGuildActive`, `RequireAudioEnabled`, `RequireVoiceChannel` |
+| `/join-channel <channel>` | Join a specific voice channel | `RequireGuildActive`, `RequireAudioEnabled` |
+| `/leave` | Leave the current voice channel | `RequireGuildActive`, `RequireAudioEnabled` |
+
+## Admin UI
+
+### Soundboard Management Page
+
+**URL:** `/Guilds/Soundboard/{guildId}`
+
+**Authorization:** RequireAdmin policy
+
+**Features:**
+- View all uploaded sounds with metadata (name, file size, duration, play count)
+- Upload new sound files (mp3, wav, ogg, m4a)
+- Delete existing sounds
+- Discover sounds from the file system (for bulk imports)
+- Voice channel control panel for testing playback
+
+### Audio Settings Page
+
+**URL:** `/Guilds/AudioSettings/{guildId}`
+
+**Authorization:** RequireAdmin policy
+
+**Settings available:**
+- Enable/disable audio features for the guild
+- Auto-leave timeout (minutes before bot leaves when idle)
+- Queue mode vs replace mode for playback
+- Maximum sound duration (seconds)
+- Maximum file size (bytes)
+- Maximum sounds per guild
+- Total storage limit (bytes)
+
+## Configuration
+
+### SoundboardOptions
+
+Configure in `appsettings.json` under the `Soundboard` section:
+
+```json
+{
+  "Soundboard": {
+    "BasePath": "./sounds",
+    "FfmpegPath": null,
+    "FfprobePath": null,
+    "DefaultMaxDurationSeconds": 30,
+    "DefaultMaxFileSizeBytes": 10485760,
+    "DefaultMaxSoundsPerGuild": 100,
+    "DefaultMaxStorageBytes": 524288000,
+    "DefaultAutoLeaveTimeoutMinutes": 0,
+    "SupportedFormats": ["mp3", "wav", "ogg"]
+  }
+}
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `BasePath` | `./sounds` | Root folder for sound file storage |
+| `FfmpegPath` | `null` | Path to FFmpeg. `null` = use system PATH |
+| `FfprobePath` | `null` | Path to FFprobe. `null` = use system PATH |
+| `DefaultMaxDurationSeconds` | 30 | Maximum sound duration |
+| `DefaultMaxFileSizeBytes` | 10485760 | Maximum file size (10MB) |
+| `DefaultMaxSoundsPerGuild` | 100 | Maximum sounds per guild |
+| `DefaultMaxStorageBytes` | 524288000 | Storage limit per guild (500MB) |
+| `DefaultAutoLeaveTimeoutMinutes` | 0 | Idle timeout (0 = indefinite) |
+| `SupportedFormats` | `["mp3", "wav", "ogg"]` | Allowed file formats |
+
+### VoiceChannelOptions
+
+Configure voice channel behavior:
+
+```json
+{
+  "VoiceChannel": {
+    "AutoLeaveTimeoutSeconds": 300,
+    "CheckIntervalSeconds": 30
+  }
+}
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `AutoLeaveTimeoutSeconds` | 300 | Timeout when bot is alone in channel (5 min) |
+| `CheckIntervalSeconds` | 30 | Interval between auto-leave checks |
+
+## Database Entities
+
+### Sound
+
+Represents an audio file in the soundboard.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Id` | Guid | Primary key |
+| `GuildId` | ulong | Discord guild ID |
+| `Name` | string | Display name |
+| `FileName` | string | Physical filename on disk |
+| `FileSizeBytes` | long | File size in bytes |
+| `DurationSeconds` | double | Audio duration |
+| `UploadedById` | ulong? | User who uploaded |
+| `UploadedAt` | DateTime | Upload timestamp (UTC) |
+| `PlayCount` | int | Number of times played |
+
+### GuildAudioSettings
+
+Per-guild audio configuration.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `GuildId` | ulong | Primary key (Discord guild ID) |
+| `AudioEnabled` | bool | Whether audio is enabled |
+| `AutoLeaveTimeoutMinutes` | int | Idle timeout (0 = indefinite) |
+| `QueueEnabled` | bool | Queue mode vs replace mode |
+| `MaxDurationSeconds` | int | Max sound duration |
+| `MaxFileSizeBytes` | long | Max file size |
+| `MaxSoundsPerGuild` | int | Max sounds |
+| `MaxStorageBytes` | long | Total storage limit |
+
+## Services
+
+### Core Services
+
+| Service | Purpose |
+|---------|---------|
+| `IAudioService` | Voice channel connection management |
+| `IPlaybackService` | Audio playback with FFmpeg transcoding |
+| `ISoundService` | Sound CRUD operations and validation |
+| `ISoundFileService` | File storage and audio metadata |
+| `IGuildAudioSettingsService` | Guild audio configuration |
+
+### Background Services
+
+| Service | Purpose |
+|---------|---------|
+| `VoiceAutoLeaveService` | Auto-disconnects bot when alone in channel |
+
+### SignalR Notifications
+
+The `IAudioNotifier` service broadcasts real-time audio status to dashboard clients:
+
+| Event | Description |
+|-------|-------------|
+| `AudioConnected` | Bot connected to voice channel |
+| `AudioDisconnected` | Bot disconnected from voice channel |
+| `PlaybackStarted` | Sound started playing |
+| `PlaybackProgress` | Playback progress update |
+| `PlaybackFinished` | Sound finished playing |
+| `QueueUpdated` | Queue changed |
+
+## Preconditions
+
+### RequireAudioEnabled
+
+Ensures audio features are enabled for the guild. Commands will fail with a user-friendly message if disabled.
+
+```csharp
+[RequireAudioEnabled]
+public async Task PlayAsync([Autocomplete] string sound) { ... }
+```
+
+### RequireVoiceChannel
+
+Ensures the user is in a voice channel before executing the command.
+
+```csharp
+[RequireVoiceChannel]
+public async Task JoinAsync() { ... }
+```
+
+## File System Structure
+
+Sounds are organized by guild ID:
+
+```
+sounds/
+├── 123456789012345678/    # Guild ID
+│   ├── airhorn.mp3
+│   └── bruh.wav
+└── 987654321098765432/    # Another guild
+    └── victory.ogg
+```
+
+## Playback Flow
+
+1. User runs `/play airhorn`
+2. Bot verifies user is in voice channel (or auto-joins)
+3. Sound file is located on disk
+4. FFmpeg transcodes to PCM (48kHz, 16-bit, stereo)
+5. Audio is encrypted via libsodium
+6. Opus-encoded audio streams to Discord voice server
+7. Play count is incremented
+
+## Queue vs Replace Mode
+
+- **Queue Mode** (`QueueEnabled = true`): New sounds are added to a queue and play in order
+- **Replace Mode** (`QueueEnabled = false`): New sounds stop current playback and play immediately
+
+Configure per-guild in the Audio Settings admin page.
+
+## Troubleshooting
+
+### Bot joins but no audio plays
+
+1. Check FFmpeg is installed: `ffmpeg -version`
+2. Verify libsodium and libopus are available
+3. Check bot has voice permissions in the channel
+4. Review logs for audio-related errors
+
+### "Audio features are disabled" error
+
+Enable audio in the Admin UI: `/Guilds/AudioSettings/{guildId}`
+
+### Sounds cut off at the beginning
+
+This is a Discord quirk. The bot sends a brief silence frame before audio to "wake up" the UDP connection.
+
+### Consecutive playback failures
+
+The bot maintains a persistent PCM stream per guild. If audio fails after the first play, there may be a stream state issue. Try `/leave` and `/join` to reset the connection.
+
+## See Also
+
+- [Audio Dependencies](audio-dependencies.md) - FFmpeg, libsodium, libopus setup
+- [SignalR Real-Time Updates](signalr-realtime.md) - Dashboard real-time notifications


### PR DESCRIPTION
## Summary

- Add comprehensive documentation for the Audio Support & Soundboard feature
- Update CLAUDE.md with audio-related command modules, preconditions, and page routes
- Enhance audio-dependencies.md with detailed Windows and Linux setup guides
- Create new soundboard.md feature documentation

## Changes

### CLAUDE.md Updates
- Added FFmpeg, libsodium, and libopus to prerequisites
- Added `SoundboardModule` (`/play`, `/sounds`, `/stop`) to command modules table
- Added `VoiceModule` (`/join`, `/join-channel`, `/leave`) to command modules table
- Added `RequireAudioEnabled` and `RequireVoiceChannel` to preconditions list
- Added Soundboard and Audio Settings page routes to UI routes table
- Added audio troubleshooting to common issues section

### audio-dependencies.md Enhancements
- Complete Windows setup guide with step-by-step FFmpeg installation
- NuGet package recommendations for libsodium and opus on Windows
- Distribution-specific Linux commands (Debian, Ubuntu, RHEL, Fedora, Arch, Alpine)
- Native library verification commands
- Production deployment checklist

### New: soundboard.md
- Feature overview and prerequisites
- Slash command documentation (SoundboardModule, VoiceModule)
- Admin UI documentation (Soundboard page, Audio Settings page)
- Configuration options (SoundboardOptions, VoiceChannelOptions)
- Database entities (Sound, GuildAudioSettings)
- Services overview and SignalR events
- Precondition attributes documentation
- File system structure and playback flow
- Queue vs Replace mode explanation
- Troubleshooting guide

## Test plan

- [ ] Verify CLAUDE.md renders correctly with new tables
- [ ] Verify audio-dependencies.md links work
- [ ] Verify soundboard.md displays properly in DocFX

Closes #756

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>