### PR TITLE
fix(ui): Center Audio Settings page content

### DIFF
--- a/src/DiscordBot.Bot/Pages/Guilds/AudioSettings/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/AudioSettings/Index.cshtml
@@ -46,7 +46,7 @@
         SoundCount = Model.SoundCount
     }' />
 
-<div class="max-w-4xl">
+<div class="max-w-4xl mx-auto">
     <!-- General Settings Section -->
     <section class="settings-section mb-6">
         <div class="settings-section-header">


### PR DESCRIPTION
## Summary
- Adds `mx-auto` class to the inner `max-w-4xl` container on the Audio Settings page to horizontally center the content
- Makes the page consistent with other admin pages like the Soundboard page

## Test plan
- [ ] Navigate to `/Guilds/AudioSettings/{guildId}`
- [ ] Verify content is horizontally centered on the page
- [ ] Verify responsive behavior at different viewport widths

Closes #929

🤖 Generated with [Claude Code](https://claude.com/claude-code)