### PR TITLE
fix(ui): Hide AudioSettings toast on page load

### DIFF
--- a/src/DiscordBot.Bot/Pages/Guilds/AudioSettings/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/AudioSettings/Index.cshtml
@@ -595,12 +595,12 @@
             flex-shrink: 0;
         }
 
-        /* Toast Styles */
+        /* Toast Styles - Override global toast animation */
         .toast {
             position: fixed;
             bottom: 1.5rem;
             right: 1.5rem;
-            display: flex;
+            display: none;
             align-items: center;
             gap: 0.75rem;
             padding: 1rem 1.25rem;
@@ -609,14 +609,39 @@
             border-radius: 0.5rem;
             box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
             z-index: 100;
-            transform: translateY(100%);
-            opacity: 0;
-            transition: transform 0.3s, opacity 0.3s;
+            animation: none;
         }
 
         .toast.show {
-            transform: translateY(0);
-            opacity: 1;
+            display: flex;
+            animation: slideUp 0.3s ease-out forwards;
+        }
+
+        @@keyframes slideUp {
+            from {
+                transform: translateY(100%);
+                opacity: 0;
+            }
+            to {
+                transform: translateY(0);
+                opacity: 1;
+            }
+        }
+
+        .toast.dismissing {
+            display: flex;
+            animation: slideDown 0.3s ease-in forwards;
+        }
+
+        @@keyframes slideDown {
+            from {
+                transform: translateY(0);
+                opacity: 1;
+            }
+            to {
+                transform: translateY(100%);
+                opacity: 0;
+            }
         }
 
         .toast-success {
@@ -745,12 +770,17 @@
                 document.getElementById('toastTitle').textContent = title;
                 document.getElementById('toastMessage').textContent = message;
 
-                toast.classList.remove('toast-success', 'toast-error');
+                toast.classList.remove('toast-success', 'toast-error', 'dismissing');
                 toast.classList.add(isError ? 'toast-error' : 'toast-success');
                 toast.classList.add('show');
 
                 setTimeout(() => {
+                    toast.classList.add('dismissing');
                     toast.classList.remove('show');
+                    // Remove dismissing class after animation completes
+                    setTimeout(() => {
+                        toast.classList.remove('dismissing');
+                    }, 300);
                 }, 3000);
             },
 


### PR DESCRIPTION
## Summary
- Fix toast notification appearing immediately on page load in Audio Settings
- Override global toast CSS animation that was making the toast visible by default
- Add smooth slide-up/slide-down animations for show/dismiss transitions

## Root Cause
The global `site.css` defines a `.toast` class with `animation: slideInRight` that runs immediately on page load. The page-specific CSS tried to hide the toast using `transform` and `opacity`, but animations override static styles, causing the toast to be visible.

## Solution
- Changed `.toast` to use `display: none` initially (more robust than transform/opacity)
- Added `animation: none` to override the global slideInRight animation
- Created custom `slideUp` keyframe animation for `.toast.show`
- Added `.toast.dismissing` state with `slideDown` animation for smooth dismiss

## Test plan
- [ ] Navigate to Audio Settings page - toast should NOT appear
- [ ] Click "Save General Settings" - toast should appear, animate up
- [ ] Toast should auto-dismiss after 3 seconds with slide-down animation
- [ ] Verify toast works correctly for error states (validation failures)

Closes #956

🤖 Generated with [Claude Code](https://claude.com/claude-code)