### PR TITLE
fix: Hide GUID filename in sounds table to prevent horizontal overflow

### DIFF
--- a/src/DiscordBot.Bot/Pages/Guilds/Soundboard/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Soundboard/Index.cshtml
@@ -172,7 +172,7 @@
                 {
                     <!-- Sounds Table -->
                     <div class="overflow-x-auto">
-                        <table class="w-full min-w-[600px]">
+                        <table class="w-full">
                             <thead class="bg-bg-tertiary">
                                 <tr>
                                     <th class="px-4 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider" style="width: 50px;"></th>
@@ -198,8 +198,7 @@
                                             </button>
                                         </td>
                                         <td class="px-4 py-3">
-                                            <div class="font-medium text-text-primary">@sound.Name</div>
-                                            <div class="text-sm text-text-tertiary">@sound.FileName</div>
+                                            <div class="font-medium text-text-primary" title="@sound.FileName">@sound.Name</div>
                                         </td>
                                         <td class="px-4 py-3">
                                             <div class="flex items-center gap-1 text-text-secondary text-sm">


### PR DESCRIPTION
## Summary
- Remove filename display from sounds table (GUID filenames like `4eb42b40-9dc6-45d8-b580-08f6d3ec8e26.mp3` provide no user value)
- Add tooltip on sound name showing the filename for users who need it
- Remove `min-w-[600px]` constraint from table to allow natural responsive flow

## Test plan
- [ ] Navigate to Soundboard page (`/Guilds/Soundboard/{guildId}`)
- [ ] Verify table no longer causes horizontal overflow
- [ ] Hover over sound name to verify filename tooltip appears
- [ ] Test on smaller screen widths to confirm responsive behavior

Closes #927

🤖 Generated with [Claude Code](https://claude.com/claude-code)