### PR TITLE
feat(portal): Add unauthenticated landing page for soundboard portal

### DIFF
--- a/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml
@@ -1,10 +1,260 @@
 @page "{guildId:long}"
 @model DiscordBot.Bot.Pages.Portal.Soundboard.IndexModel
 @{
-    ViewData["Title"] = "Soundboard";
+    ViewData["Title"] = Model.IsAuthenticated ? "Soundboard" : "Verify Your Membership";
 }
 
 <style>
+    /* ===============================================
+       Landing Page Styles (Unauthenticated View)
+       =============================================== */
+    .landing-container {
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 1rem;
+        background-color: #1d2022;
+    }
+
+    .landing-card {
+        width: 100%;
+        max-width: 480px;
+        background-color: #262a2d;
+        border: 1px solid #3f4447;
+        border-radius: 0.5rem;
+        padding: 2.5rem 2rem;
+        text-align: center;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    }
+
+    .landing-guild-icon {
+        width: 120px;
+        height: 120px;
+        margin: 0 auto 1.5rem;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border: 2px solid #3f4447;
+        box-shadow: 0 4px 12px rgba(203, 78, 27, 0.3);
+        overflow: hidden;
+        background: linear-gradient(135deg, #cb4e1b 0%, #e5591f 100%);
+    }
+
+    .landing-guild-icon img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+    }
+
+    .landing-guild-icon-placeholder {
+        font-size: 3rem;
+        color: white;
+    }
+
+    .landing-guild-name {
+        font-size: 1.75rem;
+        font-weight: 600;
+        color: #dbdee1;
+        margin-bottom: 0.5rem;
+        word-wrap: break-word;
+        word-break: break-word;
+    }
+
+    .landing-portal-badge {
+        display: inline-block;
+        font-size: 0.75rem;
+        font-weight: 500;
+        color: #cb4e1b;
+        background-color: rgba(203, 78, 27, 0.1);
+        border: 1px solid rgba(203, 78, 27, 0.3);
+        padding: 0.375rem 0.75rem;
+        border-radius: 999px;
+        margin-bottom: 1.5rem;
+    }
+
+    .landing-description {
+        font-size: 1rem;
+        color: #d7d3d0;
+        margin-bottom: 1.5rem;
+        line-height: 1.6;
+    }
+
+    .landing-description-highlight {
+        color: #cb4e1b;
+        font-weight: 500;
+    }
+
+    .landing-discord-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.75rem;
+        width: 100%;
+        padding: 0.875rem 1.5rem;
+        background-color: #5865F2;
+        color: white;
+        border: none;
+        border-radius: 0.5rem;
+        font-size: 1rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: all 0.2s;
+        text-decoration: none;
+        margin-bottom: 1.5rem;
+    }
+
+    .landing-discord-button:hover {
+        background-color: #4752C4;
+        transform: translateY(-2px);
+        box-shadow: 0 4px 12px rgba(88, 101, 242, 0.4);
+        color: white;
+        text-decoration: none;
+    }
+
+    .landing-discord-button:active {
+        transform: translateY(0);
+    }
+
+    .landing-discord-logo {
+        width: 20px;
+        height: 20px;
+    }
+
+    .landing-permissions-notice {
+        background-color: #1a1d23;
+        border: 1px solid #3f4447;
+        border-radius: 0.5rem;
+        padding: 1rem;
+        margin-bottom: 1.5rem;
+        text-align: left;
+    }
+
+    .landing-permissions-title {
+        font-size: 0.875rem;
+        font-weight: 600;
+        color: #d7d3d0;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        margin-bottom: 0.5rem;
+    }
+
+    .landing-permissions-item {
+        display: flex;
+        align-items: flex-start;
+        gap: 0.5rem;
+        margin-bottom: 0.5rem;
+        font-size: 0.813rem;
+        color: #a8a5a3;
+        line-height: 1.5;
+    }
+
+    .landing-permissions-item:last-child {
+        margin-bottom: 0;
+    }
+
+    .landing-permission-icon {
+        color: #cb4e1b;
+        font-weight: bold;
+        flex-shrink: 0;
+        margin-top: 0.125rem;
+    }
+
+    .landing-footer-text {
+        font-size: 0.813rem;
+        color: #a8a5a3;
+        line-height: 1.5;
+    }
+
+    .landing-footer-text a {
+        color: #cb4e1b;
+        text-decoration: none;
+        transition: color 0.2s;
+    }
+
+    .landing-footer-text a:hover {
+        color: #e5591f;
+        text-decoration: underline;
+    }
+
+    /* Landing page responsive */
+    @@media (max-width: 480px) {
+        .landing-card {
+            padding: 2rem 1.5rem;
+        }
+
+        .landing-guild-icon {
+            width: 100px;
+            height: 100px;
+        }
+
+        .landing-guild-icon-placeholder {
+            font-size: 2.5rem;
+        }
+
+        .landing-guild-name {
+            font-size: 1.5rem;
+            margin-bottom: 0.375rem;
+        }
+
+        .landing-description {
+            font-size: 0.9375rem;
+            margin-bottom: 1.25rem;
+        }
+
+        .landing-discord-button {
+            padding: 0.75rem 1.25rem;
+            font-size: 0.9375rem;
+        }
+    }
+
+    @@media (max-width: 360px) {
+        .landing-card {
+            padding: 1.5rem 1.25rem;
+        }
+
+        .landing-guild-icon {
+            width: 80px;
+            height: 80px;
+            margin-bottom: 1rem;
+        }
+
+        .landing-guild-icon-placeholder {
+            font-size: 2rem;
+        }
+
+        .landing-guild-name {
+            font-size: 1.25rem;
+            margin-bottom: 0.25rem;
+        }
+
+        .landing-portal-badge {
+            font-size: 0.7rem;
+            padding: 0.25rem 0.625rem;
+        }
+
+        .landing-description {
+            font-size: 0.875rem;
+            margin-bottom: 1rem;
+        }
+
+        .landing-permissions-notice {
+            padding: 0.75rem;
+        }
+
+        .landing-permissions-title {
+            font-size: 0.75rem;
+        }
+
+        .landing-permissions-item {
+            font-size: 0.75rem;
+        }
+    }
+
+    /* ===============================================
+       Soundboard Styles (Authenticated View)
+       =============================================== */
     * {
         margin: 0;
         padding: 0;
@@ -601,27 +851,91 @@
     }
 </style>
 
-<!-- Portal Header -->
-<header class="portal-header">
-    <div class="header-content">
-        <div class="header-left">
-            <div class="bot-icon">
-                <svg fill="currentColor" viewBox="0 0 24 24">
-                    <path d="M19.75 10.5a1.5 1.5 0 110-3 1.5 1.5 0 010 3zm-15.5 0a1.5 1.5 0 110-3 1.5 1.5 0 010 3z"/>
-                    <path d="M20 7a8 8 0 00-8-8 8 8 0 00-8 8v9a3 3 0 003 3h10a3 3 0 003-3V7z"/>
+@if (!Model.IsAuthenticated)
+{
+    <!-- ===============================================
+         Landing Page (Unauthenticated Users)
+         =============================================== -->
+    <div class="landing-container">
+        <div class="landing-card">
+            <!-- Guild Icon -->
+            <div class="landing-guild-icon">
+                @if (!string.IsNullOrEmpty(Model.GuildIconUrl))
+                {
+                    <img src="@Model.GuildIconUrl" alt="@Model.GuildName" />
+                }
+                else
+                {
+                    <span class="landing-guild-icon-placeholder">@(Model.GuildName.Length > 0 ? Model.GuildName[0].ToString().ToUpper() : "?")</span>
+                }
+            </div>
+
+            <!-- Guild Name -->
+            <h1 class="landing-guild-name">@Model.GuildName</h1>
+
+            <!-- Portal Badge -->
+            <span class="landing-portal-badge">Soundboard Portal</span>
+
+            <!-- Description -->
+            <p class="landing-description">
+                To access this soundboard, we need to verify you're a member of <span class="landing-description-highlight">this server</span>
+            </p>
+
+            <!-- Discord Login Button -->
+            <a href="@Model.LoginUrl" class="landing-discord-button">
+                <svg class="landing-discord-logo" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189z"/>
                 </svg>
+                Login with Discord
+            </a>
+
+            <!-- Permissions Notice -->
+            <div class="landing-permissions-notice">
+                <div class="landing-permissions-title">What we'll request</div>
+                <div class="landing-permissions-item">
+                    <span class="landing-permission-icon">✓</span>
+                    <span>Access to see your server memberships</span>
+                </div>
+                <div class="landing-permissions-item">
+                    <span class="landing-permission-icon">✓</span>
+                    <span>Your Discord username and avatar</span>
+                </div>
             </div>
-            <div class="header-text">
-                <h1>Soundboard</h1>
-                <p>@Model.GuildName</p>
-            </div>
-        </div>
-        <div class="status-badge @(Model.IsOnline ? "online" : "offline")">
-            <span class="status-dot"></span>
-            @(Model.IsOnline ? "Online" : "Offline")
+
+            <!-- Footer -->
+            <p class="landing-footer-text">
+                By logging in, you agree to our <a href="/Account/Privacy">Privacy Policy</a>
+            </p>
         </div>
     </div>
-</header>
+}
+else
+{
+    <!-- ===============================================
+         Soundboard Portal (Authenticated Users)
+         =============================================== -->
+
+    <!-- Portal Header -->
+    <header class="portal-header">
+        <div class="header-content">
+            <div class="header-left">
+                <div class="bot-icon">
+                    <svg fill="currentColor" viewBox="0 0 24 24">
+                        <path d="M19.75 10.5a1.5 1.5 0 110-3 1.5 1.5 0 010 3zm-15.5 0a1.5 1.5 0 110-3 1.5 1.5 0 010 3z"/>
+                        <path d="M20 7a8 8 0 00-8-8 8 8 0 00-8 8v9a3 3 0 003 3h10a3 3 0 003-3V7z"/>
+                    </svg>
+                </div>
+                <div class="header-text">
+                    <h1>Soundboard</h1>
+                    <p>@Model.GuildName</p>
+                </div>
+            </div>
+            <div class="status-badge @(Model.IsOnline ? "online" : "offline")">
+                <span class="status-dot"></span>
+                @(Model.IsOnline ? "Online" : "Offline")
+            </div>
+        </div>
+    </header>
 
 <!-- Main Content -->
 <main class="main-container">
@@ -779,10 +1093,13 @@
     </div>
 </main>
 
-<!-- Hidden file input for upload -->
-<input type="file" id="fileInput" accept="audio/mp3,audio/wav,audio/ogg,.mp3,.wav,.ogg" class="hidden">
+    <!-- Hidden file input for upload -->
+    <input type="file" id="fileInput" accept="audio/mp3,audio/wav,audio/ogg,.mp3,.wav,.ogg" class="hidden">
+} @* End of IsAuthenticated else block *@
 
 @@section Scripts {
+@if (Model.IsAuthenticated)
+{
     <script>
         // Pass guild ID to JavaScript as a string (critical for Discord snowflake IDs)
         window.guildId = '@Model.GuildId';
@@ -1153,4 +1470,5 @@
             document.getElementById('fileInput').value = '';
         }
     </script>
+}
 }

--- a/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml.cs
@@ -2,8 +2,10 @@ using Discord.WebSocket;
 using DiscordBot.Bot.Interfaces;
 using DiscordBot.Bot.ViewModels.Components;
 using DiscordBot.Bot.ViewModels.Portal;
+using DiscordBot.Core.Entities;
 using DiscordBot.Core.Interfaces;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
@@ -11,9 +13,10 @@ namespace DiscordBot.Bot.Pages.Portal.Soundboard;
 
 /// <summary>
 /// Page model for the Soundboard Guild Member Portal.
-/// Displays sounds and voice channel controls for authenticated guild members.
+/// Shows a landing page for unauthenticated users, or the full soundboard
+/// for authenticated guild members.
 /// </summary>
-[Authorize(Policy = "PortalGuildMember")]
+[AllowAnonymous]
 public class IndexModel : PageModel
 {
     private readonly ISoundService _soundService;
@@ -21,6 +24,7 @@ public class IndexModel : PageModel
     private readonly IGuildService _guildService;
     private readonly DiscordSocketClient _discordClient;
     private readonly IAudioService _audioService;
+    private readonly UserManager<ApplicationUser> _userManager;
     private readonly ILogger<IndexModel> _logger;
 
     public IndexModel(
@@ -29,6 +33,7 @@ public class IndexModel : PageModel
         IGuildService guildService,
         DiscordSocketClient discordClient,
         IAudioService audioService,
+        UserManager<ApplicationUser> userManager,
         ILogger<IndexModel> logger)
     {
         _soundService = soundService;
@@ -36,6 +41,7 @@ public class IndexModel : PageModel
         _guildService = guildService;
         _discordClient = discordClient;
         _audioService = audioService;
+        _userManager = userManager;
         _logger = logger;
     }
 
@@ -105,7 +111,25 @@ public class IndexModel : PageModel
     public int MaxDurationSeconds { get; set; }
 
     /// <summary>
+    /// Gets whether the user is authenticated with Discord OAuth.
+    /// When false, display the landing page instead of the soundboard.
+    /// </summary>
+    public bool IsAuthenticated { get; set; }
+
+    /// <summary>
+    /// Gets whether the authenticated user is authorized to view this portal.
+    /// True when user is a member of the guild.
+    /// </summary>
+    public bool IsAuthorized { get; set; }
+
+    /// <summary>
+    /// Gets the login URL with return URL for Discord OAuth.
+    /// </summary>
+    public string LoginUrl { get; set; } = string.Empty;
+
+    /// <summary>
     /// Handles GET requests to display the Soundboard Portal page.
+    /// Shows a landing page for unauthenticated users.
     /// </summary>
     /// <param name="guildId">The guild's Discord snowflake ID from route parameter.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
@@ -115,11 +139,22 @@ public class IndexModel : PageModel
         CancellationToken cancellationToken = default)
     {
         _logger.LogInformation("User {UserId} accessing Soundboard Portal for guild {GuildId}",
-            User.Identity?.Name, guildId);
+            User.Identity?.Name ?? "anonymous", guildId);
 
         try
         {
-            // Get guild info from service
+            // Check if portal is enabled for this guild first (before auth check)
+            var audioSettings = await _audioSettingsRepository.GetByGuildIdAsync(guildId);
+
+            // TODO: Issue #947 will add EnableMemberPortal property
+            // For now, we check AudioEnabled as a proxy
+            if (audioSettings == null || !audioSettings.AudioEnabled)
+            {
+                _logger.LogDebug("Portal not enabled for guild {GuildId}", guildId);
+                return NotFound();
+            }
+
+            // Get guild info - return 404 if not found (don't reveal guild doesn't exist)
             var guild = await _guildService.GetGuildByIdAsync(guildId, cancellationToken);
             if (guild == null)
             {
@@ -127,10 +162,59 @@ public class IndexModel : PageModel
                 return NotFound();
             }
 
+            // Check if Discord guild is available
+            var socketGuild = _discordClient.GetGuild(guildId);
+            if (socketGuild == null)
+            {
+                _logger.LogWarning("Guild {GuildId} not found in Discord client", guildId);
+                return NotFound();
+            }
+
+            // Set basic guild info for landing page (needed for both auth states)
+            GuildId = guildId;
+            GuildName = guild.Name;
+            GuildIconUrl = guild.IconUrl;
+            IsOnline = _discordClient.ConnectionState == Discord.ConnectionState.Connected;
+
+            // Build login URL with return URL
+            var returnUrl = HttpContext.Request.Path.ToString();
+            LoginUrl = $"/Account/Login?returnUrl={Uri.EscapeDataString(returnUrl)}";
+
+            // Check authentication state
+            IsAuthenticated = User.Identity?.IsAuthenticated ?? false;
+
+            if (!IsAuthenticated)
+            {
+                _logger.LogDebug("Unauthenticated user viewing landing page for guild {GuildId}", guildId);
+                return Page();
+            }
+
+            // User is authenticated - check guild membership
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null || !user.DiscordUserId.HasValue)
+            {
+                _logger.LogDebug("User not found or no Discord linked, showing landing page for guild {GuildId}", guildId);
+                IsAuthenticated = false; // Treat as unauthenticated for UI purposes
+                return Page();
+            }
+
+            // Check if user is a member of the guild
+            var guildUser = socketGuild.GetUser(user.DiscordUserId.Value);
+            if (guildUser == null)
+            {
+                _logger.LogDebug("User {DiscordUserId} is not a member of guild {GuildId}",
+                    user.DiscordUserId.Value, guildId);
+                // Return 403 - authenticated but not authorized
+                return Forbid();
+            }
+
+            // User is authenticated and authorized - load full soundboard
+            IsAuthorized = true;
+
             // Get all sounds for this guild
             var sounds = await _soundService.GetAllByGuildAsync(guildId, cancellationToken);
 
-            // Get audio settings (creates defaults if not found)
+            // Get audio settings for limits
             var settings = await _audioSettingsRepository.GetOrCreateAsync(guildId, cancellationToken);
 
             // Map sounds to portal view models
@@ -145,25 +229,17 @@ public class IndexModel : PageModel
 
             // Build voice channels list
             var voiceChannels = new List<VoiceChannelInfo>();
-            var socketGuild = _discordClient.GetGuild(guildId);
-            if (socketGuild != null)
+            foreach (var channel in socketGuild.VoiceChannels.Where(c => c != null).OrderBy(c => c.Position))
             {
-                foreach (var channel in socketGuild.VoiceChannels.Where(c => c != null).OrderBy(c => c.Position))
+                voiceChannels.Add(new VoiceChannelInfo
                 {
-                    voiceChannels.Add(new VoiceChannelInfo
-                    {
-                        Id = channel.Id,
-                        Name = channel.Name,
-                        MemberCount = channel.ConnectedUsers.Count
-                    });
-                }
+                    Id = channel.Id,
+                    Name = channel.Name,
+                    MemberCount = channel.ConnectedUsers.Count
+                });
             }
 
-            // Set all view properties
-            GuildId = guildId;
-            GuildName = guild.Name;
-            GuildIconUrl = guild.IconUrl;
-            IsOnline = _discordClient.ConnectionState == Discord.ConnectionState.Connected;
+            // Set remaining view properties
             Sounds = soundViewModels;
             VoiceChannels = voiceChannels;
             CurrentChannelId = _audioService.GetConnectedChannelId(guildId);


### PR DESCRIPTION
## Summary

- Add branded landing page for unauthenticated users visiting `/portal/soundboard/{guildId}`
- Display guild icon, name, and Discord login button instead of immediate OAuth redirect
- Show permission notice about server memberships scope
- Dark theme matches portal aesthetic
- Mobile responsive layout

## Changes

- Changed from `[Authorize(Policy = "PortalGuildMember")]` to `[AllowAnonymous]` with manual auth check
- Added `IsAuthenticated` and `LoginUrl` properties to PageModel
- Portal enabled and guild existence checks return 404 (don't reveal which)
- Non-member authenticated users receive 403

## Test plan

- [ ] Visit portal URL while logged out - see landing page with guild info
- [ ] Click "Login with Discord" - redirected to OAuth then back to portal
- [ ] Visit portal as non-member - receive 403 forbidden
- [ ] Visit portal as guild member - see full soundboard interface
- [ ] Visit invalid guild ID - receive 404
- [ ] Visit guild with portal disabled - receive 404
- [ ] Test mobile layout at various screen widths

Closes #988

🤖 Generated with [Claude Code](https://claude.com/claude-code)