### PR TITLE
fix(soundboard): Add missing SignalR event handlers to Soundboard Portal

### DIFF
--- a/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml
@@ -1713,6 +1713,11 @@ else
                 DashboardHub.on('VoiceChannelMemberCountUpdated', handleVoiceChannelMemberCountUpdated);
                 DashboardHub.on('SoundUploaded', handleSoundUploaded);
                 DashboardHub.on('SoundDeleted', handleSoundDeleted);
+                DashboardHub.on('QueueUpdated', handleQueueUpdated);
+
+                // Global events - register empty handlers to suppress SignalR warnings
+                // BotStatusUpdated is broadcast to all clients but not relevant for Portal
+                DashboardHub.on('BotStatusUpdated', () => {});
 
                 // Connection state handlers
                 DashboardHub.on('reconnected', async () => {
@@ -1945,6 +1950,14 @@ else
                     PortalToast.warning(`Sound "${soundName}" was deleted`);
                 }, 300);
             }
+        }
+
+        // Handle queue updated event from SignalR
+        function handleQueueUpdated(data) {
+            console.log('[Soundboard] QueueUpdated:', data.queue.length, 'items');
+            // Currently the Portal doesn't display a queue UI, but the handler
+            // prevents SignalR "No client method found" warnings.
+            // Future enhancement: Display queue in the Now Playing panel
         }
 
         // Helper: Show toast notification


### PR DESCRIPTION
## Summary
- Add `QueueUpdated` event handler to the Soundboard Portal's SignalR initialization
- Add empty `BotStatusUpdated` handler to suppress warnings for global events not relevant to the Portal

## Technical Details
The Portal page was receiving SignalR events but lacked handlers for:
1. **QueueUpdated** - Now logs queue changes (currently no UI for queue display, but handler prevents warnings)
2. **BotStatusUpdated** - Global event broadcast to all clients; empty handler suppresses "No client method found" warning

## Test Plan
- [ ] Load Soundboard Portal page and verify no console warnings about missing SignalR methods
- [ ] Trigger a sound playback and verify QueueUpdated event is logged to console
- [ ] Verify bot status changes don't produce console warnings

Closes #1078

🤖 Generated with [Claude Code](https://claude.com/claude-code)