### PR TITLE
feat(a11y): Add keyboard navigation and mobile responsiveness to Guild Details tabs

### DIFF
--- a/src/DiscordBot.Bot/wwwroot/css/tab-panel.css
+++ b/src/DiscordBot.Bot/wwwroot/css/tab-panel.css
@@ -60,7 +60,10 @@
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    /* Desktop: comfortable padding */
     padding: 0.75rem 1rem;
+    /* Ensure minimum touch target height of 44px */
+    min-height: 2.75rem; /* 44px */
     font-size: 0.875rem;
     font-weight: 500;
     color: var(--color-text-secondary);
@@ -74,6 +77,9 @@
     scroll-snap-align: start;
     flex-shrink: 0;
     text-decoration: none;
+    /* Improve touch handling */
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
 }
 
 .tab-panel-tab:hover:not(.active):not(.disabled):not([aria-disabled="true"]) {
@@ -113,15 +119,18 @@
     display: none;
 }
 
+/* Mobile: Maintain 44px touch targets while optimizing space */
 @media (max-width: 640px) {
     .tab-panel-tab {
-        padding: 0.625rem 0.75rem;
+        /* Wider horizontal padding for touch targets, maintain min-height for 44px target */
+        padding: 0.75rem 0.875rem;
+        min-height: 2.75rem; /* 44px - consistent with desktop */
         font-size: 0.8125rem;
     }
 
     .tab-panel-tab .tab-icon {
-        width: 1rem;
-        height: 1rem;
+        width: 1.125rem;
+        height: 1.125rem;
     }
 
     .tab-panel-tab .tab-label-long {
@@ -130,6 +139,17 @@
 
     .tab-panel-tab .tab-label-short {
         display: inline;
+    }
+}
+
+/* Extra small screens (320px+) - icon-only mode if needed */
+@media (max-width: 400px) {
+    .tab-panel-tabs {
+        gap: 0.125rem;
+    }
+
+    .tab-panel-tab {
+        padding: 0.75rem 0.75rem;
     }
 }
 


### PR DESCRIPTION
## Summary

- Ensures 44x44px minimum touch targets for WCAG 2.5.5 compliance
- Adds aria-live region for screen reader announcements on tab changes
- Improves Enter/Space key handling to explicitly activate tabs
- Adds `setLoading()` API for announcing loading states to screen readers
- Mobile-responsive styling with extra small screen (320px+) support

## Acceptance Criteria

### Keyboard Navigation
- [x] Arrow keys (Left/Right) navigate between tabs
- [x] Enter and Space activate the focused tab
- [x] Tab key moves focus into/out of the tablist
- [x] Focus ring is visible on keyboard navigation
- [x] First tab receives focus when entering tablist via Tab key

### Screen Reader Support
- [x] All ARIA attributes properly set (`role="tablist"`, `role="tab"`, `role="tabpanel"`, `aria-selected`, `aria-controls`, `aria-labelledby`)
- [x] Tab panels have appropriate labels
- [x] Loading states announced to screen readers (use `aria-live="polite"`)

### Mobile Responsiveness
- [x] Tabs remain usable on small screens (320px+)
- [x] Horizontal scroll with fade indicators if tabs overflow
- [x] Touch-friendly tap targets (min 44x44px)
- [x] Active tab scrolls into view when selected

## Changes Made

### CSS (`tab-panel.css`)
- Added `min-height: 2.75rem` (44px) to tabs for touch target compliance
- Added `touch-action: manipulation` for better mobile touch handling
- Added `-webkit-tap-highlight-color: transparent` for cleaner touch feedback
- Improved mobile breakpoint styling with slightly larger icons
- Added extra small screen (400px) breakpoint with tighter spacing

### JavaScript (`tab-panel.js`)
- Added `liveRegion` creation for screen reader announcements
- Added `announce()` method for aria-live announcements
- Tab changes now announce `"{tab label} tab selected"` to screen readers
- Enter/Space key now explicitly activates tabs in in-page mode
- Added `setLoading()` API for loading state announcements

## Test Plan

- [ ] Test with keyboard only (no mouse) - verify arrow navigation and Enter/Space activation
- [ ] Test with VoiceOver (Mac), NVDA, or JAWS - verify tab change announcements
- [ ] Test on mobile Safari and Chrome - verify touch targets feel natural
- [ ] Test at various viewport widths (320px, 375px, 768px, 1024px) - verify responsive behavior

Closes #980

---
Generated with [Claude Code](https://claude.ai/code)