### PR TITLE
feat(ui): Add unified audio tabs navigation for Soundboard and Settings pages

### DIFF
--- a/docs/prototypes/features/audio-tabs/index.html
+++ b/docs/prototypes/features/audio-tabs/index.html
@@ -1,0 +1,390 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Audio Tabs Navigation - Issue #926</title>
+
+  <!-- Shared Styles -->
+  <link rel="stylesheet" href="../../css/main.css">
+
+  <!-- Tailwind CSS CDN with shared config -->
+  <script src="../../css/tailwind.config.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = window.tailwindConfig;</script>
+
+  <style>
+    /* Audio Tabs Navigation Styles */
+    .audio-tabs-container {
+      position: relative;
+      margin-bottom: 1.5rem;
+    }
+
+    /* Scrollable tabs wrapper */
+    .audio-tabs {
+      display: flex;
+      gap: 0.25rem;
+      padding: 0.25rem;
+      background: var(--color-bg-secondary);
+      border: 1px solid var(--color-border-primary);
+      border-radius: 0.75rem;
+      overflow-x: auto;
+      scrollbar-width: none;
+      -ms-overflow-style: none;
+    }
+
+    .audio-tabs::-webkit-scrollbar {
+      display: none;
+    }
+
+    /* Individual tab button/link */
+    .audio-tab {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.625rem 1rem;
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: var(--color-text-secondary);
+      background: transparent;
+      border-radius: 0.5rem;
+      text-decoration: none;
+      white-space: nowrap;
+      transition: all 0.15s ease-out;
+      cursor: pointer;
+      border: none;
+    }
+
+    .audio-tab:hover {
+      color: var(--color-text-primary);
+      background: var(--color-bg-hover);
+    }
+
+    .audio-tab.active {
+      color: var(--color-text-primary);
+      background: var(--color-bg-tertiary);
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    }
+
+    /* Tab icon */
+    .audio-tab svg {
+      width: 1.125rem;
+      height: 1.125rem;
+      flex-shrink: 0;
+    }
+
+    /* Active tab uses solid icon style */
+    .audio-tab.active svg {
+      color: var(--color-accent-blue);
+    }
+
+    /* Optional badge on tabs */
+    .audio-tab-badge {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 1.25rem;
+      height: 1.25rem;
+      padding: 0 0.375rem;
+      font-size: 0.6875rem;
+      font-weight: 600;
+      color: var(--color-accent-blue);
+      background: var(--color-accent-blue-muted);
+      border-radius: 9999px;
+    }
+
+    /* Scroll indicator shadows for mobile */
+    .audio-tabs-container.can-scroll-left::before,
+    .audio-tabs-container.can-scroll-right::after {
+      content: '';
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      width: 2rem;
+      pointer-events: none;
+      z-index: 1;
+    }
+
+    .audio-tabs-container.can-scroll-left::before {
+      left: 0;
+      background: linear-gradient(to right, var(--color-bg-primary) 0%, transparent 100%);
+      border-radius: 0.75rem 0 0 0.75rem;
+    }
+
+    .audio-tabs-container.can-scroll-right::after {
+      right: 0;
+      background: linear-gradient(to left, var(--color-bg-primary) 0%, transparent 100%);
+      border-radius: 0 0.75rem 0.75rem 0;
+    }
+
+    /* Responsive - Pill layout on mobile */
+    @media (max-width: 640px) {
+      .audio-tab {
+        padding: 0.5rem 0.875rem;
+        font-size: 0.8125rem;
+      }
+
+      .audio-tab svg {
+        width: 1rem;
+        height: 1rem;
+      }
+    }
+  </style>
+</head>
+<body class="bg-bg-primary text-text-primary font-sans antialiased min-h-screen">
+
+  <!-- Header -->
+  <header class="bg-bg-secondary border-b border-border-primary sticky top-0 z-10">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+      <div class="flex items-center justify-between">
+        <div class="flex items-center gap-4">
+          <div class="w-10 h-10 rounded-lg bg-accent-blue flex items-center justify-center">
+            <svg class="w-6 h-6 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
+            </svg>
+          </div>
+          <div>
+            <h1 class="text-xl font-bold text-text-primary">Audio Tabs Navigation</h1>
+            <p class="text-sm text-text-secondary">Issue #926 - Unified header for Soundboard & Audio Settings</p>
+          </div>
+        </div>
+        <a href="../../component-showcase.html" class="px-3 py-1.5 text-sm font-medium text-accent-blue hover:text-accent-blue-hover transition-colors">
+          Back to Components
+        </a>
+      </div>
+    </div>
+  </header>
+
+  <!-- Main Content -->
+  <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+
+    <!-- About Section -->
+    <section class="mb-8">
+      <div class="bg-bg-secondary border border-border-primary rounded-lg p-6">
+        <h2 class="text-lg font-semibold text-text-primary mb-2">Audio Tabs Navigation Component</h2>
+        <p class="text-text-secondary mb-4">
+          This prototype demonstrates a unified tab navigation header for the Soundboard and Audio Settings pages.
+          The pattern follows the existing <code class="px-1.5 py-0.5 bg-bg-tertiary rounded text-accent-blue font-mono text-sm">_PerformanceTabs.cshtml</code> component style.
+        </p>
+        <div class="flex flex-wrap gap-2">
+          <span class="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium bg-info-bg text-info border border-info-border rounded-full">
+            2 Tabs
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium bg-success-bg text-success border border-success-border rounded-full">
+            Responsive
+          </span>
+          <span class="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium bg-accent-orange-muted text-accent-orange border border-accent-orange/30 rounded-full">
+            Accessible
+          </span>
+        </div>
+      </div>
+    </section>
+
+    <!-- Demo: Soundboard Page Context -->
+    <section class="mb-12">
+      <h2 class="text-lg font-semibold text-text-primary mb-4">Soundboard Page (Active)</h2>
+      <div class="bg-bg-tertiary border border-border-primary rounded-lg p-6">
+        <!-- Breadcrumb -->
+        <nav class="text-sm text-text-secondary mb-4" aria-label="Breadcrumb">
+          <ol class="flex items-center gap-2">
+            <li><span class="hover:text-text-primary">Home</span></li>
+            <li aria-hidden="true">
+              <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+              </svg>
+            </li>
+            <li><span class="hover:text-text-primary">Servers</span></li>
+            <li aria-hidden="true">
+              <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+              </svg>
+            </li>
+            <li><span class="hover:text-text-primary">My Server</span></li>
+            <li aria-hidden="true">
+              <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+              </svg>
+            </li>
+            <li class="text-text-primary font-medium" aria-current="page">Audio</li>
+          </ol>
+        </nav>
+
+        <!-- Page Title -->
+        <div class="mb-6">
+          <h1 class="text-2xl font-bold text-text-primary">Audio</h1>
+          <p class="text-sm text-text-secondary mt-1">Manage audio settings and soundboard for My Server</p>
+        </div>
+
+        <!-- Audio Tabs Navigation -->
+        <div class="audio-tabs-container" id="audioTabsContainer1">
+          <nav class="audio-tabs" role="tablist" aria-label="Audio sections">
+            <a href="#soundboard" class="audio-tab active" role="tab" aria-selected="true">
+              <!-- Music note icon (solid for active) -->
+              <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z"/>
+              </svg>
+              <span>Soundboard</span>
+              <span class="audio-tab-badge">12</span>
+            </a>
+            <a href="#settings" class="audio-tab" role="tab" aria-selected="false">
+              <!-- Cog icon (outline for inactive) -->
+              <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              </svg>
+              <span>Settings</span>
+            </a>
+          </nav>
+        </div>
+
+        <!-- Placeholder content -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-8 text-center">
+          <p class="text-text-tertiary">Soundboard content would appear here...</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Demo: Audio Settings Page Context -->
+    <section class="mb-12">
+      <h2 class="text-lg font-semibold text-text-primary mb-4">Audio Settings Page (Active)</h2>
+      <div class="bg-bg-tertiary border border-border-primary rounded-lg p-6">
+        <!-- Breadcrumb -->
+        <nav class="text-sm text-text-secondary mb-4" aria-label="Breadcrumb">
+          <ol class="flex items-center gap-2">
+            <li><span class="hover:text-text-primary">Home</span></li>
+            <li aria-hidden="true">
+              <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+              </svg>
+            </li>
+            <li><span class="hover:text-text-primary">Servers</span></li>
+            <li aria-hidden="true">
+              <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+              </svg>
+            </li>
+            <li><span class="hover:text-text-primary">My Server</span></li>
+            <li aria-hidden="true">
+              <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+              </svg>
+            </li>
+            <li class="text-text-primary font-medium" aria-current="page">Audio</li>
+          </ol>
+        </nav>
+
+        <!-- Page Title -->
+        <div class="mb-6">
+          <h1 class="text-2xl font-bold text-text-primary">Audio</h1>
+          <p class="text-sm text-text-secondary mt-1">Manage audio settings and soundboard for My Server</p>
+        </div>
+
+        <!-- Audio Tabs Navigation -->
+        <div class="audio-tabs-container" id="audioTabsContainer2">
+          <nav class="audio-tabs" role="tablist" aria-label="Audio sections">
+            <a href="#soundboard" class="audio-tab" role="tab" aria-selected="false">
+              <!-- Music note icon (outline for inactive) -->
+              <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
+              </svg>
+              <span>Soundboard</span>
+              <span class="audio-tab-badge">12</span>
+            </a>
+            <a href="#settings" class="audio-tab active" role="tab" aria-selected="true">
+              <!-- Cog icon (solid for active) -->
+              <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd" />
+              </svg>
+              <span>Settings</span>
+            </a>
+          </nav>
+        </div>
+
+        <!-- Placeholder content -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-8 text-center">
+          <p class="text-text-tertiary">Audio settings content would appear here...</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Implementation Notes -->
+    <section class="mb-8">
+      <h2 class="text-lg font-semibold text-text-primary mb-4">Implementation Notes</h2>
+      <div class="bg-bg-secondary border border-border-primary rounded-lg p-6 space-y-4">
+        <div>
+          <h3 class="font-medium text-text-primary mb-2">Component Location</h3>
+          <p class="text-text-secondary text-sm">
+            <code class="px-1.5 py-0.5 bg-bg-tertiary rounded text-accent-blue font-mono">Pages/Shared/Components/_AudioTabs.cshtml</code>
+          </p>
+        </div>
+        <div>
+          <h3 class="font-medium text-text-primary mb-2">ViewModel</h3>
+          <p class="text-text-secondary text-sm">
+            <code class="px-1.5 py-0.5 bg-bg-tertiary rounded text-accent-blue font-mono">ViewModels/Components/AudioTabsViewModel.cs</code>
+          </p>
+          <ul class="mt-2 text-sm text-text-secondary space-y-1">
+            <li>- <code class="text-accent-blue">GuildId</code>: Required for building tab URLs</li>
+            <li>- <code class="text-accent-blue">ActiveTab</code>: "soundboard" or "settings"</li>
+            <li>- <code class="text-accent-blue">SoundCount</code>: Optional badge showing number of sounds</li>
+          </ul>
+        </div>
+        <div>
+          <h3 class="font-medium text-text-primary mb-2">Usage</h3>
+          <pre class="bg-bg-tertiary border border-border-secondary rounded p-4 text-sm overflow-x-auto"><code class="text-text-primary">&lt;partial name="Shared/Components/_AudioTabs" model="new AudioTabsViewModel {
+    GuildId = Model.GuildId,
+    ActiveTab = "soundboard",
+    SoundCount = Model.SoundCount
+}" /&gt;</code></pre>
+        </div>
+        <div>
+          <h3 class="font-medium text-text-primary mb-2">Accessibility</h3>
+          <ul class="text-sm text-text-secondary space-y-1">
+            <li>- Uses <code class="text-accent-blue">role="tablist"</code> and <code class="text-accent-blue">role="tab"</code></li>
+            <li>- Proper <code class="text-accent-blue">aria-selected</code> state on active tab</li>
+            <li>- Descriptive <code class="text-accent-blue">aria-label</code> on navigation</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- CSS Reference -->
+    <section class="mb-8">
+      <h2 class="text-lg font-semibold text-text-primary mb-4">CSS Classes Reference</h2>
+      <div class="overflow-x-auto">
+        <table class="w-full bg-bg-secondary border border-border-primary rounded-lg overflow-hidden">
+          <thead>
+            <tr class="bg-bg-tertiary">
+              <th class="px-4 py-3 text-left text-xs font-semibold text-text-secondary uppercase">Class</th>
+              <th class="px-4 py-3 text-left text-xs font-semibold text-text-secondary uppercase">Purpose</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-border-secondary">
+            <tr>
+              <td class="px-4 py-3 font-mono text-sm text-accent-blue">.audio-tabs-container</td>
+              <td class="px-4 py-3 text-sm text-text-secondary">Wrapper with scroll indicators</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-mono text-sm text-accent-blue">.audio-tabs</td>
+              <td class="px-4 py-3 text-sm text-text-secondary">Flex container for tabs with pill background</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-mono text-sm text-accent-blue">.audio-tab</td>
+              <td class="px-4 py-3 text-sm text-text-secondary">Individual tab link/button</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-mono text-sm text-accent-blue">.audio-tab.active</td>
+              <td class="px-4 py-3 text-sm text-text-secondary">Active/selected tab state</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-mono text-sm text-accent-blue">.audio-tab-badge</td>
+              <td class="px-4 py-3 text-sm text-text-secondary">Optional count badge on tab</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/src/DiscordBot.Bot/Pages/Guilds/AudioSettings/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/AudioSettings/Index.cshtml
@@ -2,47 +2,49 @@
 @model DiscordBot.Bot.Pages.Guilds.AudioSettings.IndexModel
 @using DiscordBot.Bot.ViewModels.Components
 @{
-    ViewData["Title"] = "Audio Settings";
+    ViewData["Title"] = $"Audio - {Model.GuildName}";
 }
 
-<!-- Breadcrumb Navigation -->
-<nav class="text-sm text-text-secondary mb-6" aria-label="Breadcrumb">
-    <ol class="flex items-center gap-2">
-        <li><a asp-page="/Index" class="hover:text-text-primary transition-colors">Home</a></li>
-        <li aria-hidden="true">
-            <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-            </svg>
-        </li>
-        <li><a asp-page="/Guilds/Index" class="hover:text-text-primary transition-colors">Servers</a></li>
-        <li aria-hidden="true">
-            <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-            </svg>
-        </li>
-        <li><a asp-page="/Guilds/Details" asp-route-id="@Model.GuildId" class="hover:text-text-primary transition-colors">@Model.GuildName</a></li>
-        <li aria-hidden="true">
-            <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-            </svg>
-        </li>
-        <li class="text-text-primary font-medium" aria-current="page">Audio Settings</li>
-    </ol>
-</nav>
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <!-- Breadcrumb Navigation -->
+    <nav class="text-sm text-text-secondary mb-6" aria-label="Breadcrumb">
+        <ol class="flex items-center gap-2">
+            <li><a asp-page="/Index" class="hover:text-text-primary transition-colors">Home</a></li>
+            <li aria-hidden="true">
+                <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                </svg>
+            </li>
+            <li><a asp-page="/Guilds/Index" class="hover:text-text-primary transition-colors">Servers</a></li>
+            <li aria-hidden="true">
+                <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                </svg>
+            </li>
+            <li><a asp-page="/Guilds/Details" asp-route-id="@Model.GuildId" class="hover:text-text-primary transition-colors">@Model.GuildName</a></li>
+            <li aria-hidden="true">
+                <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                </svg>
+            </li>
+            <li class="text-text-primary font-medium" aria-current="page">Audio</li>
+        </ol>
+    </nav>
 
-<!-- Page Header -->
-<div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
-    <div>
-        <h1 class="text-2xl font-bold text-text-primary">Audio Settings</h1>
-        <p class="text-sm text-text-secondary mt-1">Configure audio and soundboard features for this server</p>
+    <!-- Page Header -->
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+        <div>
+            <h1 class="text-2xl font-bold text-text-primary">Audio</h1>
+            <p class="text-sm text-text-secondary mt-1">Manage audio settings and soundboard for @Model.GuildName</p>
+        </div>
     </div>
-    <a asp-page="/Guilds/Soundboard/Index" asp-route-guildId="@Model.GuildId" class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-text-primary bg-bg-secondary border border-border-primary rounded-lg hover:bg-bg-hover transition-colors">
-        <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
-        </svg>
-        Manage Sounds
-    </a>
-</div>
+
+    <!-- Audio Tabs Navigation -->
+    <partial name="Shared/Components/_AudioTabs" model='new AudioTabsViewModel {
+        GuildId = Model.GuildId,
+        ActiveTab = "settings",
+        SoundCount = Model.SoundCount
+    }' />
 
 <div class="max-w-4xl">
     <!-- General Settings Section -->
@@ -280,6 +282,7 @@
             Reset to Defaults
         </button>
     </div>
+</div>
 </div>
 
 <!-- Hidden form with anti-forgery token -->

--- a/src/DiscordBot.Bot/Pages/Guilds/AudioSettings/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/AudioSettings/Index.cshtml.cs
@@ -16,17 +16,20 @@ public class IndexModel : PageModel
 {
     private readonly IGuildAudioSettingsService _audioSettingsService;
     private readonly IGuildService _guildService;
+    private readonly ISoundService _soundService;
     private readonly DiscordSocketClient _discordClient;
     private readonly ILogger<IndexModel> _logger;
 
     public IndexModel(
         IGuildAudioSettingsService audioSettingsService,
         IGuildService guildService,
+        ISoundService soundService,
         DiscordSocketClient discordClient,
         ILogger<IndexModel> logger)
     {
         _audioSettingsService = audioSettingsService;
         _guildService = guildService;
+        _soundService = soundService;
         _discordClient = discordClient;
         _logger = logger;
     }
@@ -56,6 +59,11 @@ public class IndexModel : PageModel
     /// Gets or sets the sound folder path for display.
     /// </summary>
     public string SoundFolderPath { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the total sound count for display in the AudioTabs component.
+    /// </summary>
+    public int SoundCount { get; set; }
 
     /// <summary>
     /// The soundboard commands that can have role restrictions.
@@ -101,6 +109,9 @@ public class IndexModel : PageModel
 
         // Set the sound folder path for display
         SoundFolderPath = $"/data/sounds/{GuildId}";
+
+        // Load sound count for the AudioTabs badge
+        SoundCount = await _soundService.GetSoundCountAsync(GuildId, cancellationToken);
 
         return Page();
     }

--- a/src/DiscordBot.Bot/Pages/Guilds/Soundboard/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Soundboard/Index.cshtml
@@ -2,7 +2,7 @@
 @model DiscordBot.Bot.Pages.Guilds.Soundboard.IndexModel
 @using DiscordBot.Bot.ViewModels.Components
 @{
-    ViewData["Title"] = $"Soundboard - {Model.ViewModel.GuildName}";
+    ViewData["Title"] = $"Audio - {Model.ViewModel.GuildName}";
 }
 
 <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -34,7 +34,7 @@
                 </svg>
             </li>
             <li>
-                <span class="text-text-primary font-medium">Soundboard</span>
+                <span class="text-text-primary font-medium">Audio</span>
             </li>
         </ol>
     </nav>
@@ -42,10 +42,17 @@
     <!-- Page Header -->
     <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
         <div>
-            <h1 class="text-2xl font-bold text-text-primary">Soundboard</h1>
-            <p class="mt-1 text-sm text-text-secondary">Manage sounds for @Model.ViewModel.GuildName</p>
+            <h1 class="text-2xl font-bold text-text-primary">Audio</h1>
+            <p class="mt-1 text-sm text-text-secondary">Manage audio settings and soundboard for @Model.ViewModel.GuildName</p>
         </div>
     </div>
+
+    <!-- Audio Tabs Navigation -->
+    <partial name="Shared/Components/_AudioTabs" model='new AudioTabsViewModel {
+        GuildId = Model.ViewModel.GuildId,
+        ActiveTab = "soundboard",
+        SoundCount = Model.ViewModel.Stats.TotalSounds
+    }' />
 
     <!-- Success Message -->
     @if (!string.IsNullOrEmpty(Model.SuccessMessage))

--- a/src/DiscordBot.Bot/Pages/Shared/Components/_AudioTabs.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/Components/_AudioTabs.cshtml
@@ -1,0 +1,166 @@
+@model DiscordBot.Bot.ViewModels.Components.AudioTabsViewModel
+@{
+    string GetTabClass(string tab) => Model.ActiveTab == tab ? "audio-tab active" : "audio-tab";
+
+    // Icon paths - outline and solid versions
+    var icons = new Dictionary<string, (string outline, string solid)>
+    {
+        ["soundboard"] = (
+            "M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3",
+            "M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z"
+        ),
+        ["settings"] = (
+            "M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z M15 12a3 3 0 11-6 0 3 3 0 016 0z",
+            "M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z"
+        )
+    };
+}
+
+<div class="audio-tabs-container" id="audioTabsContainer">
+    <nav class="audio-tabs" id="audioTabs" role="tablist" aria-label="Audio sections">
+        <a asp-page="/Guilds/Soundboard/Index" asp-route-guildId="@Model.GuildId" class="@GetTabClass("soundboard")" role="tab" aria-selected="@(Model.ActiveTab == "soundboard" ? "true" : "false")">
+            @if (Model.ActiveTab == "soundboard")
+            {
+                <svg class="tab-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                    <path d="@icons["soundboard"].solid" />
+                </svg>
+            }
+            else
+            {
+                <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@icons["soundboard"].outline" />
+                </svg>
+            }
+            <span>Soundboard</span>
+            @if (Model.SoundCount.HasValue && Model.SoundCount.Value > 0)
+            {
+                <span class="audio-tab-badge">@Model.SoundCount</span>
+            }
+        </a>
+        <a asp-page="/Guilds/AudioSettings/Index" asp-route-guildId="@Model.GuildId" class="@GetTabClass("settings")" role="tab" aria-selected="@(Model.ActiveTab == "settings" ? "true" : "false")">
+            @if (Model.ActiveTab == "settings")
+            {
+                <svg class="tab-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                    <path fill-rule="evenodd" d="@icons["settings"].solid" clip-rule="evenodd" />
+                </svg>
+            }
+            else
+            {
+                <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@icons["settings"].outline" />
+                </svg>
+            }
+            <span>Settings</span>
+        </a>
+    </nav>
+</div>
+
+<style>
+    /* Audio Tabs Navigation Styles */
+    .audio-tabs-container {
+        position: relative;
+        margin-bottom: 1.5rem;
+    }
+
+    .audio-tabs {
+        display: flex;
+        gap: 0.25rem;
+        padding: 0.25rem;
+        background: var(--color-bg-secondary);
+        border: 1px solid var(--color-border-primary);
+        border-radius: 0.75rem;
+        overflow-x: auto;
+        scrollbar-width: none;
+        -ms-overflow-style: none;
+    }
+
+    .audio-tabs::-webkit-scrollbar {
+        display: none;
+    }
+
+    .audio-tab {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.625rem 1rem;
+        font-size: 0.875rem;
+        font-weight: 500;
+        color: var(--color-text-secondary);
+        background: transparent;
+        border-radius: 0.5rem;
+        text-decoration: none;
+        white-space: nowrap;
+        transition: all 0.15s ease-out;
+    }
+
+    .audio-tab:hover {
+        color: var(--color-text-primary);
+        background: var(--color-bg-hover);
+    }
+
+    .audio-tab.active {
+        color: var(--color-text-primary);
+        background: var(--color-bg-tertiary);
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    }
+
+    .audio-tab .tab-icon {
+        width: 1.125rem;
+        height: 1.125rem;
+        flex-shrink: 0;
+    }
+
+    .audio-tab.active .tab-icon {
+        color: var(--color-accent-blue);
+    }
+
+    .audio-tab-badge {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 1.25rem;
+        height: 1.25rem;
+        padding: 0 0.375rem;
+        font-size: 0.6875rem;
+        font-weight: 600;
+        color: var(--color-accent-blue);
+        background: var(--color-accent-blue-muted);
+        border-radius: 9999px;
+    }
+
+    /* Scroll indicator shadows for mobile */
+    .audio-tabs-container.can-scroll-left::before,
+    .audio-tabs-container.can-scroll-right::after {
+        content: '';
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        width: 2rem;
+        pointer-events: none;
+        z-index: 1;
+    }
+
+    .audio-tabs-container.can-scroll-left::before {
+        left: 0;
+        background: linear-gradient(to right, var(--color-bg-primary) 0%, transparent 100%);
+        border-radius: 0.75rem 0 0 0.75rem;
+    }
+
+    .audio-tabs-container.can-scroll-right::after {
+        right: 0;
+        background: linear-gradient(to left, var(--color-bg-primary) 0%, transparent 100%);
+        border-radius: 0 0.75rem 0.75rem 0;
+    }
+
+    @@media (max-width: 640px) {
+        .audio-tab {
+            padding: 0.5rem 0.875rem;
+            font-size: 0.8125rem;
+        }
+
+        .audio-tab .tab-icon {
+            width: 1rem;
+            height: 1rem;
+        }
+    }
+</style>

--- a/src/DiscordBot.Bot/ViewModels/Components/AudioTabsViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Components/AudioTabsViewModel.cs
@@ -1,0 +1,25 @@
+namespace DiscordBot.Bot.ViewModels.Components;
+
+/// <summary>
+/// ViewModel for the Audio pages navigation tabs component.
+/// Used to switch between Soundboard and Audio Settings pages.
+/// </summary>
+public class AudioTabsViewModel
+{
+    /// <summary>
+    /// The guild ID for building navigation URLs.
+    /// </summary>
+    public ulong GuildId { get; set; }
+
+    /// <summary>
+    /// The currently active tab identifier.
+    /// Valid values: "soundboard", "settings"
+    /// </summary>
+    public string ActiveTab { get; set; } = "soundboard";
+
+    /// <summary>
+    /// Optional: Number of sounds to display as a badge on the Soundboard tab.
+    /// Set to null or 0 to hide the badge.
+    /// </summary>
+    public int? SoundCount { get; set; }
+}


### PR DESCRIPTION
## Summary

- Add a shared `_AudioTabs.cshtml` component that provides unified navigation between Soundboard and Audio Settings pages
- Both pages now share a consistent "Audio" header with tab-style navigation following the existing `_PerformanceTabs` pattern
- Active tab is visually indicated with solid icon and highlighted background
- Optional sound count badge on Soundboard tab

## Changes

- **New component**: `Pages/Shared/Components/_AudioTabs.cshtml` with outline/solid icon variants
- **New ViewModel**: `AudioTabsViewModel` (GuildId, ActiveTab, SoundCount)
- **Soundboard page**: Updated breadcrumb to "Audio", added AudioTabs component
- **AudioSettings page**: Updated breadcrumb to "Audio", removed redundant "Manage Sounds" button, added AudioTabs component, loads sound count for badge
- **Prototype**: Added HTML prototype at `docs/prototypes/features/audio-tabs/index.html`

## Test plan

- [ ] Navigate to Soundboard page - verify "Audio" header with Soundboard tab active
- [ ] Click Settings tab - verify navigation to Audio Settings page with Settings tab active
- [ ] Verify sound count badge appears on Soundboard tab when sounds exist
- [ ] Test responsive behavior on mobile
- [ ] Verify breadcrumb shows "Audio" on both pages

Closes #926

---
Generated with [Claude Code](https://claude.ai/code)