### PR TITLE
feat(soundboard): Add SignalR real-time sound upload/deletion sync

### DIFF
--- a/src/DiscordBot.Bot/Pages/Guilds/Soundboard/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/Soundboard/Index.cshtml.cs
@@ -23,6 +23,7 @@ public class IndexModel : PageModel
     private readonly IGuildService _guildService;
     private readonly DiscordSocketClient _discordClient;
     private readonly IAudioService _audioService;
+    private readonly IAudioNotifier _audioNotifier;
     private readonly ILogger<IndexModel> _logger;
 
     public IndexModel(
@@ -32,6 +33,7 @@ public class IndexModel : PageModel
         IGuildService guildService,
         DiscordSocketClient discordClient,
         IAudioService audioService,
+        IAudioNotifier audioNotifier,
         ILogger<IndexModel> logger)
     {
         _soundService = soundService;
@@ -40,6 +42,7 @@ public class IndexModel : PageModel
         _guildService = guildService;
         _discordClient = discordClient;
         _audioService = audioService;
+        _audioNotifier = audioNotifier;
         _logger = logger;
     }
 
@@ -179,6 +182,9 @@ public class IndexModel : PageModel
                 _logger.LogInformation("Successfully deleted sound {SoundId} ({Name})",
                     soundId, sound.Name);
                 SuccessMessage = "Sound deleted successfully.";
+
+                // Broadcast deletion to portal viewers via SignalR
+                await _audioNotifier.NotifySoundDeletedAsync(guildId, soundId, cancellationToken);
             }
             else
             {

--- a/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml
@@ -1691,6 +1691,8 @@ else
                 DashboardHub.on('AudioConnected', handleAudioConnected);
                 DashboardHub.on('AudioDisconnected', handleAudioDisconnected);
                 DashboardHub.on('VoiceChannelMemberCountUpdated', handleVoiceChannelMemberCountUpdated);
+                DashboardHub.on('SoundUploaded', handleSoundUploaded);
+                DashboardHub.on('SoundDeleted', handleSoundDeleted);
 
                 // Connection state handlers
                 DashboardHub.on('reconnected', async () => {
@@ -1854,6 +1856,75 @@ else
             document.querySelectorAll('.sound-card').forEach(card => {
                 card.classList.remove('playing');
             });
+        }
+
+        // Handle sound uploaded event from SignalR (another user uploaded a sound)
+        function handleSoundUploaded(data) {
+            console.log('[Soundboard] SoundUploaded:', data.name, data.soundId);
+
+            // Check if this sound already exists (uploaded by this user)
+            const existingCard = document.querySelector(`.sound-card[data-sound-id="${data.soundId}"]`);
+            if (existingCard) {
+                console.log('[Soundboard] Sound already in grid, skipping');
+                return;
+            }
+
+            // Add the new sound to the grid
+            addSoundToGrid({
+                id: data.soundId,
+                name: data.name,
+                playCount: data.playCount
+            });
+
+            // Show a toast notification
+            PortalToast.info(`New sound "${data.name}" was added`);
+        }
+
+        // Handle sound deleted event from SignalR (admin deleted a sound)
+        function handleSoundDeleted(data) {
+            console.log('[Soundboard] SoundDeleted:', data.soundId);
+
+            const grid = document.getElementById('soundGrid');
+            const emptyState = document.getElementById('emptyState');
+
+            // Find and remove the sound card
+            const card = document.querySelector(`.sound-card[data-sound-id="${data.soundId}"]`);
+            if (card) {
+                const soundName = card.getAttribute('data-sound-name') || 'Sound';
+
+                // Add fade-out animation
+                card.style.transition = 'opacity 0.3s ease, transform 0.3s ease';
+                card.style.opacity = '0';
+                card.style.transform = 'scale(0.9)';
+
+                setTimeout(() => {
+                    card.remove();
+
+                    // If deleted sound was playing, clear now playing UI
+                    if (currentlyPlaying === data.soundId) {
+                        currentlyPlaying = null;
+                        currentlyPlayingName = null;
+                        updateNowPlayingUI(null);
+                    }
+
+                    // Remove from favorites if present
+                    const favIndex = favorites.indexOf(data.soundId);
+                    if (favIndex > -1) {
+                        favorites.splice(favIndex, 1);
+                        localStorage.setItem('soundboard_favorites_' + window.guildId, JSON.stringify(favorites));
+                    }
+
+                    // Show empty state if no sounds remain
+                    const remainingCards = grid.querySelectorAll('.sound-card');
+                    if (remainingCards.length === 0) {
+                        grid.classList.add('hidden');
+                        emptyState.classList.remove('hidden');
+                    }
+
+                    // Show toast notification
+                    PortalToast.warning(`Sound "${soundName}" was deleted`);
+                }, 300);
+            }
         }
 
         // Helper: Show toast notification

--- a/src/DiscordBot.Bot/Services/AudioNotifier.cs
+++ b/src/DiscordBot.Bot/Services/AudioNotifier.cs
@@ -39,6 +39,12 @@ public class AudioNotifier : IAudioNotifier
 
         /// <summary>Event fired when voice channel member count changes.</summary>
         public const string VoiceChannelMemberCountUpdated = "VoiceChannelMemberCountUpdated";
+
+        /// <summary>Event fired when a new sound is uploaded to the soundboard.</summary>
+        public const string SoundUploaded = "SoundUploaded";
+
+        /// <summary>Event fired when a sound is deleted from the soundboard.</summary>
+        public const string SoundDeleted = "SoundDeleted";
     }
 
     /// <summary>
@@ -250,6 +256,61 @@ public class AudioNotifier : IAudioNotifier
 
         await _hubContext.Clients.Group(groupName).SendAsync(
             Events.VoiceChannelMemberCountUpdated,
+            data,
+            cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task NotifySoundUploadedAsync(
+        ulong guildId,
+        Guid soundId,
+        string name,
+        int playCount,
+        CancellationToken cancellationToken = default)
+    {
+        var groupName = DashboardHub.GetGuildAudioGroupName(guildId);
+        var data = new SoundUploadedDto
+        {
+            GuildId = guildId,
+            SoundId = soundId,
+            Name = name,
+            PlayCount = playCount,
+            Timestamp = DateTime.UtcNow
+        };
+
+        _logger.LogDebug(
+            "Broadcasting SoundUploaded: GuildId={GuildId}, SoundId={SoundId}, Name={Name}",
+            guildId,
+            soundId,
+            name);
+
+        await _hubContext.Clients.Group(groupName).SendAsync(
+            Events.SoundUploaded,
+            data,
+            cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task NotifySoundDeletedAsync(
+        ulong guildId,
+        Guid soundId,
+        CancellationToken cancellationToken = default)
+    {
+        var groupName = DashboardHub.GetGuildAudioGroupName(guildId);
+        var data = new SoundDeletedDto
+        {
+            GuildId = guildId,
+            SoundId = soundId,
+            Timestamp = DateTime.UtcNow
+        };
+
+        _logger.LogDebug(
+            "Broadcasting SoundDeleted: GuildId={GuildId}, SoundId={SoundId}",
+            guildId,
+            soundId);
+
+        await _hubContext.Clients.Group(groupName).SendAsync(
+            Events.SoundDeleted,
             data,
             cancellationToken);
     }

--- a/src/DiscordBot.Core/DTOs/AudioEventDtos.cs
+++ b/src/DiscordBot.Core/DTOs/AudioEventDtos.cs
@@ -219,6 +219,58 @@ public class QueueUpdatedDto
 }
 
 /// <summary>
+/// DTO for sound uploaded event when a new sound is added to the soundboard.
+/// </summary>
+public class SoundUploadedDto
+{
+    /// <summary>
+    /// Gets or sets the guild ID where the sound was uploaded.
+    /// </summary>
+    public ulong GuildId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the sound ID.
+    /// </summary>
+    public Guid SoundId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the sound name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the play count (always 0 for new sounds).
+    /// </summary>
+    public int PlayCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the timestamp when the sound was uploaded.
+    /// </summary>
+    public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+}
+
+/// <summary>
+/// DTO for sound deleted event when a sound is removed from the soundboard.
+/// </summary>
+public class SoundDeletedDto
+{
+    /// <summary>
+    /// Gets or sets the guild ID where the sound was deleted.
+    /// </summary>
+    public ulong GuildId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the sound ID that was deleted.
+    /// </summary>
+    public Guid SoundId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the timestamp when the sound was deleted.
+    /// </summary>
+    public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+}
+
+/// <summary>
 /// DTO for the current audio status of a guild.
 /// </summary>
 public class AudioStatusDto

--- a/src/DiscordBot.Core/Interfaces/IAudioNotifier.cs
+++ b/src/DiscordBot.Core/Interfaces/IAudioNotifier.cs
@@ -109,4 +109,32 @@ public interface IAudioNotifier
         string channelName,
         int memberCount,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Notifies clients that a new sound has been uploaded to the soundboard.
+    /// </summary>
+    /// <param name="guildId">The guild ID.</param>
+    /// <param name="soundId">The sound ID.</param>
+    /// <param name="name">The sound name.</param>
+    /// <param name="playCount">The play count (0 for new sounds).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task NotifySoundUploadedAsync(
+        ulong guildId,
+        Guid soundId,
+        string name,
+        int playCount,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Notifies clients that a sound has been deleted from the soundboard.
+    /// </summary>
+    /// <param name="guildId">The guild ID.</param>
+    /// <param name="soundId">The sound ID that was deleted.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task NotifySoundDeletedAsync(
+        ulong guildId,
+        Guid soundId,
+        CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
## Summary
- Add real-time synchronization for soundboard sound uploads and deletions across all portal viewers
- When a user uploads a sound via the portal, it appears instantly in all other viewers' grids with a toast notification
- When an admin deletes a sound, it fades out smoothly from all portal viewers' grids

## Changes
- **DTOs**: Added `SoundUploadedDto` and `SoundDeletedDto` for SignalR event payloads
- **Interface**: Added `NotifySoundUploadedAsync` and `NotifySoundDeletedAsync` to `IAudioNotifier`
- **Service**: Implemented broadcast methods in `AudioNotifier` service
- **Portal API**: Trigger `SoundUploaded` broadcast after successful upload in `PortalSoundboardController`
- **Admin Page**: Trigger `SoundDeleted` broadcast after successful deletion in `Soundboard/Index.cshtml.cs`
- **Client-side**: Added JavaScript handlers for both events with smooth animations and toast notifications

## Edge Cases Handled
- Duplicate sound prevention (won't add if already in grid)
- Playing sound deletion (clears "Now Playing" UI when deleted sound was playing)
- Favorites cleanup (removes from local storage if deleted sound was favorited)
- Empty state (shows empty state if last sound is deleted)

## Test plan
- [ ] Upload a sound from one browser tab, verify it appears in another tab viewing the same guild soundboard
- [ ] Delete a sound from the admin page, verify it disappears from portal viewers
- [ ] Delete a sound that is currently playing, verify playback stops and "Now Playing" clears
- [ ] Delete a favorited sound, verify favorites are updated
- [ ] Delete the last sound, verify empty state appears

Closes #1030
Closes #1031

🤖 Generated with [Claude Code](https://claude.com/claude-code)