### PR TITLE
feat(core): Add command module configuration entities and interfaces

### DIFF
--- a/src/DiscordBot.Core/DTOs/CommandModuleConfigurationDto.cs
+++ b/src/DiscordBot.Core/DTOs/CommandModuleConfigurationDto.cs
@@ -1,0 +1,57 @@
+namespace DiscordBot.Core.DTOs;
+
+/// <summary>
+/// Data transfer object representing a command module configuration for display in the admin UI.
+/// </summary>
+public record CommandModuleConfigurationDto
+{
+    /// <summary>
+    /// The unique module name identifier.
+    /// </summary>
+    public string ModuleName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Indicates whether the module is currently enabled.
+    /// </summary>
+    public bool IsEnabled { get; init; }
+
+    /// <summary>
+    /// User-friendly display name for the module.
+    /// </summary>
+    public string DisplayName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Description of what the module does.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Category for grouping modules (Admin, Moderation, Features, Audio, Utility, Core).
+    /// </summary>
+    public string Category { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Indicates whether changes to this module's enabled state require a bot restart.
+    /// </summary>
+    public bool RequiresRestart { get; init; }
+
+    /// <summary>
+    /// Timestamp when the configuration was last modified.
+    /// </summary>
+    public DateTime LastModifiedAt { get; init; }
+
+    /// <summary>
+    /// User ID who last modified the configuration.
+    /// </summary>
+    public string? LastModifiedBy { get; init; }
+
+    /// <summary>
+    /// Number of commands in this module (populated from command metadata).
+    /// </summary>
+    public int CommandCount { get; init; }
+
+    /// <summary>
+    /// List of command names in this module (populated from command metadata).
+    /// </summary>
+    public IReadOnlyList<string> Commands { get; init; } = Array.Empty<string>();
+}

--- a/src/DiscordBot.Core/DTOs/CommandModuleConfigurationUpdateDto.cs
+++ b/src/DiscordBot.Core/DTOs/CommandModuleConfigurationUpdateDto.cs
@@ -1,0 +1,38 @@
+namespace DiscordBot.Core.DTOs;
+
+/// <summary>
+/// Request DTO for updating command module configurations.
+/// </summary>
+public record CommandModuleConfigurationUpdateDto
+{
+    /// <summary>
+    /// Dictionary of module names to their new enabled state.
+    /// </summary>
+    public Dictionary<string, bool> Modules { get; init; } = new();
+}
+
+/// <summary>
+/// Result DTO for command module configuration update operations.
+/// </summary>
+public record CommandModuleUpdateResultDto
+{
+    /// <summary>
+    /// Indicates whether the update was successful.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// Indicates whether a bot restart is required for changes to take effect.
+    /// </summary>
+    public bool RequiresRestart { get; init; }
+
+    /// <summary>
+    /// List of module names that were successfully updated.
+    /// </summary>
+    public IReadOnlyList<string> UpdatedModules { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// List of validation errors that occurred during the update.
+    /// </summary>
+    public IReadOnlyList<string> Errors { get; init; } = Array.Empty<string>();
+}

--- a/src/DiscordBot.Core/Entities/CommandModuleConfiguration.cs
+++ b/src/DiscordBot.Core/Entities/CommandModuleConfiguration.cs
@@ -1,0 +1,51 @@
+namespace DiscordBot.Core.Entities;
+
+/// <summary>
+/// Represents the configuration state for a Discord bot command module.
+/// Enables administrators to enable/disable command modules through the admin UI.
+/// </summary>
+public class CommandModuleConfiguration
+{
+    /// <summary>
+    /// The unique module name identifier (e.g., "AdminModule", "RatWatchModule").
+    /// This is the primary key.
+    /// </summary>
+    public string ModuleName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Indicates whether the module is currently enabled.
+    /// Disabled modules will not respond to commands.
+    /// </summary>
+    public bool IsEnabled { get; set; } = true;
+
+    /// <summary>
+    /// User-friendly display name for the module in the admin UI.
+    /// </summary>
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Optional description of what the module does.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Category for grouping modules in the admin UI.
+    /// Valid values: Admin, Moderation, Features, Audio, Utility, Core.
+    /// </summary>
+    public string Category { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Indicates whether changes to this module's enabled state require a bot restart.
+    /// </summary>
+    public bool RequiresRestart { get; set; } = true;
+
+    /// <summary>
+    /// Timestamp when the configuration was last modified.
+    /// </summary>
+    public DateTime LastModifiedAt { get; set; }
+
+    /// <summary>
+    /// User ID who last modified the configuration (nullable for system-created defaults).
+    /// </summary>
+    public string? LastModifiedBy { get; set; }
+}

--- a/src/DiscordBot.Core/Interfaces/ICommandModuleConfigurationRepository.cs
+++ b/src/DiscordBot.Core/Interfaces/ICommandModuleConfigurationRepository.cs
@@ -1,0 +1,62 @@
+using DiscordBot.Core.Entities;
+
+namespace DiscordBot.Core.Interfaces;
+
+/// <summary>
+/// Repository interface for managing command module configuration persistence.
+/// </summary>
+public interface ICommandModuleConfigurationRepository
+{
+    /// <summary>
+    /// Gets a module configuration by its name.
+    /// </summary>
+    /// <param name="moduleName">The module name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The configuration if found, otherwise null.</returns>
+    Task<CommandModuleConfiguration?> GetByNameAsync(string moduleName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets all module configurations for a specific category.
+    /// </summary>
+    /// <param name="category">The module category (e.g., "Admin", "Moderation").</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of configurations in the category.</returns>
+    Task<IReadOnlyList<CommandModuleConfiguration>> GetByCategoryAsync(
+        string category,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets all module configurations.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of all module configurations.</returns>
+    Task<IReadOnlyList<CommandModuleConfiguration>> GetAllAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets all enabled module configurations.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of enabled module configurations.</returns>
+    Task<IReadOnlyList<CommandModuleConfiguration>> GetEnabledAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Inserts or updates a module configuration.
+    /// </summary>
+    /// <param name="configuration">The configuration to upsert.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task UpsertAsync(CommandModuleConfiguration configuration, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Inserts or updates multiple module configurations.
+    /// </summary>
+    /// <param name="configurations">The configurations to upsert.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task UpsertRangeAsync(IEnumerable<CommandModuleConfiguration> configurations, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes a module configuration by its name.
+    /// </summary>
+    /// <param name="moduleName">The module name to delete.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task DeleteAsync(string moduleName, CancellationToken cancellationToken = default);
+}

--- a/src/DiscordBot.Core/Interfaces/ICommandModuleConfigurationService.cs
+++ b/src/DiscordBot.Core/Interfaces/ICommandModuleConfigurationService.cs
@@ -1,0 +1,109 @@
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Core.Interfaces;
+
+/// <summary>
+/// Service interface for managing command module configuration with business logic.
+/// </summary>
+public interface ICommandModuleConfigurationService
+{
+    /// <summary>
+    /// Gets all module configurations with metadata.
+    /// Merges database values with discovered modules from the bot.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of all module configurations.</returns>
+    Task<IReadOnlyList<CommandModuleConfigurationDto>> GetAllModulesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets all module configurations for a specific category.
+    /// </summary>
+    /// <param name="category">The module category.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of module configurations in the category.</returns>
+    Task<IReadOnlyList<CommandModuleConfigurationDto>> GetModulesByCategoryAsync(
+        string category,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a single module configuration by name.
+    /// </summary>
+    /// <param name="moduleName">The module name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The module configuration if found, otherwise null.</returns>
+    Task<CommandModuleConfigurationDto?> GetModuleAsync(string moduleName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks if a module is enabled.
+    /// </summary>
+    /// <param name="moduleName">The module name to check.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the module is enabled, false otherwise.</returns>
+    Task<bool> IsModuleEnabledAsync(string moduleName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates the enabled state of a module.
+    /// </summary>
+    /// <param name="moduleName">The module name to update.</param>
+    /// <param name="isEnabled">The new enabled state.</param>
+    /// <param name="userId">The ID of the user making the change.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result indicating success and whether restart is required.</returns>
+    Task<CommandModuleUpdateResultDto> SetModuleEnabledAsync(
+        string moduleName,
+        bool isEnabled,
+        string userId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates multiple module configurations.
+    /// </summary>
+    /// <param name="updates">The updates to apply.</param>
+    /// <param name="userId">The ID of the user making the changes.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result indicating success, errors, and restart requirement.</returns>
+    Task<CommandModuleUpdateResultDto> UpdateModulesAsync(
+        CommandModuleConfigurationUpdateDto updates,
+        string userId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Synchronizes module configurations with discovered modules from the bot.
+    /// Creates configurations for new modules and optionally removes orphaned ones.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The number of modules added or updated.</returns>
+    Task<int> SyncModulesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets whether a restart is pending due to module configuration changes.
+    /// </summary>
+    bool IsRestartPending { get; }
+
+    /// <summary>
+    /// Clears the restart pending flag.
+    /// Should be called by the bot hosted service after successful restart.
+    /// </summary>
+    void ClearRestartPending();
+
+    /// <summary>
+    /// Event that is raised when module configurations are updated.
+    /// </summary>
+    event EventHandler<CommandModuleConfigurationChangedEventArgs>? ConfigurationChanged;
+}
+
+/// <summary>
+/// Event arguments for module configuration changed events.
+/// </summary>
+public class CommandModuleConfigurationChangedEventArgs : EventArgs
+{
+    /// <summary>
+    /// The module names that were updated.
+    /// </summary>
+    public IReadOnlyList<string> UpdatedModules { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// The user who made the changes.
+    /// </summary>
+    public string UserId { get; init; } = string.Empty;
+}


### PR DESCRIPTION
## Summary

- Add `CommandModuleConfiguration` entity with properties for module state and metadata
- Add `ICommandModuleConfigurationRepository` interface for CRUD operations
- Add `ICommandModuleConfigurationService` interface for business logic (enable/disable modules, sync with discovered modules)
- Add `CommandModuleConfigurationDto` and `CommandModuleConfigurationUpdateDto` for API layer

## Test Plan

- [x] Core project builds successfully
- [x] Full solution builds with no errors
- [ ] Subsequent issues will implement repository, service, and tests

Closes #1080

🤖 Generated with [Claude Code](https://claude.com/claude-code)