### PR TITLE
feat(data): Implement bulk data purge operations (#779)

### DIFF
--- a/src/DiscordBot.Bot/Controllers/BulkPurgeController.cs
+++ b/src/DiscordBot.Bot/Controllers/BulkPurgeController.cs
@@ -1,0 +1,138 @@
+using DiscordBot.Bot.Extensions;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DiscordBot.Bot.Controllers;
+
+/// <summary>
+/// Controller for bulk data purge operations.
+/// </summary>
+[ApiController]
+[Route("api/[controller]")]
+[Authorize(Policy = "RequireSuperAdmin")]
+public class BulkPurgeController : ControllerBase
+{
+    private readonly IBulkPurgeService _bulkPurgeService;
+    private readonly ILogger<BulkPurgeController> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BulkPurgeController"/> class.
+    /// </summary>
+    /// <param name="bulkPurgeService">The bulk purge service.</param>
+    /// <param name="logger">The logger.</param>
+    public BulkPurgeController(
+        IBulkPurgeService bulkPurgeService,
+        ILogger<BulkPurgeController> logger)
+    {
+        _bulkPurgeService = bulkPurgeService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Gets a preview of records that would be deleted without actually deleting.
+    /// </summary>
+    /// <param name="criteria">The purge criteria.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Preview with estimated record count.</returns>
+    [HttpPost("preview")]
+    [ProducesResponseType(typeof(BulkPurgePreviewDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<BulkPurgePreviewDto>> Preview(
+        [FromBody] BulkPurgeCriteriaDto criteria,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug(
+            "Bulk purge preview requested for {EntityType}, DateRange: {DateRange}, GuildId: {GuildId}",
+            criteria.EntityType, criteria.GetDateRangeDescription(), criteria.GuildId);
+
+        // Validate date range
+        if (criteria.StartDate.HasValue && criteria.EndDate.HasValue &&
+            criteria.StartDate.Value > criteria.EndDate.Value)
+        {
+            _logger.LogWarning(
+                "Invalid date range: StartDate={StartDate} > EndDate={EndDate}",
+                criteria.StartDate, criteria.EndDate);
+
+            return BadRequest(new ApiErrorDto
+            {
+                Message = "Invalid date range",
+                Detail = "Start date cannot be after end date.",
+                StatusCode = StatusCodes.Status400BadRequest,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+
+        var result = await _bulkPurgeService.PreviewPurgeAsync(criteria, cancellationToken);
+
+        if (!result.Success)
+        {
+            return BadRequest(new ApiErrorDto
+            {
+                Message = "Preview failed",
+                Detail = result.ErrorMessage,
+                StatusCode = StatusCodes.Status400BadRequest,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Executes a bulk purge operation based on the specified criteria.
+    /// </summary>
+    /// <param name="criteria">The purge criteria.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result with deleted record count.</returns>
+    [HttpPost("execute")]
+    [ProducesResponseType(typeof(BulkPurgeResultDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<BulkPurgeResultDto>> Execute(
+        [FromBody] BulkPurgeCriteriaDto criteria,
+        CancellationToken cancellationToken = default)
+    {
+        var adminUserId = User.Identity?.Name ?? "unknown";
+
+        _logger.LogInformation(
+            "Bulk purge execution requested by {AdminUserId} for {EntityType}, DateRange: {DateRange}, GuildId: {GuildId}",
+            adminUserId, criteria.EntityType, criteria.GetDateRangeDescription(), criteria.GuildId);
+
+        // Validate date range
+        if (criteria.StartDate.HasValue && criteria.EndDate.HasValue &&
+            criteria.StartDate.Value > criteria.EndDate.Value)
+        {
+            _logger.LogWarning(
+                "Invalid date range: StartDate={StartDate} > EndDate={EndDate}",
+                criteria.StartDate, criteria.EndDate);
+
+            return BadRequest(new ApiErrorDto
+            {
+                Message = "Invalid date range",
+                Detail = "Start date cannot be after end date.",
+                StatusCode = StatusCodes.Status400BadRequest,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+
+        var result = await _bulkPurgeService.ExecutePurgeAsync(criteria, adminUserId, cancellationToken);
+
+        if (!result.Success)
+        {
+            return BadRequest(new ApiErrorDto
+            {
+                Message = "Purge failed",
+                Detail = result.ErrorMessage,
+                StatusCode = StatusCodes.Status400BadRequest,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+
+        _logger.LogInformation(
+            "Bulk purge completed by {AdminUserId}: {DeletedCount} {EntityType} records deleted",
+            adminUserId, result.DeletedCount, result.EntityType);
+
+        return Ok(result);
+    }
+}

--- a/src/DiscordBot.Bot/Extensions/ApplicationServiceExtensions.cs
+++ b/src/DiscordBot.Bot/Extensions/ApplicationServiceExtensions.cs
@@ -41,6 +41,7 @@ public static class ApplicationServiceExtensions
         services.AddScoped<IGuildMemberService, GuildMemberService>();
         services.AddScoped<IConsentService, ConsentService>();
         services.AddScoped<IUserPurgeService, UserPurgeService>();
+        services.AddScoped<IBulkPurgeService, BulkPurgeService>();
 
         // Metrics update background services
         services.AddHostedService<MetricsUpdateService>();

--- a/src/DiscordBot.Bot/Pages/Admin/BulkPurge.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/BulkPurge.cshtml
@@ -1,0 +1,359 @@
+@page
+@model DiscordBot.Bot.Pages.Admin.BulkPurgeModel
+@using DiscordBot.Core.Enums
+@{
+    ViewData["Title"] = "Bulk Data Purge";
+}
+
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <!-- Header -->
+    <div class="mb-6">
+        <h1 class="text-h1 text-text-primary">Bulk Data Purge</h1>
+        <p class="mt-1 text-sm text-text-secondary">Permanently delete historical data by entity type, date range, and guild</p>
+    </div>
+
+    <!-- Warning Notice -->
+    <div class="mb-6 p-4 bg-error-bg border border-error-border rounded-lg">
+        <div class="flex items-start gap-3">
+            <svg class="w-5 h-5 text-error flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
+            </svg>
+            <div>
+                <p class="text-sm font-semibold text-error">Warning: Irreversible Operation</p>
+                <p class="text-sm text-error/90 mt-1">
+                    This action permanently deletes data from the database. This operation cannot be undone. Always preview before executing.
+                </p>
+            </div>
+        </div>
+    </div>
+
+    <!-- Success/Error Messages -->
+    @if (!string.IsNullOrEmpty(Model.SuccessMessage))
+    {
+        <div class="mb-6">
+            <partial name="Shared/Components/_Alert" model="new DiscordBot.Bot.ViewModels.Components.AlertViewModel { Variant = DiscordBot.Bot.ViewModels.Components.AlertVariant.Success, Message = Model.SuccessMessage, IsDismissible = true }" />
+        </div>
+    }
+    @if (!string.IsNullOrEmpty(Model.ErrorMessage))
+    {
+        <div class="mb-6">
+            <partial name="Shared/Components/_Alert" model="new DiscordBot.Bot.ViewModels.Components.AlertViewModel { Variant = DiscordBot.Bot.ViewModels.Components.AlertVariant.Error, Message = Model.ErrorMessage, IsDismissible = true }" />
+        </div>
+    }
+
+    <!-- Filter Form -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg p-6 mb-6">
+        <h2 class="text-lg font-semibold text-text-primary mb-4">Select Purge Criteria</h2>
+        <form method="post" asp-page-handler="Preview" class="space-y-6">
+            <!-- Entity Type Selection -->
+            <div>
+                <label class="block text-sm font-medium text-text-primary mb-2">
+                    Entity Type <span class="text-error">*</span>
+                </label>
+                <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+                    @foreach (var entityType in Enum.GetValues<BulkPurgeEntityType>())
+                    {
+                        var isSelected = Model.EntityType == entityType;
+                        var description = entityType switch
+                        {
+                            BulkPurgeEntityType.Messages => "Discord message history",
+                            BulkPurgeEntityType.AuditLogs => "System audit trail",
+                            BulkPurgeEntityType.CommandLogs => "Command execution logs",
+                            BulkPurgeEntityType.ModerationCases => "Moderation case records",
+                            _ => ""
+                        };
+                        <label class="entity-type-card @(isSelected ? "selected" : "")">
+                            <input type="radio"
+                                   name="EntityType"
+                                   value="@entityType"
+                                   class="hidden"
+                                   @(isSelected ? "checked" : "") />
+                            <div class="card-content">
+                                <span class="font-medium text-text-primary">@entityType</span>
+                                <span class="text-xs text-text-secondary mt-1">@description</span>
+                            </div>
+                        </label>
+                    }
+                </div>
+            </div>
+
+            <!-- Date Range -->
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                    <label for="start-date" class="block text-sm font-medium text-text-primary mb-2">
+                        Start Date (inclusive)
+                    </label>
+                    <input type="date"
+                           id="start-date"
+                           name="StartDate"
+                           value="@(Model.StartDate?.ToString("yyyy-MM-dd"))"
+                           class="w-full py-2 px-3 text-sm text-text-primary bg-bg-primary border border-border-primary rounded-md focus:outline-none focus:ring-2 focus:ring-border-focus focus:border-transparent" />
+                    <p class="mt-1 text-xs text-text-tertiary">Leave empty for no lower bound</p>
+                    @if (ViewData.ModelState["StartDate"]?.Errors.Count > 0)
+                    {
+                        <p class="mt-1 text-sm text-error">
+                            @ViewData.ModelState["StartDate"]?.Errors[0].ErrorMessage
+                        </p>
+                    }
+                </div>
+                <div>
+                    <label for="end-date" class="block text-sm font-medium text-text-primary mb-2">
+                        End Date (exclusive)
+                    </label>
+                    <input type="date"
+                           id="end-date"
+                           name="EndDate"
+                           value="@(Model.EndDate?.ToString("yyyy-MM-dd"))"
+                           class="w-full py-2 px-3 text-sm text-text-primary bg-bg-primary border border-border-primary rounded-md focus:outline-none focus:ring-2 focus:ring-border-focus focus:border-transparent" />
+                    <p class="mt-1 text-xs text-text-tertiary">Leave empty for no upper bound</p>
+                </div>
+            </div>
+
+            <!-- Guild ID Filter -->
+            <div>
+                <label for="guild-id" class="block text-sm font-medium text-text-primary mb-2">
+                    Guild ID (optional)
+                </label>
+                <input type="text"
+                       id="guild-id"
+                       name="GuildIdInput"
+                       value="@Model.GuildIdInput"
+                       placeholder="Enter Discord guild ID to limit purge to specific server"
+                       class="w-full py-2 px-3 text-sm text-text-primary bg-bg-primary border border-border-primary rounded-md placeholder-text-tertiary focus:outline-none focus:ring-2 focus:ring-border-focus focus:border-transparent" />
+                <p class="mt-1 text-xs text-text-tertiary">Leave empty to purge across all guilds</p>
+                @if (ViewData.ModelState["GuildIdInput"]?.Errors.Count > 0)
+                {
+                    <p class="mt-1 text-sm text-error">
+                        @ViewData.ModelState["GuildIdInput"]?.Errors[0].ErrorMessage
+                    </p>
+                }
+            </div>
+
+            <!-- Actions -->
+            <div class="flex gap-3 pt-4 border-t border-border-primary">
+                <button type="submit" class="btn btn-primary">
+                    <svg class="w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                    </svg>
+                    Preview Records
+                </button>
+                <a asp-page="BulkPurge" class="btn btn-secondary">Reset</a>
+            </div>
+        </form>
+    </div>
+
+    <!-- Preview Results -->
+    @if (Model.PreviewResult != null && Model.PreviewResult.Success)
+    {
+        <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden mb-6">
+            <div class="px-6 py-4 border-b border-border-primary bg-bg-tertiary">
+                <h2 class="text-lg font-semibold text-text-primary">Preview: Records to be Deleted</h2>
+                <p class="text-sm text-text-secondary mt-1">
+                    The following records match your criteria and will be permanently deleted.
+                </p>
+            </div>
+
+            <div class="p-6">
+                @if (Model.PreviewResult.EstimatedCount > 0)
+                {
+                    <!-- Preview Summary -->
+                    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+                        <div class="bg-bg-tertiary rounded-lg p-4">
+                            <p class="text-xs font-medium text-text-secondary uppercase tracking-wider mb-1">Entity Type</p>
+                            <p class="text-lg font-semibold text-text-primary">@Model.PreviewResult.EntityType</p>
+                        </div>
+                        <div class="bg-bg-tertiary rounded-lg p-4">
+                            <p class="text-xs font-medium text-text-secondary uppercase tracking-wider mb-1">Date Range</p>
+                            <p class="text-lg font-semibold text-text-primary">@Model.PreviewResult.DateRange</p>
+                        </div>
+                        <div class="bg-bg-tertiary rounded-lg p-4">
+                            <p class="text-xs font-medium text-text-secondary uppercase tracking-wider mb-1">Estimated Records</p>
+                            <p class="text-lg font-semibold text-error">@Model.PreviewResult.EstimatedCount.ToString("N0")</p>
+                        </div>
+                    </div>
+
+                    @if (Model.PreviewResult.GuildId.HasValue)
+                    {
+                        <div class="mb-6 p-3 bg-info-bg border border-info-border rounded-md">
+                            <p class="text-sm text-info">
+                                <span class="font-semibold">Guild Filter:</span>
+                                <span class="font-mono">@Model.PreviewResult.GuildId</span>
+                            </p>
+                        </div>
+                    }
+
+                    <!-- Execute Purge Form -->
+                    <div class="pt-6 border-t border-border-primary">
+                        <form method="post" asp-page-handler="Execute" id="purge-form" onsubmit="return confirmPurge();">
+                            <input type="hidden" name="EntityType" value="@Model.EntityType" />
+                            <input type="hidden" name="StartDate" value="@Model.StartDate?.ToString("yyyy-MM-dd")" />
+                            <input type="hidden" name="EndDate" value="@Model.EndDate?.ToString("yyyy-MM-dd")" />
+                            <input type="hidden" name="GuildIdInput" value="@Model.GuildIdInput" />
+
+                            <button type="submit" class="btn btn-error">
+                                <svg class="w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                                </svg>
+                                Execute Purge (@Model.PreviewResult.EstimatedCount.ToString("N0") records)
+                            </button>
+                            <p class="mt-2 text-xs text-text-tertiary">
+                                This operation will permanently delete the records shown above. You will be asked to confirm before proceeding.
+                            </p>
+                        </form>
+                    </div>
+                }
+                else
+                {
+                    <!-- No Records Found -->
+                    <div class="text-center py-8">
+                        <div class="inline-flex items-center justify-center w-16 h-16 bg-bg-tertiary rounded-xl mb-4">
+                            <svg class="w-10 h-10 text-text-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" />
+                            </svg>
+                        </div>
+                        <h3 class="text-lg font-semibold text-text-primary mb-2">No Records Found</h3>
+                        <p class="text-sm text-text-secondary">
+                            No @Model.PreviewResult.EntityType records match the specified criteria. Try adjusting your date range or guild filter.
+                        </p>
+                    </div>
+                }
+            </div>
+        </div>
+    }
+
+    <!-- Purge Result -->
+    @if (Model.PurgeResult != null && Model.PurgeResult.Success)
+    {
+        <div class="bg-success-bg border border-success-border rounded-lg p-6 mb-6">
+            <div class="flex items-start gap-3">
+                <svg class="w-6 h-6 text-success flex-shrink-0" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
+                </svg>
+                <div class="flex-1">
+                    <h3 class="text-lg font-semibold text-success mb-2">Purge Complete</h3>
+                    <p class="text-sm text-success/90 mb-4">
+                        Successfully deleted <span class="font-mono font-bold">@Model.PurgeResult.DeletedCount.ToString("N0")</span> @Model.PurgeResult.EntityType records.
+                    </p>
+
+                    @if (!string.IsNullOrEmpty(Model.PurgeResult.AuditLogCorrelationId))
+                    {
+                        <p class="text-xs text-success/80">
+                            Audit Correlation ID: <span class="font-mono">@Model.PurgeResult.AuditLogCorrelationId</span>
+                        </p>
+                    }
+                </div>
+            </div>
+        </div>
+    }
+
+    <!-- Progress Indicator (for SignalR - hidden by default) -->
+    <div id="progress-container" class="hidden mb-6">
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-6">
+            <div class="flex items-center gap-4 mb-4">
+                <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-primary"></div>
+                <div>
+                    <p class="text-sm font-medium text-text-primary" id="progress-message">Processing...</p>
+                    <p class="text-xs text-text-secondary" id="progress-detail"></p>
+                </div>
+            </div>
+            <div class="w-full bg-bg-tertiary rounded-full h-2">
+                <div id="progress-bar" class="bg-primary h-2 rounded-full transition-all duration-300" style="width: 0%"></div>
+            </div>
+            <p class="mt-2 text-xs text-text-tertiary text-right" id="progress-percent">0%</p>
+        </div>
+    </div>
+
+    <!-- Additional Information -->
+    <div class="p-4 bg-info-bg border border-info-border rounded-md">
+        <div class="flex items-start gap-3">
+            <svg class="w-5 h-5 text-info flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd" />
+            </svg>
+            <div class="text-sm text-info">
+                <p class="font-semibold mb-1">Data Retention</p>
+                <p class="text-info/90">
+                    This tool is intended for manual data cleanup operations. For automated retention, configure the retention options in
+                    <a asp-page="/Admin/Settings" class="underline hover:no-underline">Settings</a>.
+                    All bulk purge operations are logged in the audit trail for compliance tracking.
+                </p>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+    function confirmPurge() {
+        const entityType = '@Model.EntityType';
+        const count = '@Model.PreviewResult?.EstimatedCount.ToString("N0")';
+        const dateRange = '@Model.PreviewResult?.DateRange';
+
+        const message = `WARNING: You are about to permanently delete ${count} ${entityType} records.\n\n` +
+                       `Date Range: ${dateRange}\n\n` +
+                       `This action CANNOT be undone.\n\n` +
+                       `Are you absolutely sure you want to proceed?`;
+
+        return confirm(message);
+    }
+
+    // Entity type card selection
+    document.querySelectorAll('.entity-type-card').forEach(card => {
+        card.addEventListener('click', function() {
+            document.querySelectorAll('.entity-type-card').forEach(c => c.classList.remove('selected'));
+            this.classList.add('selected');
+            this.querySelector('input[type="radio"]').checked = true;
+        });
+    });
+</script>
+
+<style>
+    .entity-type-card {
+        display: block;
+        cursor: pointer;
+        border: 2px solid var(--border-primary);
+        border-radius: 0.5rem;
+        padding: 1rem;
+        background: var(--bg-primary);
+        transition: all 0.2s;
+    }
+
+    .entity-type-card:hover {
+        border-color: var(--border-focus);
+        background: var(--bg-tertiary);
+    }
+
+    .entity-type-card.selected {
+        border-color: var(--primary);
+        background: var(--primary-bg);
+    }
+
+    .entity-type-card .card-content {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .btn-error {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.5rem;
+        padding: 0.625rem 1rem;
+        font-size: 0.875rem;
+        font-weight: 600;
+        color: white;
+        background-color: #dc2626;
+        border: 1px solid #dc2626;
+        border-radius: 0.375rem;
+        transition: background-color 0.2s, border-color 0.2s;
+    }
+
+    .btn-error:hover {
+        background-color: #b91c1c;
+        border-color: #b91c1c;
+    }
+
+    .btn-error:focus {
+        outline: none;
+        box-shadow: 0 0 0 2px var(--bg-secondary), 0 0 0 4px #ef4444;
+    }
+</style>

--- a/src/DiscordBot.Bot/Pages/Admin/BulkPurge.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Admin/BulkPurge.cshtml.cs
@@ -1,0 +1,138 @@
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Enums;
+using DiscordBot.Core.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using System.Security.Claims;
+
+namespace DiscordBot.Bot.Pages.Admin;
+
+/// <summary>
+/// Page model for bulk data purge operations.
+/// </summary>
+[Authorize(Policy = "RequireSuperAdmin")]
+public class BulkPurgeModel : PageModel
+{
+    private readonly IBulkPurgeService _bulkPurgeService;
+    private readonly ILogger<BulkPurgeModel> _logger;
+
+    public BulkPurgeModel(
+        IBulkPurgeService bulkPurgeService,
+        ILogger<BulkPurgeModel> logger)
+    {
+        _bulkPurgeService = bulkPurgeService;
+        _logger = logger;
+    }
+
+    [BindProperty]
+    public BulkPurgeEntityType EntityType { get; set; }
+
+    [BindProperty]
+    public DateTime? StartDate { get; set; }
+
+    [BindProperty]
+    public DateTime? EndDate { get; set; }
+
+    [BindProperty]
+    public string? GuildIdInput { get; set; }
+
+    public BulkPurgePreviewDto? PreviewResult { get; set; }
+    public BulkPurgeResultDto? PurgeResult { get; set; }
+
+    [TempData]
+    public string? SuccessMessage { get; set; }
+
+    [TempData]
+    public string? ErrorMessage { get; set; }
+
+    public void OnGet()
+    {
+        // Default to no specific entity type selected
+    }
+
+    public async Task<IActionResult> OnPostPreviewAsync()
+    {
+        var criteria = BuildCriteria();
+        if (criteria == null)
+        {
+            return Page();
+        }
+
+        _logger.LogDebug(
+            "Preview requested for {EntityType}, DateRange: {DateRange}, GuildId: {GuildId}",
+            criteria.EntityType, criteria.GetDateRangeDescription(), criteria.GuildId);
+
+        PreviewResult = await _bulkPurgeService.PreviewPurgeAsync(criteria);
+
+        if (!PreviewResult.Success)
+        {
+            ErrorMessage = PreviewResult.ErrorMessage ?? "Failed to generate preview.";
+        }
+
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostExecuteAsync()
+    {
+        var criteria = BuildCriteria();
+        if (criteria == null)
+        {
+            return Page();
+        }
+
+        var adminUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? "unknown";
+
+        _logger.LogInformation(
+            "Bulk purge execution requested by {AdminUserId} for {EntityType}, DateRange: {DateRange}, GuildId: {GuildId}",
+            adminUserId, criteria.EntityType, criteria.GetDateRangeDescription(), criteria.GuildId);
+
+        PurgeResult = await _bulkPurgeService.ExecutePurgeAsync(criteria, adminUserId);
+
+        if (PurgeResult.Success)
+        {
+            SuccessMessage = $"Successfully purged {PurgeResult.DeletedCount:N0} {PurgeResult.EntityType} records.";
+            _logger.LogInformation(
+                "Bulk purge completed: {DeletedCount} {EntityType} records deleted",
+                PurgeResult.DeletedCount, PurgeResult.EntityType);
+        }
+        else
+        {
+            ErrorMessage = PurgeResult.ErrorMessage ?? "An error occurred during purge.";
+            _logger.LogError(
+                "Bulk purge failed for {EntityType}: {Error}",
+                criteria.EntityType, PurgeResult.ErrorMessage);
+        }
+
+        return Page();
+    }
+
+    private BulkPurgeCriteriaDto? BuildCriteria()
+    {
+        // Validate date range
+        if (StartDate.HasValue && EndDate.HasValue && StartDate.Value > EndDate.Value)
+        {
+            ModelState.AddModelError(nameof(StartDate), "Start date cannot be after end date.");
+            return null;
+        }
+
+        ulong? guildId = null;
+        if (!string.IsNullOrWhiteSpace(GuildIdInput))
+        {
+            if (!ulong.TryParse(GuildIdInput, out var parsedGuildId))
+            {
+                ModelState.AddModelError(nameof(GuildIdInput), "Invalid Guild ID format.");
+                return null;
+            }
+            guildId = parsedGuildId;
+        }
+
+        return new BulkPurgeCriteriaDto
+        {
+            EntityType = EntityType,
+            StartDate = StartDate?.ToUniversalTime(),
+            EndDate = EndDate?.ToUniversalTime(),
+            GuildId = guildId
+        };
+    }
+}

--- a/src/DiscordBot.Bot/Pages/Shared/_Sidebar.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/_Sidebar.cshtml
@@ -160,6 +160,26 @@
           </svg>
           <span class="sidebar-link-text">Audit Logs</span>
         </a>
+        <authorize policy="RequireSuperAdmin">
+          @{
+            var bulkPurgeActive = ViewContext.RouteData.Values["page"]?.ToString() == "/Admin/BulkPurge";
+          }
+          <a href="/Admin/BulkPurge" class="sidebar-link-redesign @(bulkPurgeActive ? "active" : "")" @(bulkPurgeActive ? "aria-current=page" : "")>
+            <svg class="w-5 h-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+            </svg>
+            <span class="sidebar-link-text">Bulk Purge</span>
+          </a>
+          @{
+            var userPurgeActive = ViewContext.RouteData.Values["page"]?.ToString() == "/Admin/UserPurge";
+          }
+          <a href="/Admin/UserPurge" class="sidebar-link-redesign @(userPurgeActive ? "active" : "")" @(userPurgeActive ? "aria-current=page" : "")>
+            <svg class="w-5 h-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+            </svg>
+            <span class="sidebar-link-text">User Purge</span>
+          </a>
+        </authorize>
       </div>
       <div class="my-4 border-t border-border-secondary" role="separator"></div>
     </authorize>

--- a/src/DiscordBot.Bot/Services/BulkPurgeService.cs
+++ b/src/DiscordBot.Bot/Services/BulkPurgeService.cs
@@ -1,0 +1,416 @@
+using DiscordBot.Bot.Hubs;
+using DiscordBot.Bot.Tracing;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Enums;
+using DiscordBot.Core.Interfaces;
+using DiscordBot.Infrastructure.Data;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+
+namespace DiscordBot.Bot.Services;
+
+/// <summary>
+/// Service for bulk data purge operations.
+/// </summary>
+public class BulkPurgeService : IBulkPurgeService
+{
+    private readonly BotDbContext _dbContext;
+    private readonly IAuditLogService _auditLogService;
+    private readonly IHubContext<DashboardHub> _hubContext;
+    private readonly ILogger<BulkPurgeService> _logger;
+
+    public BulkPurgeService(
+        BotDbContext dbContext,
+        IAuditLogService auditLogService,
+        IHubContext<DashboardHub> hubContext,
+        ILogger<BulkPurgeService> logger)
+    {
+        _dbContext = dbContext;
+        _auditLogService = auditLogService;
+        _hubContext = hubContext;
+        _logger = logger;
+    }
+
+    public async Task<BulkPurgePreviewDto> PreviewPurgeAsync(
+        BulkPurgeCriteriaDto criteria,
+        CancellationToken cancellationToken = default)
+    {
+        using var activity = BotActivitySource.StartServiceActivity(
+            "bulkpurge",
+            "preview_purge");
+
+        try
+        {
+            activity?.SetTag("purge.entity_type", criteria.EntityType.ToString());
+            activity?.SetTag("purge.guild_id", criteria.GuildId?.ToString());
+
+            _logger.LogDebug(
+                "Previewing bulk purge for {EntityType}, DateRange: {DateRange}, GuildId: {GuildId}",
+                criteria.EntityType, criteria.GetDateRangeDescription(), criteria.GuildId);
+
+            var count = criteria.EntityType switch
+            {
+                BulkPurgeEntityType.Messages => await CountMessagesAsync(criteria, cancellationToken),
+                BulkPurgeEntityType.AuditLogs => await CountAuditLogsAsync(criteria, cancellationToken),
+                BulkPurgeEntityType.CommandLogs => await CountCommandLogsAsync(criteria, cancellationToken),
+                BulkPurgeEntityType.ModerationCases => await CountModerationCasesAsync(criteria, cancellationToken),
+                _ => throw new ArgumentOutOfRangeException(nameof(criteria.EntityType))
+            };
+
+            activity?.SetTag("preview.estimated_count", count);
+            BotActivitySource.SetSuccess(activity);
+
+            return BulkPurgePreviewDto.Succeeded(
+                criteria.EntityType,
+                count,
+                criteria.GetDateRangeDescription(),
+                criteria.GuildId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error previewing bulk purge for {EntityType}", criteria.EntityType);
+            BotActivitySource.RecordException(activity, ex);
+
+            return BulkPurgePreviewDto.Failed($"Failed to preview: {ex.Message}");
+        }
+    }
+
+    public async Task<BulkPurgeResultDto> ExecutePurgeAsync(
+        BulkPurgeCriteriaDto criteria,
+        string adminUserId,
+        CancellationToken cancellationToken = default)
+    {
+        using var activity = BotActivitySource.StartServiceActivity(
+            "bulkpurge",
+            "execute_purge");
+
+        try
+        {
+            activity?.SetTag("purge.entity_type", criteria.EntityType.ToString());
+            activity?.SetTag("purge.guild_id", criteria.GuildId?.ToString());
+            activity?.SetTag("purge.admin_user_id", adminUserId);
+
+            _logger.LogInformation(
+                "Starting bulk purge for {EntityType}, DateRange: {DateRange}, GuildId: {GuildId}, Admin: {AdminUserId}",
+                criteria.EntityType, criteria.GetDateRangeDescription(), criteria.GuildId, adminUserId);
+
+            // Get count first for progress tracking
+            var totalCount = criteria.EntityType switch
+            {
+                BulkPurgeEntityType.Messages => await CountMessagesAsync(criteria, cancellationToken),
+                BulkPurgeEntityType.AuditLogs => await CountAuditLogsAsync(criteria, cancellationToken),
+                BulkPurgeEntityType.CommandLogs => await CountCommandLogsAsync(criteria, cancellationToken),
+                BulkPurgeEntityType.ModerationCases => await CountModerationCasesAsync(criteria, cancellationToken),
+                _ => throw new ArgumentOutOfRangeException(nameof(criteria.EntityType))
+            };
+
+            if (totalCount == 0)
+            {
+                _logger.LogWarning("No records found matching criteria for {EntityType}", criteria.EntityType);
+                activity?.SetTag("purge.no_records", true);
+
+                return BulkPurgeResultDto.Failed(
+                    BulkPurgeResultDto.NoRecordsFound,
+                    "No records found matching the specified criteria.");
+            }
+
+            // Broadcast initial progress
+            await BroadcastProgressAsync(criteria.EntityType, 0, totalCount, false, "Starting purge...");
+
+            // Begin transaction
+            await using var transaction = await _dbContext.Database.BeginTransactionAsync(cancellationToken);
+            var correlationId = Guid.NewGuid().ToString();
+
+            try
+            {
+                var deletedCount = criteria.EntityType switch
+                {
+                    BulkPurgeEntityType.Messages => await DeleteMessagesAsync(criteria, totalCount, cancellationToken),
+                    BulkPurgeEntityType.AuditLogs => await DeleteAuditLogsAsync(criteria, totalCount, cancellationToken),
+                    BulkPurgeEntityType.CommandLogs => await DeleteCommandLogsAsync(criteria, totalCount, cancellationToken),
+                    BulkPurgeEntityType.ModerationCases => await DeleteModerationCasesAsync(criteria, totalCount, cancellationToken),
+                    _ => throw new ArgumentOutOfRangeException(nameof(criteria.EntityType))
+                };
+
+                await transaction.CommitAsync(cancellationToken);
+
+                _logger.LogInformation(
+                    "Successfully purged {DeletedCount} {EntityType} records",
+                    deletedCount, criteria.EntityType);
+
+                // Broadcast completion
+                await BroadcastProgressAsync(criteria.EntityType, deletedCount, totalCount, true, "Purge complete.");
+
+                // Create audit log entry
+                try
+                {
+                    _auditLogService.CreateBuilder()
+                        .ForCategory(AuditLogCategory.System)
+                        .WithAction(AuditLogAction.BulkDataPurged)
+                        .ByUser(adminUserId)
+                        .OnTarget(criteria.EntityType.ToString(), $"{deletedCount} records")
+                        .InGuild(criteria.GuildId ?? 0)
+                        .WithDetails(new
+                        {
+                            entityType = criteria.EntityType.ToString(),
+                            dateRange = criteria.GetDateRangeDescription(),
+                            guildId = criteria.GuildId,
+                            deletedCount,
+                            timestamp = DateTime.UtcNow
+                        })
+                        .WithCorrelationId(correlationId)
+                        .Enqueue();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to create audit log entry for bulk purge");
+                }
+
+                activity?.SetTag("purge.success", true);
+                activity?.SetTag("purge.deleted_count", deletedCount);
+                BotActivitySource.SetSuccess(activity);
+
+                return BulkPurgeResultDto.Succeeded(criteria.EntityType, deletedCount, correlationId);
+            }
+            catch (Exception ex)
+            {
+                await transaction.RollbackAsync(cancellationToken);
+
+                _logger.LogError(ex,
+                    "Transaction failed while bulk purging {EntityType}",
+                    criteria.EntityType);
+
+                // Broadcast failure
+                await BroadcastProgressAsync(criteria.EntityType, 0, totalCount, true, $"Purge failed: {ex.Message}");
+
+                activity?.SetTag("purge.success", false);
+                BotActivitySource.RecordException(activity, ex);
+
+                return BulkPurgeResultDto.Failed(
+                    BulkPurgeResultDto.TransactionFailed,
+                    $"Failed to purge: {ex.Message}");
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Unexpected error while bulk purging {EntityType}",
+                criteria.EntityType);
+
+            BotActivitySource.RecordException(activity, ex);
+
+            return BulkPurgeResultDto.Failed(
+                BulkPurgeResultDto.DatabaseError,
+                "An unexpected error occurred while purging data.");
+        }
+    }
+
+    private async Task<int> CountMessagesAsync(BulkPurgeCriteriaDto criteria, CancellationToken cancellationToken)
+    {
+        var query = _dbContext.MessageLogs.AsQueryable();
+
+        if (criteria.StartDate.HasValue)
+        {
+            query = query.Where(m => m.Timestamp >= criteria.StartDate.Value);
+        }
+
+        if (criteria.EndDate.HasValue)
+        {
+            query = query.Where(m => m.Timestamp < criteria.EndDate.Value);
+        }
+
+        if (criteria.GuildId.HasValue)
+        {
+            query = query.Where(m => m.GuildId == criteria.GuildId.Value);
+        }
+
+        return await query.CountAsync(cancellationToken);
+    }
+
+    private async Task<int> CountAuditLogsAsync(BulkPurgeCriteriaDto criteria, CancellationToken cancellationToken)
+    {
+        var query = _dbContext.AuditLogs.AsQueryable();
+
+        if (criteria.StartDate.HasValue)
+        {
+            query = query.Where(a => a.Timestamp >= criteria.StartDate.Value);
+        }
+
+        if (criteria.EndDate.HasValue)
+        {
+            query = query.Where(a => a.Timestamp < criteria.EndDate.Value);
+        }
+
+        if (criteria.GuildId.HasValue)
+        {
+            query = query.Where(a => a.GuildId == criteria.GuildId.Value);
+        }
+
+        return await query.CountAsync(cancellationToken);
+    }
+
+    private async Task<int> CountCommandLogsAsync(BulkPurgeCriteriaDto criteria, CancellationToken cancellationToken)
+    {
+        var query = _dbContext.CommandLogs.AsQueryable();
+
+        if (criteria.StartDate.HasValue)
+        {
+            query = query.Where(c => c.ExecutedAt >= criteria.StartDate.Value);
+        }
+
+        if (criteria.EndDate.HasValue)
+        {
+            query = query.Where(c => c.ExecutedAt < criteria.EndDate.Value);
+        }
+
+        if (criteria.GuildId.HasValue)
+        {
+            query = query.Where(c => c.GuildId == criteria.GuildId.Value);
+        }
+
+        return await query.CountAsync(cancellationToken);
+    }
+
+    private async Task<int> CountModerationCasesAsync(BulkPurgeCriteriaDto criteria, CancellationToken cancellationToken)
+    {
+        var query = _dbContext.ModerationCases.AsQueryable();
+
+        if (criteria.StartDate.HasValue)
+        {
+            query = query.Where(m => m.CreatedAt >= criteria.StartDate.Value);
+        }
+
+        if (criteria.EndDate.HasValue)
+        {
+            query = query.Where(m => m.CreatedAt < criteria.EndDate.Value);
+        }
+
+        if (criteria.GuildId.HasValue)
+        {
+            query = query.Where(m => m.GuildId == criteria.GuildId.Value);
+        }
+
+        return await query.CountAsync(cancellationToken);
+    }
+
+    private async Task<int> DeleteMessagesAsync(BulkPurgeCriteriaDto criteria, int totalCount, CancellationToken cancellationToken)
+    {
+        var query = _dbContext.MessageLogs.AsQueryable();
+
+        if (criteria.StartDate.HasValue)
+        {
+            query = query.Where(m => m.Timestamp >= criteria.StartDate.Value);
+        }
+
+        if (criteria.EndDate.HasValue)
+        {
+            query = query.Where(m => m.Timestamp < criteria.EndDate.Value);
+        }
+
+        if (criteria.GuildId.HasValue)
+        {
+            query = query.Where(m => m.GuildId == criteria.GuildId.Value);
+        }
+
+        var deleted = await query.ExecuteDeleteAsync(cancellationToken);
+        await BroadcastProgressAsync(criteria.EntityType, deleted, totalCount, false, "Deleting message logs...");
+
+        return deleted;
+    }
+
+    private async Task<int> DeleteAuditLogsAsync(BulkPurgeCriteriaDto criteria, int totalCount, CancellationToken cancellationToken)
+    {
+        var query = _dbContext.AuditLogs.AsQueryable();
+
+        if (criteria.StartDate.HasValue)
+        {
+            query = query.Where(a => a.Timestamp >= criteria.StartDate.Value);
+        }
+
+        if (criteria.EndDate.HasValue)
+        {
+            query = query.Where(a => a.Timestamp < criteria.EndDate.Value);
+        }
+
+        if (criteria.GuildId.HasValue)
+        {
+            query = query.Where(a => a.GuildId == criteria.GuildId.Value);
+        }
+
+        var deleted = await query.ExecuteDeleteAsync(cancellationToken);
+        await BroadcastProgressAsync(criteria.EntityType, deleted, totalCount, false, "Deleting audit logs...");
+
+        return deleted;
+    }
+
+    private async Task<int> DeleteCommandLogsAsync(BulkPurgeCriteriaDto criteria, int totalCount, CancellationToken cancellationToken)
+    {
+        var query = _dbContext.CommandLogs.AsQueryable();
+
+        if (criteria.StartDate.HasValue)
+        {
+            query = query.Where(c => c.ExecutedAt >= criteria.StartDate.Value);
+        }
+
+        if (criteria.EndDate.HasValue)
+        {
+            query = query.Where(c => c.ExecutedAt < criteria.EndDate.Value);
+        }
+
+        if (criteria.GuildId.HasValue)
+        {
+            query = query.Where(c => c.GuildId == criteria.GuildId.Value);
+        }
+
+        var deleted = await query.ExecuteDeleteAsync(cancellationToken);
+        await BroadcastProgressAsync(criteria.EntityType, deleted, totalCount, false, "Deleting command logs...");
+
+        return deleted;
+    }
+
+    private async Task<int> DeleteModerationCasesAsync(BulkPurgeCriteriaDto criteria, int totalCount, CancellationToken cancellationToken)
+    {
+        var query = _dbContext.ModerationCases.AsQueryable();
+
+        if (criteria.StartDate.HasValue)
+        {
+            query = query.Where(m => m.CreatedAt >= criteria.StartDate.Value);
+        }
+
+        if (criteria.EndDate.HasValue)
+        {
+            query = query.Where(m => m.CreatedAt < criteria.EndDate.Value);
+        }
+
+        if (criteria.GuildId.HasValue)
+        {
+            query = query.Where(m => m.GuildId == criteria.GuildId.Value);
+        }
+
+        var deleted = await query.ExecuteDeleteAsync(cancellationToken);
+        await BroadcastProgressAsync(criteria.EntityType, deleted, totalCount, false, "Deleting moderation cases...");
+
+        return deleted;
+    }
+
+    private async Task BroadcastProgressAsync(
+        BulkPurgeEntityType entityType,
+        int processedCount,
+        int totalCount,
+        bool isComplete,
+        string? message = null)
+    {
+        try
+        {
+            var progress = BulkPurgeProgressDto.Create(entityType, processedCount, totalCount, isComplete, message);
+
+            await _hubContext.Clients
+                .Group(DashboardHub.BulkPurgeGroupName)
+                .SendAsync("BulkPurgeProgress", progress);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to broadcast bulk purge progress");
+        }
+    }
+}

--- a/src/DiscordBot.Core/DTOs/BulkPurgeCriteriaDto.cs
+++ b/src/DiscordBot.Core/DTOs/BulkPurgeCriteriaDto.cs
@@ -1,0 +1,54 @@
+using System.ComponentModel.DataAnnotations;
+using DiscordBot.Core.Enums;
+
+namespace DiscordBot.Core.DTOs;
+
+/// <summary>
+/// Criteria for bulk purge operations.
+/// </summary>
+public class BulkPurgeCriteriaDto
+{
+    /// <summary>
+    /// The type of entity to purge.
+    /// </summary>
+    [Required]
+    public BulkPurgeEntityType EntityType { get; set; }
+
+    /// <summary>
+    /// Start date for the purge range (inclusive). Null means no lower bound.
+    /// </summary>
+    public DateTime? StartDate { get; set; }
+
+    /// <summary>
+    /// End date for the purge range (exclusive). Null means no upper bound.
+    /// </summary>
+    public DateTime? EndDate { get; set; }
+
+    /// <summary>
+    /// Optional guild ID to limit purge to specific guild.
+    /// </summary>
+    public ulong? GuildId { get; set; }
+
+    /// <summary>
+    /// Gets a human-readable description of the date range.
+    /// </summary>
+    public string GetDateRangeDescription()
+    {
+        if (StartDate.HasValue && EndDate.HasValue)
+        {
+            return $"{StartDate.Value:yyyy-MM-dd} to {EndDate.Value:yyyy-MM-dd}";
+        }
+
+        if (StartDate.HasValue)
+        {
+            return $"from {StartDate.Value:yyyy-MM-dd}";
+        }
+
+        if (EndDate.HasValue)
+        {
+            return $"until {EndDate.Value:yyyy-MM-dd}";
+        }
+
+        return "all time";
+    }
+}

--- a/src/DiscordBot.Core/DTOs/BulkPurgePreviewDto.cs
+++ b/src/DiscordBot.Core/DTOs/BulkPurgePreviewDto.cs
@@ -1,0 +1,70 @@
+using DiscordBot.Core.Enums;
+
+namespace DiscordBot.Core.DTOs;
+
+/// <summary>
+/// Preview result for a bulk purge operation showing estimated counts.
+/// </summary>
+public class BulkPurgePreviewDto
+{
+    /// <summary>
+    /// Whether the preview was successful.
+    /// </summary>
+    public bool Success { get; set; }
+
+    /// <summary>
+    /// Error message if preview failed.
+    /// </summary>
+    public string? ErrorMessage { get; set; }
+
+    /// <summary>
+    /// The entity type being previewed.
+    /// </summary>
+    public BulkPurgeEntityType EntityType { get; set; }
+
+    /// <summary>
+    /// Estimated number of records that would be deleted.
+    /// </summary>
+    public int EstimatedCount { get; set; }
+
+    /// <summary>
+    /// Human-readable description of the date range.
+    /// </summary>
+    public string DateRange { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Guild ID if filtering by guild.
+    /// </summary>
+    public ulong? GuildId { get; set; }
+
+    /// <summary>
+    /// Creates a successful preview result.
+    /// </summary>
+    public static BulkPurgePreviewDto Succeeded(
+        BulkPurgeEntityType entityType,
+        int estimatedCount,
+        string dateRange,
+        ulong? guildId = null)
+    {
+        return new BulkPurgePreviewDto
+        {
+            Success = true,
+            EntityType = entityType,
+            EstimatedCount = estimatedCount,
+            DateRange = dateRange,
+            GuildId = guildId
+        };
+    }
+
+    /// <summary>
+    /// Creates a failed preview result.
+    /// </summary>
+    public static BulkPurgePreviewDto Failed(string errorMessage)
+    {
+        return new BulkPurgePreviewDto
+        {
+            Success = false,
+            ErrorMessage = errorMessage
+        };
+    }
+}

--- a/src/DiscordBot.Core/DTOs/BulkPurgeProgressDto.cs
+++ b/src/DiscordBot.Core/DTOs/BulkPurgeProgressDto.cs
@@ -1,0 +1,67 @@
+using DiscordBot.Core.Enums;
+
+namespace DiscordBot.Core.DTOs;
+
+/// <summary>
+/// Progress update for bulk purge operations sent via SignalR.
+/// </summary>
+public class BulkPurgeProgressDto
+{
+    /// <summary>
+    /// The entity type being purged.
+    /// </summary>
+    public BulkPurgeEntityType EntityType { get; set; }
+
+    /// <summary>
+    /// Number of records processed so far.
+    /// </summary>
+    public int ProcessedCount { get; set; }
+
+    /// <summary>
+    /// Total number of records to process.
+    /// </summary>
+    public int TotalCount { get; set; }
+
+    /// <summary>
+    /// Percentage complete (0-100).
+    /// </summary>
+    public int PercentComplete => TotalCount > 0
+        ? (int)Math.Round((double)ProcessedCount / TotalCount * 100)
+        : 0;
+
+    /// <summary>
+    /// Whether the operation is complete.
+    /// </summary>
+    public bool IsComplete { get; set; }
+
+    /// <summary>
+    /// Timestamp of this progress update.
+    /// </summary>
+    public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Optional message about current operation.
+    /// </summary>
+    public string? Message { get; set; }
+
+    /// <summary>
+    /// Creates a progress update.
+    /// </summary>
+    public static BulkPurgeProgressDto Create(
+        BulkPurgeEntityType entityType,
+        int processedCount,
+        int totalCount,
+        bool isComplete = false,
+        string? message = null)
+    {
+        return new BulkPurgeProgressDto
+        {
+            EntityType = entityType,
+            ProcessedCount = processedCount,
+            TotalCount = totalCount,
+            IsComplete = isComplete,
+            Message = message,
+            Timestamp = DateTime.UtcNow
+        };
+    }
+}

--- a/src/DiscordBot.Core/DTOs/BulkPurgeResultDto.cs
+++ b/src/DiscordBot.Core/DTOs/BulkPurgeResultDto.cs
@@ -1,0 +1,82 @@
+using DiscordBot.Core.Enums;
+
+namespace DiscordBot.Core.DTOs;
+
+/// <summary>
+/// Result of a bulk purge operation.
+/// </summary>
+public class BulkPurgeResultDto
+{
+    /// <summary>
+    /// Whether the purge was successful.
+    /// </summary>
+    public bool Success { get; set; }
+
+    /// <summary>
+    /// Error message if purge failed.
+    /// </summary>
+    public string? ErrorMessage { get; set; }
+
+    /// <summary>
+    /// Error code if purge failed.
+    /// </summary>
+    public string? ErrorCode { get; set; }
+
+    /// <summary>
+    /// The entity type that was purged.
+    /// </summary>
+    public BulkPurgeEntityType EntityType { get; set; }
+
+    /// <summary>
+    /// Number of records deleted.
+    /// </summary>
+    public int DeletedCount { get; set; }
+
+    /// <summary>
+    /// Timestamp when the purge was executed.
+    /// </summary>
+    public DateTime PurgedAt { get; set; }
+
+    /// <summary>
+    /// Correlation ID for the audit log entry.
+    /// </summary>
+    public string AuditLogCorrelationId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Creates a successful result.
+    /// </summary>
+    public static BulkPurgeResultDto Succeeded(
+        BulkPurgeEntityType entityType,
+        int deletedCount,
+        string correlationId)
+    {
+        return new BulkPurgeResultDto
+        {
+            Success = true,
+            EntityType = entityType,
+            DeletedCount = deletedCount,
+            PurgedAt = DateTime.UtcNow,
+            AuditLogCorrelationId = correlationId
+        };
+    }
+
+    /// <summary>
+    /// Creates a failed result.
+    /// </summary>
+    public static BulkPurgeResultDto Failed(string errorCode, string errorMessage)
+    {
+        return new BulkPurgeResultDto
+        {
+            Success = false,
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage,
+            PurgedAt = DateTime.UtcNow
+        };
+    }
+
+    // Error codes
+    public const string NoRecordsFound = "NO_RECORDS_FOUND";
+    public const string DatabaseError = "DATABASE_ERROR";
+    public const string TransactionFailed = "TRANSACTION_FAILED";
+    public const string InvalidCriteria = "INVALID_CRITERIA";
+}

--- a/src/DiscordBot.Core/Enums/AuditLogAction.cs
+++ b/src/DiscordBot.Core/Enums/AuditLogAction.cs
@@ -103,5 +103,10 @@ public enum AuditLogAction
     /// <summary>
     /// User data was purged from the system (GDPR right to be forgotten).
     /// </summary>
-    UserDataPurged = 20
+    UserDataPurged = 20,
+
+    /// <summary>
+    /// Bulk data purge operation was executed.
+    /// </summary>
+    BulkDataPurged = 21
 }

--- a/src/DiscordBot.Core/Enums/BulkPurgeEntityType.cs
+++ b/src/DiscordBot.Core/Enums/BulkPurgeEntityType.cs
@@ -1,0 +1,27 @@
+namespace DiscordBot.Core.Enums;
+
+/// <summary>
+/// Represents the entity types that can be bulk purged.
+/// </summary>
+public enum BulkPurgeEntityType
+{
+    /// <summary>
+    /// Message logs from Discord channels.
+    /// </summary>
+    Messages = 1,
+
+    /// <summary>
+    /// System audit logs.
+    /// </summary>
+    AuditLogs = 2,
+
+    /// <summary>
+    /// Command execution logs.
+    /// </summary>
+    CommandLogs = 3,
+
+    /// <summary>
+    /// Moderation case records.
+    /// </summary>
+    ModerationCases = 4
+}

--- a/src/DiscordBot.Core/Interfaces/IBulkPurgeService.cs
+++ b/src/DiscordBot.Core/Interfaces/IBulkPurgeService.cs
@@ -1,0 +1,31 @@
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Core.Interfaces;
+
+/// <summary>
+/// Service interface for bulk data purge operations.
+/// </summary>
+public interface IBulkPurgeService
+{
+    /// <summary>
+    /// Gets a preview of records that would be deleted without actually deleting.
+    /// </summary>
+    /// <param name="criteria">The purge criteria (entity type, date range, guild).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Preview with estimated record count.</returns>
+    Task<BulkPurgePreviewDto> PreviewPurgeAsync(
+        BulkPurgeCriteriaDto criteria,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Executes a bulk purge operation based on the specified criteria.
+    /// </summary>
+    /// <param name="criteria">The purge criteria (entity type, date range, guild).</param>
+    /// <param name="adminUserId">The ID of the admin executing the purge.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result with deleted record count.</returns>
+    Task<BulkPurgeResultDto> ExecutePurgeAsync(
+        BulkPurgeCriteriaDto criteria,
+        string adminUserId,
+        CancellationToken cancellationToken = default);
+}


### PR DESCRIPTION
## Summary

- Adds bulk purge capabilities for Messages, Audit Logs, Command Logs, and Moderation Cases
- Creates Admin UI at `/Admin/BulkPurge` with date range and guild filters
- Includes preview functionality to show record counts before execution
- Implements real-time progress updates via SignalR during purge operations
- Creates audit trail for all bulk purge operations with correlation IDs

## Changes

**Core Layer:**
- `BulkPurgeCriteriaDto` - Filter criteria (entity type, date range, guild ID)
- `BulkPurgePreviewDto` - Preview results with estimated counts
- `BulkPurgeResultDto` - Execution results with deleted counts
- `BulkPurgeProgressDto` - Progress updates for SignalR
- `BulkPurgeEntityType` enum - Messages, AuditLogs, CommandLogs, ModerationCases
- `IBulkPurgeService` interface
- `AuditLogAction.BulkDataPurged` enum value

**Bot Layer:**
- `BulkPurgeService` - Service implementation with transaction support
- `BulkPurgeController` - REST API endpoints (`preview`, `execute`)
- `BulkPurge.cshtml` - Admin UI page with entity selection and filters
- `DashboardHub` - Added `BulkPurgeGroupName` and join/leave methods

**UI:**
- Added Bulk Purge and User Purge links to admin sidebar (SuperAdmin only)

## Test plan

- [ ] Navigate to `/Admin/BulkPurge` as SuperAdmin
- [ ] Select entity type (Messages, Audit Logs, Command Logs, or Moderation Cases)
- [ ] Set date range and optionally filter by guild ID
- [ ] Click "Preview Records" to see estimated counts
- [ ] Click "Execute Purge" and confirm the deletion
- [ ] Verify records are deleted and audit log entry is created
- [ ] Verify progress updates appear during execution

Closes #779

🤖 Generated with [Claude Code](https://claude.com/claude-code)