### PR TITLE
feat(security): Add auth and guild membership validation to Public Leaderboard

### DIFF
--- a/src/DiscordBot.Bot/Pages/Guilds/PublicLeaderboard.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/PublicLeaderboard.cshtml
@@ -119,9 +119,55 @@
             </div>
         </div>
     }
+    else if (!Model.IsAuthenticated)
+    {
+        <!-- Landing Page for Unauthenticated Users -->
+        <div class="min-h-screen flex items-center justify-center p-4">
+            <div class="max-w-md w-full bg-bg-secondary border border-border-primary rounded-xl p-8 text-center">
+                <!-- Guild Icon -->
+                <div class="mb-6">
+                    @if (!string.IsNullOrEmpty(Model.GuildIconUrl))
+                    {
+                        <img src="@Model.GuildIconUrl" alt="@Model.GuildName icon" class="w-24 h-24 rounded-full mx-auto mb-4 border-2 border-border-primary" />
+                    }
+                    else
+                    {
+                        <div class="w-24 h-24 rounded-full mx-auto mb-4 bg-bg-tertiary border-2 border-border-primary flex items-center justify-center">
+                            <span class="rat-emoji text-4xl">🐀</span>
+                        </div>
+                    }
+                    <h1 class="text-2xl font-bold text-text-primary mb-2">@Model.GuildName</h1>
+                    <span class="inline-block text-xs font-medium text-accent-primary bg-accent-primary/10 border border-accent-primary/30 px-3 py-1 rounded-full mb-4">
+                        Hall of Shame
+                    </span>
+                    <p class="text-text-secondary">
+                        View accountability metrics and fun stats for this server's Rat Watch leaderboard.
+                    </p>
+                </div>
+
+                <!-- Login Prompt -->
+                <div class="pt-6 border-t border-border-primary">
+                    <p class="text-sm text-text-tertiary mb-4">
+                        Log in with Discord to verify your guild membership and view the leaderboard.
+                    </p>
+                    <a href="@Model.LoginUrl" class="inline-flex items-center justify-center gap-2 w-full px-4 py-3 bg-[#5865F2] hover:bg-[#4752C4] text-white font-medium rounded-lg transition-colors">
+                        <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/>
+                        </svg>
+                        Log in with Discord
+                    </a>
+                </div>
+
+                <!-- Footer -->
+                <div class="pt-6 mt-6 border-t border-border-primary">
+                    <p class="text-xs text-text-tertiary">Powered by @Model.AppTitle</p>
+                </div>
+            </div>
+        </div>
+    }
     else
     {
-        <!-- Public Leaderboard Content -->
+        <!-- Public Leaderboard Content (Authenticated & Authorized Users) -->
         <div class="min-h-screen py-12 px-4 sm:px-6 lg:px-8">
             <div class="max-w-5xl mx-auto">
 


### PR DESCRIPTION
## Summary
- Adds authentication and guild membership validation to the Public Leaderboard page
- Unauthenticated users now see a landing page with login prompt (Discord OAuth)
- Authenticated users without guild membership receive 403 Forbidden
- Authenticated guild members can view the full leaderboard
- Follows the same pattern as TTS and Soundboard Portal pages

## Test plan
- [ ] Visit `/Guilds/{guildId}/Leaderboard` while logged out → see landing page with login button
- [ ] Click login button → redirect to Discord OAuth → return to leaderboard page
- [ ] Visit page as authenticated user who is NOT a guild member → receive 403 Forbid
- [ ] Visit page as authenticated guild member → see full leaderboard content
- [ ] Verify `PublicLeaderboardEnabled` setting still controls access (returns private message if disabled)

Closes #1011

🤖 Generated with [Claude Code](https://claude.com/claude-code)