### PR TITLE
feat(ratwatch): Add GetRecentActivityAsync method to IRatWatchService

### DIFF
--- a/src/DiscordBot.Core/DTOs/RatWatchDtos.cs
+++ b/src/DiscordBot.Core/DTOs/RatWatchDtos.cs
@@ -61,6 +61,11 @@ public record RatWatchDto
     public ulong GuildId { get; init; }
 
     /// <summary>
+    /// Name of the guild where this watch was created (resolved from Discord).
+    /// </summary>
+    public string GuildName { get; init; } = string.Empty;
+
+    /// <summary>
     /// Discord channel snowflake ID where this watch was created.
     /// </summary>
     public ulong ChannelId { get; init; }
@@ -121,6 +126,18 @@ public record RatWatchDto
     /// Null if voting has not started yet.
     /// </summary>
     public DateTime? VotingStartedAt { get; init; }
+
+    /// <summary>
+    /// Timestamp when voting ended (UTC).
+    /// Null if voting has not ended.
+    /// </summary>
+    public DateTime? VotingEndedAt { get; init; }
+
+    /// <summary>
+    /// Timestamp when the accused cleared themselves early (UTC).
+    /// Null if not cleared early.
+    /// </summary>
+    public DateTime? ClearedAt { get; init; }
 
     /// <summary>
     /// Number of guilty votes cast.

--- a/src/DiscordBot.Core/Interfaces/IRatWatchRepository.cs
+++ b/src/DiscordBot.Core/Interfaces/IRatWatchRepository.cs
@@ -136,4 +136,14 @@ public interface IRatWatchRepository : IRepository<RatWatch>
         ulong guildId,
         RatWatchIncidentFilterDto filter,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets recent Rat Watch events across all guilds ordered by most recent activity timestamp.
+    /// The activity timestamp is determined by status: CreatedAt for Pending, VotingStartedAt for Voting,
+    /// VotingEndedAt for Guilty/NotGuilty, ClearedAt for ClearedEarly.
+    /// </summary>
+    /// <param name="limit">Maximum number of watches to return.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Collection of recent watches with Guild navigation property included.</returns>
+    Task<IEnumerable<RatWatch>> GetRecentAsync(int limit, CancellationToken cancellationToken = default);
 }

--- a/src/DiscordBot.Core/Interfaces/IRatWatchService.cs
+++ b/src/DiscordBot.Core/Interfaces/IRatWatchService.cs
@@ -178,4 +178,13 @@ public interface IRatWatchService
         ulong guildId,
         RatWatchIncidentFilterDto filter,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets recent Rat Watch events across all guilds for activity feeds.
+    /// Returns watches ordered by most recent status change timestamp.
+    /// </summary>
+    /// <param name="limit">Maximum number of watches to return. Defaults to 10.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Collection of recent watches with guild names included.</returns>
+    Task<IEnumerable<RatWatchDto>> GetRecentActivityAsync(int limit = 10, CancellationToken ct = default);
 }


### PR DESCRIPTION
## Summary
- Add `GetRecentActivityAsync(int limit, CancellationToken ct)` method to retrieve recent Rat Watch events across all guilds for dashboard activity feeds
- Returns watches ordered by most recent status change timestamp based on status (CreatedAt for Pending, VotingStartedAt for Voting, VotingEndedAt for Guilty/NotGuilty, ClearedAt for ClearedEarly)
- Include guild name in returned DTO for display

## Changes
- **RatWatchDto**: Add `GuildName`, `VotingEndedAt`, and `ClearedAt` properties
- **IRatWatchRepository**: Add `GetRecentAsync(int limit, CancellationToken ct)` method
- **RatWatchRepository**: Implement with status-based timestamp ordering
- **IRatWatchService**: Add `GetRecentActivityAsync(int limit, CancellationToken ct)` method  
- **RatWatchService**: Implement with guild name resolution from Discord client or database
- **Unit Tests**: Add 6 tests covering the new functionality

## Test plan
- [x] All 6 new unit tests pass
- [x] Solution builds without errors
- [ ] Manual verification in activity feed (future task)

Closes #1005

🤖 Generated with [Claude Code](https://claude.com/claude-code)