### PR TITLE
fix(ui): Add vertical height limit and scroll to sounds table

### DIFF
--- a/src/DiscordBot.Bot/Pages/Guilds/Soundboard/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Soundboard/Index.cshtml
@@ -178,9 +178,9 @@
                 @if (Model.ViewModel.Sounds.Any())
                 {
                     <!-- Sounds Table -->
-                    <div class="overflow-x-auto">
+                    <div class="overflow-x-auto overflow-y-auto max-h-[60vh] scroll-smooth">
                         <table class="w-full">
-                            <thead class="bg-bg-tertiary">
+                            <thead class="bg-bg-tertiary sticky top-0 z-10">
                                 <tr>
                                     <th class="px-4 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider" style="width: 50px;"></th>
                                     <th class="px-4 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Name</th>


### PR DESCRIPTION
## Summary
- Add max-height with viewport-based sizing (60vh) to sounds table container
- Enable vertical scrollbar when content exceeds max-height
- Make table header sticky so it remains visible when scrolling
- Add smooth scrolling behavior for better UX

Closes #932

## Test plan
- [ ] Navigate to Soundboard page with multiple sounds
- [ ] Verify table has max-height and scrollbar appears with many sounds
- [ ] Verify table header stays visible when scrolling
- [ ] Test on different viewport sizes for responsiveness

🤖 Generated with [Claude Code](https://claude.com/claude-code)