### PR TITLE
feat(soundboard): Add filter parameter to /play command with autocomplete

### DIFF
--- a/src/DiscordBot.Bot/Autocomplete/FilterAutocompleteHandler.cs
+++ b/src/DiscordBot.Bot/Autocomplete/FilterAutocompleteHandler.cs
@@ -1,0 +1,47 @@
+using Discord;
+using Discord.Interactions;
+using DiscordBot.Core.Constants;
+using DiscordBot.Core.Enums;
+
+namespace DiscordBot.Bot.Autocomplete;
+
+/// <summary>
+/// Provides autocomplete suggestions for audio filter selection in the /play command.
+/// Displays all available audio filters with their descriptions.
+/// </summary>
+public class FilterAutocompleteHandler : AutocompleteHandler
+{
+    /// <summary>
+    /// Generates autocomplete suggestions for audio filters.
+    /// Returns all available filters except None when no input is provided,
+    /// or filters matching the user's input.
+    /// </summary>
+    /// <param name="context">The interaction context for the current command execution.</param>
+    /// <param name="autocompleteInteraction">The autocomplete interaction data.</param>
+    /// <param name="parameter">Information about the command parameter being completed.</param>
+    /// <param name="services">Service provider for resolving dependencies.</param>
+    /// <returns>An AutocompletionResult containing matching audio filter options.</returns>
+    public override Task<AutocompletionResult> GenerateSuggestionsAsync(
+        IInteractionContext context,
+        IAutocompleteInteraction autocompleteInteraction,
+        IParameterInfo parameter,
+        IServiceProvider services)
+    {
+        var userInput = autocompleteInteraction.Data.Current.Value?.ToString() ?? string.Empty;
+
+        // Get all filter definitions except None (None is the default when no filter selected)
+        var results = AudioFilters.Definitions
+            .Where(kvp => kvp.Key != AudioFilter.None)
+            .Where(kvp => string.IsNullOrEmpty(userInput) ||
+                         kvp.Value.Name.Contains(userInput, StringComparison.OrdinalIgnoreCase) ||
+                         kvp.Value.Description.Contains(userInput, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(kvp => kvp.Value.Name)
+            .Take(25) // Discord autocomplete result limit
+            .Select(kvp => new AutocompleteResult(
+                $"{kvp.Value.Name} - {kvp.Value.Description}",
+                (int)kvp.Key))
+            .ToList();
+
+        return Task.FromResult(AutocompletionResult.FromSuccess(results));
+    }
+}


### PR DESCRIPTION
## Summary
- Add optional `filter` parameter to `/play` slash command with autocomplete support
- Create `FilterAutocompleteHandler` that shows all available audio filters with descriptions
- Update embed responses to show applied filter (e.g., "Now playing: **sound** (with Bass Boost effect)")
- Include filter selection in command execution logs

## Test plan
- [ ] Verify `/play` command shows filter autocomplete when typing
- [ ] Confirm filter suggestions show name and description
- [ ] Test playing sound with filter shows effect in response embed
- [ ] Test playing sound without filter shows normal response
- [ ] Verify queued sounds with filters display correctly

Closes #997

🤖 Generated with [Claude Code](https://claude.com/claude-code)