### PR TITLE
feat(audio): Add AudioFilter enum and filter definitions

### DIFF
--- a/src/DiscordBot.Core/Constants/AudioFilters.cs
+++ b/src/DiscordBot.Core/Constants/AudioFilters.cs
@@ -1,0 +1,78 @@
+using DiscordBot.Core.Enums;
+using DiscordBot.Core.Models;
+
+namespace DiscordBot.Core.Constants;
+
+/// <summary>
+/// Static definitions for audio filter presets and their FFmpeg mappings.
+/// </summary>
+public static class AudioFilters
+{
+    /// <summary>
+    /// Dictionary mapping audio filter enum values to their definitions.
+    /// </summary>
+    public static readonly IReadOnlyDictionary<AudioFilter, AudioFilterDefinition> Definitions =
+        new Dictionary<AudioFilter, AudioFilterDefinition>
+        {
+            [AudioFilter.None] = new AudioFilterDefinition
+            {
+                Name = "None",
+                Description = "No audio filter applied",
+                FfmpegFilter = string.Empty
+            },
+            [AudioFilter.Reverb] = new AudioFilterDefinition
+            {
+                Name = "Reverb",
+                Description = "Adds a reverb/echo effect to the audio",
+                FfmpegFilter = "aecho=0.8:0.9:40:0.4"
+            },
+            [AudioFilter.BassBoost] = new AudioFilterDefinition
+            {
+                Name = "Bass Boost",
+                Description = "Boosts bass frequencies for deeper sound",
+                FfmpegFilter = "equalizer=f=60:width_type=h:width=50:g=10"
+            },
+            [AudioFilter.TrebleBoost] = new AudioFilterDefinition
+            {
+                Name = "Treble Boost",
+                Description = "Boosts treble frequencies for brighter sound",
+                FfmpegFilter = "equalizer=f=3000:width_type=h:width=200:g=5"
+            },
+            [AudioFilter.PitchUp] = new AudioFilterDefinition
+            {
+                Name = "Pitch Up",
+                Description = "Raises the pitch of the audio",
+                FfmpegFilter = "asetrate=48000*1.25,aresample=48000"
+            },
+            [AudioFilter.PitchDown] = new AudioFilterDefinition
+            {
+                Name = "Pitch Down",
+                Description = "Lowers the pitch of the audio",
+                FfmpegFilter = "asetrate=48000*0.75,aresample=48000"
+            },
+            [AudioFilter.Nightcore] = new AudioFilterDefinition
+            {
+                Name = "Nightcore",
+                Description = "Nightcore effect - higher pitch and faster tempo",
+                FfmpegFilter = "asetrate=48000*1.25,aresample=48000,atempo=1.25"
+            },
+            [AudioFilter.SlowMo] = new AudioFilterDefinition
+            {
+                Name = "Slow Mo",
+                Description = "Slows down the audio playback",
+                FfmpegFilter = "atempo=0.8"
+            }
+        };
+
+    /// <summary>
+    /// Gets the FFmpeg filter string for a given audio filter.
+    /// </summary>
+    /// <param name="filter">The audio filter.</param>
+    /// <returns>The FFmpeg -af argument string, or empty string if None.</returns>
+    public static string GetFfmpegFilter(AudioFilter filter)
+    {
+        return Definitions.TryGetValue(filter, out var definition)
+            ? definition.FfmpegFilter
+            : string.Empty;
+    }
+}

--- a/src/DiscordBot.Core/Enums/AudioFilter.cs
+++ b/src/DiscordBot.Core/Enums/AudioFilter.cs
@@ -1,0 +1,47 @@
+namespace DiscordBot.Core.Enums;
+
+/// <summary>
+/// Represents audio filter presets that can be applied to soundboard playback.
+/// </summary>
+public enum AudioFilter
+{
+    /// <summary>
+    /// No audio filter applied.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Adds a reverb/echo effect to the audio.
+    /// </summary>
+    Reverb = 1,
+
+    /// <summary>
+    /// Boosts bass frequencies for deeper sound.
+    /// </summary>
+    BassBoost = 2,
+
+    /// <summary>
+    /// Boosts treble frequencies for brighter sound.
+    /// </summary>
+    TrebleBoost = 3,
+
+    /// <summary>
+    /// Raises the pitch of the audio.
+    /// </summary>
+    PitchUp = 4,
+
+    /// <summary>
+    /// Lowers the pitch of the audio.
+    /// </summary>
+    PitchDown = 5,
+
+    /// <summary>
+    /// Nightcore effect - higher pitch and faster tempo.
+    /// </summary>
+    Nightcore = 6,
+
+    /// <summary>
+    /// Slows down the audio playback.
+    /// </summary>
+    SlowMo = 7
+}

--- a/src/DiscordBot.Core/Models/AudioFilterDefinition.cs
+++ b/src/DiscordBot.Core/Models/AudioFilterDefinition.cs
@@ -1,0 +1,26 @@
+namespace DiscordBot.Core.Models;
+
+/// <summary>
+/// Defines an audio filter with its display properties and FFmpeg filter string.
+/// </summary>
+public class AudioFilterDefinition
+{
+    /// <summary>
+    /// Gets the display name of the filter.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Gets the description of what the filter does.
+    /// </summary>
+    public required string Description { get; init; }
+
+    /// <summary>
+    /// Gets the FFmpeg audio filter argument string.
+    /// </summary>
+    /// <remarks>
+    /// This value is passed to FFmpeg's -af parameter.
+    /// For example: "aecho=0.8:0.9:40:0.4" for reverb effect.
+    /// </remarks>
+    public required string FfmpegFilter { get; init; }
+}

--- a/tests/DiscordBot.Tests/Core/Constants/AudioFiltersTests.cs
+++ b/tests/DiscordBot.Tests/Core/Constants/AudioFiltersTests.cs
@@ -1,0 +1,122 @@
+using DiscordBot.Core.Constants;
+using DiscordBot.Core.Enums;
+using FluentAssertions;
+
+namespace DiscordBot.Tests.Core.Constants;
+
+/// <summary>
+/// Unit tests for the AudioFilters constants class.
+/// </summary>
+public class AudioFiltersTests
+{
+    [Fact]
+    public void Definitions_ContainsAllEnumValues()
+    {
+        // Arrange
+        var allEnumValues = Enum.GetValues<AudioFilter>();
+
+        // Act & Assert
+        AudioFilters.Definitions.Keys.Should().BeEquivalentTo(allEnumValues,
+            "all AudioFilter enum values should have a definition");
+    }
+
+    [Theory]
+    [InlineData(AudioFilter.None, "")]
+    [InlineData(AudioFilter.Reverb, "aecho=0.8:0.9:40:0.4")]
+    [InlineData(AudioFilter.BassBoost, "equalizer=f=60:width_type=h:width=50:g=10")]
+    [InlineData(AudioFilter.TrebleBoost, "equalizer=f=3000:width_type=h:width=200:g=5")]
+    [InlineData(AudioFilter.PitchUp, "asetrate=48000*1.25,aresample=48000")]
+    [InlineData(AudioFilter.PitchDown, "asetrate=48000*0.75,aresample=48000")]
+    [InlineData(AudioFilter.Nightcore, "asetrate=48000*1.25,aresample=48000,atempo=1.25")]
+    [InlineData(AudioFilter.SlowMo, "atempo=0.8")]
+    public void Definitions_HasCorrectFfmpegFilter(AudioFilter filter, string expectedFfmpegFilter)
+    {
+        // Act
+        var definition = AudioFilters.Definitions[filter];
+
+        // Assert
+        definition.FfmpegFilter.Should().Be(expectedFfmpegFilter,
+            $"FFmpeg filter for {filter} should match the expected value");
+    }
+
+    [Theory]
+    [InlineData(AudioFilter.None, "None")]
+    [InlineData(AudioFilter.Reverb, "Reverb")]
+    [InlineData(AudioFilter.BassBoost, "Bass Boost")]
+    [InlineData(AudioFilter.TrebleBoost, "Treble Boost")]
+    [InlineData(AudioFilter.PitchUp, "Pitch Up")]
+    [InlineData(AudioFilter.PitchDown, "Pitch Down")]
+    [InlineData(AudioFilter.Nightcore, "Nightcore")]
+    [InlineData(AudioFilter.SlowMo, "Slow Mo")]
+    public void Definitions_HasCorrectName(AudioFilter filter, string expectedName)
+    {
+        // Act
+        var definition = AudioFilters.Definitions[filter];
+
+        // Assert
+        definition.Name.Should().Be(expectedName,
+            $"display name for {filter} should match the expected value");
+    }
+
+    [Fact]
+    public void Definitions_AllHaveNonEmptyDescriptions()
+    {
+        // Act & Assert
+        foreach (var (filter, definition) in AudioFilters.Definitions)
+        {
+            definition.Description.Should().NotBeNullOrWhiteSpace(
+                $"description for {filter} should not be empty");
+        }
+    }
+
+    [Theory]
+    [InlineData(AudioFilter.None, "")]
+    [InlineData(AudioFilter.Reverb, "aecho=0.8:0.9:40:0.4")]
+    [InlineData(AudioFilter.BassBoost, "equalizer=f=60:width_type=h:width=50:g=10")]
+    public void GetFfmpegFilter_ReturnsCorrectFilter(AudioFilter filter, string expectedFfmpegFilter)
+    {
+        // Act
+        var result = AudioFilters.GetFfmpegFilter(filter);
+
+        // Assert
+        result.Should().Be(expectedFfmpegFilter);
+    }
+
+    [Fact]
+    public void GetFfmpegFilter_ReturnsEmptyForUndefinedFilter()
+    {
+        // Arrange - use an invalid enum value
+        var invalidFilter = (AudioFilter)999;
+
+        // Act
+        var result = AudioFilters.GetFfmpegFilter(invalidFilter);
+
+        // Assert
+        result.Should().BeEmpty("undefined filter should return empty string");
+    }
+
+    [Fact]
+    public void Definitions_NoneHasEmptyFfmpegFilter()
+    {
+        // Arrange & Act
+        var noneDefinition = AudioFilters.Definitions[AudioFilter.None];
+
+        // Assert
+        noneDefinition.FfmpegFilter.Should().BeEmpty(
+            "None filter should have an empty FFmpeg filter string");
+    }
+
+    [Fact]
+    public void Definitions_AllNonNoneHaveNonEmptyFfmpegFilter()
+    {
+        // Act & Assert
+        foreach (var (filter, definition) in AudioFilters.Definitions)
+        {
+            if (filter != AudioFilter.None)
+            {
+                definition.FfmpegFilter.Should().NotBeNullOrWhiteSpace(
+                    $"FFmpeg filter for {filter} should not be empty");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Create `AudioFilter` enum with 8 filter presets: None, Reverb, BassBoost, TrebleBoost, PitchUp, PitchDown, Nightcore, SlowMo
- Add `AudioFilterDefinition` model with Name, Description, and FfmpegFilter properties
- Add `AudioFilters` static class with FFmpeg filter string mappings dictionary and helper method
- Add comprehensive unit tests (24 tests) covering all definitions

## Files Changed
- `src/DiscordBot.Core/Enums/AudioFilter.cs` - New enum
- `src/DiscordBot.Core/Models/AudioFilterDefinition.cs` - New model class
- `src/DiscordBot.Core/Constants/AudioFilters.cs` - Static filter definitions
- `tests/DiscordBot.Tests/Core/Constants/AudioFiltersTests.cs` - Unit tests

## Test plan
- [x] All 24 new unit tests pass
- [x] Build succeeds with no errors

Closes #995

🤖 Generated with [Claude Code](https://claude.com/claude-code)