### PR TITLE
fix(ui): Remove escaped quotes from guild ID in user preview popup

### DIFF
--- a/src/DiscordBot.Bot/Pages/Admin/Performance/Tabs/_CommandsTab.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/Tabs/_CommandsTab.cshtml
@@ -182,11 +182,11 @@ else
                                 <td class="text-text-secondary">
                                     @if (!string.IsNullOrEmpty(cmd.Username))
                                     {
-                                        <span class="preview-trigger" data-preview-type="user" data-user-id="@cmd.UserId" @(cmd.GuildId.HasValue ? $"data-context-guild-id=\"{cmd.GuildId}\"" : "") title="User ID: @cmd.UserId">@cmd.Username</span>
+                                        <span class="preview-trigger" data-preview-type="user" data-user-id="@cmd.UserId" @(cmd.GuildId.HasValue ? $"data-context-guild-id={cmd.GuildId}" : "") title="User ID: @cmd.UserId">@cmd.Username</span>
                                     }
                                     else
                                     {
-                                        <span class="preview-trigger text-mono" data-preview-type="user" data-user-id="@cmd.UserId" @(cmd.GuildId.HasValue ? $"data-context-guild-id=\"{cmd.GuildId}\"" : "")>@cmd.UserId</span>
+                                        <span class="preview-trigger text-mono" data-preview-type="user" data-user-id="@cmd.UserId" @(cmd.GuildId.HasValue ? $"data-context-guild-id={cmd.GuildId}" : "")>@cmd.UserId</span>
                                     }
                                 </td>
                                 <td class="text-text-secondary">


### PR DESCRIPTION
## Summary
Fixes #1023

The user preview popup on the Command Performance page (`/Admin/Performance/Commands`) was generating malformed API URLs with double-quoted guild IDs like `/api/preview/users/140899190757654528/guild/%221245799202873802772%22`.

## Changes
- Removed escaped quotes from `data-context-guild-id` attribute in `_CommandsTab.cshtml` (lines 185, 189)
- Changed from: `data-context-guild-id=\"{cmd.GuildId}\"`
- Changed to: `data-context-guild-id={cmd.GuildId}`

## Root Cause
The conditional string interpolation was wrapping the guild ID value in escaped quotes, which rendered as literal quotes in the HTML attribute. When `preview-popup.js` URL-encoded this value, it produced `%22` (quotes) around the ID.

## Test Plan
- [x] Navigate to `/Admin/Performance/Commands`
- [x] Hover over a username in the "Slowest Commands" table
- [x] Verify the API request URL is correctly formatted: `/api/preview/users/{userId}/guild/{guildId}` (without `%22` encoding)
- [x] Verify the user preview popup displays correctly with guild context

🤖 Generated with [Claude Code](https://claude.com/claude-code)