### PR TITLE
feat(soundboard): Add SignalR real-time voice connection state sync

### DIFF
--- a/src/DiscordBot.Bot/Extensions/DiscordServiceExtensions.cs
+++ b/src/DiscordBot.Bot/Extensions/DiscordServiceExtensions.cs
@@ -77,6 +77,9 @@ public static class DiscordServiceExtensions
         // Register MemberEventHandler as singleton
         services.AddSingleton<MemberEventHandler>();
 
+        // Register VoiceStateHandler for real-time voice channel member count updates
+        services.AddSingleton<VoiceStateHandler>();
+
         // Register member sync services
         services.AddSingleton<IMemberSyncQueue, MemberSyncQueue>();
         services.AddHostedService<MemberSyncService>();

--- a/src/DiscordBot.Bot/Handlers/VoiceStateHandler.cs
+++ b/src/DiscordBot.Bot/Handlers/VoiceStateHandler.cs
@@ -1,0 +1,124 @@
+using Discord.WebSocket;
+using DiscordBot.Bot.Interfaces;
+using DiscordBot.Bot.Tracing;
+using DiscordBot.Core.Interfaces;
+
+namespace DiscordBot.Bot.Handlers;
+
+/// <summary>
+/// Handles Discord voice state events (UserVoiceStateUpdated) to broadcast
+/// real-time member count updates to connected portal clients via SignalR.
+/// </summary>
+public class VoiceStateHandler
+{
+    private readonly IAudioService _audioService;
+    private readonly IAudioNotifier _audioNotifier;
+    private readonly ILogger<VoiceStateHandler> _logger;
+
+    public VoiceStateHandler(
+        IAudioService audioService,
+        IAudioNotifier audioNotifier,
+        ILogger<VoiceStateHandler> logger)
+    {
+        _audioService = audioService;
+        _audioNotifier = audioNotifier;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Handles the UserVoiceStateUpdated event. Broadcasts member count updates
+    /// when users join or leave voice channels where the bot is connected.
+    /// </summary>
+    /// <param name="user">The user whose voice state changed.</param>
+    /// <param name="before">The previous voice state.</param>
+    /// <param name="after">The current voice state.</param>
+    public async Task HandleUserVoiceStateUpdatedAsync(
+        SocketUser user,
+        SocketVoiceState before,
+        SocketVoiceState after)
+    {
+        // Skip if user is a bot (including our own state changes)
+        if (user.IsBot)
+        {
+            return;
+        }
+
+        // Get affected channel IDs
+        var leftChannelId = before.VoiceChannel?.Id;
+        var joinedChannelId = after.VoiceChannel?.Id;
+
+        // Skip if no channel change
+        if (leftChannelId == joinedChannelId)
+        {
+            return;
+        }
+
+        // Handle user leaving a channel
+        if (leftChannelId.HasValue)
+        {
+            await NotifyIfBotConnectedAsync(before.VoiceChannel!);
+        }
+
+        // Handle user joining a channel
+        if (joinedChannelId.HasValue)
+        {
+            await NotifyIfBotConnectedAsync(after.VoiceChannel!);
+        }
+    }
+
+    /// <summary>
+    /// Sends a member count update if the bot is connected to the given channel.
+    /// </summary>
+    private async Task NotifyIfBotConnectedAsync(SocketVoiceChannel channel)
+    {
+        var guildId = channel.Guild.Id;
+
+        // Check if bot is connected to this guild
+        if (!_audioService.IsConnected(guildId))
+        {
+            return;
+        }
+
+        // Check if bot is connected to this specific channel
+        var connectedChannelId = _audioService.GetConnectedChannelId(guildId);
+        if (connectedChannelId != channel.Id)
+        {
+            return;
+        }
+
+        using var activity = BotActivitySource.StartEventActivity(
+            "voice_member_count_updated",
+            guildId: guildId);
+
+        try
+        {
+            // Count members excluding bots
+            var memberCount = channel.ConnectedUsers.Count(u => !u.IsBot);
+
+            _logger.LogDebug(
+                "Broadcasting voice channel member count update: GuildId={GuildId}, ChannelId={ChannelId}, MemberCount={MemberCount}",
+                guildId,
+                channel.Id,
+                memberCount);
+
+            activity?.SetTag(TracingConstants.Attributes.VoiceChannelId, channel.Id.ToString());
+            activity?.SetTag(TracingConstants.Attributes.VoiceChannelName, channel.Name);
+            activity?.SetTag("voice.member_count", memberCount);
+
+            await _audioNotifier.NotifyVoiceChannelMemberCountUpdatedAsync(
+                guildId,
+                channel.Id,
+                channel.Name,
+                memberCount);
+
+            BotActivitySource.SetSuccess(activity);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to broadcast voice channel member count update for channel {ChannelId} in guild {GuildId}",
+                channel.Id, guildId);
+            BotActivitySource.RecordException(activity, ex);
+        }
+    }
+}

--- a/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml
@@ -403,6 +403,15 @@
         color: #ef4444;
     }
 
+    .channel-member-count {
+        font-size: 0.75rem;
+        color: #949ba4;
+    }
+
+    .channel-member-count.hidden {
+        display: none;
+    }
+
     .channel-label {
         display: block;
         font-size: 0.75rem;
@@ -1362,6 +1371,12 @@ else
                         <span class="status-dot"></span>
                         <span id="connectionStatusText">@(Model.IsConnected ? "Connected" : "Disconnected")</span>
                     </span>
+                    <span id="channelMemberCount" class="channel-member-count @(Model.IsConnected ? "" : "hidden")">
+                        @if (Model.IsConnected && Model.CurrentChannelMemberCount.HasValue)
+                        {
+                            <text>@Model.CurrentChannelMemberCount @(Model.CurrentChannelMemberCount == 1 ? "member" : "members")</text>
+                        }
+                    </span>
                 </div>
 
                 <!-- Channel Selector -->
@@ -1675,6 +1690,7 @@ else
                 DashboardHub.on('PlaybackProgress', handlePlaybackProgress);
                 DashboardHub.on('AudioConnected', handleAudioConnected);
                 DashboardHub.on('AudioDisconnected', handleAudioDisconnected);
+                DashboardHub.on('VoiceChannelMemberCountUpdated', handleVoiceChannelMemberCountUpdated);
 
                 // Connection state handlers
                 DashboardHub.on('reconnected', async () => {
@@ -1787,16 +1803,36 @@ else
 
         // Handle audio connected event from SignalR
         function handleAudioConnected(data) {
-            console.log('[Soundboard] AudioConnected:', data.channelName);
+            console.log('[Soundboard] AudioConnected:', data.channelName, 'MemberCount:', data.memberCount);
 
             isConnected = true;
-            updateConnectionUI(true);
+            updateConnectionUI(true, data.memberCount);
 
             // Update channel selector to show connected channel
             const channelSelect = document.getElementById('channelSelect');
             if (data.channelId && channelSelect) {
                 channelSelect.value = data.channelId.toString();
                 selectedChannel = data.channelId.toString();
+            }
+        }
+
+        // Handle voice channel member count update from SignalR
+        function handleVoiceChannelMemberCountUpdated(data) {
+            console.log('[Soundboard] VoiceChannelMemberCountUpdated:', data.channelId, 'MemberCount:', data.memberCount);
+
+            // Update member count display if connected to this channel
+            if (isConnected && selectedChannel === data.channelId.toString()) {
+                updateMemberCountDisplay(data.memberCount);
+            }
+
+            // Update the channel selector option for this channel
+            const channelSelect = document.getElementById('channelSelect');
+            if (channelSelect) {
+                const option = channelSelect.querySelector(`option[value="${data.channelId}"]`);
+                if (option) {
+                    const channelName = data.channelName || option.textContent.replace(/\s*\(\d+\s*members?\)\s*$/, '').trim();
+                    option.textContent = `${channelName} (${data.memberCount} ${data.memberCount === 1 ? 'member' : 'members'})`;
+                }
             }
         }
 
@@ -1810,7 +1846,7 @@ else
             currentlyPlayingName = null;
 
             // Update UI
-            updateConnectionUI(false);
+            updateConnectionUI(false, null);
             updateNowPlayingUI(null);
             document.getElementById('channelSelect').value = '';
 
@@ -1846,11 +1882,12 @@ else
         }
 
         // Helper: Update connection status UI
-        function updateConnectionUI(connected) {
+        function updateConnectionUI(connected, memberCount) {
             const statusBadge = document.getElementById('connectionStatus');
             const statusText = document.getElementById('connectionStatusText');
             const joinBtn = document.getElementById('joinBtn');
             const leaveBtn = document.getElementById('leaveBtn');
+            const memberCountEl = document.getElementById('channelMemberCount');
 
             if (connected) {
                 statusBadge.classList.remove('disconnected');
@@ -1858,12 +1895,31 @@ else
                 statusText.textContent = 'Connected';
                 joinBtn.disabled = true;
                 leaveBtn.disabled = false;
+                // Show and update member count
+                if (memberCountEl) {
+                    memberCountEl.classList.remove('hidden');
+                    if (memberCount !== undefined && memberCount !== null) {
+                        memberCountEl.textContent = `${memberCount} ${memberCount === 1 ? 'member' : 'members'}`;
+                    }
+                }
             } else {
                 statusBadge.classList.remove('connected');
                 statusBadge.classList.add('disconnected');
                 statusText.textContent = 'Disconnected';
                 joinBtn.disabled = false;
                 leaveBtn.disabled = true;
+                // Hide member count
+                if (memberCountEl) {
+                    memberCountEl.classList.add('hidden');
+                }
+            }
+        }
+
+        // Helper: Update member count display
+        function updateMemberCountDisplay(memberCount) {
+            const memberCountEl = document.getElementById('channelMemberCount');
+            if (memberCountEl && memberCount !== undefined && memberCount !== null) {
+                memberCountEl.textContent = `${memberCount} ${memberCount === 1 ? 'member' : 'members'}`;
             }
         }
 

--- a/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml.cs
@@ -86,6 +86,11 @@ public class IndexModel : PageModel
     public bool IsConnected { get; set; }
 
     /// <summary>
+    /// Gets the number of members in the currently connected voice channel (excluding bots).
+    /// </summary>
+    public int? CurrentChannelMemberCount { get; set; }
+
+    /// <summary>
     /// Gets the maximum number of sounds allowed per guild.
     /// </summary>
     public int MaxSounds { get; set; }
@@ -244,6 +249,16 @@ public class IndexModel : PageModel
             VoiceChannels = voiceChannels;
             CurrentChannelId = _audioService.GetConnectedChannelId(guildId);
             IsConnected = _audioService.IsConnected(guildId);
+
+            // Get member count if connected
+            if (IsConnected && CurrentChannelId.HasValue)
+            {
+                var connectedChannel = socketGuild.GetVoiceChannel(CurrentChannelId.Value);
+                if (connectedChannel != null)
+                {
+                    CurrentChannelMemberCount = connectedChannel.ConnectedUsers.Count(u => !u.IsBot);
+                }
+            }
             MaxSounds = settings.MaxSoundsPerGuild;
             CurrentSoundCount = sounds.Count;
             SupportedFormats = "MP3, WAV, OGG";

--- a/src/DiscordBot.Bot/Services/AudioNotifier.cs
+++ b/src/DiscordBot.Bot/Services/AudioNotifier.cs
@@ -36,6 +36,9 @@ public class AudioNotifier : IAudioNotifier
 
         /// <summary>Event fired when the playback queue changes.</summary>
         public const string QueueUpdated = "QueueUpdated";
+
+        /// <summary>Event fired when voice channel member count changes.</summary>
+        public const string VoiceChannelMemberCountUpdated = "VoiceChannelMemberCountUpdated";
     }
 
     /// <summary>
@@ -56,6 +59,7 @@ public class AudioNotifier : IAudioNotifier
         ulong guildId,
         ulong channelId,
         string channelName,
+        int memberCount,
         CancellationToken cancellationToken = default)
     {
         var groupName = DashboardHub.GetGuildAudioGroupName(guildId);
@@ -64,14 +68,16 @@ public class AudioNotifier : IAudioNotifier
             GuildId = guildId,
             ChannelId = channelId,
             ChannelName = channelName,
+            MemberCount = memberCount,
             Timestamp = DateTime.UtcNow
         };
 
         _logger.LogDebug(
-            "Broadcasting AudioConnected: GuildId={GuildId}, ChannelId={ChannelId}, ChannelName={ChannelName}",
+            "Broadcasting AudioConnected: GuildId={GuildId}, ChannelId={ChannelId}, ChannelName={ChannelName}, MemberCount={MemberCount}",
             guildId,
             channelId,
-            channelName);
+            channelName,
+            memberCount);
 
         await _hubContext.Clients.Group(groupName).SendAsync(
             Events.AudioConnected,
@@ -215,6 +221,36 @@ public class AudioNotifier : IAudioNotifier
         await _hubContext.Clients.Group(groupName).SendAsync(
             Events.QueueUpdated,
             queue,
+            cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task NotifyVoiceChannelMemberCountUpdatedAsync(
+        ulong guildId,
+        ulong channelId,
+        string channelName,
+        int memberCount,
+        CancellationToken cancellationToken = default)
+    {
+        var groupName = DashboardHub.GetGuildAudioGroupName(guildId);
+        var data = new VoiceChannelMemberCountUpdatedDto
+        {
+            GuildId = guildId,
+            ChannelId = channelId,
+            ChannelName = channelName,
+            MemberCount = memberCount,
+            Timestamp = DateTime.UtcNow
+        };
+
+        _logger.LogDebug(
+            "Broadcasting VoiceChannelMemberCountUpdated: GuildId={GuildId}, ChannelId={ChannelId}, MemberCount={MemberCount}",
+            guildId,
+            channelId,
+            memberCount);
+
+        await _hubContext.Clients.Group(groupName).SendAsync(
+            Events.VoiceChannelMemberCountUpdated,
+            data,
             cancellationToken);
     }
 }

--- a/src/DiscordBot.Bot/Services/AudioService.cs
+++ b/src/DiscordBot.Bot/Services/AudioService.cs
@@ -106,8 +106,11 @@ public class AudioService : IAudioService
             _logger.LogInformation("Successfully joined voice channel {ChannelId} ({ChannelName}) in guild {GuildId}",
                 voiceChannelId, voiceChannel.Name, guildId);
 
+            // Get member count (excluding bots)
+            var memberCount = voiceChannel.ConnectedUsers.Count(u => !u.IsBot);
+
             // Broadcast AudioConnected event to subscribed clients
-            _ = _audioNotifier.NotifyAudioConnectedAsync(guildId, voiceChannelId, voiceChannel.Name, cancellationToken);
+            _ = _audioNotifier.NotifyAudioConnectedAsync(guildId, voiceChannelId, voiceChannel.Name, memberCount, cancellationToken);
 
             BotActivitySource.SetSuccess(activity);
             return audioClient;

--- a/src/DiscordBot.Bot/Services/BotHostedService.cs
+++ b/src/DiscordBot.Bot/Services/BotHostedService.cs
@@ -24,6 +24,7 @@ public class BotHostedService : IHostedService
     private readonly MessageLoggingHandler _messageLoggingHandler;
     private readonly WelcomeHandler _welcomeHandler;
     private readonly MemberEventHandler _memberEventHandler;
+    private readonly VoiceStateHandler _voiceStateHandler;
     private readonly AutoModerationHandler _autoModerationHandler;
     private readonly BusinessMetrics _businessMetrics;
     private readonly IDashboardUpdateService _dashboardUpdateService;
@@ -49,6 +50,7 @@ public class BotHostedService : IHostedService
         MessageLoggingHandler messageLoggingHandler,
         WelcomeHandler welcomeHandler,
         MemberEventHandler memberEventHandler,
+        VoiceStateHandler voiceStateHandler,
         AutoModerationHandler autoModerationHandler,
         BusinessMetrics businessMetrics,
         IDashboardUpdateService dashboardUpdateService,
@@ -72,6 +74,7 @@ public class BotHostedService : IHostedService
         _messageLoggingHandler = messageLoggingHandler;
         _welcomeHandler = welcomeHandler;
         _memberEventHandler = memberEventHandler;
+        _voiceStateHandler = voiceStateHandler;
         _autoModerationHandler = autoModerationHandler;
         _businessMetrics = businessMetrics;
         _dashboardUpdateService = dashboardUpdateService;
@@ -129,6 +132,9 @@ public class BotHostedService : IHostedService
             _client.UserJoined += _memberEventHandler.HandleUserJoinedAsync;
             _client.UserLeft += _memberEventHandler.HandleUserLeftAsync;
             _client.GuildMemberUpdated += _memberEventHandler.HandleGuildMemberUpdatedAsync;
+
+            // Wire voice state handler for real-time member count updates
+            _client.UserVoiceStateUpdated += _voiceStateHandler.HandleUserVoiceStateUpdatedAsync;
 
             // Queue member sync for new guilds
             _client.JoinedGuild += OnBotJoinedGuild;

--- a/src/DiscordBot.Core/DTOs/AudioEventDtos.cs
+++ b/src/DiscordBot.Core/DTOs/AudioEventDtos.cs
@@ -21,7 +21,43 @@ public class AudioConnectedDto
     public string ChannelName { get; set; } = string.Empty;
 
     /// <summary>
+    /// Gets or sets the number of members in the voice channel (excluding bots).
+    /// </summary>
+    public int MemberCount { get; set; }
+
+    /// <summary>
     /// Gets or sets the timestamp when the connection was established.
+    /// </summary>
+    public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+}
+
+/// <summary>
+/// DTO for voice channel member count updated event when users join/leave the channel.
+/// </summary>
+public class VoiceChannelMemberCountUpdatedDto
+{
+    /// <summary>
+    /// Gets or sets the guild ID.
+    /// </summary>
+    public ulong GuildId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the voice channel ID.
+    /// </summary>
+    public ulong ChannelId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the voice channel name.
+    /// </summary>
+    public string ChannelName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the updated member count (excluding bots).
+    /// </summary>
+    public int MemberCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the timestamp of the update.
     /// </summary>
     public DateTime Timestamp { get; set; } = DateTime.UtcNow;
 }

--- a/src/DiscordBot.Core/Interfaces/IAudioNotifier.cs
+++ b/src/DiscordBot.Core/Interfaces/IAudioNotifier.cs
@@ -14,12 +14,14 @@ public interface IAudioNotifier
     /// <param name="guildId">The guild ID.</param>
     /// <param name="channelId">The voice channel ID.</param>
     /// <param name="channelName">The voice channel name.</param>
+    /// <param name="memberCount">The number of members in the voice channel (excluding bots).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     Task NotifyAudioConnectedAsync(
         ulong guildId,
         ulong channelId,
         string channelName,
+        int memberCount,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -90,5 +92,21 @@ public interface IAudioNotifier
     Task NotifyQueueUpdatedAsync(
         ulong guildId,
         QueueUpdatedDto queue,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Notifies clients that the voice channel member count has changed.
+    /// </summary>
+    /// <param name="guildId">The guild ID.</param>
+    /// <param name="channelId">The voice channel ID.</param>
+    /// <param name="channelName">The voice channel name.</param>
+    /// <param name="memberCount">The updated number of members in the channel (excluding bots).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task NotifyVoiceChannelMemberCountUpdatedAsync(
+        ulong guildId,
+        ulong channelId,
+        string channelName,
+        int memberCount,
         CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
## Summary
- Add real-time voice channel member count updates to the soundboard portal
- Enable instant sync of voice connection state across all connected portal clients
- Replace implicit polling with SignalR push events for member count changes

## Changes
- **Core DTOs**: Add `MemberCount` to `AudioConnectedDto`, add new `VoiceChannelMemberCountUpdatedDto`
- **Interface**: Update `IAudioNotifier` with member count parameter and new `NotifyVoiceChannelMemberCountUpdatedAsync` method
- **AudioNotifier**: Implement new `VoiceChannelMemberCountUpdated` SignalR event
- **VoiceStateHandler**: New handler subscribing to Discord's `UserVoiceStateUpdated` event
- **AudioService**: Pass member count when broadcasting audio connected events
- **Portal UI**: Display member count in connection status, handle real-time updates

## Test plan
- [x] Build succeeds
- [x] Existing audio tests pass
- [x] Existing notifier tests pass
- [ ] Manual test: Join voice channel and verify member count displays
- [ ] Manual test: Have other user join/leave channel and verify count updates in real-time
- [ ] Manual test: Multiple portal sessions should sync member counts

Closes #1029

🤖 Generated with [Claude Code](https://claude.com/claude-code)