### PR TITLE
feat(soundboard): Add audio filter support to PlaybackService

### DIFF
--- a/src/DiscordBot.Bot/Controllers/PortalSoundboardController.cs
+++ b/src/DiscordBot.Bot/Controllers/PortalSoundboardController.cs
@@ -338,7 +338,7 @@ public class PortalSoundboardController : ControllerBase
         // Play the sound (queueEnabled: false for immediate playback)
         try
         {
-            await _playbackService.PlayAsync(guildId, sound, queueEnabled: false, cancellationToken);
+            await _playbackService.PlayAsync(guildId, sound, queueEnabled: false, cancellationToken: cancellationToken);
             _logger.LogInformation("Successfully started playback of sound {SoundName} ({SoundId}) in guild {GuildId}",
                 sound.Name, sound.Id, guildId);
             return Ok(new { Message = "Playing sound", SoundName = sound.Name, SoundId = soundId });

--- a/src/DiscordBot.Bot/Interfaces/IPlaybackService.cs
+++ b/src/DiscordBot.Bot/Interfaces/IPlaybackService.cs
@@ -1,4 +1,5 @@
 using DiscordBot.Core.Entities;
+using DiscordBot.Core.Enums;
 
 namespace DiscordBot.Bot.Interfaces;
 
@@ -17,16 +18,18 @@ public interface IPlaybackService
     /// <param name="guildId">Discord guild snowflake ID.</param>
     /// <param name="sound">The sound entity to play.</param>
     /// <param name="queueEnabled">Whether to queue the sound or replace current playback.</param>
+    /// <param name="filter">Optional audio filter to apply during playback.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     /// <remarks>
     /// Requires an active voice connection via IAudioService.JoinChannelAsync before calling.
     /// The audio file is transcoded using FFmpeg to Opus PCM format (48kHz, stereo, 16-bit).
     /// Updates the sound's play count and last activity timestamp on the voice connection.
+    /// If a filter is specified and causes an FFmpeg error, playback will retry without the filter.
     /// </remarks>
     /// <exception cref="InvalidOperationException">Thrown if no audio client is available for the guild.</exception>
     /// <exception cref="FileNotFoundException">Thrown if the sound file does not exist.</exception>
-    Task PlayAsync(ulong guildId, Sound sound, bool queueEnabled, CancellationToken cancellationToken = default);
+    Task PlayAsync(ulong guildId, Sound sound, bool queueEnabled, AudioFilter filter = AudioFilter.None, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Stops the currently playing sound in the specified guild and clears the queue.

--- a/tests/DiscordBot.Tests/Bot/Services/PlaybackServiceTests.cs
+++ b/tests/DiscordBot.Tests/Bot/Services/PlaybackServiceTests.cs
@@ -1,0 +1,117 @@
+using DiscordBot.Bot.Services;
+using DiscordBot.Core.Enums;
+using FluentAssertions;
+
+namespace DiscordBot.Tests.Bot.Services;
+
+/// <summary>
+/// Unit tests for PlaybackService internal methods.
+/// </summary>
+public class PlaybackServiceTests
+{
+    private const string TestFilePath = "/sounds/test.mp3";
+
+    [Fact]
+    public void BuildFfmpegArguments_WithNoFilter_ReturnsStandardArguments()
+    {
+        // Act
+        var result = PlaybackService.BuildFfmpegArguments(TestFilePath, AudioFilter.None);
+
+        // Assert
+        result.Should().Be($"-hide_banner -loglevel warning -i \"{TestFilePath}\" -ac 2 -f s16le -ar 48000 pipe:1");
+    }
+
+    [Fact]
+    public void BuildFfmpegArguments_WithFilter_IncludesAfArgument()
+    {
+        // Act
+        var result = PlaybackService.BuildFfmpegArguments(TestFilePath, AudioFilter.BassBoost);
+
+        // Assert
+        result.Should().Contain("-af \"");
+        result.Should().Contain("equalizer=f=60:width_type=h:width=50:g=10");
+    }
+
+    [Theory]
+    [InlineData(AudioFilter.Reverb, "aecho=0.8:0.9:40:0.4")]
+    [InlineData(AudioFilter.BassBoost, "equalizer=f=60:width_type=h:width=50:g=10")]
+    [InlineData(AudioFilter.TrebleBoost, "equalizer=f=3000:width_type=h:width=200:g=5")]
+    [InlineData(AudioFilter.PitchUp, "asetrate=48000*1.25,aresample=48000")]
+    [InlineData(AudioFilter.PitchDown, "asetrate=48000*0.75,aresample=48000")]
+    [InlineData(AudioFilter.Nightcore, "asetrate=48000*1.25,aresample=48000,atempo=1.25")]
+    [InlineData(AudioFilter.SlowMo, "atempo=0.8")]
+    public void BuildFfmpegArguments_WithFilter_ContainsCorrectFilterString(AudioFilter filter, string expectedFilterString)
+    {
+        // Act
+        var result = PlaybackService.BuildFfmpegArguments(TestFilePath, filter);
+
+        // Assert
+        result.Should().Contain($"-af \"{expectedFilterString}\"");
+    }
+
+    [Fact]
+    public void BuildFfmpegArguments_AlwaysOutputs48kHzStereo()
+    {
+        // Arrange
+        var filters = Enum.GetValues<AudioFilter>();
+
+        // Act & Assert
+        foreach (var filter in filters)
+        {
+            var result = PlaybackService.BuildFfmpegArguments(TestFilePath, filter);
+
+            result.Should().Contain("-ac 2", $"should output stereo for filter {filter}");
+            result.Should().Contain("-ar 48000", $"should output 48kHz for filter {filter}");
+            result.Should().Contain("-f s16le", $"should output s16le format for filter {filter}");
+        }
+    }
+
+    [Fact]
+    public void BuildFfmpegArguments_FilterIsInsertedBetweenInputAndOutput()
+    {
+        // Act
+        var result = PlaybackService.BuildFfmpegArguments(TestFilePath, AudioFilter.Reverb);
+
+        // Assert - verify ordering: input file comes before filter, filter comes before output format
+        var inputIndex = result.IndexOf($"-i \"{TestFilePath}\"");
+        var filterIndex = result.IndexOf("-af \"");
+        var outputIndex = result.IndexOf("-ac 2");
+
+        inputIndex.Should().BeLessThan(filterIndex, "input should come before filter");
+        filterIndex.Should().BeLessThan(outputIndex, "filter should come before output format");
+    }
+
+    [Fact]
+    public void BuildFfmpegArguments_WithSpacesInFilePath_QuotesPath()
+    {
+        // Arrange
+        var pathWithSpaces = "/sounds/my folder/test sound.mp3";
+
+        // Act
+        var result = PlaybackService.BuildFfmpegArguments(pathWithSpaces, AudioFilter.None);
+
+        // Assert
+        result.Should().Contain($"-i \"{pathWithSpaces}\"");
+    }
+
+    [Fact]
+    public void BuildFfmpegArguments_OutputsToStdout()
+    {
+        // Act
+        var result = PlaybackService.BuildFfmpegArguments(TestFilePath, AudioFilter.None);
+
+        // Assert
+        result.Should().EndWith("pipe:1");
+    }
+
+    [Fact]
+    public void BuildFfmpegArguments_SuppressesBannerAndLimitsLogging()
+    {
+        // Act
+        var result = PlaybackService.BuildFfmpegArguments(TestFilePath, AudioFilter.None);
+
+        // Assert
+        result.Should().Contain("-hide_banner");
+        result.Should().Contain("-loglevel warning");
+    }
+}


### PR DESCRIPTION
## Summary
- Added optional `AudioFilter` parameter to `IPlaybackService.PlayAsync` for applying FFmpeg audio filters during playback
- Created `BuildFfmpegArguments` helper method to construct FFmpeg command line with `-af` filter arguments
- Implemented graceful fallback to unfiltered playback if filter causes FFmpeg error
- Added comprehensive logging for filter usage and filter fallback events

## Technical Details
- Updated `PlaybackState.Queue` to store `QueuedSound` records containing both `Sound` and `AudioFilter`
- Extracted `StreamAudioAsync` method to enable retry logic with/without filter
- Filter is inserted between input file and output format in FFmpeg arguments: `-i "{file}" -af "{filter}" -ac 2 -f s16le -ar 48000 pipe:1`
- Filter failure is detected by checking exit code and bytes read (< 200ms of audio indicates early failure)

## Test plan
- [x] Build succeeds
- [x] All existing tests pass (2922 passed)
- [x] New unit tests for `BuildFfmpegArguments` pass (14 tests)
- [ ] Manual test: Play sound without filter
- [ ] Manual test: Play sound with filter (requires #997 /play command update)
- [ ] Manual test: Verify filter fallback works with invalid filter

Closes #996

🤖 Generated with [Claude Code](https://claude.com/claude-code)