### PR TITLE
fix(ui): Disable Alert Settings controls for non-admin users

### DIFF
--- a/src/DiscordBot.Bot/Pages/Admin/Performance/Alerts.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/Alerts.cshtml
@@ -134,6 +134,16 @@
     </div>
 }
 
+@if (!Model.CanEdit)
+{
+    <div class="mb-6 p-4 bg-warning/10 border border-warning/20 rounded-lg text-warning text-sm flex items-center gap-2">
+        <svg class="w-5 h-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+        </svg>
+        <span>You have read-only access to this page. Admin privileges are required to modify alert settings.</span>
+    </div>
+}
+
 <!-- Navigation Tabs -->
 @await Html.PartialAsync("Components/_PerformanceTabs", new PerformanceTabsViewModel
 {

--- a/src/DiscordBot.Bot/Pages/Admin/Performance/Alerts.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/Alerts.cshtml.cs
@@ -22,6 +22,12 @@ public class AlertsModel : PageModel
     public AlertsPageViewModel ViewModel { get; private set; } = new();
 
     /// <summary>
+    /// Gets a value indicating whether the current user can edit alert settings.
+    /// Only Admin and SuperAdmin roles can modify alert configurations.
+    /// </summary>
+    public bool CanEdit => User.IsInRole("Admin") || User.IsInRole("SuperAdmin");
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="AlertsModel"/> class.
     /// </summary>
     /// <param name="alertService">The performance alert service.</param>
@@ -73,7 +79,8 @@ public class AlertsModel : PageModel
                 RecentIncidents = recentIncidentsTask.Result.Items,
                 AutoRecoveryEvents = autoRecoveryEventsTask.Result,
                 AlertFrequencyData = alertFrequencyTask.Result,
-                AlertSummary = summaryTask.Result
+                AlertSummary = summaryTask.Result,
+                CanEdit = CanEdit
             };
 
             _logger.LogDebug(

--- a/src/DiscordBot.Bot/Pages/Admin/Performance/Tabs/_AlertsTab.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/Tabs/_AlertsTab.cshtml
@@ -12,7 +12,7 @@
             <h2 class="chart-card-title">Active Alerts</h2>
             <p class="chart-card-subtitle">Current issues requiring attention</p>
         </div>
-        @if (Model.ActiveIncidents.Any())
+        @if (Model.ActiveIncidents.Any() && Model.CanEdit)
         {
             @await Html.PartialAsync("Components/_Button", new ButtonViewModel
             {
@@ -78,7 +78,7 @@
                                 <span data-utc-time="@incident.TriggeredAt.ToString("o")" data-format="relative">Triggered @AlertsPageViewModel.FormatRelativeTime(incident.TriggeredAt)</span>
                             </div>
                         </div>
-                        @if (!incident.IsAcknowledged)
+                        @if (!incident.IsAcknowledged && Model.CanEdit)
                         {
                             <div class="alert-actions flex items-center gap-2">
                                 @await Html.PartialAsync("Components/_Button", new ButtonViewModel
@@ -116,19 +116,22 @@
             <h2 class="chart-card-title">Alert Threshold Configuration</h2>
             <p class="chart-card-subtitle">Define warning and critical thresholds for key metrics</p>
         </div>
-        @await Html.PartialAsync("Components/_Button", new ButtonViewModel
+        @if (Model.CanEdit)
         {
-            Text = "Save Changes",
-            Type = "button",
-            Variant = ButtonVariant.Primary,
-            OnClick = "alertsTabSaveConfig()",
-            IconLeft = "M5 13l4 4L19 7",
-            AdditionalAttributes = new Dictionary<string, string>
+            @await Html.PartialAsync("Components/_Button", new ButtonViewModel
             {
-                { "id", "alertsTabSaveConfigBtn" },
-                { "style", "display: none;" }
-            }
-        })
+                Text = "Save Changes",
+                Type = "button",
+                Variant = ButtonVariant.Primary,
+                OnClick = "alertsTabSaveConfig()",
+                IconLeft = "M5 13l4 4L19 7",
+                AdditionalAttributes = new Dictionary<string, string>
+                {
+                    { "id", "alertsTabSaveConfigBtn" },
+                    { "style", "display: none;" }
+                }
+            })
+        }
     </div>
     <div class="overflow-x-auto">
         <table class="config-table">
@@ -172,7 +175,8 @@
                                        min="0"
                                        data-field="warning"
                                        class="alerts-threshold-input"
-                                       aria-label="Warning threshold for @config.DisplayName" />
+                                       aria-label="Warning threshold for @config.DisplayName"
+                                       @(Model.CanEdit ? "" : "disabled") />
                                 <span class="text-text-secondary">@config.ThresholdUnit</span>
                             </div>
                         </td>
@@ -183,7 +187,8 @@
                                        min="0"
                                        data-field="critical"
                                        class="alerts-threshold-input"
-                                       aria-label="Critical threshold for @config.DisplayName" />
+                                       aria-label="Critical threshold for @config.DisplayName"
+                                       @(Model.CanEdit ? "" : "disabled") />
                                 <span class="text-text-secondary">@config.ThresholdUnit</span>
                             </div>
                         </td>
@@ -198,7 +203,8 @@
                                        @(config.IsEnabled ? "checked" : "")
                                        data-field="enabled"
                                        class="alerts-enabled-toggle"
-                                       aria-label="Enable alerts for @config.DisplayName">
+                                       aria-label="Enable alerts for @config.DisplayName"
+                                       @(Model.CanEdit ? "" : "disabled")>
                                 <span class="toggle-slider"></span>
                             </label>
                         </td>

--- a/src/DiscordBot.Bot/ViewModels/Pages/AlertsPageViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Pages/AlertsPageViewModel.cs
@@ -39,6 +39,12 @@ public record AlertsPageViewModel
     public ActiveAlertSummaryDto AlertSummary { get; init; } = new();
 
     /// <summary>
+    /// Gets a value indicating whether the current user can edit alert settings.
+    /// Only Admin and SuperAdmin roles can modify alert configurations.
+    /// </summary>
+    public bool CanEdit { get; init; }
+
+    /// <summary>
     /// Gets the CSS class for an alert severity level.
     /// </summary>
     /// <param name="severity">The alert severity level.</param>


### PR DESCRIPTION
## Summary
- Add read-only mode for Viewer and Moderator roles on the Performance Alerts page
- Users without Admin or SuperAdmin role can view alert configurations but cannot modify settings
- Added informational banner explaining read-only access for non-admin users

## Changes
- Added `CanEdit` property to `AlertsPageViewModel` and `AlertsModel` page model
- Hidden "Acknowledge" and "Acknowledge All" buttons for non-admin users
- Disabled threshold input fields (warning/critical) for non-admin users
- Disabled enabled/disabled toggle switches for non-admin users
- Hidden "Save Changes" button for non-admin users
- Added warning banner with lock icon explaining read-only access

## Test Plan
- [ ] Login as Viewer role user and verify:
  - [ ] Can access `/Admin/Performance/Alerts` page
  - [ ] Cannot see Acknowledge/Acknowledge All buttons
  - [ ] Cannot edit threshold input fields (disabled)
  - [ ] Cannot toggle enabled/disabled switches (disabled)
  - [ ] Cannot see Save Changes button
  - [ ] See read-only warning banner at top of page
- [ ] Login as Admin/SuperAdmin and verify all controls still work normally

Closes #1087

🤖 Generated with [Claude Code](https://claude.com/claude-code)