### PR TITLE
feat(tts): Add Azure Cognitive Services Speech integration for text-to-speech

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,26 @@ dotnet user-secrets set "Identity:DefaultAdmin:Password" "InitialPassword123!"
 
 See [Identity Configuration](docs/articles/identity-configuration.md) for detailed authentication setup and troubleshooting.
 
+### Azure Speech Configuration (TTS)
+
+Azure Cognitive Services Speech is used for text-to-speech functionality. Configure via User Secrets:
+
+```bash
+cd src/DiscordBot.Bot
+dotnet user-secrets set "AzureSpeech:SubscriptionKey" "your-azure-speech-subscription-key"
+dotnet user-secrets set "AzureSpeech:Region" "eastus"  # Optional, defaults to eastus
+```
+
+#### Azure Portal Setup
+
+1. Go to https://portal.azure.com
+2. Create a Speech service resource (or use existing)
+3. Go to Keys and Endpoint
+4. Copy Key 1 or Key 2 to user secrets as `SubscriptionKey`
+5. Note the region (e.g., "eastus", "westus2") and set as `Region` if different from default
+
+See Azure Speech SDK documentation for available voices and regions.
+
 ## Configuration Options
 
 The application uses the `IOptions<T>` pattern for strongly-typed configuration. Options classes are located in `src/DiscordBot.Core/Configuration/` (with `DatabaseSettings` in `src/DiscordBot.Infrastructure/Configuration/`):
@@ -95,6 +115,7 @@ The application uses the `IOptions<T>` pattern for strongly-typed configuration.
 | `AnalyticsRetentionOptions` | `AnalyticsRetention` | Analytics data retention settings |
 | `AuditLogRetentionOptions` | `AuditLogRetention` | Audit log cleanup settings |
 | `AutoModerationOptions` | `AutoModeration` | Auto-moderation rules and thresholds |
+| `AzureSpeechOptions` | `AzureSpeech` | Azure TTS service settings (use user secrets for SubscriptionKey) |
 | `BackgroundServicesOptions` | `BackgroundServices` | Background task intervals and delays |
 | `CachingOptions` | `Caching` | Cache duration settings for various services |
 | `DatabaseSettings` | `Database` | Query performance logging (slow query threshold, parameter logging) |

--- a/src/DiscordBot.Bot/DiscordBot.Bot.csproj
+++ b/src/DiscordBot.Bot/DiscordBot.Bot.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Discord.Net" Version="3.19.0-beta.1" />
     <PackageReference Include="libsodium" Version="1.0.20.1" />
     <PackageReference Include="OpusDotNet.opus.win-x64" Version="1.3.1" />
+    <PackageReference Include="Microsoft.CognitiveServices.Speech" Version="1.41.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.*">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/DiscordBot.Bot/Program.cs
+++ b/src/DiscordBot.Bot/Program.cs
@@ -349,6 +349,11 @@ try
     builder.Services.AddSingleton<IPlaybackService, PlaybackService>();
     builder.Services.AddHostedService<VoiceAutoLeaveService>();
 
+    // Add Azure Speech TTS services
+    builder.Services.Configure<AzureSpeechOptions>(
+        builder.Configuration.GetSection(AzureSpeechOptions.SectionName));
+    builder.Services.AddSingleton<ITtsService, AzureTtsService>();
+
     // Add Analytics Aggregation services
     builder.Services.Configure<AnalyticsRetentionOptions>(
         builder.Configuration.GetSection(AnalyticsRetentionOptions.SectionName));

--- a/src/DiscordBot.Bot/Services/AzureTtsService.cs
+++ b/src/DiscordBot.Bot/Services/AzureTtsService.cs
@@ -1,0 +1,269 @@
+using System.Collections.Concurrent;
+using System.Text;
+using DiscordBot.Core.Configuration;
+using DiscordBot.Core.Interfaces;
+using Microsoft.CognitiveServices.Speech;
+using Microsoft.CognitiveServices.Speech.Audio;
+using Microsoft.Extensions.Options;
+
+namespace DiscordBot.Bot.Services;
+
+/// <summary>
+/// Service for text-to-speech synthesis using Azure Cognitive Services Speech.
+/// Converts text to PCM audio compatible with Discord voice channels (48kHz, 16-bit, stereo).
+/// </summary>
+public class AzureTtsService : ITtsService
+{
+    private readonly AzureSpeechOptions _options;
+    private readonly ILogger<AzureTtsService> _logger;
+    private readonly SpeechConfig? _speechConfig;
+    private readonly ConcurrentDictionary<string, List<Core.Models.VoiceInfo>> _voiceCache = new();
+    private readonly SemaphoreSlim _voiceCacheLock = new(1, 1);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AzureTtsService"/> class.
+    /// </summary>
+    /// <param name="options">Azure Speech configuration options.</param>
+    /// <param name="logger">The logger.</param>
+    public AzureTtsService(
+        IOptions<AzureSpeechOptions> options,
+        ILogger<AzureTtsService> logger)
+    {
+        _options = options.Value;
+        _logger = logger;
+
+        // Initialize SpeechConfig if subscription key is provided
+        if (!string.IsNullOrWhiteSpace(_options.SubscriptionKey))
+        {
+            try
+            {
+                _speechConfig = SpeechConfig.FromSubscription(_options.SubscriptionKey, _options.Region);
+                _logger.LogInformation("Azure Speech service configured for region {Region}", _options.Region);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to initialize Azure Speech service with region {Region}", _options.Region);
+                _speechConfig = null;
+            }
+        }
+        else
+        {
+            _logger.LogWarning("Azure Speech service not configured - SubscriptionKey is missing. TTS features will be disabled.");
+        }
+    }
+
+    /// <inheritdoc/>
+    public bool IsConfigured => _speechConfig != null;
+
+    /// <inheritdoc/>
+    public async Task<Stream> SynthesizeSpeechAsync(string text, Core.Models.TtsOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            throw new ArgumentException("Text cannot be null or empty.", nameof(text));
+        }
+
+        if (text.Length > _options.MaxTextLength)
+        {
+            throw new ArgumentException($"Text length ({text.Length}) exceeds maximum allowed length ({_options.MaxTextLength}).", nameof(text));
+        }
+
+        if (!IsConfigured)
+        {
+            throw new InvalidOperationException("Azure Speech service is not configured. Configure SubscriptionKey in user secrets.");
+        }
+
+        // Use provided options or create defaults
+        var ttsOptions = options ?? new Core.Models.TtsOptions
+        {
+            Voice = _options.DefaultVoice,
+            Speed = _options.DefaultSpeed,
+            Pitch = _options.DefaultPitch,
+            Volume = _options.DefaultVolume
+        };
+
+        _logger.LogInformation("Synthesizing speech: {TextLength} characters with voice {Voice} (speed: {Speed}, pitch: {Pitch}, volume: {Volume})",
+            text.Length, ttsOptions.Voice, ttsOptions.Speed, ttsOptions.Pitch, ttsOptions.Volume);
+
+        try
+        {
+            // Build SSML for synthesis
+            var ssml = BuildSsml(text, ttsOptions);
+            _logger.LogDebug("SSML: {Ssml}", ssml);
+
+            // Create synthesizer with raw PCM output format (mono - we'll convert to stereo)
+            // Azure Speech SDK outputs Raw48Khz16BitMonoPcm
+            _speechConfig!.SetSpeechSynthesisOutputFormat(SpeechSynthesisOutputFormat.Raw48Khz16BitMonoPcm);
+
+            using var synthesizer = new SpeechSynthesizer(_speechConfig, null); // null = no audio output, we'll handle the stream
+
+            // Synthesize speech from SSML
+            var result = await synthesizer.SpeakSsmlAsync(ssml);
+
+            if (result.Reason == ResultReason.SynthesizingAudioCompleted)
+            {
+                _logger.LogInformation("Speech synthesis completed successfully. Audio data size: {SizeBytes} bytes", result.AudioData.Length);
+
+                // Convert mono PCM to stereo PCM for Discord
+                var stereoData = ConvertMonoToStereo(result.AudioData);
+
+                return new MemoryStream(stereoData);
+            }
+            else if (result.Reason == ResultReason.Canceled)
+            {
+                var cancellation = SpeechSynthesisCancellationDetails.FromResult(result);
+                _logger.LogError("Speech synthesis cancelled: {Reason} - {ErrorDetails}", cancellation.Reason, cancellation.ErrorDetails);
+
+                throw new InvalidOperationException($"Speech synthesis failed: {cancellation.ErrorDetails}");
+            }
+            else
+            {
+                _logger.LogError("Speech synthesis failed with reason: {Reason}", result.Reason);
+                throw new InvalidOperationException($"Speech synthesis failed: {result.Reason}");
+            }
+        }
+        catch (Exception ex) when (ex is not ArgumentException && ex is not InvalidOperationException)
+        {
+            _logger.LogError(ex, "Unexpected error during speech synthesis");
+            throw new InvalidOperationException("Speech synthesis failed. See inner exception for details.", ex);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<Core.Models.VoiceInfo>> GetAvailableVoicesAsync(string? locale = "en-US", CancellationToken cancellationToken = default)
+    {
+        if (!IsConfigured)
+        {
+            _logger.LogWarning("Cannot retrieve voices - Azure Speech service is not configured");
+            return Enumerable.Empty<Core.Models.VoiceInfo>();
+        }
+
+        var cacheKey = locale ?? "all";
+
+        // Check cache first
+        if (_voiceCache.TryGetValue(cacheKey, out var cachedVoices))
+        {
+            _logger.LogDebug("Returning {Count} voices from cache for locale '{Locale}'", cachedVoices.Count, cacheKey);
+            return cachedVoices;
+        }
+
+        // Not in cache, fetch from Azure
+        await _voiceCacheLock.WaitAsync(cancellationToken);
+        try
+        {
+            // Double-check after acquiring lock
+            if (_voiceCache.TryGetValue(cacheKey, out cachedVoices))
+            {
+                return cachedVoices;
+            }
+
+            _logger.LogInformation("Fetching available voices from Azure Speech service for locale '{Locale}'", cacheKey);
+
+            using var synthesizer = new SpeechSynthesizer(_speechConfig!, null);
+            var result = await synthesizer.GetVoicesAsync(locale);
+
+            if (result.Reason == ResultReason.VoicesListRetrieved)
+            {
+                var voices = result.Voices
+                    .Select(v => new Core.Models.VoiceInfo
+                    {
+                        ShortName = v.ShortName,
+                        DisplayName = v.LocalName,
+                        Locale = v.Locale,
+                        Gender = v.Gender.ToString()
+                    })
+                    .ToList();
+
+                _logger.LogInformation("Retrieved {Count} voices for locale '{Locale}'", voices.Count, cacheKey);
+
+                // Cache the results
+                _voiceCache[cacheKey] = voices;
+
+                return voices;
+            }
+            else
+            {
+                _logger.LogError("Failed to retrieve voices. Reason: {Reason}", result.Reason);
+                return Enumerable.Empty<Core.Models.VoiceInfo>();
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error retrieving available voices for locale '{Locale}'", locale);
+            return Enumerable.Empty<Core.Models.VoiceInfo>();
+        }
+        finally
+        {
+            _voiceCacheLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Builds SSML markup for speech synthesis with the specified options.
+    /// </summary>
+    /// <param name="text">The text to synthesize.</param>
+    /// <param name="options">TTS options for voice, speed, pitch, and volume.</param>
+    /// <returns>SSML string.</returns>
+    private static string BuildSsml(string text, Core.Models.TtsOptions options)
+    {
+        // Escape XML special characters in the text
+        var escapedText = System.Security.SecurityElement.Escape(text);
+
+        // Convert pitch from multiplier (0.5-1.5) to percentage (-50% to +50%)
+        var pitchPercent = (options.Pitch - 1.0) * 100.0;
+        var pitchStr = pitchPercent >= 0 ? $"+{pitchPercent:F0}%" : $"{pitchPercent:F0}%";
+
+        // Convert speed multiplier to rate string
+        var speedStr = options.Speed.ToString("F2", System.Globalization.CultureInfo.InvariantCulture);
+
+        // Convert volume (0.0-1.0) to percentage (0-100)
+        var volumePercent = (int)(options.Volume * 100);
+
+        var ssml = new StringBuilder();
+        ssml.AppendLine("<speak version=\"1.0\" xmlns=\"http://www.w3.org/2001/10/synthesis\" xml:lang=\"en-US\">");
+        ssml.AppendLine($"  <voice name=\"{options.Voice}\">");
+        ssml.AppendLine($"    <prosody rate=\"{speedStr}\" pitch=\"{pitchStr}\" volume=\"{volumePercent}\">");
+        ssml.AppendLine($"      {escapedText}");
+        ssml.AppendLine("    </prosody>");
+        ssml.AppendLine("  </voice>");
+        ssml.AppendLine("</speak>");
+
+        return ssml.ToString();
+    }
+
+    /// <summary>
+    /// Converts mono PCM audio to stereo by duplicating each sample (interleaving left and right channels).
+    /// </summary>
+    /// <param name="monoData">Mono PCM data (16-bit samples).</param>
+    /// <returns>Stereo PCM data (16-bit samples, interleaved).</returns>
+    /// <remarks>
+    /// Input: Mono 48kHz 16-bit PCM (2 bytes per sample)
+    /// Output: Stereo 48kHz 16-bit PCM (4 bytes per frame - 2 bytes left, 2 bytes right)
+    /// Discord expects stereo, so we duplicate each mono sample for both channels.
+    /// </remarks>
+    private byte[] ConvertMonoToStereo(byte[] monoData)
+    {
+        // Each sample is 2 bytes (16-bit). For stereo, we need to duplicate each sample.
+        var stereoData = new byte[monoData.Length * 2];
+
+        for (int i = 0; i < monoData.Length; i += 2)
+        {
+            // Get the mono sample (2 bytes)
+            var sampleLow = monoData[i];
+            var sampleHigh = monoData[i + 1];
+
+            // Write to left channel
+            stereoData[i * 2] = sampleLow;
+            stereoData[i * 2 + 1] = sampleHigh;
+
+            // Write to right channel (duplicate)
+            stereoData[i * 2 + 2] = sampleLow;
+            stereoData[i * 2 + 3] = sampleHigh;
+        }
+
+        _logger.LogDebug("Converted mono audio ({MonoBytes} bytes) to stereo ({StereoBytes} bytes)",
+            monoData.Length, stereoData.Length);
+
+        return stereoData;
+    }
+}

--- a/src/DiscordBot.Core/Configuration/AzureSpeechOptions.cs
+++ b/src/DiscordBot.Core/Configuration/AzureSpeechOptions.cs
@@ -1,0 +1,80 @@
+namespace DiscordBot.Core.Configuration;
+
+/// <summary>
+/// Configuration options for Azure Cognitive Services Speech integration.
+/// </summary>
+public class AzureSpeechOptions
+{
+    /// <summary>
+    /// The configuration section name for binding.
+    /// </summary>
+    public const string SectionName = "AzureSpeech";
+
+    /// <summary>
+    /// Gets or sets the Azure Speech subscription key.
+    /// This should be configured via user secrets, never in appsettings.json.
+    /// </summary>
+    /// <remarks>
+    /// Required for speech synthesis. If not configured, the TTS service will be disabled.
+    /// Set via user secrets: dotnet user-secrets set "AzureSpeech:SubscriptionKey" "your-key-here"
+    /// </remarks>
+    public string? SubscriptionKey { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Azure region for the Speech service.
+    /// Default is "eastus".
+    /// </summary>
+    /// <remarks>
+    /// Common regions: eastus, westus, westus2, eastus2, westeurope, southeastasia.
+    /// Must match the region of your Azure Speech resource.
+    /// </remarks>
+    public string Region { get; set; } = "eastus";
+
+    /// <summary>
+    /// Gets or sets the default voice to use for speech synthesis.
+    /// Default is "en-US-JennyNeural" (female, US English).
+    /// </summary>
+    /// <remarks>
+    /// Full list of voices: https://learn.microsoft.com/azure/ai-services/speech-service/language-support
+    /// Examples: en-US-JennyNeural, en-US-GuyNeural, en-GB-SoniaNeural
+    /// </remarks>
+    public string DefaultVoice { get; set; } = "en-US-JennyNeural";
+
+    /// <summary>
+    /// Gets or sets the maximum allowed text length for synthesis in characters.
+    /// Default is 500 characters.
+    /// </summary>
+    /// <remarks>
+    /// Azure Speech service limits single requests to around 400KB of text.
+    /// Keeping this limit lower prevents abuse and excessive API usage.
+    /// </remarks>
+    public int MaxTextLength { get; set; } = 500;
+
+    /// <summary>
+    /// Gets or sets the default speech rate multiplier.
+    /// Range: 0.5 to 2.0. Default is 1.0 (normal speed).
+    /// </summary>
+    /// <remarks>
+    /// 0.5 = 50% speed (slow), 1.0 = normal speed, 2.0 = 200% speed (fast).
+    /// </remarks>
+    public double DefaultSpeed { get; set; } = 1.0;
+
+    /// <summary>
+    /// Gets or sets the default pitch adjustment.
+    /// Range: 0.5 to 1.5. Default is 1.0 (no adjustment).
+    /// </summary>
+    /// <remarks>
+    /// 0.5 = -50% pitch (lower), 1.0 = normal pitch, 1.5 = +50% pitch (higher).
+    /// This is converted to a percentage offset for SSML.
+    /// </remarks>
+    public double DefaultPitch { get; set; } = 1.0;
+
+    /// <summary>
+    /// Gets or sets the default volume level.
+    /// Range: 0.0 to 1.0. Default is 0.8 (80% volume).
+    /// </summary>
+    /// <remarks>
+    /// 0.0 = silent, 0.5 = 50% volume, 1.0 = 100% volume.
+    /// </remarks>
+    public double DefaultVolume { get; set; } = 0.8;
+}

--- a/src/DiscordBot.Core/Interfaces/ITtsService.cs
+++ b/src/DiscordBot.Core/Interfaces/ITtsService.cs
@@ -1,0 +1,34 @@
+using DiscordBot.Core.Models;
+
+namespace DiscordBot.Core.Interfaces;
+
+/// <summary>
+/// Service interface for text-to-speech synthesis.
+/// </summary>
+public interface ITtsService
+{
+    /// <summary>
+    /// Synthesizes speech from text and returns the audio as a stream.
+    /// </summary>
+    /// <param name="text">The text to synthesize.</param>
+    /// <param name="options">TTS options (voice, speed, pitch, volume).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A stream containing the synthesized audio in PCM format (48kHz, 16-bit, stereo).</returns>
+    /// <exception cref="ArgumentException">Thrown when text is null, empty, or exceeds max length.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when TTS service is not configured.</exception>
+    Task<Stream> SynthesizeSpeechAsync(string text, TtsOptions? options = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets available voices for the specified locale.
+    /// </summary>
+    /// <param name="locale">The locale to filter voices by (e.g., "en-US"). Pass null for all locales.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Collection of available voice information.</returns>
+    Task<IEnumerable<VoiceInfo>> GetAvailableVoicesAsync(string? locale = "en-US", CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks if the TTS service is configured and available.
+    /// </summary>
+    /// <returns>True if the service is properly configured, false otherwise.</returns>
+    bool IsConfigured { get; }
+}

--- a/src/DiscordBot.Core/Models/TtsOptions.cs
+++ b/src/DiscordBot.Core/Models/TtsOptions.cs
@@ -1,0 +1,31 @@
+namespace DiscordBot.Core.Models;
+
+/// <summary>
+/// Options for text-to-speech synthesis.
+/// </summary>
+public class TtsOptions
+{
+    /// <summary>
+    /// The voice to use for synthesis (e.g., "en-US-JennyNeural").
+    /// </summary>
+    public string Voice { get; set; } = "en-US-JennyNeural";
+
+    /// <summary>
+    /// Speech rate multiplier. Range: 0.5 to 2.0. Default is 1.0 (normal speed).
+    /// </summary>
+    public double Speed { get; set; } = 1.0;
+
+    /// <summary>
+    /// Pitch adjustment. Range: 0.5 to 1.5 (relative). Default is 1.0 (no adjustment).
+    /// </summary>
+    /// <remarks>
+    /// This value is converted to a percentage for SSML: (Pitch - 1.0) * 100%.
+    /// Example: 0.5 = -50%, 1.0 = 0%, 1.5 = +50%.
+    /// </remarks>
+    public double Pitch { get; set; } = 1.0;
+
+    /// <summary>
+    /// Volume level. Range: 0.0 to 1.0. Default is 1.0.
+    /// </summary>
+    public double Volume { get; set; } = 1.0;
+}

--- a/src/DiscordBot.Core/Models/VoiceInfo.cs
+++ b/src/DiscordBot.Core/Models/VoiceInfo.cs
@@ -1,0 +1,27 @@
+namespace DiscordBot.Core.Models;
+
+/// <summary>
+/// Information about an available text-to-speech voice.
+/// </summary>
+public class VoiceInfo
+{
+    /// <summary>
+    /// Short name identifier for the voice (e.g., "en-US-JennyNeural").
+    /// </summary>
+    public required string ShortName { get; init; }
+
+    /// <summary>
+    /// Human-readable display name for the voice (e.g., "Jenny").
+    /// </summary>
+    public required string DisplayName { get; init; }
+
+    /// <summary>
+    /// Locale/language code for the voice (e.g., "en-US").
+    /// </summary>
+    public required string Locale { get; init; }
+
+    /// <summary>
+    /// Gender of the voice ("Female" or "Male").
+    /// </summary>
+    public required string Gender { get; init; }
+}

--- a/tests/DiscordBot.Tests/Bot/Services/AzureTtsServiceTests.cs
+++ b/tests/DiscordBot.Tests/Bot/Services/AzureTtsServiceTests.cs
@@ -1,0 +1,640 @@
+using DiscordBot.Bot.Services;
+using DiscordBot.Core.Configuration;
+using DiscordBot.Core.Models;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace DiscordBot.Tests.Bot.Services;
+
+/// <summary>
+/// Unit tests for <see cref="AzureTtsService"/>.
+/// Tests cover configuration validation, input validation, and audio format handling.
+/// Note: Actual Azure SDK calls are not tested as they require a valid subscription.
+/// </summary>
+public class AzureTtsServiceTests : IDisposable
+{
+    private readonly Mock<ILogger<AzureTtsService>> _mockLogger;
+    private readonly Mock<IOptions<AzureSpeechOptions>> _mockOptions;
+
+    public AzureTtsServiceTests()
+    {
+        _mockLogger = new Mock<ILogger<AzureTtsService>>();
+        _mockOptions = new Mock<IOptions<AzureSpeechOptions>>();
+    }
+
+    public void Dispose()
+    {
+        // No resources to clean up
+    }
+
+    private AzureTtsService CreateService(AzureSpeechOptions? options = null)
+    {
+        var opts = options ?? new AzureSpeechOptions();
+        _mockOptions.Setup(x => x.Value).Returns(opts);
+        return new AzureTtsService(_mockOptions.Object, _mockLogger.Object);
+    }
+
+    #region IsConfigured Property Tests
+
+    [Fact]
+    public void IsConfigured_ReturnsFalse_WhenSubscriptionKeyIsNull()
+    {
+        // Arrange
+        var options = new AzureSpeechOptions { SubscriptionKey = null };
+        var service = CreateService(options);
+
+        // Act
+        var result = service.IsConfigured;
+
+        // Assert
+        result.Should().BeFalse("service should not be configured when subscription key is null");
+    }
+
+    [Fact]
+    public void IsConfigured_ReturnsFalse_WhenSubscriptionKeyIsEmpty()
+    {
+        // Arrange
+        var options = new AzureSpeechOptions { SubscriptionKey = string.Empty };
+        var service = CreateService(options);
+
+        // Act
+        var result = service.IsConfigured;
+
+        // Assert
+        result.Should().BeFalse("service should not be configured when subscription key is empty");
+    }
+
+    [Fact]
+    public void IsConfigured_ReturnsFalse_WhenSubscriptionKeyIsWhitespace()
+    {
+        // Arrange
+        var options = new AzureSpeechOptions { SubscriptionKey = "   " };
+        var service = CreateService(options);
+
+        // Act
+        var result = service.IsConfigured;
+
+        // Assert
+        result.Should().BeFalse("service should not be configured when subscription key is whitespace");
+    }
+
+    [Fact]
+    public void IsConfigured_ReturnsTrue_WhenSubscriptionKeyIsProvided()
+    {
+        // Arrange - Even a short key will be accepted by SpeechConfig.FromSubscription
+        // Azure SDK validates the key later during actual API calls
+        var options = new AzureSpeechOptions { SubscriptionKey = "test-key" };
+        var service = CreateService(options);
+
+        // Act
+        var result = service.IsConfigured;
+
+        // Assert
+        result.Should().BeTrue("service should be configured when subscription key is provided");
+    }
+
+    #endregion
+
+    #region SynthesizeSpeechAsync Validation Tests
+
+    [Fact]
+    public async Task SynthesizeSpeechAsync_ThrowsArgumentException_WhenTextIsNull()
+    {
+        // Arrange
+        var options = new AzureSpeechOptions { SubscriptionKey = null };
+        var service = CreateService(options);
+
+        // Act
+        var act = async () => await service.SynthesizeSpeechAsync(null!);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*Text cannot be null or empty.*")
+            .Where(ex => ex.ParamName == "text", "exception should reference the text parameter");
+    }
+
+    [Fact]
+    public async Task SynthesizeSpeechAsync_ThrowsArgumentException_WhenTextIsEmpty()
+    {
+        // Arrange
+        var options = new AzureSpeechOptions { SubscriptionKey = null };
+        var service = CreateService(options);
+
+        // Act
+        var act = async () => await service.SynthesizeSpeechAsync(string.Empty);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*Text cannot be null or empty.*")
+            .Where(ex => ex.ParamName == "text", "exception should reference the text parameter");
+    }
+
+    [Fact]
+    public async Task SynthesizeSpeechAsync_ThrowsArgumentException_WhenTextIsWhitespace()
+    {
+        // Arrange
+        var options = new AzureSpeechOptions { SubscriptionKey = null };
+        var service = CreateService(options);
+
+        // Act
+        var act = async () => await service.SynthesizeSpeechAsync("   ");
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*Text cannot be null or empty.*")
+            .Where(ex => ex.ParamName == "text", "exception should reference the text parameter");
+    }
+
+    [Fact]
+    public async Task SynthesizeSpeechAsync_ThrowsArgumentException_WhenTextExceedsMaxLength()
+    {
+        // Arrange
+        var maxLength = 500;
+        var options = new AzureSpeechOptions
+        {
+            SubscriptionKey = null,
+            MaxTextLength = maxLength
+        };
+        var service = CreateService(options);
+        var textExceedingLimit = new string('a', maxLength + 1);
+
+        // Act
+        var act = async () => await service.SynthesizeSpeechAsync(textExceedingLimit);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage($"*Text length ({maxLength + 1}) exceeds maximum allowed length ({maxLength}).*")
+            .Where(ex => ex.ParamName == "text", "exception should reference the text parameter");
+    }
+
+    [Fact]
+    public async Task SynthesizeSpeechAsync_ThrowsArgumentException_WhenTextIsAtMaxLength()
+    {
+        // Arrange - Text that exactly meets the limit should NOT throw
+        var maxLength = 500;
+        var options = new AzureSpeechOptions
+        {
+            SubscriptionKey = null,
+            MaxTextLength = maxLength
+        };
+        var service = CreateService(options);
+        var textAtLimit = new string('a', maxLength);
+
+        // Act - This should not throw for length validation
+        var act = async () => await service.SynthesizeSpeechAsync(textAtLimit);
+
+        // Assert - Will throw InvalidOperationException for not configured, not ArgumentException for length
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Azure Speech service is not configured*");
+    }
+
+    [Fact]
+    public async Task SynthesizeSpeechAsync_ThrowsInvalidOperationException_WhenServiceNotConfigured()
+    {
+        // Arrange
+        var options = new AzureSpeechOptions { SubscriptionKey = null };
+        var service = CreateService(options);
+
+        // Act
+        var act = async () => await service.SynthesizeSpeechAsync("hello world");
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Azure Speech service is not configured*")
+            .WithMessage("*Configure SubscriptionKey in user secrets*");
+    }
+
+    #endregion
+
+    #region SynthesizeSpeechAsync Options Tests
+
+    [Fact]
+    public async Task SynthesizeSpeechAsync_UsesDefaultOptions_WhenOptionsParameterIsNull()
+    {
+        // Arrange
+        var defaultVoice = "en-US-CustomVoice";
+        var defaultSpeed = 1.5;
+        var defaultPitch = 0.8;
+        var defaultVolume = 0.7;
+        var options = new AzureSpeechOptions
+        {
+            SubscriptionKey = null,
+            DefaultVoice = defaultVoice,
+            DefaultSpeed = defaultSpeed,
+            DefaultPitch = defaultPitch,
+            DefaultVolume = defaultVolume
+        };
+        var service = CreateService(options);
+
+        // Act
+        var act = async () => await service.SynthesizeSpeechAsync("test", options: null);
+
+        // Assert - Will throw due to not configured
+        // We verify that InvalidOperationException is thrown (validation passed)
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task SynthesizeSpeechAsync_UsesProvidedOptions_WhenOptionsParameterIsNotNull()
+    {
+        // Arrange
+        var options = new AzureSpeechOptions { SubscriptionKey = null };
+        var service = CreateService(options);
+        var customOptions = new TtsOptions
+        {
+            Voice = "en-US-CustomVoice",
+            Speed = 1.2,
+            Pitch = 1.1,
+            Volume = 0.9
+        };
+
+        // Act
+        var act = async () => await service.SynthesizeSpeechAsync("test", customOptions);
+
+        // Assert - Will throw due to not configured
+        // The fact that it validates text and reaches the configuration check means provided options are processed
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Azure Speech service is not configured*");
+    }
+
+    #endregion
+
+    #region GetAvailableVoicesAsync Tests
+
+    [Fact]
+    public async Task GetAvailableVoicesAsync_ReturnsEmptyCollection_WhenServiceNotConfigured()
+    {
+        // Arrange
+        var options = new AzureSpeechOptions { SubscriptionKey = null };
+        var service = CreateService(options);
+
+        // Act
+        var result = await service.GetAvailableVoicesAsync();
+
+        // Assert
+        result.Should().BeEmpty("should return empty collection when service not configured");
+        result.Should().HaveCount(0);
+    }
+
+    [Fact]
+    public async Task GetAvailableVoicesAsync_ReturnsEmptyCollection_WhenServiceNotConfiguredWithLocale()
+    {
+        // Arrange
+        var options = new AzureSpeechOptions { SubscriptionKey = null };
+        var service = CreateService(options);
+
+        // Act
+        var result = await service.GetAvailableVoicesAsync("en-GB");
+
+        // Assert
+        result.Should().BeEmpty("should return empty collection when service not configured");
+    }
+
+    [Fact]
+    public async Task GetAvailableVoicesAsync_LogsWarning_WhenServiceNotConfigured()
+    {
+        // Arrange
+        var options = new AzureSpeechOptions { SubscriptionKey = null };
+        var service = CreateService(options);
+
+        // Act
+        await service.GetAvailableVoicesAsync();
+
+        // Assert - Logger is called in constructor (for missing key) and again in GetAvailableVoicesAsync (service not configured)
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Cannot retrieve voices")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once,
+            "logger should warn when voices cannot be retrieved");
+    }
+
+    [Fact]
+    public async Task GetAvailableVoicesAsync_CachesResults_OnMultipleCalls()
+    {
+        // Arrange
+        var options = new AzureSpeechOptions { SubscriptionKey = null };
+        var service = CreateService(options);
+
+        // Act - Call twice
+        var result1 = await service.GetAvailableVoicesAsync();
+        var result2 = await service.GetAvailableVoicesAsync();
+
+        // Assert - Both should be empty since service is not configured
+        result1.Should().BeEmpty();
+        result2.Should().BeEmpty();
+
+        // Verify both calls complete successfully
+        // (Logger will be called for each call since service is not configured)
+    }
+
+    [Fact]
+    public async Task GetAvailableVoicesAsync_UsesDefaultLocale_WhenLocaleNotSpecified()
+    {
+        // Arrange
+        var options = new AzureSpeechOptions { SubscriptionKey = null };
+        var service = CreateService(options);
+
+        // Act
+        await service.GetAvailableVoicesAsync();
+
+        // Assert - Should complete without error, using default locale
+        // No exception thrown means the default locale "en-US" was used
+    }
+
+    [Fact]
+    public async Task GetAvailableVoicesAsync_ReturnsEmptyCollection_WhenServiceNotConfiguredWithNullLocale()
+    {
+        // Arrange
+        var options = new AzureSpeechOptions { SubscriptionKey = null };
+        var service = CreateService(options);
+
+        // Act
+        var result = await service.GetAvailableVoicesAsync(locale: null);
+
+        // Assert
+        result.Should().BeEmpty("should return empty collection when service not configured");
+    }
+
+    #endregion
+
+    #region Configuration Tests
+
+    [Fact]
+    public void Constructor_LogsInformation_WhenSubscriptionKeyIsEmpty()
+    {
+        // Arrange
+        var options = new AzureSpeechOptions { SubscriptionKey = null };
+
+        // Act
+        var service = CreateService(options);
+
+        // Assert
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) =>
+                    v.ToString()!.Contains("not configured") &&
+                    v.ToString()!.Contains("SubscriptionKey")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once,
+            "logger should warn about missing subscription key");
+    }
+
+    [Fact]
+    public void Constructor_UsesProvidedRegion_InConfiguration()
+    {
+        // Arrange
+        var customRegion = "westeurope";
+        var options = new AzureSpeechOptions
+        {
+            SubscriptionKey = null,
+            Region = customRegion
+        };
+
+        // Act
+        var service = CreateService(options);
+
+        // Assert - Service should not be configured, but region should be used in initialization attempt
+        service.IsConfigured.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Constructor_UsesDefaultRegion_WhenNotSpecified()
+    {
+        // Arrange
+        var options = new AzureSpeechOptions { SubscriptionKey = null };
+
+        // Act
+        var service = CreateService(options);
+
+        // Assert
+        options.Region.Should().Be("eastus", "default region should be eastus");
+    }
+
+    [Fact]
+    public void Constructor_UsesDefaultVoice_WhenNotOverridden()
+    {
+        // Arrange
+        var options = new AzureSpeechOptions { SubscriptionKey = null };
+
+        // Act
+        var service = CreateService(options);
+
+        // Assert
+        options.DefaultVoice.Should().Be("en-US-JennyNeural", "default voice should be en-US-JennyNeural");
+    }
+
+    [Fact]
+    public void Constructor_UsesDefaultMaxTextLength_WhenNotOverridden()
+    {
+        // Arrange
+        var options = new AzureSpeechOptions { SubscriptionKey = null };
+
+        // Act
+        var service = CreateService(options);
+
+        // Assert
+        options.MaxTextLength.Should().Be(500, "default max text length should be 500");
+    }
+
+    [Fact]
+    public void Constructor_UsesDefaultSpeed_WhenNotOverridden()
+    {
+        // Arrange
+        var options = new AzureSpeechOptions { SubscriptionKey = null };
+
+        // Act
+        var service = CreateService(options);
+
+        // Assert
+        options.DefaultSpeed.Should().Be(1.0, "default speed should be 1.0");
+    }
+
+    [Fact]
+    public void Constructor_UsesDefaultPitch_WhenNotOverridden()
+    {
+        // Arrange
+        var options = new AzureSpeechOptions { SubscriptionKey = null };
+
+        // Act
+        var service = CreateService(options);
+
+        // Assert
+        options.DefaultPitch.Should().Be(1.0, "default pitch should be 1.0");
+    }
+
+    [Fact]
+    public void Constructor_UsesDefaultVolume_WhenNotOverridden()
+    {
+        // Arrange
+        var options = new AzureSpeechOptions { SubscriptionKey = null };
+
+        // Act
+        var service = CreateService(options);
+
+        // Assert
+        options.DefaultVolume.Should().Be(0.8, "default volume should be 0.8");
+    }
+
+    #endregion
+
+    #region Edge Cases and Boundary Tests
+
+    [Fact]
+    public async Task SynthesizeSpeechAsync_ThrowsArgumentException_WithTextJustOverLimit()
+    {
+        // Arrange
+        var maxLength = 100;
+        var options = new AzureSpeechOptions
+        {
+            SubscriptionKey = null,
+            MaxTextLength = maxLength
+        };
+        var service = CreateService(options);
+        var textOneCharOver = new string('a', maxLength + 1);
+
+        // Act
+        var act = async () => await service.SynthesizeSpeechAsync(textOneCharOver);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage($"*({maxLength + 1}) exceeds*({maxLength})*");
+    }
+
+    [Fact]
+    public async Task SynthesizeSpeechAsync_ValidatesTextLengthBeforeConfiguration()
+    {
+        // Arrange - Text validation should happen before checking if configured
+        var options = new AzureSpeechOptions
+        {
+            SubscriptionKey = null,
+            MaxTextLength = 100
+        };
+        var service = CreateService(options);
+        var oversizeText = new string('a', 101);
+
+        // Act
+        var act = async () => await service.SynthesizeSpeechAsync(oversizeText);
+
+        // Assert - Should throw ArgumentException for text length, not InvalidOperationException for configuration
+        await act.Should().ThrowAsync<ArgumentException>()
+            .Where(ex => ex.Message.Contains("exceeds maximum"), "should validate text length before configuration");
+    }
+
+    [Fact]
+    public async Task SynthesizeSpeechAsync_ValidatesTextNullnessBeforeConfiguration()
+    {
+        // Arrange - Null check should happen before checking if configured
+        var options = new AzureSpeechOptions { SubscriptionKey = null };
+        var service = CreateService(options);
+
+        // Act
+        var act = async () => await service.SynthesizeSpeechAsync(null!);
+
+        // Assert - Should throw ArgumentException for null text, not InvalidOperationException for configuration
+        await act.Should().ThrowAsync<ArgumentException>()
+            .Where(ex => ex.ParamName == "text", "should validate text nullness before configuration");
+    }
+
+    #endregion
+
+    #region Concurrency and Thread Safety Tests
+
+    [Fact]
+    public async Task GetAvailableVoicesAsync_HandlesMultipleSimultaneousCalls()
+    {
+        // Arrange
+        var options = new AzureSpeechOptions { SubscriptionKey = null };
+        var service = CreateService(options);
+
+        // Act - Call the service multiple times simultaneously
+        var tasks = Enumerable.Range(0, 5)
+            .Select(_ => service.GetAvailableVoicesAsync())
+            .ToList();
+
+        var results = await Task.WhenAll(tasks);
+
+        // Assert - All calls should complete and return empty collections
+        results.Should().HaveCount(5, "all calls should complete");
+        results.Should().AllSatisfy(r => r.Should().BeEmpty());
+    }
+
+    #endregion
+
+    #region Input Validation with Special Characters
+
+    [Fact]
+    public async Task SynthesizeSpeechAsync_AcceptsValidSpecialCharacters()
+    {
+        // Arrange
+        var options = new AzureSpeechOptions { SubscriptionKey = null };
+        var service = CreateService(options);
+        var textWithSpecialChars = "Hello, world! How are you? I'm fine.";
+
+        // Act
+        var act = async () => await service.SynthesizeSpeechAsync(textWithSpecialChars);
+
+        // Assert - Should not throw for text validation, only for configuration
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Azure Speech service is not configured*");
+    }
+
+    [Fact]
+    public async Task SynthesizeSpeechAsync_AcceptsTextWithNumbers()
+    {
+        // Arrange
+        var options = new AzureSpeechOptions { SubscriptionKey = null };
+        var service = CreateService(options);
+        var textWithNumbers = "The answer is 42 and the year is 2024.";
+
+        // Act
+        var act = async () => await service.SynthesizeSpeechAsync(textWithNumbers);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Azure Speech service is not configured*");
+    }
+
+    [Fact]
+    public async Task SynthesizeSpeechAsync_AcceptsTextWithUnicodeCharacters()
+    {
+        // Arrange
+        var options = new AzureSpeechOptions { SubscriptionKey = null };
+        var service = CreateService(options);
+        var textWithUnicode = "Hello 世界 and Привет мир!";
+
+        // Act
+        var act = async () => await service.SynthesizeSpeechAsync(textWithUnicode);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Azure Speech service is not configured*");
+    }
+
+    #endregion
+
+    #region TtsOptions Defaults
+
+    [Fact]
+    public void TtsOptionsDefaults_AreCorrect()
+    {
+        // Arrange & Act
+        var options = new TtsOptions();
+
+        // Assert
+        options.Voice.Should().Be("en-US-JennyNeural");
+        options.Speed.Should().Be(1.0);
+        options.Pitch.Should().Be(1.0);
+        options.Volume.Should().Be(1.0);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

- Implement Azure TTS service integration as part of the TTS support feature
- Add `AzureSpeechOptions` configuration class with user secrets support
- Add `TtsOptions` and `VoiceInfo` models for TTS synthesis options
- Add `ITtsService` interface and `AzureTtsService` implementation
- Output Discord-compatible audio format (48kHz, 16-bit, stereo PCM)
- SSML-based synthesis with speed, pitch, and volume controls
- Voice enumeration with caching to reduce API calls
- Graceful handling when Azure Speech is not configured

## Test plan

- [x] Build succeeds with no errors
- [x] All 34 unit tests pass
- [x] Verify configuration binding works with appsettings.json
- [ ] Test with actual Azure Speech subscription (requires Azure credentials)
- [ ] Verify audio output is compatible with Discord playback

## Configuration

```bash
cd src/DiscordBot.Bot
dotnet user-secrets set "AzureSpeech:SubscriptionKey" "your-key"
dotnet user-secrets set "AzureSpeech:Region" "eastus"
```

Closes #895

🤖 Generated with [Claude Code](https://claude.ai/code)