### PR TITLE
fix(ui): Consolidate Soundboard and Audio Settings links in Guild Details

### DIFF
--- a/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml
@@ -165,16 +165,7 @@
                                     <svg class="w-5 h-5 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
                                     </svg>
-                                    Soundboard
-                                </a>
-
-                                <a asp-page="AudioSettings/Index" asp-route-guildId="@guild.Id"
-                                   class="flex items-center gap-3 px-4 py-2.5 text-sm text-text-primary hover:bg-bg-hover transition-colors">
-                                    <svg class="w-5 h-5 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                                    </svg>
-                                    Audio Settings
+                                    Audio
                                 </a>
 
                                 <div class="border-t border-border-primary my-1"></div>


### PR DESCRIPTION
## Summary
- Replaces separate "Soundboard" and "Audio Settings" menu items in the Guild Details "More Actions" dropdown with a single "Audio" link
- Links to the Soundboard page which serves as the primary audio tab
- Users can navigate to Audio Settings via the tab navigation component once on the Audio pages

## Test plan
- [ ] Navigate to Guild Details page
- [ ] Open the "More Actions" dropdown
- [ ] Verify there is a single "Audio" link with the music note icon
- [ ] Click the Audio link and verify it navigates to the Soundboard page
- [ ] Verify the tab navigation allows switching to Audio Settings

Closes #965

🤖 Generated with [Claude Code](https://claude.com/claude-code)