### PR TITLE
fix(security): Apply GuildAccess policy to guild-scoped pages

### DIFF
--- a/src/DiscordBot.Bot/Pages/Guilds/Analytics/Engagement.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/Analytics/Engagement.cshtml.cs
@@ -11,6 +11,7 @@ namespace DiscordBot.Bot.Pages.Guilds.Analytics;
 /// Displays engagement metrics, message trends, channel analytics, and new member retention.
 /// </summary>
 [Authorize(Policy = "RequireViewer")]
+[Authorize(Policy = "GuildAccess")]
 public class EngagementModel : PageModel
 {
     private readonly IEngagementAnalyticsService _engagementAnalyticsService;

--- a/src/DiscordBot.Bot/Pages/Guilds/Analytics/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/Analytics/Index.cshtml.cs
@@ -13,6 +13,7 @@ namespace DiscordBot.Bot.Pages.Guilds.Analytics;
 /// Displays activity metrics, charts, and leaderboards for a specific guild.
 /// </summary>
 [Authorize(Policy = "RequireViewer")]
+[Authorize(Policy = "GuildAccess")]
 public class IndexModel : PageModel
 {
     private readonly IServerAnalyticsService _analyticsService;

--- a/src/DiscordBot.Bot/Pages/Guilds/Analytics/Moderation.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/Analytics/Moderation.cshtml.cs
@@ -13,6 +13,7 @@ namespace DiscordBot.Bot.Pages.Guilds.Analytics;
 /// Displays moderation metrics, trends, case distribution, and repeat offender tracking.
 /// </summary>
 [Authorize(Policy = "RequireModerator")]
+[Authorize(Policy = "GuildAccess")]
 public class ModerationModel : PageModel
 {
     private readonly IModerationAnalyticsService _analyticsService;

--- a/src/DiscordBot.Bot/Pages/Guilds/AudioSettings/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/AudioSettings/Index.cshtml.cs
@@ -14,6 +14,7 @@ namespace DiscordBot.Bot.Pages.Guilds.AudioSettings;
 /// Allows administrators to configure audio and soundboard settings for a guild.
 /// </summary>
 [Authorize(Policy = "RequireAdmin")]
+[Authorize(Policy = "GuildAccess")]
 public class IndexModel : PageModel
 {
     private readonly IGuildAudioSettingsService _audioSettingsService;

--- a/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml.cs
@@ -14,6 +14,7 @@ namespace DiscordBot.Bot.Pages.Guilds;
 /// Page model for displaying detailed guild information.
 /// </summary>
 [Authorize(Policy = "RequireModerator")]
+[Authorize(Policy = "GuildAccess")]
 public class DetailsModel : PageModel
 {
     private readonly IGuildService _guildService;

--- a/src/DiscordBot.Bot/Pages/Guilds/Edit.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/Edit.cshtml.cs
@@ -12,6 +12,7 @@ namespace DiscordBot.Bot.Pages.Guilds;
 /// Page model for editing guild settings.
 /// </summary>
 [Authorize(Policy = "RequireAdmin")]
+[Authorize(Policy = "GuildAccess")]
 public class EditModel : PageModel
 {
     private readonly IGuildService _guildService;

--- a/src/DiscordBot.Bot/Pages/Guilds/FlaggedEvents/Details.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/FlaggedEvents/Details.cshtml.cs
@@ -11,6 +11,7 @@ namespace DiscordBot.Bot.Pages.Guilds.FlaggedEvents;
 /// Displays full event details, evidence, and action panel.
 /// </summary>
 [Authorize(Policy = "RequireAdmin")]
+[Authorize(Policy = "GuildAccess")]
 public class DetailsModel : PageModel
 {
     private readonly IFlaggedEventService _flaggedEventService;

--- a/src/DiscordBot.Bot/Pages/Guilds/FlaggedEvents/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/FlaggedEvents/Index.cshtml.cs
@@ -12,6 +12,7 @@ namespace DiscordBot.Bot.Pages.Guilds.FlaggedEvents;
 /// Displays auto-detected moderation events with filtering and bulk actions.
 /// </summary>
 [Authorize(Policy = "RequireAdmin")]
+[Authorize(Policy = "GuildAccess")]
 public class IndexModel : PageModel
 {
     private readonly IFlaggedEventService _flaggedEventService;

--- a/src/DiscordBot.Bot/Pages/Guilds/Members/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/Members/Index.cshtml.cs
@@ -12,6 +12,7 @@ namespace DiscordBot.Bot.Pages.Guilds.Members;
 /// Page model for displaying the guild member directory with search, filter, sort, and pagination.
 /// </summary>
 [Authorize(Policy = "RequireModerator")]
+[Authorize(Policy = "GuildAccess")]
 public class IndexModel : PageModel
 {
     private readonly IGuildMemberService _memberService;

--- a/src/DiscordBot.Bot/Pages/Guilds/Members/Moderation.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/Members/Moderation.cshtml.cs
@@ -12,6 +12,7 @@ namespace DiscordBot.Bot.Pages.Guilds.Members;
 /// Page model for displaying a user's moderation profile with cases, notes, tags, and flagged events.
 /// </summary>
 [Authorize(Policy = "RequireAdmin")]
+[Authorize(Policy = "GuildAccess")]
 public class ModerationModel : PageModel
 {
     private readonly IGuildService _guildService;

--- a/src/DiscordBot.Bot/Pages/Guilds/ModerationSettings/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/ModerationSettings/Index.cshtml.cs
@@ -13,6 +13,7 @@ namespace DiscordBot.Bot.Pages.Guilds.ModerationSettings;
 /// Allows administrators to configure auto-moderation settings for a guild.
 /// </summary>
 [Authorize(Policy = "RequireAdmin")]
+[Authorize(Policy = "GuildAccess")]
 public class IndexModel : PageModel
 {
     private readonly IGuildModerationConfigService _configService;

--- a/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Analytics.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Analytics.cshtml.cs
@@ -13,6 +13,7 @@ namespace DiscordBot.Bot.Pages.Guilds.RatWatch;
 /// Displays analytics metrics, charts, and leaderboards for a specific guild.
 /// </summary>
 [Authorize(Policy = "RequireModerator")]
+[Authorize(Policy = "GuildAccess")]
 public class AnalyticsModel : PageModel
 {
     private readonly IRatWatchRepository _ratWatchRepository;

--- a/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Incidents.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Incidents.cshtml.cs
@@ -13,6 +13,7 @@ namespace DiscordBot.Bot.Pages.Guilds.RatWatch;
 /// Displays a filterable, sortable, paginated list of all Rat Watch incidents for a guild.
 /// </summary>
 [Authorize(Policy = "RequireModerator")]
+[Authorize(Policy = "GuildAccess")]
 public class IncidentsModel : PageModel
 {
     private readonly IRatWatchService _ratWatchService;

--- a/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Index.cshtml.cs
@@ -11,6 +11,7 @@ namespace DiscordBot.Bot.Pages.Guilds.RatWatch;
 /// Displays watches, settings, and leaderboard for a guild.
 /// </summary>
 [Authorize(Policy = "RequireAdmin")]
+[Authorize(Policy = "GuildAccess")]
 public class IndexModel : PageModel
 {
     private readonly IRatWatchService _ratWatchService;

--- a/src/DiscordBot.Bot/Pages/Guilds/Reminders/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/Reminders/Index.cshtml.cs
@@ -12,7 +12,7 @@ namespace DiscordBot.Bot.Pages.Guilds.Reminders;
 /// Page model for the Reminders admin page.
 /// Displays reminders for a guild with pagination and filtering.
 /// </summary>
-[Authorize(Policy = "RequireGuildAccess")]
+[Authorize(Policy = "GuildAccess")]
 public class IndexModel : PageModel
 {
     private readonly IReminderRepository _reminderRepository;

--- a/src/DiscordBot.Bot/Pages/Guilds/ScheduledMessages/Create.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/ScheduledMessages/Create.cshtml.cs
@@ -15,6 +15,7 @@ namespace DiscordBot.Bot.Pages.Guilds.ScheduledMessages;
 /// Page model for creating a new scheduled message.
 /// </summary>
 [Authorize(Policy = "RequireAdmin")]
+[Authorize(Policy = "GuildAccess")]
 public class CreateModel : PageModel
 {
     private readonly IScheduledMessageService _scheduledMessageService;

--- a/src/DiscordBot.Bot/Pages/Guilds/ScheduledMessages/Edit.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/ScheduledMessages/Edit.cshtml.cs
@@ -15,6 +15,7 @@ namespace DiscordBot.Bot.Pages.Guilds.ScheduledMessages;
 /// Page model for editing an existing scheduled message.
 /// </summary>
 [Authorize(Policy = "RequireAdmin")]
+[Authorize(Policy = "GuildAccess")]
 public class EditModel : PageModel
 {
     private readonly IScheduledMessageService _scheduledMessageService;

--- a/src/DiscordBot.Bot/Pages/Guilds/ScheduledMessages/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/ScheduledMessages/Index.cshtml.cs
@@ -12,6 +12,7 @@ namespace DiscordBot.Bot.Pages.Guilds.ScheduledMessages;
 /// Displays all scheduled messages for a guild with pagination support.
 /// </summary>
 [Authorize(Policy = "RequireAdmin")]
+[Authorize(Policy = "GuildAccess")]
 public class IndexModel : PageModel
 {
     private readonly IScheduledMessageService _scheduledMessageService;

--- a/src/DiscordBot.Bot/Pages/Guilds/Soundboard/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/Soundboard/Index.cshtml.cs
@@ -15,6 +15,7 @@ namespace DiscordBot.Bot.Pages.Guilds.Soundboard;
 /// Displays sounds, statistics, and settings for a guild's soundboard.
 /// </summary>
 [Authorize(Policy = "RequireAdmin")]
+[Authorize(Policy = "GuildAccess")]
 public class IndexModel : PageModel
 {
     private readonly ISoundService _soundService;

--- a/src/DiscordBot.Bot/Pages/Guilds/TextToSpeech/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/TextToSpeech/Index.cshtml.cs
@@ -17,6 +17,7 @@ namespace DiscordBot.Bot.Pages.Guilds.TextToSpeech;
 /// Displays TTS settings, statistics, and recent messages for a guild.
 /// </summary>
 [Authorize(Policy = "RequireAdmin")]
+[Authorize(Policy = "GuildAccess")]
 public class IndexModel : PageModel
 {
     private readonly ITtsHistoryService _ttsHistoryService;

--- a/src/DiscordBot.Bot/Pages/Guilds/Welcome.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/Welcome.cshtml.cs
@@ -13,6 +13,7 @@ namespace DiscordBot.Bot.Pages.Guilds;
 /// Page model for managing welcome configuration for a guild.
 /// </summary>
 [Authorize(Policy = "RequireAdmin")]
+[Authorize(Policy = "GuildAccess")]
 public class WelcomeModel : PageModel
 {
     private readonly IWelcomeService _welcomeService;


### PR DESCRIPTION
## Summary

- Adds `GuildAccess` authorization policy to all guild-scoped Razor Pages under `Pages/Guilds/`
- Fixes Reminders page using non-existent `RequireGuildAccess` policy (changed to `GuildAccess`)
- Prevents horizontal privilege escalation by validating guild membership for non-admin users

## Details

The `GuildAccessAuthorizationHandler` checks:
1. **SuperAdmin/Admin bypass** - Full access to all guilds
2. **Discord guild membership** - User must be a member of the guild (via UserDiscordGuild)
3. **Explicit grant** - Fallback check for UserGuildAccess records with sufficient level

### Pages Updated (21 files)
| Area | Files |
|------|-------|
| Core | Details, Edit, Welcome |
| Analytics | Index, Engagement, Moderation |
| Settings | AudioSettings, ModerationSettings |
| Moderation | FlaggedEvents (Index, Details) |
| Members | Index, Moderation |
| RatWatch | Index, Analytics, Incidents |
| Reminders | Index (also fixed policy name) |
| Scheduled | Index, Create, Edit |
| Audio | Soundboard, TextToSpeech |

### Excluded by Design
- `Guilds/Index` - Lists all guilds user has access to (no specific guildId)
- `PublicLeaderboard` - Uses `[AllowAnonymous]` with custom membership checks

## Test plan

- [ ] Verify Admin users can still access all guild pages
- [ ] Verify non-admin users without guild membership get 403
- [ ] Verify non-admin users with guild membership can access pages
- [ ] Confirm build succeeds without new errors

Closes #1132

🤖 Generated with [Claude Code](https://claude.com/claude-code)