### PR TITLE
feat(portal): Add sound grid search improvements and fix API endpoints

### DIFF
--- a/src/DiscordBot.Bot/Controllers/PortalSoundboardController.cs
+++ b/src/DiscordBot.Bot/Controllers/PortalSoundboardController.cs
@@ -489,6 +489,37 @@ public class PortalSoundboardController : ControllerBase
     }
 
     /// <summary>
+    /// Stops the currently playing sound in the guild.
+    /// </summary>
+    /// <param name="guildId">The guild's Discord snowflake ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Success status.</returns>
+    [HttpPost("stop")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> StopPlayback(ulong guildId, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Stop playback request for guild {GuildId}", guildId);
+
+        if (!_audioService.IsConnected(guildId))
+        {
+            _logger.LogDebug("Not connected to voice in guild {GuildId}", guildId);
+            return BadRequest(new ApiErrorDto
+            {
+                Message = "Not connected to voice",
+                Detail = "The bot is not currently connected to a voice channel in this guild.",
+                StatusCode = StatusCodes.Status400BadRequest,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+
+        await _playbackService.StopAsync(guildId, cancellationToken);
+
+        _logger.LogInformation("Successfully stopped playback in guild {GuildId}", guildId);
+        return Ok(new { Message = "Playback stopped" });
+    }
+
+    /// <summary>
     /// Gets the bot's current connection status and now playing information.
     /// </summary>
     /// <param name="guildId">The guild's Discord snowflake ID.</param>

--- a/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml
@@ -420,6 +420,34 @@
         color: #949ba4;
     }
 
+    .search-input-wrapper {
+        position: relative;
+        flex: 1;
+    }
+
+    .search-clear-btn {
+        position: absolute;
+        right: 0.75rem;
+        top: 50%;
+        transform: translateY(-50%);
+        background: transparent;
+        border: none;
+        cursor: pointer;
+        padding: 0.25rem;
+        color: #949ba4;
+        display: none;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .search-clear-btn:hover {
+        color: #dbdee1;
+    }
+
+    .search-clear-btn.visible {
+        display: flex;
+    }
+
     /* Sound Grid */
     .sound-grid {
         display: grid;
@@ -740,7 +768,12 @@
                     <svg class="search-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
                     </svg>
-                    <input type="text" id="searchInput" class="search-input" placeholder="Search sounds...">
+                    <input type="text" id="searchInput" class="search-input" placeholder="Search sounds..." style="padding-right: 2.5rem;">
+                    <button type="button" id="searchClearBtn" class="search-clear-btn" title="Clear search">
+                        <svg style="width: 16px; height: 16px;" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                        </svg>
+                    </button>
                 </div>
 
                 <!-- Sound Grid -->
@@ -792,6 +825,7 @@
         let currentlyPlaying = null;
         let isConnected = @Model.IsConnected.ToString().ToLower();
         let selectedChannel = '@(Model.CurrentChannelId?.ToString() ?? "")';
+        let searchDebounceTimer = null;
 
         // Initialize
         document.addEventListener('DOMContentLoaded', function() {
@@ -833,8 +867,31 @@
 
         // Setup event handlers
         function setupEventHandlers() {
-            // Search functionality
-            document.getElementById('searchInput').addEventListener('input', filterSounds);
+            // Search functionality with debounce
+            const searchInput = document.getElementById('searchInput');
+            const clearBtn = document.getElementById('searchClearBtn');
+
+            searchInput.addEventListener('input', function() {
+                // Update clear button visibility
+                clearBtn.classList.toggle('visible', this.value.length > 0);
+
+                // Debounce search (150ms)
+                clearTimeout(searchDebounceTimer);
+                if (this.value === '') {
+                    // Immediate clear when emptied
+                    filterSounds();
+                } else {
+                    searchDebounceTimer = setTimeout(filterSounds, 150);
+                }
+            });
+
+            // Clear search button
+            clearBtn.addEventListener('click', function() {
+                searchInput.value = '';
+                clearBtn.classList.remove('visible');
+                filterSounds();
+                searchInput.focus();
+            });
 
             // Channel select
             document.getElementById('channelSelect').addEventListener('change', function() {
@@ -1006,8 +1063,8 @@
                 return;
             }
 
-            // Call API to join channel
-            fetch(`/api/portal/soundboard/${window.guildId}/join`, {
+            // Call API to join channel (POST /channel)
+            fetch(`/api/portal/soundboard/${window.guildId}/channel`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json'
@@ -1039,9 +1096,9 @@
         }
 
         function leaveChannel() {
-            // Call API to leave channel
-            fetch(`/api/portal/soundboard/${window.guildId}/leave`, {
-                method: 'POST',
+            // Call API to leave channel (DELETE /channel)
+            fetch(`/api/portal/soundboard/${window.guildId}/channel`, {
+                method: 'DELETE',
                 headers: {
                     'Content-Type': 'application/json'
                 }
@@ -1109,8 +1166,6 @@
         }
 
         function handleFiles(files) {
-            const formData = new FormData();
-
             for (const file of files) {
                 // Validate file type
                 const validTypes = ['audio/mpeg', 'audio/wav', 'audio/ogg', 'audio/mp3'];
@@ -1126,28 +1181,33 @@
                     continue;
                 }
 
-                formData.append('file', file);
-            }
+                // Derive sound name from file name (without extension)
+                const soundName = file.name.replace(/\.[^/.]+$/, '');
 
-            // Upload file
-            fetch(`/api/portal/soundboard/${window.guildId}/upload`, {
-                method: 'POST',
-                body: formData
-            })
-            .then(response => {
-                if (!response.ok) {
-                    throw new Error('Upload failed');
-                }
-                return response.json();
-            })
-            .then(data => {
-                alert('Upload successful! Reloading page...');
-                location.reload();
-            })
-            .catch(error => {
-                console.error('Error uploading file:', error);
-                alert('Failed to upload file. Please try again.');
-            });
+                const formData = new FormData();
+                formData.append('file', file);
+                formData.append('name', soundName);
+
+                // Upload file (POST /sounds)
+                fetch(`/api/portal/soundboard/${window.guildId}/sounds`, {
+                    method: 'POST',
+                    body: formData
+                })
+                .then(response => {
+                    if (!response.ok) {
+                        throw new Error('Upload failed');
+                    }
+                    return response.json();
+                })
+                .then(data => {
+                    alert('Upload successful! Reloading page...');
+                    location.reload();
+                })
+                .catch(error => {
+                    console.error('Error uploading file:', error);
+                    alert('Failed to upload file. Please try again.');
+                });
+            }
 
             // Reset file input
             document.getElementById('fileInput').value = '';


### PR DESCRIPTION
## Summary

- Add stop playback API endpoint (POST /api/portal/soundboard/{guildId}/stop)
- Fix JavaScript API calls to match controller routes
- Add 150ms debounced search for better performance
- Add search clear button with X icon

## Changes

### API
- Added `POST /stop` endpoint to `PortalSoundboardController` to stop audio playback

### JavaScript
- Fixed join channel call: `POST /channel` (was `/join`)
- Fixed leave channel call: `DELETE /channel` (was `/leave`) 
- Fixed upload call: `POST /sounds` with required `name` parameter (was `/upload`)
- Added 150ms debounce on search input for performance
- Added clear button (X) that appears when search has text
- Sound name is derived from filename during upload

## Test plan

- [ ] Search sounds - verify debounce works (no flicker during typing)
- [ ] Click clear button - verify search resets and clear button hides
- [ ] Join voice channel - verify bot connects
- [ ] Leave voice channel - verify bot disconnects
- [ ] Play sound - verify playback starts and "Now Playing" shows
- [ ] Stop playback - verify sound stops
- [ ] Upload sound - verify file uploads with correct name

Closes #952

🤖 Generated with [Claude Code](https://claude.com/claude-code)