### PR TITLE
feat(moderation): Add /unban command for lifting user bans

### DIFF
--- a/src/DiscordBot.Core/Enums/CaseType.cs
+++ b/src/DiscordBot.Core/Enums/CaseType.cs
@@ -28,5 +28,10 @@ public enum CaseType
     /// <summary>
     /// Informational note only (no enforcement action).
     /// </summary>
-    Note = 4
+    Note = 4,
+
+    /// <summary>
+    /// User was unbanned from the guild.
+    /// </summary>
+    Unban = 5
 }


### PR DESCRIPTION
## Summary

- Adds `/unban` command to `ModerationActionModule` for manually lifting user bans
- Adds `Unban = 5` to `CaseType` enum for audit trail tracking
- Command accepts `user_id` (string) and optional `reason` parameters

## Changes

- **CaseType enum**: Added `Unban = 5` case type
- **ModerationActionModule**: Added `/unban` command that:
  - Validates user ID format
  - Verifies user is actually banned before attempting unban
  - Creates moderation case for audit trail
  - Removes ban using Discord API
  - Shows confirmation embed with case number, user info, and original ban reason

## Test Plan

- [ ] Test `/unban` with valid banned user ID - should unban and show confirmation
- [ ] Test `/unban` with invalid ID format - should show validation error
- [ ] Test `/unban` with user who isn't banned - should show "not banned" message
- [ ] Test `/unban` without BanMembers permission - should be denied by precondition
- [ ] Verify moderation case is created and visible in audit logs

Closes #797

🤖 Generated with [Claude Code](https://claude.com/claude-code)