### PR TITLE
feat(theme): Add CSS variable system and theme definitions

### DIFF
--- a/src/DiscordBot.Bot/Pages/Shared/_Layout.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/_Layout.cshtml
@@ -1,9 +1,20 @@
+@inject DiscordBot.Core.Interfaces.IThemeService ThemeService
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="@(await ThemeService.GetCurrentThemeKeyAsync())">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@ViewData["Title"] - Discord Bot Admin</title>
+    <!-- Blocking theme application script - runs before first paint to prevent flash -->
+    <script>
+        (function() {
+            try {
+                var match = document.cookie.match(/theme-preference=([^;]+)/);
+                var theme = match ? decodeURIComponent(match[1]) : localStorage.getItem('theme-preference');
+                if (theme) document.documentElement.setAttribute('data-theme', theme);
+            } catch (e) {}
+        })();
+    </script>
     <!-- Compiled Tailwind CSS (built from site.css via npm run build:css) -->
     <link rel="stylesheet" href="~/css/app.css" asp-append-version="true" />
     @await RenderSectionAsync("Styles", required: false)
@@ -70,6 +81,8 @@
     <script src="~/js/search.js" asp-append-version="true"></script>
     <!-- Preview Popup Module -->
     <script src="~/js/preview-popup.js" asp-append-version="true"></script>
+    <!-- Theme Manager Module -->
+    <script src="~/js/theme.js" asp-append-version="true"></script>
 
     @await RenderSectionAsync("Scripts", required: false)
 </body>

--- a/src/DiscordBot.Bot/tailwind.config.js
+++ b/src/DiscordBot.Bot/tailwind.config.js
@@ -8,68 +8,68 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        // Background layers
+        // Background layers - mapped to CSS variables for theme support
         bg: {
-          primary: '#1d2022',
-          secondary: '#262a2d',
-          tertiary: '#2f3336',
-          hover: '#363a3e',
+          primary: 'var(--color-bg-primary)',
+          secondary: 'var(--color-bg-secondary)',
+          tertiary: 'var(--color-bg-tertiary)',
+          hover: 'var(--color-bg-hover)',
         },
-        // Text colors
+        // Text colors - mapped to CSS variables for theme support
         text: {
-          primary: '#d7d3d0',
-          secondary: '#a8a5a3',
-          tertiary: '#7a7876',
-          placeholder: '#8a8886',
-          inverse: '#1d2022',
+          primary: 'var(--color-text-primary)',
+          secondary: 'var(--color-text-secondary)',
+          tertiary: 'var(--color-text-tertiary)',
+          placeholder: 'var(--color-text-placeholder)',
+          inverse: '#1d2022', // Kept static for specific use cases
         },
-        // Brand accent colors
+        // Brand accent colors - mapped to CSS variables for theme support
         accent: {
           orange: {
-            DEFAULT: '#cb4e1b',
-            hover: '#e5591f',
-            active: '#b04517',
-            muted: '#cb4e1b33',
+            DEFAULT: 'var(--color-accent-orange)',
+            hover: 'var(--color-accent-orange-hover)',
+            active: 'var(--color-accent-orange-active)',
+            muted: 'var(--color-accent-orange-muted)',
           },
           blue: {
-            DEFAULT: '#098ecf',
-            hover: '#0ba3ea',
-            active: '#0879b3',
-            muted: '#098ecf33',
+            DEFAULT: 'var(--color-accent-blue)',
+            hover: 'var(--color-accent-blue-hover)',
+            active: 'var(--color-accent-blue-active)',
+            muted: 'var(--color-accent-blue-muted)',
           },
         },
-        // Semantic colors
+        // Semantic colors - mapped to CSS variables for theme support
         success: {
-          DEFAULT: '#10b981',
+          DEFAULT: 'var(--color-success)',
           bg: '#10b98120',
           border: '#10b98150',
         },
         warning: {
-          DEFAULT: '#f59e0b',
+          DEFAULT: 'var(--color-warning)',
           bg: '#f59e0b20',
           border: '#f59e0b50',
         },
         error: {
-          DEFAULT: '#ef4444',
+          DEFAULT: 'var(--color-error)',
           hover: '#dc2626',
           bg: '#ef444420',
           border: '#ef444450',
         },
         info: {
-          DEFAULT: '#06b6d4',
+          DEFAULT: 'var(--color-info)',
           bg: '#06b6d420',
           border: '#06b6d450',
         },
-        // Border colors
+        // Border colors - mapped to CSS variables for theme support
         border: {
-          primary: '#3f4447',
-          secondary: '#2f3336',
-          focus: '#098ecf',
+          primary: 'var(--color-border-primary)',
+          secondary: 'var(--color-border-secondary)',
+          focus: 'var(--color-border-focus)',
         },
         // Discord brand color
         discord: {
-          DEFAULT: '#5865F2',
-          hover: '#4752C4',
+          DEFAULT: 'var(--color-discord)',
+          hover: 'var(--color-discord-hover)',
         },
       },
       fontFamily: {

--- a/src/DiscordBot.Bot/wwwroot/css/site.css
+++ b/src/DiscordBot.Bot/wwwroot/css/site.css
@@ -46,8 +46,12 @@
     /* Accent colors */
     --color-accent-blue: #098ecf;
     --color-accent-blue-hover: #0ba3ea;
+    --color-accent-blue-active: #0778ab;
+    --color-accent-blue-muted: rgba(9, 142, 207, 0.2);
     --color-accent-orange: #cb4e1b;
     --color-accent-orange-hover: #e5591f;
+    --color-accent-orange-active: #b3440f;
+    --color-accent-orange-muted: rgba(203, 78, 27, 0.2);
 
     /* Semantic colors */
     --color-success: #10b981;
@@ -68,6 +72,69 @@
     --z-fixed: 300;
     --z-popover: 350;
     --z-notification: 400;
+  }
+
+  /* ============================================
+     PURPLE DUSK THEME
+     Light theme with warm beige backgrounds
+     and purple/pink accent colors
+     ============================================ */
+  [data-theme="purple-dusk"] {
+    /* Background colors - warm beige palette */
+    --color-bg-primary: #E8E3DF;
+    --color-bg-secondary: #DAD4D0;
+    --color-bg-tertiary: #CCC5C0;
+    --color-bg-hover: #C0B8B2;
+
+    /* Text colors - deep purple palette */
+    --color-text-primary: #4F214A;
+    --color-text-secondary: #614978;
+    --color-text-tertiary: #887A99;
+    --color-text-placeholder: #9A8DA8;
+
+    /* Orange → Purple mapping (primary accent)
+       Maps existing accent-orange classes to purple */
+    --color-accent-orange: #614978;
+    --color-accent-orange-hover: #7A5C8F;
+    --color-accent-orange-active: #4F214A;
+    --color-accent-orange-muted: rgba(97, 73, 120, 0.2);
+
+    /* Blue → Pink mapping (secondary accent)
+       Maps existing accent-blue classes to pink */
+    --color-accent-blue: #D5345B;
+    --color-accent-blue-hover: #E5476D;
+    --color-accent-blue-active: #B82A4D;
+    --color-accent-blue-muted: rgba(213, 52, 91, 0.2);
+
+    /* Semantic colors - slightly adjusted for light background */
+    --color-success: #059669;
+    --color-warning: #D97706;
+    --color-error: #DC2626;
+    --color-info: #0891B2;
+
+    /* Border colors - light theme appropriate */
+    --color-border-primary: #C0B8B2;
+    --color-border-secondary: #DAD4D0;
+    --color-border-focus: #614978;
+
+    /* Discord brand colors remain consistent */
+    --color-discord: #5865F2;
+    --color-discord-hover: #4752C4;
+
+    /* Glass effect overrides for light theme */
+    --color-glass-bg: rgba(218, 212, 208, 0.6);
+    --color-glass-bg-hover: rgba(204, 197, 192, 0.7);
+    --color-glass-bg-active: rgba(192, 184, 178, 0.8);
+    --color-glass-border: rgba(192, 184, 178, 0.8);
+    --color-glass-border-hover: rgba(97, 73, 120, 0.5);
+
+    /* Status colors adjusted for light background */
+    --color-status-active: #059669;
+    --color-status-active-bg: rgba(5, 150, 105, 0.15);
+    --color-status-active-border: rgba(5, 150, 105, 0.35);
+    --color-status-inactive: #6B7280;
+    --color-status-inactive-bg: rgba(107, 114, 128, 0.15);
+    --color-status-inactive-border: rgba(107, 114, 128, 0.35);
   }
 
   /* Button base class */
@@ -163,7 +230,8 @@
     @apply cursor-pointer transition-all duration-200 ease-in-out;
   }
   .card-interactive:hover {
-    @apply border-accent-blue -translate-y-0.5 shadow-md shadow-accent-blue/15;
+    @apply border-accent-blue -translate-y-0.5 shadow-md;
+    box-shadow: 0 4px 6px -1px rgba(9, 142, 207, 0.15);
   }
 
   /* Enhanced Card - Dashboard Redesign */
@@ -369,7 +437,8 @@
     @apply text-text-primary bg-bg-hover;
   }
   .navbar-link.active {
-    @apply text-accent-orange bg-accent-orange/10;
+    @apply text-accent-orange;
+    background-color: var(--color-accent-orange-muted);
   }
 
   .navbar-actions {
@@ -393,7 +462,8 @@
     @apply text-text-primary bg-bg-hover;
   }
   .sidebar-link.active {
-    @apply text-text-primary bg-accent-orange/15 border-l-[3px] border-accent-orange;
+    @apply text-text-primary border-l-[3px] border-accent-orange;
+    background-color: rgba(203, 78, 27, 0.15);
   }
   .sidebar-link-disabled {
     @apply opacity-50 cursor-not-allowed;
@@ -595,7 +665,8 @@
 
   /* Sidebar mobile transform */
   .sidebar-overlay {
-    @apply fixed inset-0 bg-black/50 lg:hidden;
+    @apply fixed inset-0 lg:hidden;
+    background-color: rgba(0, 0, 0, 0.5);
     z-index: 299;
   }
 
@@ -768,7 +839,8 @@
 
   /* Connection Status Indicator */
   #connection-status[data-state="connected"] {
-    @apply bg-success/10 text-success;
+    @apply text-success;
+    background-color: rgba(16, 185, 129, 0.1);
   }
   #connection-status[data-state="connected"] .connection-dot {
     @apply bg-success;
@@ -781,7 +853,8 @@
 
   #connection-status[data-state="connecting"],
   #connection-status[data-state="reconnecting"] {
-    @apply bg-warning/10 text-warning;
+    @apply text-warning;
+    background-color: rgba(245, 158, 11, 0.1);
   }
   #connection-status[data-state="connecting"] .connection-dot,
   #connection-status[data-state="reconnecting"] .connection-dot {
@@ -790,7 +863,8 @@
   }
 
   #connection-status[data-state="disconnected"] {
-    @apply bg-error/10 text-error;
+    @apply text-error;
+    background-color: rgba(239, 68, 68, 0.1);
   }
   #connection-status[data-state="disconnected"] .connection-dot {
     @apply bg-error;

--- a/src/DiscordBot.Bot/wwwroot/js/theme.js
+++ b/src/DiscordBot.Bot/wwwroot/js/theme.js
@@ -1,0 +1,207 @@
+/**
+ * Theme Manager Module
+ * Handles theme application, persistence, and synchronization.
+ *
+ * Theme persistence strategy:
+ * - Cookie (theme-preference): Read by server for SSR
+ * - localStorage (theme-preference): Fast client-side access
+ *
+ * Both are kept in sync for seamless UX across page loads.
+ */
+const ThemeManager = {
+    COOKIE_NAME: 'theme-preference',
+    STORAGE_KEY: 'theme-preference',
+    COOKIE_MAX_AGE: 31536000, // 1 year in seconds
+
+    /**
+     * Applies a theme immediately and persists the preference.
+     * @param {string} themeKey - The theme key (e.g., 'discord-dark', 'purple-dusk')
+     * @param {boolean} persistToServer - If true, also sends preference to server API (for authenticated users)
+     */
+    applyTheme(themeKey, persistToServer = false) {
+        if (!themeKey) {
+            console.warn('ThemeManager: No theme key provided');
+            return;
+        }
+
+        // Apply to DOM immediately
+        document.documentElement.setAttribute('data-theme', themeKey);
+
+        // Persist to cookie (for SSR on next page load)
+        this.setCookie(themeKey);
+
+        // Persist to localStorage (for JS access)
+        try {
+            localStorage.setItem(this.STORAGE_KEY, themeKey);
+        } catch (e) {
+            console.warn('ThemeManager: localStorage not available', e);
+        }
+
+        // Dispatch custom event for other components to react
+        window.dispatchEvent(new CustomEvent('themechange', {
+            detail: { themeKey }
+        }));
+
+        // Optionally persist to server for authenticated users
+        if (persistToServer) {
+            this.persistToServer(themeKey);
+        }
+    },
+
+    /**
+     * Gets the current theme from cookie or localStorage.
+     * @returns {string|null} The current theme key, or null if not set
+     */
+    getCurrentTheme() {
+        // Check cookie first (SSR source of truth)
+        const cookieTheme = this.getCookie();
+        if (cookieTheme) return cookieTheme;
+
+        // Fallback to localStorage
+        try {
+            return localStorage.getItem(this.STORAGE_KEY);
+        } catch (e) {
+            return null;
+        }
+    },
+
+    /**
+     * Gets the current theme from the DOM.
+     * @returns {string|null} The data-theme attribute value, or null if not set
+     */
+    getActiveTheme() {
+        return document.documentElement.getAttribute('data-theme');
+    },
+
+    /**
+     * Clears the theme preference, reverting to system default.
+     * @param {boolean} persistToServer - If true, also clears preference on server
+     */
+    clearTheme(persistToServer = false) {
+        document.documentElement.removeAttribute('data-theme');
+
+        // Clear cookie
+        document.cookie = `${this.COOKIE_NAME}=; path=/; max-age=0; SameSite=Lax`;
+
+        // Clear localStorage
+        try {
+            localStorage.removeItem(this.STORAGE_KEY);
+        } catch (e) {
+            console.warn('ThemeManager: localStorage not available', e);
+        }
+
+        // Dispatch custom event
+        window.dispatchEvent(new CustomEvent('themechange', {
+            detail: { themeKey: null }
+        }));
+
+        if (persistToServer) {
+            this.clearServerPreference();
+        }
+    },
+
+    /**
+     * Sets the theme preference cookie.
+     * @param {string} themeKey - The theme key to persist
+     */
+    setCookie(themeKey) {
+        document.cookie = `${this.COOKIE_NAME}=${encodeURIComponent(themeKey)}; path=/; max-age=${this.COOKIE_MAX_AGE}; SameSite=Lax`;
+    },
+
+    /**
+     * Gets the theme preference from cookie.
+     * @returns {string|null} The theme key from cookie, or null if not set
+     */
+    getCookie() {
+        const match = document.cookie.match(new RegExp(`(?:^|; )${this.COOKIE_NAME}=([^;]*)`));
+        return match ? decodeURIComponent(match[1]) : null;
+    },
+
+    /**
+     * Persists the theme preference to the server via API.
+     * Called for authenticated users to save preference to database.
+     * @param {string} themeKey - The theme key to persist
+     */
+    async persistToServer(themeKey) {
+        try {
+            const response = await fetch('/api/theme/preference', {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'RequestVerificationToken': this.getAntiForgeryToken()
+                },
+                body: JSON.stringify({ themeKey })
+            });
+
+            if (!response.ok) {
+                console.warn('ThemeManager: Failed to persist theme to server', response.status);
+            }
+        } catch (e) {
+            console.warn('ThemeManager: Error persisting theme to server', e);
+        }
+    },
+
+    /**
+     * Clears the theme preference on the server.
+     */
+    async clearServerPreference() {
+        try {
+            const response = await fetch('/api/theme/preference', {
+                method: 'DELETE',
+                headers: {
+                    'RequestVerificationToken': this.getAntiForgeryToken()
+                }
+            });
+
+            if (!response.ok) {
+                console.warn('ThemeManager: Failed to clear server preference', response.status);
+            }
+        } catch (e) {
+            console.warn('ThemeManager: Error clearing server preference', e);
+        }
+    },
+
+    /**
+     * Gets the anti-forgery token from the page.
+     * @returns {string} The token value, or empty string if not found
+     */
+    getAntiForgeryToken() {
+        const tokenInput = document.querySelector('input[name="__RequestVerificationToken"]');
+        return tokenInput ? tokenInput.value : '';
+    },
+
+    /**
+     * Initializes the theme manager.
+     * Called on page load to ensure theme is applied (fallback for SSR).
+     */
+    init() {
+        // The theme should already be set by SSR or blocking script.
+        // This is a safety net in case neither worked.
+        const domTheme = this.getActiveTheme();
+        const storedTheme = this.getCurrentTheme();
+
+        if (!domTheme && storedTheme) {
+            // DOM doesn't have theme but we have a stored preference
+            document.documentElement.setAttribute('data-theme', storedTheme);
+        }
+
+        // Listen for storage events from other tabs
+        window.addEventListener('storage', (e) => {
+            if (e.key === this.STORAGE_KEY && e.newValue) {
+                document.documentElement.setAttribute('data-theme', e.newValue);
+            }
+        });
+    }
+};
+
+// Initialize on DOM ready
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => ThemeManager.init());
+} else {
+    ThemeManager.init();
+}
+
+// Export for ES modules (if needed)
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = ThemeManager;
+}


### PR DESCRIPTION
## Summary

- Implements the CSS variable system and theme definitions for theme switching support
- Adds Purple Dusk light theme with warm beige backgrounds and purple/pink accent colors
- Updates Tailwind configuration to use CSS variables for theme-aware color classes
- Creates JavaScript theme manager module for client-side theme persistence (cookie + localStorage)
- Integrates server-side rendering of `data-theme` attribute via ThemeService

## Changes

### CSS Variables (`site.css`)
- Added missing accent color variants: `--color-accent-*-active` and `--color-accent-*-muted`
- Defined complete Purple Dusk theme via `[data-theme="purple-dusk"]` selector
- Maps existing accent-orange → purple and accent-blue → pink for the light theme
- Fixed Tailwind opacity modifier incompatibility with CSS variables

### Tailwind Configuration (`tailwind.config.js`)
- Updated all color definitions to reference CSS variables
- Enables automatic theme switching when `data-theme` attribute changes

### Theme JavaScript Module (`theme.js`)
- `applyTheme(themeKey)` - applies theme and persists to cookie + localStorage
- `getCurrentTheme()` - reads current theme preference
- `clearTheme()` - resets to system default
- Cross-tab synchronization via storage events
- Optional server persistence for authenticated users

### Layout Updates (`_Layout.cshtml`)
- Server-side renders `data-theme` attribute via `IThemeService.GetCurrentThemeKeyAsync()`
- Blocking script in `<head>` applies theme from cookie before first paint
- Prevents flash of wrong theme on page load

## Test Plan

- [ ] Verify Discord Dark theme renders correctly (default)
- [ ] Verify Purple Dusk theme applies via browser dev tools (`document.documentElement.setAttribute('data-theme', 'purple-dusk')`)
- [ ] Verify all UI components (buttons, cards, forms, tables) render correctly in both themes
- [ ] Verify theme persists across page refreshes via cookie
- [ ] Verify no flash of wrong theme on initial page load
- [ ] Verify server-side rendering includes correct `data-theme` attribute (view page source)

Part of Epic #1040 (Theme Switching Support)
Closes #1043

🤖 Generated with [Claude Code](https://claude.com/claude-code)