### PR TITLE
fix(auth): Use RequireViewer policy for dashboard authorization

### DIFF
--- a/src/DiscordBot.Bot/Filters/DashboardAnonymousRedirectFilter.cs
+++ b/src/DiscordBot.Bot/Filters/DashboardAnonymousRedirectFilter.cs
@@ -1,0 +1,49 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace DiscordBot.Bot.Filters;
+
+/// <summary>
+/// Page filter that redirects anonymous users accessing the dashboard to the landing page.
+/// This filter runs before authorization and handles the special case where the dashboard
+/// should redirect unauthenticated users to /Landing instead of /Account/Login.
+/// </summary>
+public class DashboardAnonymousRedirectFilter : IAsyncPageFilter
+{
+    private readonly ILogger<DashboardAnonymousRedirectFilter> _logger;
+
+    public DashboardAnonymousRedirectFilter(ILogger<DashboardAnonymousRedirectFilter> logger)
+    {
+        _logger = logger;
+    }
+
+    public Task OnPageHandlerSelectionAsync(PageHandlerSelectedContext context)
+    {
+        // Check if this is the dashboard page and user is anonymous
+        var path = context.HttpContext.Request.Path.Value?.TrimEnd('/');
+        if ((string.IsNullOrEmpty(path) || path == "/Index") &&
+            context.HttpContext.User.Identity?.IsAuthenticated != true)
+        {
+            _logger.LogDebug("Anonymous user redirected from dashboard to landing page");
+            // Short-circuit by setting the handler descriptor to null, which causes MVC to not process
+            // We can't set Result here, so we handle redirect in OnPageHandlerExecutionAsync
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        // Check if this is the dashboard page and user is anonymous
+        var path = context.HttpContext.Request.Path.Value?.TrimEnd('/');
+        if ((string.IsNullOrEmpty(path) || path == "/Index") &&
+            context.HttpContext.User.Identity?.IsAuthenticated != true)
+        {
+            _logger.LogDebug("Anonymous user redirected from dashboard to landing page");
+            context.Result = new RedirectToPageResult("/Landing");
+            return;
+        }
+
+        await next();
+    }
+}

--- a/src/DiscordBot.Bot/Pages/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Index.cshtml.cs
@@ -12,9 +12,9 @@ namespace DiscordBot.Bot.Pages;
 
 /// <summary>
 /// Dashboard page for authenticated users.
-/// Anonymous users are redirected to the public landing page.
+/// Anonymous users are redirected to the public landing page via DashboardAnonymousRedirectFilter.
 /// </summary>
-[AllowAnonymous]
+[Authorize(Policy = "RequireViewer")]
 public class IndexModel : PageModel
 {
     private readonly ILogger<IndexModel> _logger;
@@ -58,21 +58,9 @@ public class IndexModel : PageModel
 
     public async Task<IActionResult> OnGetAsync()
     {
-        // Redirect anonymous users to the public landing page
-        if (User.Identity?.IsAuthenticated != true)
-        {
-            _logger.LogDebug("Anonymous user redirected from dashboard to landing page");
-            return RedirectToPage("/Landing");
-        }
-
-        // Require at least Viewer role for authenticated users
-        if (!User.IsInRole("Viewer") && !User.IsInRole("Moderator") && !User.IsInRole("Admin") && !User.IsInRole("SuperAdmin"))
-        {
-            _logger.LogWarning("User {UserId} does not have required role to access dashboard", User.Identity?.Name);
-            return Forbid();
-        }
-
-        _logger.LogDebug("Dashboard accessed by authenticated user");
+        // Authorization is handled by [Authorize(Policy = "RequireViewer")] attribute
+        // Anonymous users are redirected to /Landing by DashboardAnonymousRedirectFilter
+        _logger.LogDebug("Dashboard accessed by authenticated user {UserId}", User.Identity?.Name);
 
         var statusDto = _botService.GetStatus();
         BotStatus = BotStatusViewModel.FromDto(statusDto);

--- a/src/DiscordBot.Bot/Program.cs
+++ b/src/DiscordBot.Bot/Program.cs
@@ -189,7 +189,11 @@ try
 
     // Add Web API services
     builder.Services.AddControllers();
-    builder.Services.AddRazorPages();
+    builder.Services.AddRazorPages()
+        .AddMvcOptions(options =>
+        {
+            options.Filters.Add<DiscordBot.Bot.Filters.DashboardAnonymousRedirectFilter>();
+        });
     builder.Services.AddEndpointsApiExplorer();
 
     // Add SignalR for real-time dashboard updates


### PR DESCRIPTION
## Summary
- Replace manual `User.IsInRole()` checks with `[Authorize(Policy = "RequireViewer")]` attribute on the dashboard page
- Add `DashboardAnonymousRedirectFilter` to redirect anonymous users to `/Landing` instead of `/Account/Login`
- Manual role checks can fail due to claims timing issues during authentication; the policy-based approach is more robust

## Test plan
- [ ] Log in as a Viewer role user and verify dashboard loads successfully (no 403)
- [ ] Log in as Moderator, Admin, and SuperAdmin and verify dashboard access
- [ ] Access dashboard while logged out and verify redirect to `/Landing`
- [ ] Verify audit log widget is still only visible to Admin/SuperAdmin users

Closes #1105

🤖 Generated with [Claude Code](https://claude.com/claude-code)