### PR TITLE
feat(soundboard): Sound play tracking and analytics (#930)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,7 @@ The application uses the `IOptions<T>` pattern for strongly-typed configuration.
 | `SamplingOptions` | `OpenTelemetry:Tracing:Sampling` | OpenTelemetry trace sampling rates (priority-based sampling) |
 | `ScheduledMessagesOptions` | `ScheduledMessages` | Scheduled message delivery settings |
 | `SoundboardOptions` | `Soundboard` | Audio/soundboard settings (FFmpeg path, file limits, supported formats) |
+| `SoundPlayLogRetentionOptions` | `SoundPlayLogRetention` | Sound play log cleanup settings |
 | `VerificationOptions` | `Verification` | Verification code generation settings |
 | `VoiceChannelOptions` | `VoiceChannel` | Voice channel auto-leave settings (timeout, check interval) |
 | `ElasticApm:*` | `ElasticApm` | Elastic APM distributed tracing configuration (see appsettings.json for full options) |

--- a/src/DiscordBot.Bot/Commands/SoundboardModule.cs
+++ b/src/DiscordBot.Bot/Commands/SoundboardModule.cs
@@ -198,6 +198,9 @@ public class SoundboardModule : InteractionModuleBase<SocketInteractionContext>
 
                 await RespondAsync(embed: playingEmbed, ephemeral: true);
             }
+
+            // Log play event (fire-and-forget - don't block on logging)
+            _ = _soundService.LogPlayAsync(sound.Id, guildId, userId);
         }
         catch (FileNotFoundException)
         {

--- a/src/DiscordBot.Bot/Extensions/VoiceServiceExtensions.cs
+++ b/src/DiscordBot.Bot/Extensions/VoiceServiceExtensions.cs
@@ -62,11 +62,16 @@ public static class VoiceServiceExtensions
         // Bind options
         services.Configure<SoundboardOptions>(
             configuration.GetSection(SoundboardOptions.SectionName));
+        services.Configure<SoundPlayLogRetentionOptions>(
+            configuration.GetSection(SoundPlayLogRetentionOptions.SectionName));
 
         // Soundboard services (scoped for per-request)
         services.AddScoped<ISoundService, SoundService>();
         services.AddScoped<ISoundFileService, SoundFileService>();
         services.AddScoped<IGuildAudioSettingsService, GuildAudioSettingsService>();
+
+        // Background service for play log retention cleanup
+        services.AddHostedService<SoundPlayLogRetentionService>();
 
         return services;
     }

--- a/src/DiscordBot.Bot/Pages/Guilds/Soundboard/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Soundboard/Index.cshtml
@@ -54,6 +54,19 @@
         SoundCount = Model.ViewModel.Stats.TotalSounds
     }' />
 
+    <!-- Audio Globally Disabled Warning -->
+    @if (Model.IsAudioGloballyDisabled)
+    {
+        <div class="mb-6">
+            <partial name="Shared/Components/_Alert" model='new AlertViewModel {
+                Variant = AlertVariant.Warning,
+                Title = "Audio Features Disabled",
+                Message = "Audio features have been disabled globally by an administrator. Soundboard commands will not work until audio is re-enabled in Settings.",
+                IsDismissible = false
+            }' />
+        </div>
+    }
+
     <!-- Success Message -->
     @if (!string.IsNullOrEmpty(Model.SuccessMessage))
     {
@@ -109,7 +122,14 @@
                     </svg>
                 </div>
             </div>
-            <p class="text-xs text-text-tertiary">Play tracking coming soon</p>
+            @if (!string.IsNullOrEmpty(Model.ViewModel.Stats.ComparisonText))
+            {
+                <p class="text-xs @Model.ViewModel.Stats.ComparisonCssClass">@Model.ViewModel.Stats.ComparisonText</p>
+            }
+            else
+            {
+                <p class="text-xs text-text-tertiary">No comparison data</p>
+            }
         </div>
 
         <!-- Storage Used Card -->

--- a/src/DiscordBot.Bot/Services/SoundPlayLogRetentionService.cs
+++ b/src/DiscordBot.Bot/Services/SoundPlayLogRetentionService.cs
@@ -1,0 +1,189 @@
+using DiscordBot.Bot.Tracing;
+using DiscordBot.Core.Configuration;
+using DiscordBot.Core.Interfaces;
+using Microsoft.Extensions.Options;
+
+namespace DiscordBot.Bot.Services;
+
+/// <summary>
+/// Background service that periodically cleans up old sound play logs according to the retention policy.
+/// Deletes play log entries older than configured retention period.
+/// </summary>
+public class SoundPlayLogRetentionService : MonitoredBackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IOptions<SoundPlayLogRetentionOptions> _options;
+    private readonly IOptions<BackgroundServicesOptions> _bgOptions;
+
+    public override string ServiceName => "Sound Play Log Retention Service";
+
+    /// <summary>
+    /// Gets the service name formatted for tracing (snake_case).
+    /// </summary>
+    private string TracingServiceName => "sound_play_log_retention_service";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SoundPlayLogRetentionService"/> class.
+    /// </summary>
+    /// <param name="serviceProvider">The service provider for health monitoring.</param>
+    /// <param name="scopeFactory">The service scope factory for creating scoped services.</param>
+    /// <param name="options">Sound play log retention configuration options.</param>
+    /// <param name="bgOptions">Background services configuration options.</param>
+    /// <param name="logger">The logger.</param>
+    public SoundPlayLogRetentionService(
+        IServiceProvider serviceProvider,
+        IServiceScopeFactory scopeFactory,
+        IOptions<SoundPlayLogRetentionOptions> options,
+        IOptions<BackgroundServicesOptions> bgOptions,
+        ILogger<SoundPlayLogRetentionService> logger)
+        : base(serviceProvider, logger)
+    {
+        _scopeFactory = scopeFactory;
+        _options = options;
+        _bgOptions = bgOptions;
+    }
+
+    /// <inheritdoc/>
+    protected override async Task ExecuteMonitoredAsync(CancellationToken stoppingToken)
+    {
+        if (!_options.Value.Enabled)
+        {
+            _logger.LogInformation("Sound play log retention cleanup is disabled via configuration");
+            return;
+        }
+
+        _logger.LogInformation("Sound play log retention service starting");
+
+        _logger.LogInformation(
+            "Sound play log retention enabled. Retention: {RetentionDays} days, Interval: {IntervalHours}h, Batch size: {BatchSize}",
+            _options.Value.RetentionDays,
+            _options.Value.CleanupIntervalHours,
+            _options.Value.CleanupBatchSize);
+
+        // Initial delay to let the app start up
+        var initialDelay = TimeSpan.FromMinutes(_bgOptions.Value.AnalyticsAggregationInitialDelayMinutes);
+        await Task.Delay(initialDelay, stoppingToken);
+
+        var executionCycle = 0;
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            executionCycle++;
+            var correlationId = Guid.NewGuid().ToString("N")[..16];
+
+            using var activity = BotActivitySource.StartBackgroundServiceActivity(
+                TracingServiceName,
+                executionCycle,
+                correlationId);
+
+            UpdateHeartbeat();
+
+            try
+            {
+                var totalDeleted = await PerformCleanupAsync(stoppingToken);
+
+                BotActivitySource.SetRecordsDeleted(activity, totalDeleted);
+                BotActivitySource.SetSuccess(activity);
+                ClearError();
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                // Normal shutdown
+                break;
+            }
+            catch (Exception ex)
+            {
+                BotActivitySource.RecordException(activity, ex);
+                _logger.LogError(ex, "Error during sound play log retention cleanup");
+                RecordError(ex);
+            }
+
+            // Wait for next cleanup interval
+            var interval = TimeSpan.FromHours(_options.Value.CleanupIntervalHours);
+            await Task.Delay(interval, stoppingToken);
+        }
+
+        _logger.LogInformation("Sound play log retention service stopping");
+    }
+
+    /// <summary>
+    /// Performs a single cleanup operation by removing old sound play logs.
+    /// </summary>
+    /// <param name="stoppingToken">Cancellation token to respect during cleanup.</param>
+    /// <returns>The total number of play log entries deleted.</returns>
+    private async Task<int> PerformCleanupAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Starting sound play log retention cleanup");
+
+        using var scope = _scopeFactory.CreateScope();
+        var soundPlayLogRepo = scope.ServiceProvider.GetRequiredService<ISoundPlayLogRepository>();
+
+        var totalDeleted = await CleanupPlayLogsAsync(soundPlayLogRepo, stoppingToken);
+
+        _logger.LogInformation("Sound play log retention cleanup completed. Deleted {TotalCount} total play logs", totalDeleted);
+
+        return totalDeleted;
+    }
+
+    /// <summary>
+    /// Cleans up sound play logs older than the configured retention period.
+    /// </summary>
+    /// <param name="soundPlayLogRepo">The sound play log repository.</param>
+    /// <param name="stoppingToken">Cancellation token.</param>
+    /// <returns>Total number of play logs deleted.</returns>
+    private async Task<int> CleanupPlayLogsAsync(
+        ISoundPlayLogRepository soundPlayLogRepo,
+        CancellationToken stoppingToken)
+    {
+        using var cleanupActivity = BotActivitySource.StartBackgroundCleanupActivity(
+            TracingServiceName,
+            "sound_play_logs");
+
+        try
+        {
+            var cutoff = DateTime.UtcNow.AddDays(-_options.Value.RetentionDays);
+            var batchSize = _options.Value.CleanupBatchSize;
+            var totalDeleted = 0;
+
+            _logger.LogDebug("Cleaning up sound play logs older than {Cutoff}", cutoff);
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                var deleted = await soundPlayLogRepo.DeleteOlderThanAsync(cutoff, batchSize, stoppingToken);
+
+                if (deleted == 0)
+                {
+                    break; // No more records to delete
+                }
+
+                totalDeleted += deleted;
+                _logger.LogDebug("Deleted {Count} sound play logs (batch)", deleted);
+
+                // If we deleted fewer than batch size, we're done
+                if (deleted < batchSize)
+                {
+                    break;
+                }
+
+                // Brief delay between batches to avoid long-running transactions
+                await Task.Delay(TimeSpan.FromMilliseconds(100), stoppingToken);
+            }
+
+            if (totalDeleted > 0)
+            {
+                _logger.LogInformation("Deleted {Count} sound play logs older than {RetentionDays} days",
+                    totalDeleted, _options.Value.RetentionDays);
+            }
+
+            BotActivitySource.SetRecordsDeleted(cleanupActivity, totalDeleted);
+            BotActivitySource.SetSuccess(cleanupActivity);
+
+            return totalDeleted;
+        }
+        catch (Exception ex)
+        {
+            BotActivitySource.RecordException(cleanupActivity, ex);
+            throw;
+        }
+    }
+}

--- a/src/DiscordBot.Bot/appsettings.json
+++ b/src/DiscordBot.Bot/appsettings.json
@@ -195,6 +195,12 @@
     "DefaultAutoLeaveTimeoutMinutes": 0,
     "SupportedFormats": [ "mp3", "wav", "ogg" ]
   },
+  "SoundPlayLogRetention": {
+    "Enabled": true,
+    "RetentionDays": 90,
+    "CleanupBatchSize": 1000,
+    "CleanupIntervalHours": 24
+  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Information",

--- a/src/DiscordBot.Core/Configuration/SoundPlayLogRetentionOptions.cs
+++ b/src/DiscordBot.Core/Configuration/SoundPlayLogRetentionOptions.cs
@@ -1,0 +1,36 @@
+namespace DiscordBot.Core.Configuration;
+
+/// <summary>
+/// Configuration options for sound play log data retention.
+/// </summary>
+public class SoundPlayLogRetentionOptions
+{
+    /// <summary>
+    /// The configuration section name for binding.
+    /// </summary>
+    public const string SectionName = "SoundPlayLogRetention";
+
+    /// <summary>
+    /// Gets or sets the number of days to retain sound play logs before cleanup.
+    /// Default is 90 days.
+    /// </summary>
+    public int RetentionDays { get; set; } = 90;
+
+    /// <summary>
+    /// Gets or sets whether sound play log cleanup is enabled.
+    /// Default is true.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the maximum number of records to delete in a single cleanup operation.
+    /// Used to prevent long-running transactions. Default is 1000.
+    /// </summary>
+    public int CleanupBatchSize { get; set; } = 1000;
+
+    /// <summary>
+    /// Gets or sets the interval (in hours) between automatic cleanup operations.
+    /// Default is 24 hours (daily cleanup).
+    /// </summary>
+    public int CleanupIntervalHours { get; set; } = 24;
+}

--- a/src/DiscordBot.Core/Interfaces/ISoundService.cs
+++ b/src/DiscordBot.Core/Interfaces/ISoundService.cs
@@ -106,4 +106,19 @@ public interface ISoundService
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Count of sounds in the guild.</returns>
     Task<int> GetSoundCountAsync(ulong guildId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Logs a sound play event for analytics tracking.
+    /// Creates a new SoundPlayLog entry with the current timestamp.
+    /// </summary>
+    /// <param name="soundId">Unique identifier of the sound.</param>
+    /// <param name="guildId">Discord guild ID where the sound was played.</param>
+    /// <param name="userId">Discord user ID who played the sound.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    /// <remarks>
+    /// This method logs failures as warnings but does not throw exceptions.
+    /// Logging failures should not block playback functionality.
+    /// </remarks>
+    Task LogPlayAsync(Guid soundId, ulong guildId, ulong userId, CancellationToken ct = default);
 }

--- a/tests/DiscordBot.Tests/Services/SoundServiceTests.cs
+++ b/tests/DiscordBot.Tests/Services/SoundServiceTests.cs
@@ -17,6 +17,7 @@ public class SoundServiceTests
 {
     private readonly Mock<ISoundRepository> _mockSoundRepository;
     private readonly Mock<IGuildAudioSettingsRepository> _mockSettingsRepository;
+    private readonly Mock<ISoundPlayLogRepository> _mockPlayLogRepository;
     private readonly Mock<ILogger<SoundService>> _mockLogger;
     private readonly IOptions<SoundboardOptions> _options;
     private readonly SoundService _service;
@@ -25,6 +26,7 @@ public class SoundServiceTests
     {
         _mockSoundRepository = new Mock<ISoundRepository>();
         _mockSettingsRepository = new Mock<IGuildAudioSettingsRepository>();
+        _mockPlayLogRepository = new Mock<ISoundPlayLogRepository>();
         _mockLogger = new Mock<ILogger<SoundService>>();
         _options = Options.Create(new SoundboardOptions
         {
@@ -38,6 +40,7 @@ public class SoundServiceTests
         _service = new SoundService(
             _mockSoundRepository.Object,
             _mockSettingsRepository.Object,
+            _mockPlayLogRepository.Object,
             _mockLogger.Object,
             _options);
     }


### PR DESCRIPTION
## Summary

Implements sound play tracking feature (#930) with all sub-issues completed:

- #939 - Backend: Create SoundPlayLog entity and repository ✓
- #940 - Backend: Add play logging to service layer ✓
- #941 - Frontend: Query and display soundboard analytics ✓
- #942 - Backend: Implement SoundPlayLog retention service ✓

## Features

- Each `/play` command is logged with timestamp, sound ID, guild ID, and user ID
- "Plays Today" card shows actual count with comparison to yesterday
- Historical data retained with configurable 90-day retention policy
- Automatic cleanup via background service

## Files Changed

- Core: `SoundPlayLog` entity, `ISoundPlayLogRepository`, `SoundPlayLogRetentionOptions`
- Infrastructure: `SoundPlayLogRepository`, `SoundPlayLogConfiguration`, migration
- Bot: `SoundService.LogPlayAsync`, `SoundPlayLogRetentionService`, UI updates

## Test plan

- [ ] Play sounds via `/play` and verify logs created
- [ ] Check "Plays Today" shows real counts on Soundboard page
- [ ] Verify comparison metrics after plays on consecutive days
- [ ] Confirm retention service runs and cleans old records

Closes #930

🤖 Generated with [Claude Code](https://claude.com/claude-code)