### PR TITLE
fix(apm): Always sample error transactions for 100% error capture

### DIFF
--- a/docs/articles/elastic-apm.md
+++ b/docs/articles/elastic-apm.md
@@ -217,7 +217,7 @@ The application implements **priority-based sampling** via `ElasticApmTransactio
 
 | Priority | Sample Rate | Operations |
 |----------|-------------|------------|
-| **Always Sample** | 100% | Rate limit hits (`discord.api.rate_limit.remaining == 0`), Discord API errors (`discord.api.error.*`), auto-moderation detections (`automod.*`) |
+| **Always Sample** | 100% | Error transactions (outcome = failure), rate limit hits (`discord.api.rate_limit.remaining == 0`), Discord API errors (`discord.api.error.*`), auto-moderation detections (`automod.*`) |
 | **High Priority** | 50% (configurable) | Welcome flow (`member.joined`, `welcome.*`), moderation actions (`/warn`, `/kick`, `/ban`, `/mute`), Rat Watch operations (`ratwatch`, `rat-*`), scheduled messages |
 | **Default** | 10% (configurable) | Normal operations (most Discord commands, API requests, database queries) |
 | **Low Priority** | 1% (configurable) | Health checks (`/health`), metrics scraping (`/metrics`), high-frequency cache operations |
@@ -236,6 +236,7 @@ The application implements **priority-based sampling** via `ElasticApmTransactio
 
 ```csharp
 // Always sample critical operations (100%)
+// Includes error transactions (outcome = failure) to ensure 100% error capture
 if (IsAlwaysSampleOperation(name, transaction))
 {
     return 1.0;

--- a/src/DiscordBot.Bot/Tracing/ElasticApmTransactionFilter.cs
+++ b/src/DiscordBot.Bot/Tracing/ElasticApmTransactionFilter.cs
@@ -106,6 +106,13 @@ public class ElasticApmTransactionFilter
     /// <returns>True if the operation should always be sampled.</returns>
     private static bool IsAlwaysSampleOperation(string name, ITransaction transaction)
     {
+        // Always sample transactions with failures (100% error rate)
+        // This ensures all exceptions are captured in APM for diagnostics
+        if (transaction.Outcome == Outcome.Failure)
+        {
+            return true;
+        }
+
         // Note: Using Labels dictionary is deprecated but necessary for reading labels.
         // The SetLabel method only supports writing, not reading.
 #pragma warning disable CS0618 // Type or member is obsolete


### PR DESCRIPTION
## Summary

Fixes #1022 - Ensures all error transactions are captured in Elastic APM, even when sampling rates are < 100%.

## Problem

The `ElasticApmTransactionFilter` was dropping transactions based on sampling rates, which also dropped any exceptions captured on those transactions. This caused errors to be invisible in Kibana APM's error tracking UI, even though the `ErrorRate` config was set to 1.0 (100%).

**Root cause:** The `IsAlwaysSampleOperation()` method didn't check for `transaction.Outcome == Outcome.Failure`, so error transactions could be dropped if they didn't match other "always sample" criteria (rate limits, API errors, auto-mod).

## Solution

Add a check for `transaction.Outcome == Outcome.Failure` at the start of `IsAlwaysSampleOperation()` to ensure all error transactions return a 1.0 sampling rate (100%).

**Key changes:**
- **ElasticApmTransactionFilter.cs:** Added outcome check before other always-sample logic
- **elastic-apm.md:** Updated documentation to reflect error transactions are always sampled

## Testing

- Built solution successfully (0 errors)
- Logic verified: `InteractionHandler.cs:276` sets `apmTransaction.Outcome = Outcome.Failure` when exceptions occur, which will now trigger the new check in the filter
- Documentation updated to match implementation

## Impact

✅ **Positive:**
- All errors will now appear in Kibana APM → Services → discordbot → Errors
- Error transactions include full context: stack traces, correlation IDs, command context
- Honors the `SamplingOptions.ErrorRate` (1.0) that was configured but not applied

⚠️ **Considerations:**
- Slight increase in APM storage for error transactions (expected and desired)
- No impact on successful transaction sampling behavior

## Acceptance Criteria

- [x] Transactions with captured exceptions are always sampled (100% error rate)
- [x] Filter logic checks transaction outcome for failures
- [x] Documentation updated to reflect behavior
- [x] Build succeeds with no compilation errors
- [ ] Manual testing: Trigger command error and verify it appears in Kibana APM (requires running bot with APM enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)