### PR TITLE
fix(security): Restrict Swagger UI to development environment only

### DIFF
--- a/src/DiscordBot.Bot/Program.cs
+++ b/src/DiscordBot.Bot/Program.cs
@@ -262,13 +262,16 @@ try
     // Enable static file serving for wwwroot
     app.UseStaticFiles();
 
-    // Enable Swagger in all environments for now (can be restricted to Development later)
-    app.UseSwagger();
-    app.UseSwaggerUI(c =>
+    // Enable Swagger only in development environment
+    if (app.Environment.IsDevelopment())
     {
-        c.SwaggerEndpoint("/swagger/v1/swagger.json", "Discord Bot Management API v1");
-        c.RoutePrefix = "swagger";
-    });
+        app.UseSwagger();
+        app.UseSwaggerUI(c =>
+        {
+            c.SwaggerEndpoint("/swagger/v1/swagger.json", "Discord Bot Management API v1");
+            c.RoutePrefix = "swagger";
+        });
+    }
 
     // Enable authentication and authorization middleware
     app.UseAuthentication();


### PR DESCRIPTION
## Summary

- Restricts Swagger and SwaggerUI middleware to development environment only by wrapping in `IsDevelopment()` check
- Addresses CWE-489 (Active Debug Code) security finding from security audit

## Changes

**`Program.cs`**: Added environment check around Swagger middleware configuration to prevent API documentation from being exposed in production environments.

Closes #1133

## Test plan

- [x] Build succeeds (0 errors)
- [ ] Verify Swagger UI is accessible at `/swagger` in development environment
- [ ] Verify Swagger UI returns 404 in non-development environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)