### PR TITLE
feat(api): Add sound file download endpoint

### DIFF
--- a/src/DiscordBot.Bot/Controllers/SoundsController.cs
+++ b/src/DiscordBot.Bot/Controllers/SoundsController.cs
@@ -1,0 +1,103 @@
+using DiscordBot.Bot.Extensions;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DiscordBot.Bot.Controllers;
+
+/// <summary>
+/// Controller for soundboard sound operations including file downloads.
+/// </summary>
+[ApiController]
+[Route("api/guilds/{guildId}/sounds")]
+[Authorize(Policy = "RequireViewer")]
+public class SoundsController : ControllerBase
+{
+    private readonly ISoundService _soundService;
+    private readonly ISoundFileService _soundFileService;
+    private readonly ILogger<SoundsController> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SoundsController"/> class.
+    /// </summary>
+    /// <param name="soundService">The sound service for metadata operations.</param>
+    /// <param name="soundFileService">The sound file service for file operations.</param>
+    /// <param name="logger">The logger.</param>
+    public SoundsController(
+        ISoundService soundService,
+        ISoundFileService soundFileService,
+        ILogger<SoundsController> logger)
+    {
+        _soundService = soundService;
+        _soundFileService = soundFileService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Downloads a sound file from the guild's soundboard.
+    /// </summary>
+    /// <param name="guildId">The guild's Discord snowflake ID.</param>
+    /// <param name="soundId">The sound's unique identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The sound file for download.</returns>
+    [HttpGet("{soundId}/download")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DownloadSound(
+        ulong guildId,
+        Guid soundId,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Download sound request for sound {SoundId} in guild {GuildId}", soundId, guildId);
+
+        // Get sound metadata with guild validation
+        var sound = await _soundService.GetByIdAsync(soundId, guildId, cancellationToken);
+        if (sound == null)
+        {
+            _logger.LogWarning("Sound {SoundId} not found in guild {GuildId}", soundId, guildId);
+            return NotFound(new ApiErrorDto
+            {
+                Message = "Sound not found",
+                Detail = "The requested sound does not exist or does not belong to this guild.",
+                StatusCode = StatusCodes.Status404NotFound,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+
+        // Get physical file path
+        var filePath = _soundFileService.GetSoundFilePath(guildId, sound.FileName);
+
+        // Verify file exists on disk
+        if (!_soundFileService.SoundFileExists(guildId, sound.FileName))
+        {
+            _logger.LogError("Sound file missing: {FilePath} for sound {SoundId}", filePath, soundId);
+            return NotFound(new ApiErrorDto
+            {
+                Message = "Sound file not found",
+                Detail = "The sound exists in the database but the file is missing from storage.",
+                StatusCode = StatusCodes.Status404NotFound,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+
+        // Determine MIME type from file extension
+        var extension = Path.GetExtension(sound.FileName).ToLowerInvariant();
+        var contentType = extension switch
+        {
+            ".mp3" => "audio/mpeg",
+            ".wav" => "audio/wav",
+            ".ogg" => "audio/ogg",
+            ".m4a" => "audio/mp4",
+            _ => "application/octet-stream"
+        };
+
+        // Build download filename from sound name
+        var downloadFileName = $"{sound.Name}{extension}";
+
+        _logger.LogInformation("Serving sound file {FileName} as {DownloadFileName}", sound.FileName, downloadFileName);
+
+        // Return file with range request support for audio playback
+        return PhysicalFile(filePath, contentType, downloadFileName, enableRangeProcessing: true);
+    }
+}

--- a/src/DiscordBot.Bot/Pages/Guilds/Soundboard/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Soundboard/Index.cshtml
@@ -487,11 +487,10 @@
             }
         });
 
-        // Download sound (placeholder - would need API endpoint)
+        // Download sound
         function downloadSound(soundId, fileName) {
-            // For now, just close the menu - actual download would need an API endpoint
             document.querySelectorAll('[id^="menu-"]').forEach(m => m.classList.add('hidden'));
-            alert('Download feature coming soon. File: ' + fileName);
+            window.location.href = `/api/guilds/${window.guildId}/sounds/${soundId}/download`;
         }
 
         // File upload handling


### PR DESCRIPTION
## Summary
- Implements sound file download functionality for the soundboard admin UI
- Creates new `SoundsController` with download endpoint
- Updates frontend to use the new API instead of showing placeholder alert

## Test plan
- [ ] Navigate to Soundboard page (`/Guilds/Soundboard/{guildId}`)
- [ ] Click 3-dot menu on any sound
- [ ] Click "Download" button
- [ ] Verify file downloads with correct name (sound display name, not GUID)
- [ ] Verify correct Content-Type header for audio files

Closes #931

🤖 Generated with [Claude Code](https://claude.com/claude-code)