### PR TITLE
fix(ui): Add user preview popups to Guild Details command activity

### DIFF
--- a/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml
@@ -661,7 +661,7 @@
                                     <span class="text-sm font-medium text-text-primary font-mono">/@cmd.CommandName</span>
                                 </td>
                                 <td class="px-6 py-4 whitespace-nowrap text-sm text-text-secondary">
-                                    @cmd.Username
+                                    <span class="preview-trigger" data-preview-type="user" data-user-id="@cmd.UserId" data-context-guild-id="@guild.Id">@cmd.Username</span>
                                 </td>
                                 <td class="px-6 py-4 whitespace-nowrap text-sm text-text-secondary">
                                     <span data-utc="@cmd.ExecutedAtUtcIso" data-format="datetime-short">
@@ -708,7 +708,7 @@
                         <div class="space-y-1 text-sm">
                             <div class="flex justify-between">
                                 <span class="text-text-tertiary">User:</span>
-                                <span class="text-text-secondary">@cmd.Username</span>
+                                <span class="text-text-secondary preview-trigger" data-preview-type="user" data-user-id="@cmd.UserId" data-context-guild-id="@guild.Id">@cmd.Username</span>
                             </div>
                             <div class="flex justify-between">
                                 <span class="text-text-tertiary">Time:</span>

--- a/src/DiscordBot.Bot/ViewModels/Pages/GuildDetailViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Pages/GuildDetailViewModel.cs
@@ -98,6 +98,11 @@ public record RecentCommandLogItem
     public Guid Id { get; init; }
 
     /// <summary>
+    /// Gets the Discord user ID of the user who executed the command.
+    /// </summary>
+    public ulong UserId { get; init; }
+
+    /// <summary>
     /// Gets the username of the user who executed the command.
     /// </summary>
     public string Username { get; init; } = string.Empty;
@@ -142,6 +147,7 @@ public record RecentCommandLogItem
         return new RecentCommandLogItem
         {
             Id = dto.Id,
+            UserId = dto.UserId,
             Username = dto.Username ?? "Unknown",
             CommandName = dto.CommandName,
             ExecutedAt = dto.ExecutedAt,


### PR DESCRIPTION
## Summary
- Added `UserId` property to `RecentCommandLogItem` record in `GuildDetailViewModel.cs`
- Updated `FromDto` method to map `UserId` from `CommandLogDto`
- Added `preview-trigger` class and data attributes to username spans in both desktop table and mobile card layouts

## Test plan
- [ ] Navigate to Guild Details page (`/Guilds/Details?id={guildId}`)
- [ ] Scroll to "Recent Command Activity" section
- [ ] Hover over a username in the desktop table - verify popup appears
- [ ] On mobile view, hover/tap on a username - verify popup appears
- [ ] Verify popup shows correct user information with guild context

Closes #959

🤖 Generated with [Claude Code](https://claude.com/claude-code)