### PR TITLE
perf(ratwatch): Optimize RatWatchExecutionService performance

### DIFF
--- a/src/DiscordBot.Bot/Services/RatWatch/RatWatchExecutionService.cs
+++ b/src/DiscordBot.Bot/Services/RatWatch/RatWatchExecutionService.cs
@@ -154,8 +154,9 @@ public class RatWatchExecutionService : MonitoredBackgroundService
                     }
 
                     // Re-check status before posting (handles race condition with cancellation)
-                    var currentWatch = await service.GetByIdAsync(watch.Id, cts.Token);
-                    if (currentWatch == null || currentWatch.Status != RatWatchStatus.Pending)
+                    // Use HasStatusAsync for efficiency - avoids loading full entity just for status check
+                    var isPending = await service.HasStatusAsync(watch.Id, RatWatchStatus.Pending, cts.Token);
+                    if (!isPending)
                     {
                         return false;
                     }

--- a/src/DiscordBot.Core/Interfaces/IGuildRatWatchSettingsRepository.cs
+++ b/src/DiscordBot.Core/Interfaces/IGuildRatWatchSettingsRepository.cs
@@ -26,4 +26,16 @@ public interface IGuildRatWatchSettingsRepository : IRepository<GuildRatWatchSet
     Task<GuildRatWatchSettings> GetOrCreateAsync(
         ulong guildId,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the voting duration for specific guilds.
+    /// Returns a dictionary mapping guild ID to voting duration in minutes.
+    /// Only includes guilds that have custom settings configured.
+    /// </summary>
+    /// <param name="guildIds">The guild IDs to get voting durations for.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Dictionary mapping guild ID to voting duration in minutes.</returns>
+    Task<Dictionary<ulong, int>> GetVotingDurationsForGuildsAsync(
+        IEnumerable<ulong> guildIds,
+        CancellationToken cancellationToken = default);
 }

--- a/src/DiscordBot.Core/Interfaces/IRatWatchRepository.cs
+++ b/src/DiscordBot.Core/Interfaces/IRatWatchRepository.cs
@@ -146,4 +146,14 @@ public interface IRatWatchRepository : IRepository<RatWatch>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Collection of recent watches with Guild navigation property included.</returns>
     Task<IEnumerable<RatWatch>> GetRecentAsync(int limit, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks if a watch exists with the specified status.
+    /// More efficient than loading the full entity when only status verification is needed.
+    /// </summary>
+    /// <param name="watchId">The watch ID to check.</param>
+    /// <param name="expectedStatus">The expected status.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the watch exists and has the expected status, false otherwise.</returns>
+    Task<bool> HasStatusAsync(Guid watchId, Enums.RatWatchStatus expectedStatus, CancellationToken cancellationToken = default);
 }

--- a/src/DiscordBot.Core/Interfaces/IRatWatchService.cs
+++ b/src/DiscordBot.Core/Interfaces/IRatWatchService.cs
@@ -187,4 +187,15 @@ public interface IRatWatchService
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Collection of recent watches with guild names included.</returns>
     Task<IEnumerable<RatWatchDto>> GetRecentActivityAsync(int limit = 10, CancellationToken ct = default);
+
+    /// <summary>
+    /// Checks if a watch has the specified status.
+    /// More efficient than loading the full entity when only status verification is needed.
+    /// Used by background services to verify watch status before processing.
+    /// </summary>
+    /// <param name="watchId">The watch ID to check.</param>
+    /// <param name="expectedStatus">The expected status.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>True if the watch exists and has the expected status, false otherwise.</returns>
+    Task<bool> HasStatusAsync(Guid watchId, Enums.RatWatchStatus expectedStatus, CancellationToken ct = default);
 }

--- a/src/DiscordBot.Infrastructure/Data/Repositories/RatWatchRepository.cs
+++ b/src/DiscordBot.Infrastructure/Data/Repositories/RatWatchRepository.cs
@@ -469,4 +469,17 @@ public class RatWatchRepository : Repository<RatWatch>, IRatWatchRepository
         _logger.LogDebug("Retrieved {Count} recent Rat Watches", watches.Count);
         return watches;
     }
+
+    public async Task<bool> HasStatusAsync(Guid watchId, RatWatchStatus expectedStatus, CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Checking if Rat Watch {WatchId} has status {ExpectedStatus}", watchId, expectedStatus);
+
+        var hasStatus = await DbSet
+            .AsNoTracking()
+            .Where(r => r.Id == watchId && r.Status == expectedStatus)
+            .AnyAsync(cancellationToken);
+
+        _logger.LogDebug("Rat Watch {WatchId} has status {ExpectedStatus}: {Result}", watchId, expectedStatus, hasStatus);
+        return hasStatus;
+    }
 }


### PR DESCRIPTION
## Summary
- Optimize `RatWatchExecutionService` background service to reduce database queries per execution cycle
- Add `GetVotingDurationsForGuildsAsync` to only fetch settings for guilds with active voting watches
- Add `HasStatusAsync` for lightweight status checks without loading full entities
- Update `MapToDtoAsync` to use pre-loaded votes when available

## Performance Improvements

| Issue | Before | After |
|-------|--------|-------|
| Guild settings load | Loads ALL settings every cycle | Only loads settings for active voting guilds |
| Status verification | Full entity load via GetByIdAsync | Simple boolean check via HasStatusAsync |
| Vote tally calculation | Separate DB query per watch | Uses pre-loaded votes from Include |

## Test plan
- [x] All 93 RatWatch tests pass
- [x] Solution builds without errors
- [ ] Manual verification with active Rat Watches

Closes #784

🤖 Generated with [Claude Code](https://claude.com/claude-code)