### PR TITLE
feat(audio): Add Portal navigation links to Audio pages

### DIFF
--- a/src/DiscordBot.Bot/Pages/Guilds/AudioSettings/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/AudioSettings/Index.cshtml
@@ -128,6 +128,34 @@
                 </label>
             </div>
 
+            <!-- Portal Links (shown when Member Portal is enabled) -->
+            <div class="settings-row portal-links-row" id="portalLinksRow" style="@(Model.Settings.EnableMemberPortal ? "" : "display: none;")">
+                <div class="settings-row-content">
+                    <div class="settings-row-title">Portal Links</div>
+                    <div class="settings-row-description">Open the member portal pages. These links open in a new tab using Discord OAuth authentication.</div>
+                </div>
+                <div class="portal-link-buttons">
+                    <a href="/Portal/Soundboard/@Model.GuildId" target="_blank" rel="noopener noreferrer" class="portal-link-btn">
+                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
+                        </svg>
+                        Soundboard Portal
+                        <svg class="w-3 h-3 external-link-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                        </svg>
+                    </a>
+                    <a href="/Portal/TTS/@Model.GuildId" target="_blank" rel="noopener noreferrer" class="portal-link-btn">
+                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z" />
+                        </svg>
+                        TTS Portal
+                        <svg class="w-3 h-3 external-link-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                        </svg>
+                    </a>
+                </div>
+            </div>
+
             <!-- Sound Storage Path (Read-only) -->
             <div class="settings-row">
                 <div class="settings-row-content">
@@ -698,6 +726,50 @@
         .input-error {
             border-color: var(--color-error) !important;
         }
+
+        /* Portal Link Buttons */
+        .portal-link-buttons {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+        }
+
+        .portal-link-btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.375rem;
+            padding: 0.5rem 0.75rem;
+            background: var(--color-bg-tertiary);
+            border: 1px solid var(--color-border-primary);
+            border-radius: 0.375rem;
+            font-size: 0.8125rem;
+            font-weight: 500;
+            color: var(--color-text-primary);
+            text-decoration: none;
+            transition: all 0.15s ease;
+        }
+
+        .portal-link-btn:hover {
+            background: var(--color-bg-hover);
+            border-color: var(--color-border-focus);
+            color: var(--color-accent-blue);
+        }
+
+        .portal-link-btn .external-link-icon {
+            opacity: 0.5;
+            transition: opacity 0.15s;
+        }
+
+        .portal-link-btn:hover .external-link-icon {
+            opacity: 1;
+        }
+
+        .portal-links-row {
+            background: var(--color-bg-tertiary);
+            margin: -0.5rem -1.5rem;
+            padding: 1rem 1.5rem !important;
+            border-top: 1px dashed var(--color-border-secondary);
+        }
     </style>
 }
 
@@ -976,6 +1048,16 @@
         document.addEventListener('keydown', function(e) {
             if (e.key === 'Escape') {
                 document.querySelectorAll('.role-select-dropdown').forEach(d => d.classList.remove('open'));
+            }
+        });
+
+        // Toggle portal links visibility when Member Portal checkbox changes
+        document.getElementById('enableMemberPortal').addEventListener('change', function() {
+            const portalLinksRow = document.getElementById('portalLinksRow');
+            if (this.checked) {
+                portalLinksRow.style.display = '';
+            } else {
+                portalLinksRow.style.display = 'none';
             }
         });
     </script>

--- a/src/DiscordBot.Bot/Pages/Guilds/Soundboard/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Soundboard/Index.cshtml
@@ -45,6 +45,20 @@
             <h1 class="text-2xl font-bold text-text-primary">Audio</h1>
             <p class="mt-1 text-sm text-text-secondary">Manage audio settings and soundboard for @Model.ViewModel.GuildName</p>
         </div>
+        @if (Model.IsMemberPortalEnabled)
+        {
+            <a href="/Portal/Soundboard/@Model.ViewModel.GuildId" target="_blank" rel="noopener noreferrer"
+               class="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-text-secondary hover:text-accent-blue bg-bg-secondary border border-border-primary rounded-lg hover:border-border-focus transition-colors">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                </svg>
+                Open Member Portal
+                <svg class="w-3 h-3 opacity-50" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                </svg>
+            </a>
+        }
     </div>
 
     <!-- Audio Tabs Navigation -->

--- a/src/DiscordBot.Bot/Pages/Guilds/Soundboard/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/Soundboard/Index.cshtml.cs
@@ -88,6 +88,11 @@ public class IndexModel : PageModel
     public bool IsAudioGloballyDisabled { get; set; }
 
     /// <summary>
+    /// Gets whether the member portal is enabled for this guild.
+    /// </summary>
+    public bool IsMemberPortalEnabled { get; set; }
+
+    /// <summary>
     /// Handles GET requests to display the Soundboard management page.
     /// </summary>
     /// <param name="guildId">The guild's Discord snowflake ID from route parameter.</param>
@@ -121,6 +126,9 @@ public class IndexModel : PageModel
 
             // Get audio settings (creates defaults if not found)
             var settings = await _audioSettingsRepository.GetOrCreateAsync(guildId, cancellationToken);
+
+            // Set member portal enabled flag for UI
+            IsMemberPortalEnabled = settings.EnableMemberPortal;
 
             // Query play statistics
             var todayUtc = DateTime.UtcNow.Date;

--- a/src/DiscordBot.Bot/Pages/Guilds/TextToSpeech/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/TextToSpeech/Index.cshtml
@@ -45,6 +45,20 @@
             <h1 class="text-2xl font-bold text-text-primary">Text-to-Speech</h1>
             <p class="mt-1 text-sm text-text-secondary">Send TTS messages to voice channels in @Model.ViewModel.GuildName</p>
         </div>
+        @if (Model.IsMemberPortalEnabled)
+        {
+            <a href="/Portal/TTS/@Model.ViewModel.GuildId" target="_blank" rel="noopener noreferrer"
+               class="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-text-secondary hover:text-accent-blue bg-bg-secondary border border-border-primary rounded-lg hover:border-border-focus transition-colors">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                </svg>
+                Open Member Portal
+                <svg class="w-3 h-3 opacity-50" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                </svg>
+            </a>
+        }
     </div>
 
     <!-- Audio Tabs Navigation -->

--- a/src/DiscordBot.Bot/Pages/Guilds/TextToSpeech/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/TextToSpeech/Index.cshtml.cs
@@ -26,6 +26,7 @@ public class IndexModel : PageModel
     private readonly DiscordSocketClient _discordClient;
     private readonly IGuildService _guildService;
     private readonly ISettingsService _settingsService;
+    private readonly IGuildAudioSettingsRepository _audioSettingsRepository;
     private readonly ILogger<IndexModel> _logger;
 
     public IndexModel(
@@ -36,6 +37,7 @@ public class IndexModel : PageModel
         DiscordSocketClient discordClient,
         IGuildService guildService,
         ISettingsService settingsService,
+        IGuildAudioSettingsRepository audioSettingsRepository,
         ILogger<IndexModel> logger)
     {
         _ttsHistoryService = ttsHistoryService;
@@ -45,6 +47,7 @@ public class IndexModel : PageModel
         _discordClient = discordClient;
         _guildService = guildService;
         _settingsService = settingsService;
+        _audioSettingsRepository = audioSettingsRepository;
         _logger = logger;
     }
 
@@ -76,6 +79,11 @@ public class IndexModel : PageModel
     public bool IsAudioGloballyDisabled { get; set; }
 
     /// <summary>
+    /// Gets whether the member portal is enabled for this guild.
+    /// </summary>
+    public bool IsMemberPortalEnabled { get; set; }
+
+    /// <summary>
     /// Handles GET requests to display the TTS management page.
     /// </summary>
     /// <param name="guildId">The guild's Discord snowflake ID from route parameter.</param>
@@ -103,6 +111,10 @@ public class IndexModel : PageModel
 
             // Get TTS settings (creates defaults if not found)
             var settings = await _ttsSettingsService.GetOrCreateSettingsAsync(guildId, cancellationToken);
+
+            // Get audio settings to check if member portal is enabled
+            var audioSettings = await _audioSettingsRepository.GetOrCreateAsync(guildId, cancellationToken);
+            IsMemberPortalEnabled = audioSettings.EnableMemberPortal;
 
             // Get TTS statistics
             var stats = await _ttsHistoryService.GetStatsAsync(guildId, cancellationToken);


### PR DESCRIPTION
## Summary
- Add "Portal Links" section to Audio Settings page, visible only when Member Portal is enabled
- Add "Open Member Portal" navigation buttons to Soundboard and TTS admin pages
- Links open Portal pages in new tabs with Discord OAuth authentication

## Changes
- **Audio Settings**: Added Portal Links section with buttons for both Soundboard and TTS portals, dynamically shown/hidden based on Member Portal toggle
- **Soundboard page**: Added contextual "Open Member Portal" button in the header (only shown when Member Portal is enabled)
- **TTS page**: Added contextual "Open Member Portal" button in the header (only shown when Member Portal is enabled)

## Test plan
- [ ] Navigate to Audio Settings page with Member Portal disabled - Portal Links section should be hidden
- [ ] Enable Member Portal toggle - Portal Links section should appear with two buttons
- [ ] Click Soundboard Portal link - should open Portal/Soundboard in new tab
- [ ] Click TTS Portal link - should open Portal/TTS in new tab
- [ ] Navigate to Soundboard page with Member Portal enabled - "Open Member Portal" button should appear
- [ ] Navigate to TTS page with Member Portal enabled - "Open Member Portal" button should appear
- [ ] Disable Member Portal - contextual buttons on Soundboard/TTS pages should disappear

Closes #1074

🤖 Generated with [Claude Code](https://claude.com/claude-code)