### PR TITLE
feat(ui): Add user profile page with theme selector

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -393,6 +393,7 @@ The `preview-popup.js` module is loaded globally via `_Layout.cshtml`. See exist
 | Error 404 | `/Error/404` | Not found error page |
 | Error 500 | `/Error/500` | Server error page |
 | Privacy | `/Account/Privacy` | Privacy information |
+| Profile | `/Account/Profile` | User profile and theme preferences |
 | Account Lockout | `/Account/Lockout` | Account lockout page |
 | Access Denied | `/Account/AccessDenied` | Access denied page |
 

--- a/src/DiscordBot.Bot/Pages/Account/Profile.cshtml
+++ b/src/DiscordBot.Bot/Pages/Account/Profile.cshtml
@@ -1,0 +1,144 @@
+@page
+@model ProfileModel
+@{
+    ViewData["Title"] = "Profile";
+}
+
+<!-- Page Header -->
+<div class="mb-8">
+    <h1 class="text-3xl font-bold text-text-primary mb-2">Profile</h1>
+    <p class="text-text-secondary">Manage your personal preferences</p>
+</div>
+
+<!-- Status Message -->
+@if (!string.IsNullOrEmpty(Model.StatusMessage))
+{
+    <div class="mb-6 p-4 rounded-lg flex items-start gap-3 @(Model.IsSuccess ? "bg-success-bg border border-success-border" : "bg-error-bg border border-error-border")" role="alert">
+        @if (Model.IsSuccess)
+        {
+            <!-- Success Icon -->
+            <svg class="w-5 h-5 text-success flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
+            </svg>
+        }
+        else
+        {
+            <!-- Error Icon -->
+            <svg class="w-5 h-5 text-error flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
+            </svg>
+        }
+        <div>
+            <p class="text-sm font-semibold @(Model.IsSuccess ? "text-success" : "text-error")">
+                @(Model.IsSuccess ? "Success" : "Error")
+            </p>
+            <p class="text-sm @(Model.IsSuccess ? "text-success" : "text-error") mt-1">
+                @Model.StatusMessage
+            </p>
+        </div>
+    </div>
+}
+
+<!-- User Info Card -->
+<div class="bg-bg-secondary border border-border-primary rounded-lg p-6 shadow-lg mb-6">
+    <div class="flex items-center gap-4">
+        <div class="w-12 h-12 rounded-full bg-accent-blue flex items-center justify-center text-white font-semibold text-lg">
+            @(string.Join("", Model.DisplayName.Split(' ').Take(2).Select(w => w.FirstOrDefault())).ToUpper())
+        </div>
+        <div>
+            <h2 class="text-lg font-semibold text-text-primary">@Model.DisplayName</h2>
+            @if (!string.IsNullOrEmpty(Model.Email))
+            {
+                <p class="text-sm text-text-secondary">@Model.Email</p>
+            }
+        </div>
+    </div>
+</div>
+
+<!-- Theme Preferences Card -->
+<div class="bg-bg-secondary border border-border-primary rounded-lg shadow-lg">
+    <div class="px-6 py-4 border-b border-border-primary">
+        <h3 class="text-lg font-semibold text-text-primary">Theme Preferences</h3>
+        <p class="text-sm text-text-secondary mt-1">Choose your preferred color scheme</p>
+    </div>
+
+    <form method="post" class="p-6">
+        @Html.AntiForgeryToken()
+
+        <div class="space-y-4">
+            <!-- Theme Selector -->
+            <div>
+                <label for="SelectedThemeId" class="block text-sm font-medium text-text-primary mb-2">
+                    Theme Preference
+                </label>
+                <select asp-for="SelectedThemeId"
+                        asp-items="Model.AvailableThemes"
+                        class="w-full max-w-md px-3 py-2 bg-bg-primary border border-border-primary rounded-lg text-text-primary text-sm focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors"
+                        required>
+                    <option value="">Select a theme...</option>
+                </select>
+                <span asp-validation-for="SelectedThemeId" class="text-sm text-error mt-1"></span>
+                <p class="text-xs text-text-tertiary mt-2">
+                    Choose your preferred color scheme for the admin interface.
+                </p>
+            </div>
+
+            <!-- Current Theme Info -->
+            @if (!string.IsNullOrEmpty(Model.CurrentThemeName))
+            {
+                <div class="p-4 bg-bg-primary rounded-lg border border-border-secondary">
+                    <div class="flex items-center gap-2 mb-1">
+                        <span class="text-sm font-medium text-text-primary">Current theme:</span>
+                        <span class="text-sm text-text-secondary">@Model.CurrentThemeName</span>
+                    </div>
+                    <div class="flex items-center gap-2">
+                        <span class="text-xs text-text-tertiary">Source:</span>
+                        <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium @GetSourceBadgeClasses(Model.CurrentThemeSource)">
+                            @Model.CurrentThemeSource.ToString()
+                        </span>
+                    </div>
+                </div>
+            }
+
+            <!-- Submit Button -->
+            <div class="pt-4">
+                <button type="submit"
+                        class="inline-flex items-center justify-center gap-2 py-2.5 px-6 text-sm font-semibold text-white bg-accent-purple border border-accent-purple rounded-md transition-colors hover:bg-accent-purple-hover hover:border-accent-purple-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-purple focus-visible:ring-offset-2 focus-visible:ring-offset-bg-secondary">
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+                    </svg>
+                    Save Preferences
+                </button>
+            </div>
+        </div>
+    </form>
+</div>
+
+<!-- Additional Info -->
+<div class="mt-6 p-4 bg-info-bg border border-info-border rounded-md">
+    <div class="flex items-start gap-3">
+        <svg class="w-5 h-5 text-info flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+            <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd" />
+        </svg>
+        <div class="text-sm text-info">
+            <p class="font-semibold mb-1">About Theme Preferences</p>
+            <p class="text-info/90">
+                Your theme preference is saved to your account and will be applied across all devices when you're signed in.
+                If you haven't set a preference, the system default theme will be used.
+            </p>
+        </div>
+    </div>
+</div>
+
+@functions {
+    private string GetSourceBadgeClasses(DiscordBot.Core.DTOs.ThemeSource source)
+    {
+        return source switch
+        {
+            DiscordBot.Core.DTOs.ThemeSource.User => "bg-success-bg text-success border border-success-border",
+            DiscordBot.Core.DTOs.ThemeSource.Admin => "bg-info-bg text-info border border-info-border",
+            DiscordBot.Core.DTOs.ThemeSource.System => "bg-bg-tertiary text-text-secondary border border-border-primary",
+            _ => "bg-bg-tertiary text-text-secondary border border-border-primary"
+        };
+    }
+}

--- a/src/DiscordBot.Bot/Pages/Account/Profile.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Account/Profile.cshtml.cs
@@ -1,0 +1,200 @@
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Entities;
+using DiscordBot.Core.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace DiscordBot.Bot.Pages.Account;
+
+/// <summary>
+/// Page model for managing user profile settings including theme preferences.
+/// </summary>
+[Authorize]
+public class ProfileModel : PageModel
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly IThemeService _themeService;
+    private readonly ILogger<ProfileModel> _logger;
+
+    public ProfileModel(
+        UserManager<ApplicationUser> userManager,
+        IThemeService themeService,
+        ILogger<ProfileModel> logger)
+    {
+        _userManager = userManager;
+        _themeService = themeService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// The display name of the current user.
+    /// </summary>
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The email of the current user.
+    /// </summary>
+    public string? Email { get; set; }
+
+    /// <summary>
+    /// Available themes for selection.
+    /// </summary>
+    public SelectList AvailableThemes { get; set; } = null!;
+
+    /// <summary>
+    /// The currently selected theme ID.
+    /// </summary>
+    [BindProperty]
+    public int? SelectedThemeId { get; set; }
+
+    /// <summary>
+    /// The current theme's display name.
+    /// </summary>
+    public string CurrentThemeName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The source of the current theme (User, Admin, System).
+    /// </summary>
+    public ThemeSource CurrentThemeSource { get; set; }
+
+    /// <summary>
+    /// Status message to display to the user (success or error).
+    /// </summary>
+    [TempData]
+    public string? StatusMessage { get; set; }
+
+    /// <summary>
+    /// Indicates whether the status message is a success message.
+    /// </summary>
+    [TempData]
+    public bool IsSuccess { get; set; }
+
+    /// <summary>
+    /// Handles GET requests to display the profile page.
+    /// </summary>
+    public async Task<IActionResult> OnGetAsync()
+    {
+        _logger.LogTrace("Entering {MethodName}", nameof(OnGetAsync));
+
+        var user = await _userManager.GetUserAsync(User);
+        if (user == null)
+        {
+            _logger.LogWarning("User not found during Profile page load");
+            return NotFound("User not found.");
+        }
+
+        _logger.LogDebug("Loading profile for user {UserId}", user.Id);
+
+        DisplayName = user.DisplayName ?? user.Email ?? "User";
+        Email = user.Email;
+
+        await LoadThemeDataAsync(user.Id);
+
+        return Page();
+    }
+
+    /// <summary>
+    /// Handles POST requests to save the user's theme preference.
+    /// </summary>
+    public async Task<IActionResult> OnPostAsync()
+    {
+        _logger.LogTrace("Entering {MethodName} with SelectedThemeId={ThemeId}",
+            nameof(OnPostAsync), SelectedThemeId);
+
+        var user = await _userManager.GetUserAsync(User);
+        if (user == null)
+        {
+            _logger.LogWarning("User not found during profile save");
+            return NotFound("User not found.");
+        }
+
+        // Validate that a theme is selected
+        if (!SelectedThemeId.HasValue)
+        {
+            _logger.LogWarning("User {UserId} attempted to save without selecting a theme", user.Id);
+            StatusMessage = "Please select a theme.";
+            IsSuccess = false;
+            return RedirectToPage();
+        }
+
+        // Validate theme exists and is active
+        var theme = await _themeService.GetThemeByIdAsync(SelectedThemeId.Value);
+        if (theme == null || !theme.IsActive)
+        {
+            _logger.LogWarning("User {UserId} attempted to select invalid theme {ThemeId}",
+                user.Id, SelectedThemeId.Value);
+            StatusMessage = "The selected theme is not available.";
+            IsSuccess = false;
+            return RedirectToPage();
+        }
+
+        _logger.LogInformation("User {UserId} setting theme preference to {ThemeId} ({ThemeName})",
+            user.Id, theme.Id, theme.DisplayName);
+
+        try
+        {
+            var success = await _themeService.SetUserThemeAsync(user.Id, SelectedThemeId.Value);
+
+            if (success)
+            {
+                // Set cookie for SSR on next page load
+                Response.Cookies.Append(IThemeService.ThemePreferenceCookieName, theme.ThemeKey, new CookieOptions
+                {
+                    Path = "/",
+                    MaxAge = TimeSpan.FromDays(365),
+                    SameSite = SameSiteMode.Lax,
+                    IsEssential = true
+                });
+
+                _logger.LogInformation("Successfully updated theme preference for user {UserId} to {ThemeName}",
+                    user.Id, theme.DisplayName);
+
+                StatusMessage = "Theme preference saved successfully.";
+                IsSuccess = true;
+            }
+            else
+            {
+                _logger.LogWarning("Failed to update theme preference for user {UserId}", user.Id);
+                StatusMessage = "Failed to save theme preference. Please try again.";
+                IsSuccess = false;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error saving theme preference for user {UserId}", user.Id);
+            StatusMessage = "An error occurred while saving your preferences.";
+            IsSuccess = false;
+        }
+
+        return RedirectToPage();
+    }
+
+    private async Task LoadThemeDataAsync(string userId)
+    {
+        try
+        {
+            // Load available themes
+            var themes = await _themeService.GetActiveThemesAsync();
+            AvailableThemes = new SelectList(themes, nameof(ThemeDto.Id), nameof(ThemeDto.DisplayName));
+
+            // Load current theme
+            var currentTheme = await _themeService.GetUserThemeAsync(userId);
+            SelectedThemeId = currentTheme.Theme.Id;
+            CurrentThemeName = currentTheme.Theme.DisplayName;
+            CurrentThemeSource = currentTheme.Source;
+
+            _logger.LogDebug("Loaded {ThemeCount} themes. Current theme: {ThemeName} (Source: {Source})",
+                themes.Count, CurrentThemeName, CurrentThemeSource);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error loading theme data for user {UserId}", userId);
+            AvailableThemes = new SelectList(Enumerable.Empty<ThemeDto>(), nameof(ThemeDto.Id), nameof(ThemeDto.DisplayName));
+            StatusMessage = "Failed to load theme preferences.";
+            IsSuccess = false;
+        }
+    }
+}

--- a/src/DiscordBot.Bot/Pages/Shared/_Navbar.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/_Navbar.cshtml
@@ -130,6 +130,12 @@
             <p class="text-xs text-text-secondary">@user?.Email</p>
           </div>
           <div class="pt-1">
+            <a asp-page="/Account/Profile" role="menuitem" class="flex items-center gap-2 px-4 py-2 text-sm text-text-primary hover:bg-bg-hover transition-colors">
+              <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+              </svg>
+              Profile
+            </a>
             <a asp-page="/Account/Privacy" role="menuitem" class="flex items-center gap-2 px-4 py-2 text-sm text-text-primary hover:bg-bg-hover transition-colors">
               <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />


### PR DESCRIPTION
## Summary

- Add Profile page at `/Account/Profile` for authenticated users to manage theme preferences
- Theme dropdown populated from available active themes via `IThemeService`
- Current theme pre-selected with source indicator (User, Admin, System)
- Profile link added to user dropdown menu in navbar (before Privacy & Consent)
- CLAUDE.md updated with new route

Closes #1044

## Test plan

- [ ] Navigate to /Account/Profile when authenticated
- [ ] Verify dropdown shows available themes
- [ ] Select a different theme and click "Save Preferences"
- [ ] Verify theme changes after page reload
- [ ] Verify success message displays
- [ ] Verify Profile link appears in user dropdown menu
- [ ] Test unauthenticated access redirects to login

🤖 Generated with [Claude Code](https://claude.com/claude-code)