### PR TITLE
fix(signalr): Register pre-stored handlers after DashboardHub connection

### DIFF
--- a/src/DiscordBot.Bot/wwwroot/js/dashboard-hub.js
+++ b/src/DiscordBot.Bot/wwwroot/js/dashboard-hub.js
@@ -63,6 +63,14 @@ const DashboardHub = (function() {
             await connection.start();
             isConnected = true;
             reconnectAttempts = 0;
+
+            // Register all pre-stored event handlers with the new connection
+            for (const [eventName, handlers] of Object.entries(eventHandlers)) {
+                for (const handler of handlers) {
+                    connection.on(eventName, handler);
+                }
+            }
+
             console.log('[DashboardHub] Connected successfully');
             triggerEvent('connected', { connectionId: connection.connectionId });
 


### PR DESCRIPTION
## Summary

- Fixes timing bug where event handlers registered via `DashboardHub.on()` before `connect()` were never attached to the SignalR connection
- After `connection.start()` succeeds, iterate over all stored `eventHandlers` and register them with the new connection
- Resolves "No client method found" warnings in browser console

## Test plan

- [ ] Open Soundboard Portal, verify "Now Playing" panel updates in real-time when sounds play
- [ ] Open browser console, verify no "No client method found" warnings for playback events
- [ ] Test TTS Portal and Performance dashboards to ensure SignalR events work correctly

Closes #1111

🤖 Generated with [Claude Code](https://claude.com/claude-code)