### PR TITLE
fix(auth): Remove redundant IsInRole checks in Admin pages

### DIFF
--- a/src/DiscordBot.Bot/Pages/Admin/BotControl.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Admin/BotControl.cshtml.cs
@@ -57,12 +57,6 @@ public class BotControlModel : PageModel
     /// </summary>
     public async Task<IActionResult> OnPostRestartBotAsync()
     {
-        if (!User.IsInRole("Admin") && !User.IsInRole("SuperAdmin"))
-        {
-            _logger.LogWarning("Non-admin user {UserId} attempted to restart bot", User.Identity?.Name);
-            return Forbid();
-        }
-
         _logger.LogWarning("Bot restart requested by user {UserId}", User.Identity?.Name);
 
         try
@@ -96,12 +90,6 @@ public class BotControlModel : PageModel
     /// </summary>
     public async Task<IActionResult> OnPostShutdownBotAsync()
     {
-        if (!User.IsInRole("Admin") && !User.IsInRole("SuperAdmin"))
-        {
-            _logger.LogWarning("Non-admin user {UserId} attempted to shutdown bot", User.Identity?.Name);
-            return Forbid();
-        }
-
         _logger.LogCritical("Bot SHUTDOWN requested by user {UserId}", User.Identity?.Name);
 
         try

--- a/src/DiscordBot.Bot/Pages/Admin/Settings.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Admin/Settings.cshtml.cs
@@ -89,12 +89,6 @@ public class SettingsModel : PageModel
     /// <param name="category">The category to save.</param>
     public async Task<IActionResult> OnPostSaveCategoryAsync(string category)
     {
-        if (!User.IsInRole("Admin") && !User.IsInRole("SuperAdmin"))
-        {
-            _logger.LogWarning("Non-admin user {UserId} attempted to save settings", User.Identity?.Name);
-            return Forbid();
-        }
-
         _logger.LogInformation("Settings save requested for category {Category} by user {UserId}", category, User.Identity?.Name);
 
         try
@@ -179,12 +173,6 @@ public class SettingsModel : PageModel
     /// </summary>
     public async Task<IActionResult> OnPostSaveAllAsync()
     {
-        if (!User.IsInRole("Admin") && !User.IsInRole("SuperAdmin"))
-        {
-            _logger.LogWarning("Non-admin user {UserId} attempted to save all settings", User.Identity?.Name);
-            return Forbid();
-        }
-
         _logger.LogInformation("Save all settings requested by user {UserId}", User.Identity?.Name);
 
         try
@@ -270,12 +258,6 @@ public class SettingsModel : PageModel
     /// <param name="category">The category to reset.</param>
     public async Task<IActionResult> OnPostResetCategoryAsync(string category)
     {
-        if (!User.IsInRole("Admin") && !User.IsInRole("SuperAdmin"))
-        {
-            _logger.LogWarning("Non-admin user {UserId} attempted to reset category {Category}", User.Identity?.Name, category);
-            return Forbid();
-        }
-
         _logger.LogWarning("Reset category {Category} requested by user {UserId}", category, User.Identity?.Name);
 
         try
@@ -359,12 +341,6 @@ public class SettingsModel : PageModel
     /// </summary>
     public async Task<IActionResult> OnPostResetAllAsync()
     {
-        if (!User.IsInRole("Admin") && !User.IsInRole("SuperAdmin"))
-        {
-            _logger.LogWarning("Non-admin user {UserId} attempted to reset all settings", User.Identity?.Name);
-            return Forbid();
-        }
-
         _logger.LogCritical("Reset ALL settings requested by user {UserId}", User.Identity?.Name);
 
         try
@@ -434,12 +410,6 @@ public class SettingsModel : PageModel
     /// </summary>
     public async Task<IActionResult> OnPostSaveCommandModulesAsync()
     {
-        if (!User.IsInRole("Admin") && !User.IsInRole("SuperAdmin"))
-        {
-            _logger.LogWarning("Non-admin user {UserId} attempted to save command module settings", User.Identity?.Name);
-            return Forbid();
-        }
-
         _logger.LogInformation("Command module settings save requested by user {UserId}", User.Identity?.Name);
 
         try


### PR DESCRIPTION
## Summary

- Removed 7 redundant `User.IsInRole("Admin") && User.IsInRole("SuperAdmin")` checks from Admin pages
- The `[Authorize(Policy = "RequireAdmin")]` attribute at class level already enforces admin access for all handlers

## Files Changed

- `src/DiscordBot.Bot/Pages/Admin/Settings.cshtml.cs` - Removed 5 redundant checks in POST handlers
- `src/DiscordBot.Bot/Pages/Admin/BotControl.cshtml.cs` - Removed 2 redundant checks in POST handlers

## Test Plan

- [x] Build succeeds with no errors
- [ ] Manual verification: Admin pages still require Admin role (via class-level authorize attribute)
- [ ] Manual verification: No behavioral changes to settings save/reset functionality

Closes #1107

🤖 Generated with [Claude Code](https://claude.ai/code)