### PR TITLE
fix(ui): Remove extra quotes from guild ID in user preview popup

### DIFF
--- a/src/DiscordBot.Bot/Pages/CommandLogs/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/CommandLogs/Index.cshtml
@@ -262,7 +262,7 @@
                                 </td>
                                 <!-- User -->
                                 <td class="px-6 py-4 text-text-secondary text-sm">
-                                    <span class="preview-trigger" data-preview-type="user" data-user-id="@log.UserId" @(log.GuildId.HasValue ? $"data-context-guild-id=\"{log.GuildId}\"" : "")>@log.Username</span>
+                                    <span class="preview-trigger" data-preview-type="user" data-user-id="@log.UserId" data-context-guild-id="@log.GuildId">@log.Username</span>
                                 </td>
                                 <!-- Duration (xl screens only) -->
                                 <td class="px-6 py-4 text-text-secondary text-sm hidden xl:table-cell">
@@ -369,7 +369,7 @@
                         </div>
                         <div>
                             <span class="text-text-tertiary">User:</span>
-                            <span class="text-text-primary ml-1 preview-trigger" data-preview-type="user" data-user-id="@log.UserId" @(log.GuildId.HasValue ? $"data-context-guild-id=\"{log.GuildId}\"" : "")>@log.Username</span>
+                            <span class="text-text-primary ml-1 preview-trigger" data-preview-type="user" data-user-id="@log.UserId" data-context-guild-id="@log.GuildId">@log.Username</span>
                         </div>
                         <div>
                             <span class="text-text-tertiary">Duration:</span>


### PR DESCRIPTION
## Summary
- Fixed user preview popups failing on CommandLogs page with "Invalid guild ID format" error
- Changed from manual Razor conditional expression to direct attribute binding for proper null handling
- Fixed both desktop table (line 265) and mobile card (line 372) user preview triggers

## Root Cause
The guild ID was being rendered with escaped quotes, producing `data-context-guild-id=""1245799202873802772""` instead of `data-context-guild-id="1245799202873802772"`.

## Test plan
- [ ] Navigate to CommandLogs page
- [ ] Hover over a username to trigger user preview popup
- [ ] Verify preview loads without "Invalid guild ID format" error
- [ ] Test on both desktop and mobile layouts

Closes #962

🤖 Generated with [Claude Code](https://claude.com/claude-code)