### PR TITLE
fix(portal): Remove escaped @ from section directive in Soundboard page

### DIFF
--- a/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml
@@ -1553,7 +1553,7 @@ else
 <!-- Toast Container -->
 <div id="portalToastContainer" class="portal-toast-container"></div>
 
-@@section Scripts {
+@section Scripts {
 @if (Model.IsAuthenticated)
 {
     <script>


### PR DESCRIPTION
## Summary
- Fixed `@@section Scripts` escaping in Portal Soundboard page that caused literal text to render at bottom of page
- Changed to correct `@section Scripts` Razor directive syntax

## Test plan
- [ ] Navigate to Portal Soundboard page (`/Portal/Soundboard/{guildId}`)
- [ ] Verify `@section Scripts { }` text no longer appears at bottom
- [ ] Verify JavaScript functionality still works for authenticated users

Closes #1009

🤖 Generated with [Claude Code](https://claude.com/claude-code)