### PR TITLE
fix(ui): Prevent button text wrapping in preview popups

### DIFF
--- a/src/DiscordBot.Bot/wwwroot/js/preview-popup.js
+++ b/src/DiscordBot.Bot/wwwroot/js/preview-popup.js
@@ -292,9 +292,9 @@ const PreviewPopup = (() => {
 
         const modHistoryUrl = guildId ? `/Guilds/${guildId}/Members/${data.userId}/Moderation` : null;
         const modHistoryHtml = modHistoryUrl
-            ? `<a href="${modHistoryUrl}" class="flex-1 px-3 py-1.5 text-xs font-medium text-text-secondary bg-bg-tertiary border border-border-primary rounded hover:bg-bg-hover transition-colors text-center inline-flex items-center justify-center gap-1">
+            ? `<a href="${modHistoryUrl}" class="flex-1 min-w-0 px-3 py-1.5 text-xs font-medium text-text-secondary bg-bg-tertiary border border-border-primary rounded hover:bg-bg-hover transition-colors text-center inline-flex items-center justify-center gap-1 whitespace-nowrap">
                    Mod History
-                   ${data.hasActiveModeration ? '<span class="w-1.5 h-1.5 bg-warning rounded-full" title="Active case"></span>' : ''}
+                   ${data.hasActiveModeration ? '<span class="w-1.5 h-1.5 bg-warning rounded-full flex-shrink-0" title="Active case"></span>' : ''}
                </a>`
             : '';
 
@@ -313,7 +313,7 @@ const PreviewPopup = (() => {
                 </div>
             </div>
             <div class="preview-footer flex gap-2 p-3 border-t border-border-secondary bg-bg-secondary">
-                <a href="${profileUrl}" class="flex-1 px-3 py-1.5 text-xs font-medium text-white bg-accent-blue rounded hover:bg-accent-blue-hover transition-colors text-center">
+                <a href="${profileUrl}" class="flex-1 min-w-0 px-3 py-1.5 text-xs font-medium text-white bg-accent-blue rounded hover:bg-accent-blue-hover transition-colors text-center whitespace-nowrap">
                     View Profile
                 </a>
                 ${modHistoryHtml}
@@ -385,10 +385,10 @@ const PreviewPopup = (() => {
                 </div>
             </div>
             <div class="preview-footer flex gap-2 p-3 border-t border-border-secondary bg-bg-secondary">
-                <a href="/Guilds/Details?id=${data.guildId}" class="flex-1 px-3 py-1.5 text-xs font-medium text-white bg-accent-blue rounded hover:bg-accent-blue-hover transition-colors text-center">
+                <a href="/Guilds/Details?id=${data.guildId}" class="flex-1 min-w-0 px-3 py-1.5 text-xs font-medium text-white bg-accent-blue rounded hover:bg-accent-blue-hover transition-colors text-center whitespace-nowrap">
                     View Guild
                 </a>
-                <a href="/Guilds/Edit/${data.guildId}" class="flex-1 px-3 py-1.5 text-xs font-medium text-text-secondary bg-bg-tertiary border border-border-primary rounded hover:bg-bg-hover transition-colors text-center">
+                <a href="/Guilds/Edit/${data.guildId}" class="flex-1 min-w-0 px-3 py-1.5 text-xs font-medium text-text-secondary bg-bg-tertiary border border-border-primary rounded hover:bg-bg-hover transition-colors text-center whitespace-nowrap">
                     Settings
                 </a>
             </div>


### PR DESCRIPTION
## Summary
- Add `whitespace-nowrap` and `min-w-0` classes to footer buttons in user and guild preview popups
- Prevents button text (like "Mod History") from wrapping to multiple lines when popup width is constrained
- Also added `flex-shrink-0` to the moderation warning indicator dot

## Test plan
- [ ] Hover over usernames to trigger user preview popup - verify "View Profile" and "Mod History" buttons stay on single lines
- [ ] Hover over guild names to trigger guild preview popup - verify "View Guild" and "Settings" buttons stay on single lines
- [ ] Test with narrow viewport/popup width to ensure buttons truncate with ellipsis rather than wrap

Fixes #974

🤖 Generated with [Claude Code](https://claude.com/claude-code)