### PR TITLE
fix(ui): Add user preview popups to Rat Watch Analytics leaderboard tabs

### DIFF
--- a/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Analytics.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Analytics.cshtml
@@ -508,7 +508,10 @@
                                         <span class="inline-flex items-center justify-center w-8 h-8 rounded-full @rankBadgeClass font-bold text-sm">@rank</span>
                                     </td>
                                     <td class="px-5 py-4">
-                                        <p class="font-medium text-text-primary">@user.Username</p>
+                                        <span class="preview-trigger font-medium text-text-primary"
+                                              data-preview-type="user"
+                                              data-user-id="@user.UserId"
+                                              data-context-guild-id="@Model.ViewModel.GuildId">@user.Username</span>
                                     </td>
                                     <td class="px-5 py-4 text-text-primary font-medium">@user.WatchesAgainst</td>
                                     <td class="px-5 py-4">
@@ -562,7 +565,10 @@
                                         <span class="inline-flex items-center justify-center w-8 h-8 rounded-full @rankBadgeClass font-bold text-sm">@rank</span>
                                     </td>
                                     <td class="px-5 py-4">
-                                        <p class="font-medium text-text-primary">@accuser.Username</p>
+                                        <span class="preview-trigger font-medium text-text-primary"
+                                              data-preview-type="user"
+                                              data-user-id="@accuser.UserId"
+                                              data-context-guild-id="@Model.ViewModel.GuildId">@accuser.Username</span>
                                     </td>
                                     <td class="px-5 py-4 text-text-primary font-medium">@accuser.WatchesCreated</td>
                                     <td class="px-5 py-4">
@@ -624,7 +630,10 @@
                                         <span class="inline-flex items-center justify-center w-8 h-8 rounded-full @rankBadgeClass font-bold text-sm">@rank</span>
                                     </td>
                                     <td class="px-5 py-4">
-                                        <p class="font-medium text-text-primary">@user.Username</p>
+                                        <span class="preview-trigger font-medium text-text-primary"
+                                              data-preview-type="user"
+                                              data-user-id="@user.UserId"
+                                              data-context-guild-id="@Model.ViewModel.GuildId">@user.Username</span>
                                     </td>
                                     <td class="px-5 py-4">
                                         <span class="inline-flex items-center px-2.5 py-0.5 text-xs font-semibold text-error bg-error/10 rounded-full">


### PR DESCRIPTION
## Summary
- Add preview-trigger class and data attributes to user names in the "Most Watched" leaderboard tab
- Add preview-trigger class and data attributes to user names in the "Top Accusers" leaderboard tab
- Add preview-trigger class and data attributes to user names in the "Biggest Rats" leaderboard tab

## Test plan
- [ ] Navigate to `/Guilds/RatWatch/{guildId}/Analytics`
- [ ] Hover over a username in the "Most Watched" tab - verify preview popup appears
- [ ] Hover over a username in the "Top Accusers" tab - verify preview popup appears
- [ ] Hover over a username in the "Biggest Rats" tab - verify preview popup appears
- [ ] Verify user IDs are passed as strings (inspect element) to preserve Discord snowflake precision

Closes #963

🤖 Generated with [Claude Code](https://claude.ai/code)