### PR TITLE
feat(settings): Add Appearance tab for admin default theme configuration

### DIFF
--- a/src/DiscordBot.Bot/Pages/Admin/Settings.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Settings.cshtml
@@ -119,6 +119,20 @@
             </svg>
             Advanced
         </button>
+        @if (Model.IsSuperAdmin)
+        {
+            <button class="settings-tab @(Model.ViewModel.ActiveCategory == "Appearance" ? "active" : "")"
+                    role="tab"
+                    aria-selected="@(Model.ViewModel.ActiveCategory == "Appearance" ? "true" : "false")"
+                    aria-controls="appearance-settings"
+                    data-tab="Appearance"
+                    onclick="window.settingsManager?.switchTab('Appearance')">
+                <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01" />
+                </svg>
+                Appearance
+            </button>
+        }
     </div>
 </div>
 
@@ -455,6 +469,85 @@
             </div>
         </div>
     </section>
+
+    <!-- Appearance Settings (SuperAdmin only) -->
+    @if (Model.IsSuperAdmin)
+    {
+        <section id="appearance-settings" class="settings-section @(Model.ViewModel.ActiveCategory == "Appearance" ? "active" : "")" role="tabpanel" aria-labelledby="appearance-tab">
+            <div class="bg-bg-secondary border border-border-primary rounded-lg mb-6">
+                <div class="px-6 py-4 border-b border-border-primary">
+                    <h2 class="text-lg font-semibold text-text-primary">Appearance Settings</h2>
+                    <p class="text-sm text-text-secondary mt-1">Configure the default theme for your application</p>
+                </div>
+                <div class="p-6">
+                    <div class="max-w-md">
+                        <label for="SelectedThemeId" class="block text-sm font-semibold text-text-primary mb-2">Default Theme</label>
+                        <select id="SelectedThemeId" name="SelectedThemeId" class="w-full px-3 py-2 bg-bg-primary border border-border-primary rounded-lg text-text-primary focus:ring-2 focus:ring-accent-orange focus:border-accent-orange transition-colors">
+                            @foreach (var theme in Model.AvailableThemes)
+                            {
+                                if (theme.Selected)
+                                {
+                                    <option value="@theme.Value" selected>@theme.Text</option>
+                                }
+                                else
+                                {
+                                    <option value="@theme.Value">@theme.Text</option>
+                                }
+                            }
+                        </select>
+                        <p class="text-xs text-text-secondary mt-2">This will be the default theme for all users who haven't set a personal preference.</p>
+                    </div>
+                </div>
+                <div class="px-6 py-4 border-t border-border-primary">
+                    <div class="flex justify-end gap-3">
+                        <button type="button"
+                                onclick="window.settingsManager?.resetAppearance()"
+                                class="inline-flex items-center gap-2 px-4 py-2 bg-bg-secondary hover:bg-bg-hover border border-border-primary text-text-primary font-medium text-sm rounded-lg transition-colors">
+                            Reset
+                        </button>
+                        <button type="button"
+                                onclick="window.settingsManager?.saveAppearance()"
+                                class="inline-flex items-center gap-2 px-4 py-2 bg-accent-orange hover:bg-orange-600 active:bg-orange-700 text-text-inverse font-medium text-sm rounded-lg transition-colors">
+                            Save Changes
+                        </button>
+                    </div>
+                    <!-- Category Inline Alerts -->
+                    <div id="saveSuccessAlert-Appearance" class="hidden mt-4 bg-success/10 border border-success/30 rounded-lg p-4">
+                        <div class="flex items-start gap-3">
+                            <svg class="w-5 h-5 text-success flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                            </svg>
+                            <div class="flex-1">
+                                <p class="text-sm font-semibold text-success">Changes saved successfully</p>
+                                <p class="inline-alert-message text-sm text-text-secondary mt-1"></p>
+                            </div>
+                            <button type="button" onclick="this.closest('[id^=saveSuccessAlert]').classList.add('hidden')" class="text-text-secondary hover:text-text-primary transition-colors" aria-label="Dismiss">
+                                <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                                </svg>
+                            </button>
+                        </div>
+                    </div>
+                    <div id="saveErrorAlert-Appearance" class="hidden mt-4 bg-error/10 border border-error/30 rounded-lg p-4">
+                        <div class="flex items-start gap-3">
+                            <svg class="w-5 h-5 text-error flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                            </svg>
+                            <div class="flex-1">
+                                <p class="text-sm font-semibold text-error">Failed to save changes</p>
+                                <p class="inline-alert-message text-sm text-text-secondary mt-1"></p>
+                            </div>
+                            <button type="button" onclick="this.closest('[id^=saveErrorAlert]').classList.add('hidden')" class="text-text-secondary hover:text-text-primary transition-colors" aria-label="Dismiss">
+                                <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                                </svg>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+    }
 </form>
 
 <!-- Danger Zone -->

--- a/src/DiscordBot.Bot/wwwroot/js/settings.js
+++ b/src/DiscordBot.Bot/wwwroot/js/settings.js
@@ -613,6 +613,135 @@
     }
 
     /**
+     * Save appearance settings (default theme)
+     */
+    async function saveAppearance() {
+        const formData = new FormData();
+
+        // Add the anti-forgery token
+        const form = document.getElementById('settingsForm');
+        const token = form?.querySelector('input[name="__RequestVerificationToken"]');
+        if (token) {
+            formData.append('__RequestVerificationToken', token.value);
+        }
+
+        // Get the selected theme ID
+        const themeSelect = document.getElementById('SelectedThemeId');
+        if (themeSelect) {
+            formData.append('SelectedThemeId', themeSelect.value);
+        }
+
+        // Get the save button from the event
+        const saveButton = event?.target;
+
+        // Hide any existing inline alerts for Appearance
+        hideInlineAlerts('Appearance');
+
+        // Show loading state
+        setButtonLoading(saveButton);
+
+        try {
+            const response = await fetch('?handler=SaveAppearance', {
+                method: 'POST',
+                headers: {
+                    'RequestVerificationToken': token?.value || ''
+                },
+                body: formData
+            });
+
+            const data = await response.json();
+
+            if (response.ok && data.success) {
+                // Show success button state
+                setButtonSuccess(saveButton);
+
+                // Show inline success alert
+                showInlineSuccess(data.message, 'Appearance');
+
+                // Show toast
+                window.quickActions?.showToast(data.message, 'success');
+                isDirty = false;
+            } else {
+                const errorMsg = data.errors ? data.errors.join(', ') : data.message || 'Failed to save appearance settings.';
+
+                // Show error button state (allows retry)
+                setButtonError(saveButton);
+
+                // Show inline error alert
+                showInlineError(errorMsg, 'Appearance');
+
+                // Show toast with longer duration for errors
+                window.quickActions?.showToast(errorMsg, 'error');
+            }
+        } catch (error) {
+            console.error('Save appearance error:', error);
+            const errorMsg = 'An error occurred while saving appearance settings.';
+
+            // Show error button state
+            setButtonError(saveButton);
+
+            // Show inline error alert
+            showInlineError(errorMsg, 'Appearance');
+
+            // Show toast
+            window.quickActions?.showToast(errorMsg, 'error');
+        }
+    }
+
+    /**
+     * Reset appearance settings to default
+     */
+    async function resetAppearance() {
+        const token = document.querySelector('input[name="__RequestVerificationToken"]').value;
+
+        // Get the reset button from the event
+        const resetButton = event?.target;
+
+        // Hide any existing inline alerts for Appearance
+        hideInlineAlerts('Appearance');
+
+        try {
+            const response = await fetch('?handler=ResetAppearance', {
+                method: 'POST',
+                headers: {
+                    'RequestVerificationToken': token,
+                    'Content-Type': 'application/x-www-form-urlencoded'
+                }
+            });
+
+            const data = await response.json();
+
+            if (response.ok && data.success) {
+                // Show inline success alert
+                showInlineSuccess(data.message, 'Appearance');
+
+                // Show toast
+                window.quickActions?.showToast(data.message, 'success');
+
+                // Reload page to show updated default theme selection
+                setTimeout(() => window.location.reload(), 1000);
+            } else {
+                const errorMsg = data.errors ? data.errors.join(', ') : data.message || 'Failed to reset appearance settings.';
+
+                // Show inline error alert
+                showInlineError(errorMsg, 'Appearance');
+
+                // Show toast
+                window.quickActions?.showToast(errorMsg, 'error');
+            }
+        } catch (error) {
+            console.error('Reset appearance error:', error);
+            const errorMsg = 'An error occurred while resetting appearance settings.';
+
+            // Show inline error alert
+            showInlineError(errorMsg, 'Appearance');
+
+            // Show toast
+            window.quickActions?.showToast(errorMsg, 'error');
+        }
+    }
+
+    /**
      * Track form changes to set dirty flag
      */
     function trackFormChanges() {
@@ -665,6 +794,8 @@
         saveCategory,
         saveAllSettings,
         saveCommandModules,
+        saveAppearance,
+        resetAppearance,
         showResetCategoryModal,
         showResetAllModal
     };


### PR DESCRIPTION
## Summary
- Add new "Appearance" tab to the Admin Settings page (/Admin/Settings)
- Allow SuperAdmin users to configure the default theme for the application
- Default theme applies to users who haven't set a personal preference

## Changes
- **Settings.cshtml**: Added Appearance tab button (with palette icon) and tab content section with theme dropdown, save/reset buttons, and inline alerts
- **Settings.cshtml.cs**: Added IThemeService and IAuthorizationService injection, theme data loading, OnPostSaveAppearanceAsync and OnPostResetAppearanceAsync handlers with proper SuperAdmin authorization checks and audit logging
- **settings.js**: Added saveAppearance() and resetAppearance() functions with AJAX handling and exposed them in the settingsManager public API

## Features
- Tab only visible to SuperAdmin users
- Theme dropdown populated with active themes from database
- Current default theme pre-selected on page load
- Save changes updates system default theme via ThemeService
- Reset restores system default (Discord Dark)
- Audit logging for all theme configuration changes
- Inline success/error alerts consistent with other tabs

## Test plan
- [ ] Access Settings page as SuperAdmin - Appearance tab should be visible
- [ ] Access Settings page as Admin - Appearance tab should NOT be visible
- [ ] Select a different theme and click Save Changes - should succeed
- [ ] Click Reset - should reset to Discord Dark
- [ ] Verify audit logs capture theme changes
- [ ] Verify users without personal preferences see the new default theme

Closes #1045

🤖 Generated with [Claude Code](https://claude.ai/code)