### PR TITLE
fix(security): Change SameSite cookie policy from Lax to Strict

### DIFF
--- a/src/DiscordBot.Bot/Extensions/IdentityServiceExtensions.cs
+++ b/src/DiscordBot.Bot/Extensions/IdentityServiceExtensions.cs
@@ -62,7 +62,7 @@ public static class IdentityServiceExtensions
         {
             options.Cookie.HttpOnly = true;
             options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
-            options.Cookie.SameSite = SameSiteMode.Lax;
+            options.Cookie.SameSite = SameSiteMode.Strict;
             options.ExpireTimeSpan = TimeSpan.FromDays(identityConfig.CookieExpireDays);
             options.SlidingExpiration = identityConfig.CookieSlidingExpiration;
             options.LoginPath = identityConfig.LoginPath;


### PR DESCRIPTION
## Summary

- Changes authentication cookie `SameSite` attribute from `Lax` to `Strict` for enhanced CSRF protection
- Strict mode prevents cookies from being sent on any cross-origin requests

## Security Details

| Field | Value |
|-------|-------|
| **Severity** | Low |
| **CWE** | CWE-1275 (Sensitive Cookie with Improper SameSite Attribute) |
| **OWASP** | A01:2021 - Broken Access Control |

## Test plan

- [ ] Verify login flow works correctly with local credentials
- [ ] Test Discord OAuth login flow completes successfully
- [ ] Confirm session persists after navigation within the app
- [ ] Verify cookies are not sent when navigating from external sites

Closes #1131

🤖 Generated with [Claude Code](https://claude.com/claude-code)