### PR TITLE
feat(assistant): Implement tool providers, repositories, and services (#1061)

### DIFF
--- a/src/DiscordBot.Bot/Services/LLM/Providers/UserGuildInfoToolProvider.cs
+++ b/src/DiscordBot.Bot/Services/LLM/Providers/UserGuildInfoToolProvider.cs
@@ -1,0 +1,331 @@
+using System.Text.Json;
+using Discord;
+using Discord.WebSocket;
+using DiscordBot.Core.DTOs.LLM;
+using DiscordBot.Core.Interfaces;
+using DiscordBot.Core.Interfaces.LLM;
+using DiscordBot.Infrastructure.Services.LLM.Implementations;
+using Microsoft.Extensions.Logging;
+
+namespace DiscordBot.Bot.Services.LLM.Providers;
+
+/// <summary>
+/// Tool provider for user and guild information access.
+/// Provides tools for getting user profiles, guild info, and user roles.
+/// </summary>
+public class UserGuildInfoToolProvider : IToolProvider
+{
+    private readonly ILogger<UserGuildInfoToolProvider> _logger;
+    private readonly DiscordSocketClient _discordClient;
+    private readonly IGuildService _guildService;
+
+    /// <inheritdoc />
+    public string Name => "UserGuildInfo";
+
+    /// <inheritdoc />
+    public string Description => "Get information about Discord users and guilds";
+
+    /// <summary>
+    /// Initializes a new instance of the UserGuildInfoToolProvider.
+    /// </summary>
+    /// <param name="logger">Logger for diagnostic output.</param>
+    /// <param name="discordClient">Discord socket client for real-time data.</param>
+    /// <param name="guildService">Guild service for database data.</param>
+    public UserGuildInfoToolProvider(
+        ILogger<UserGuildInfoToolProvider> logger,
+        DiscordSocketClient discordClient,
+        IGuildService guildService)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
+        _guildService = guildService ?? throw new ArgumentNullException(nameof(guildService));
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<LlmToolDefinition> GetTools()
+    {
+        return UserGuildInfoTools.GetAllTools();
+    }
+
+    /// <inheritdoc />
+    public async Task<ToolExecutionResult> ExecuteToolAsync(
+        string toolName,
+        JsonElement input,
+        ToolContext context,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Executing user/guild info tool {ToolName}", toolName);
+
+        try
+        {
+            return toolName.ToLowerInvariant() switch
+            {
+                "get_user_profile" => await ExecuteGetUserProfileAsync(input, context, cancellationToken),
+                "get_guild_info" => await ExecuteGetGuildInfoAsync(input, context, cancellationToken),
+                "get_user_roles" => ExecuteGetUserRoles(input, context),
+                _ => throw new NotSupportedException($"Tool '{toolName}' is not supported by this provider")
+            };
+        }
+        catch (NotSupportedException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error executing user/guild info tool {ToolName}", toolName);
+            return ToolExecutionResult.CreateError($"Error executing tool: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Executes the get_user_profile tool.
+    /// </summary>
+    private async Task<ToolExecutionResult> ExecuteGetUserProfileAsync(
+        JsonElement input,
+        ToolContext context,
+        CancellationToken cancellationToken)
+    {
+        // Get user ID from input or use requesting user
+        ulong userId = context.UserId;
+        if (input.TryGetProperty("user_id", out var userIdElement))
+        {
+            var userIdString = userIdElement.GetString();
+            if (!string.IsNullOrWhiteSpace(userIdString) && ulong.TryParse(userIdString, out var parsedUserId))
+            {
+                userId = parsedUserId;
+            }
+        }
+
+        var includeRoles = false;
+        if (input.TryGetProperty("include_roles", out var includeRolesElement))
+        {
+            includeRoles = includeRolesElement.GetBoolean();
+        }
+
+        _logger.LogDebug("Getting user profile for user {UserId}, includeRoles: {IncludeRoles}", userId, includeRoles);
+
+        // Get user from Discord client - use IUser interface for compatibility
+        IUser? user = _discordClient.GetUser(userId);
+        if (user == null)
+        {
+            // Try to fetch from REST API
+            try
+            {
+                user = await _discordClient.Rest.GetUserAsync(userId);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to fetch user {UserId}", userId);
+            }
+        }
+
+        if (user == null)
+        {
+            return CreateJsonResult(new
+            {
+                error = true,
+                message = $"User with ID {userId} not found"
+            });
+        }
+
+        // Build base profile
+        var profile = new Dictionary<string, object?>
+        {
+            ["user_id"] = userId.ToString(),
+            ["username"] = user.Username,
+            ["global_name"] = user.GlobalName,
+            ["discriminator"] = user.Discriminator,
+            ["avatar_url"] = user.GetAvatarUrl() ?? user.GetDefaultAvatarUrl(),
+            ["created_at"] = user.CreatedAt.UtcDateTime.ToString("o"),
+            ["is_bot"] = user.IsBot
+        };
+
+        // Include roles if requested and guild context is available
+        if (includeRoles && context.GuildId > 0)
+        {
+            var guild = _discordClient.GetGuild(context.GuildId);
+            if (guild != null)
+            {
+                var guildUser = guild.GetUser(userId);
+                if (guildUser != null)
+                {
+                    profile["roles"] = guildUser.Roles
+                        .Where(r => !r.IsEveryone)
+                        .OrderByDescending(r => r.Position)
+                        .Select(r => new
+                        {
+                            name = r.Name,
+                            id = r.Id.ToString(),
+                            position = r.Position,
+                            color = r.Color.RawValue != 0 ? $"#{r.Color.RawValue:X6}" : null
+                        })
+                        .ToList();
+                }
+            }
+        }
+
+        _logger.LogDebug("Successfully retrieved profile for user {UserId}", userId);
+        return CreateJsonResult(profile);
+    }
+
+    /// <summary>
+    /// Executes the get_guild_info tool.
+    /// </summary>
+    private async Task<ToolExecutionResult> ExecuteGetGuildInfoAsync(
+        JsonElement input,
+        ToolContext context,
+        CancellationToken cancellationToken)
+    {
+        // Get guild ID from input or use context guild
+        ulong guildId = context.GuildId;
+        if (input.TryGetProperty("guild_id", out var guildIdElement))
+        {
+            var guildIdString = guildIdElement.GetString();
+            if (!string.IsNullOrWhiteSpace(guildIdString) && ulong.TryParse(guildIdString, out var parsedGuildId))
+            {
+                guildId = parsedGuildId;
+            }
+        }
+
+        if (guildId == 0)
+        {
+            return ToolExecutionResult.CreateError("No guild context available. This tool requires a guild context.");
+        }
+
+        _logger.LogDebug("Getting guild info for guild {GuildId}", guildId);
+
+        var guild = _discordClient.GetGuild(guildId);
+        if (guild == null)
+        {
+            // Try to get from database
+            var dbGuild = await _guildService.GetGuildByIdAsync(guildId, cancellationToken);
+            if (dbGuild != null)
+            {
+                return CreateJsonResult(new
+                {
+                    guild_id = guildId.ToString(),
+                    name = dbGuild.Name,
+                    icon_url = dbGuild.IconUrl,
+                    member_count = dbGuild.MemberCount,
+                    is_active = dbGuild.IsActive,
+                    bot_connected = false,
+                    note = "Bot is not currently connected to this guild. Data may be stale."
+                });
+            }
+
+            return CreateJsonResult(new
+            {
+                error = true,
+                message = $"Guild with ID {guildId} not found"
+            });
+        }
+
+        _logger.LogDebug("Successfully retrieved guild info for {GuildName}", guild.Name);
+
+        return CreateJsonResult(new
+        {
+            guild_id = guildId.ToString(),
+            name = guild.Name,
+            icon_url = guild.IconUrl,
+            created_at = guild.CreatedAt.UtcDateTime.ToString("o"),
+            member_count = guild.MemberCount,
+            owner = new
+            {
+                id = guild.OwnerId.ToString(),
+                username = guild.Owner?.Username
+            },
+            bot_connected = true,
+            bot_joined_at = guild.CurrentUser?.JoinedAt?.UtcDateTime.ToString("o"),
+            premium_tier = guild.PremiumTier.ToString(),
+            verification_level = guild.VerificationLevel.ToString()
+        });
+    }
+
+    /// <summary>
+    /// Executes the get_user_roles tool.
+    /// </summary>
+    private ToolExecutionResult ExecuteGetUserRoles(JsonElement input, ToolContext context)
+    {
+        // Get user ID from input or use requesting user
+        ulong userId = context.UserId;
+        if (input.TryGetProperty("user_id", out var userIdElement))
+        {
+            var userIdString = userIdElement.GetString();
+            if (!string.IsNullOrWhiteSpace(userIdString) && ulong.TryParse(userIdString, out var parsedUserId))
+            {
+                userId = parsedUserId;
+            }
+        }
+
+        if (context.GuildId == 0)
+        {
+            return ToolExecutionResult.CreateError("No guild context available. This tool requires a guild context.");
+        }
+
+        _logger.LogDebug("Getting roles for user {UserId} in guild {GuildId}", userId, context.GuildId);
+
+        var guild = _discordClient.GetGuild(context.GuildId);
+        if (guild == null)
+        {
+            return CreateJsonResult(new
+            {
+                error = true,
+                message = $"Guild with ID {context.GuildId} not found"
+            });
+        }
+
+        var guildUser = guild.GetUser(userId);
+        if (guildUser == null)
+        {
+            return CreateJsonResult(new
+            {
+                error = true,
+                message = $"User with ID {userId} not found in guild"
+            });
+        }
+
+        var roles = guildUser.Roles
+            .OrderByDescending(r => r.Position)
+            .Select(r => new
+            {
+                name = r.Name,
+                id = r.Id.ToString(),
+                position = r.Position,
+                color = r.Color.RawValue != 0 ? $"#{r.Color.RawValue:X6}" : null,
+                is_managed = r.IsManaged,
+                is_mentionable = r.IsMentionable,
+                is_everyone = r.IsEveryone
+            })
+            .ToList();
+
+        var highestRole = guildUser.Roles
+            .Where(r => !r.IsEveryone)
+            .OrderByDescending(r => r.Position)
+            .FirstOrDefault();
+
+        _logger.LogDebug("Retrieved {RoleCount} roles for user {UserId}", roles.Count, userId);
+
+        return CreateJsonResult(new
+        {
+            user_id = userId.ToString(),
+            guild_id = context.GuildId.ToString(),
+            roles,
+            highest_role_position = highestRole?.Position ?? 0,
+            highest_role_name = highestRole?.Name
+        });
+    }
+
+    /// <summary>
+    /// Creates a JSON result from an object.
+    /// </summary>
+    private static ToolExecutionResult CreateJsonResult(object data)
+    {
+        var jsonString = JsonSerializer.Serialize(data, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+            WriteIndented = false
+        });
+        var jsonElement = JsonDocument.Parse(jsonString).RootElement.Clone();
+        return ToolExecutionResult.CreateSuccess(jsonElement);
+    }
+}

--- a/src/DiscordBot.Infrastructure/Data/Repositories/AssistantGuildSettingsRepository.cs
+++ b/src/DiscordBot.Infrastructure/Data/Repositories/AssistantGuildSettingsRepository.cs
@@ -1,0 +1,122 @@
+using DiscordBot.Core.Entities;
+using DiscordBot.Core.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace DiscordBot.Infrastructure.Data.Repositories;
+
+/// <summary>
+/// Repository implementation for AssistantGuildSettings entities.
+/// Provides data access operations for assistant configuration per guild.
+/// </summary>
+public class AssistantGuildSettingsRepository : Repository<AssistantGuildSettings>, IAssistantGuildSettingsRepository
+{
+    private readonly ILogger<AssistantGuildSettingsRepository> _logger;
+
+    public AssistantGuildSettingsRepository(
+        BotDbContext context,
+        ILogger<AssistantGuildSettingsRepository> logger,
+        ILogger<Repository<AssistantGuildSettings>> baseLogger)
+        : base(context, baseLogger)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<AssistantGuildSettings?> GetByGuildIdAsync(
+        ulong guildId,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Retrieving assistant settings for guild {GuildId}", guildId);
+
+        var settings = await DbSet
+            .AsNoTracking()
+            .Include(s => s.Guild)
+            .FirstOrDefaultAsync(s => s.GuildId == guildId, cancellationToken);
+
+        _logger.LogDebug("Settings found for guild {GuildId}: {Found}", guildId, settings != null);
+        return settings;
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<AssistantGuildSettings>> GetEnabledGuildsAsync(
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Retrieving all guilds with assistant enabled");
+
+        var settings = await DbSet
+            .AsNoTracking()
+            .Include(s => s.Guild)
+            .Where(s => s.IsEnabled)
+            .ToListAsync(cancellationToken);
+
+        _logger.LogDebug("Found {Count} guilds with assistant enabled", settings.Count);
+        return settings;
+    }
+
+    /// <summary>
+    /// Gets or creates settings for a guild.
+    /// If settings don't exist, creates default settings with the assistant disabled.
+    /// </summary>
+    /// <param name="guildId">Discord guild ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The existing or newly created settings.</returns>
+    public async Task<AssistantGuildSettings> GetOrCreateAsync(
+        ulong guildId,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Getting or creating assistant settings for guild {GuildId}", guildId);
+
+        var settings = await DbSet
+            .Include(s => s.Guild)
+            .FirstOrDefaultAsync(s => s.GuildId == guildId, cancellationToken);
+
+        if (settings != null)
+        {
+            _logger.LogDebug("Existing settings found for guild {GuildId}", guildId);
+            return settings;
+        }
+
+        _logger.LogInformation("Creating default assistant settings for guild {GuildId}", guildId);
+
+        var now = DateTime.UtcNow;
+        settings = new AssistantGuildSettings
+        {
+            GuildId = guildId,
+            IsEnabled = false, // Disabled by default
+            AllowedChannelIds = "[]",
+            RateLimitOverride = null,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        await DbSet.AddAsync(settings, cancellationToken);
+        await Context.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Created default assistant settings for guild {GuildId}",
+            guildId);
+
+        return settings;
+    }
+
+    /// <summary>
+    /// Updates settings for a guild.
+    /// </summary>
+    /// <param name="settings">The settings to update.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task UpdateSettingsAsync(
+        AssistantGuildSettings settings,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Updating assistant settings for guild {GuildId}", settings.GuildId);
+
+        settings.UpdatedAt = DateTime.UtcNow;
+        DbSet.Update(settings);
+        await Context.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Updated assistant settings for guild {GuildId}. Enabled: {IsEnabled}",
+            settings.GuildId, settings.IsEnabled);
+    }
+}

--- a/src/DiscordBot.Infrastructure/Data/Repositories/AssistantInteractionLogRepository.cs
+++ b/src/DiscordBot.Infrastructure/Data/Repositories/AssistantInteractionLogRepository.cs
@@ -1,0 +1,217 @@
+using DiscordBot.Core.Entities;
+using DiscordBot.Core.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace DiscordBot.Infrastructure.Data.Repositories;
+
+/// <summary>
+/// Repository implementation for AssistantInteractionLog entities.
+/// Provides data access operations for assistant conversation history and audit trails.
+/// </summary>
+public class AssistantInteractionLogRepository : Repository<AssistantInteractionLog>, IAssistantInteractionLogRepository
+{
+    private readonly ILogger<AssistantInteractionLogRepository> _logger;
+
+    public AssistantInteractionLogRepository(
+        BotDbContext context,
+        ILogger<AssistantInteractionLogRepository> logger,
+        ILogger<Repository<AssistantInteractionLog>> baseLogger)
+        : base(context, baseLogger)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<AssistantInteractionLog>> GetRecentByGuildAsync(
+        ulong guildId,
+        int limit,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug(
+            "Retrieving {Limit} recent interaction logs for guild {GuildId}",
+            limit, guildId);
+
+        var logs = await DbSet
+            .AsNoTracking()
+            .Include(l => l.User)
+            .Where(l => l.GuildId == guildId)
+            .OrderByDescending(l => l.Timestamp)
+            .Take(limit)
+            .ToListAsync(cancellationToken);
+
+        _logger.LogDebug(
+            "Retrieved {Count} interaction logs for guild {GuildId}",
+            logs.Count, guildId);
+
+        return logs;
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<AssistantInteractionLog>> GetRecentByUserAsync(
+        ulong userId,
+        int limit,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug(
+            "Retrieving {Limit} recent interaction logs for user {UserId}",
+            limit, userId);
+
+        var logs = await DbSet
+            .AsNoTracking()
+            .Include(l => l.Guild)
+            .Where(l => l.UserId == userId)
+            .OrderByDescending(l => l.Timestamp)
+            .Take(limit)
+            .ToListAsync(cancellationToken);
+
+        _logger.LogDebug(
+            "Retrieved {Count} interaction logs for user {UserId}",
+            logs.Count, userId);
+
+        return logs;
+    }
+
+    /// <inheritdoc />
+    public async Task<int> DeleteOlderThanAsync(
+        DateTime cutoffDate,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation(
+            "Deleting assistant interaction logs older than {CutoffDate}",
+            cutoffDate);
+
+        var deletedCount = await DbSet
+            .Where(l => l.Timestamp < cutoffDate)
+            .ExecuteDeleteAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Deleted {Count} assistant interaction logs older than {CutoffDate}",
+            deletedCount, cutoffDate);
+
+        return deletedCount;
+    }
+
+    /// <summary>
+    /// Logs a new interaction.
+    /// </summary>
+    /// <param name="log">The interaction log entry.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The created log entry with ID.</returns>
+    public async Task<AssistantInteractionLog> LogInteractionAsync(
+        AssistantInteractionLog log,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug(
+            "Logging assistant interaction for user {UserId} in guild {GuildId}",
+            log.UserId, log.GuildId);
+
+        log.Timestamp = DateTime.UtcNow;
+        await DbSet.AddAsync(log, cancellationToken);
+        await Context.SaveChangesAsync(cancellationToken);
+
+        _logger.LogDebug(
+            "Logged assistant interaction {Id} for user {UserId} in guild {GuildId}. Success: {Success}",
+            log.Id, log.UserId, log.GuildId, log.Success);
+
+        return log;
+    }
+
+    /// <summary>
+    /// Gets interaction statistics for a guild.
+    /// </summary>
+    /// <param name="guildId">Discord guild ID.</param>
+    /// <param name="startDate">Start date for statistics (UTC).</param>
+    /// <param name="endDate">End date for statistics (UTC).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Interaction statistics.</returns>
+    public async Task<InteractionStatistics> GetStatisticsAsync(
+        ulong guildId,
+        DateTime startDate,
+        DateTime endDate,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug(
+            "Getting interaction statistics for guild {GuildId} from {StartDate} to {EndDate}",
+            guildId, startDate, endDate);
+
+        var stats = await DbSet
+            .AsNoTracking()
+            .Where(l => l.GuildId == guildId &&
+                       l.Timestamp >= startDate &&
+                       l.Timestamp <= endDate)
+            .GroupBy(l => 1)
+            .Select(g => new InteractionStatistics
+            {
+                TotalInteractions = g.Count(),
+                SuccessfulInteractions = g.Count(l => l.Success),
+                FailedInteractions = g.Count(l => !l.Success),
+                TotalInputTokens = g.Sum(l => l.InputTokens),
+                TotalOutputTokens = g.Sum(l => l.OutputTokens),
+                TotalCachedTokens = g.Sum(l => l.CachedTokens),
+                TotalToolCalls = g.Sum(l => l.ToolCalls),
+                TotalCost = g.Sum(l => l.EstimatedCostUsd),
+                AverageLatencyMs = (int)g.Average(l => l.LatencyMs),
+                UniqueUsers = g.Select(l => l.UserId).Distinct().Count(),
+                CacheHitCount = g.Count(l => l.CacheHit)
+            })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        return stats ?? new InteractionStatistics();
+    }
+
+    /// <summary>
+    /// Gets the most recent interactions for a user in a guild (for context).
+    /// </summary>
+    /// <param name="userId">Discord user ID.</param>
+    /// <param name="guildId">Discord guild ID.</param>
+    /// <param name="limit">Maximum number of interactions to return.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Recent interactions ordered by timestamp ascending (oldest first).</returns>
+    public async Task<IEnumerable<AssistantInteractionLog>> GetRecentContextAsync(
+        ulong userId,
+        ulong guildId,
+        int limit,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug(
+            "Getting {Limit} recent interactions for context: user {UserId} in guild {GuildId}",
+            limit, userId, guildId);
+
+        var logs = await DbSet
+            .AsNoTracking()
+            .Where(l => l.UserId == userId && l.GuildId == guildId && l.Success)
+            .OrderByDescending(l => l.Timestamp)
+            .Take(limit)
+            .ToListAsync(cancellationToken);
+
+        // Return in chronological order (oldest first) for conversation context
+        return logs.OrderBy(l => l.Timestamp);
+    }
+}
+
+/// <summary>
+/// Statistics for assistant interactions.
+/// </summary>
+public class InteractionStatistics
+{
+    public int TotalInteractions { get; set; }
+    public int SuccessfulInteractions { get; set; }
+    public int FailedInteractions { get; set; }
+    public int TotalInputTokens { get; set; }
+    public int TotalOutputTokens { get; set; }
+    public int TotalCachedTokens { get; set; }
+    public int TotalToolCalls { get; set; }
+    public decimal TotalCost { get; set; }
+    public int AverageLatencyMs { get; set; }
+    public int UniqueUsers { get; set; }
+    public int CacheHitCount { get; set; }
+
+    public double SuccessRate => TotalInteractions > 0
+        ? (double)SuccessfulInteractions / TotalInteractions
+        : 0;
+
+    public double CacheHitRate => TotalInteractions > 0
+        ? (double)CacheHitCount / TotalInteractions
+        : 0;
+}

--- a/src/DiscordBot.Infrastructure/Data/Repositories/AssistantUsageMetricsRepository.cs
+++ b/src/DiscordBot.Infrastructure/Data/Repositories/AssistantUsageMetricsRepository.cs
@@ -1,0 +1,255 @@
+using DiscordBot.Core.Entities;
+using DiscordBot.Core.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace DiscordBot.Infrastructure.Data.Repositories;
+
+/// <summary>
+/// Repository implementation for AssistantUsageMetrics entities.
+/// Provides data access operations for assistant usage tracking, token consumption, and cost analytics.
+/// </summary>
+public class AssistantUsageMetricsRepository : Repository<AssistantUsageMetrics>, IAssistantUsageMetricsRepository
+{
+    private readonly ILogger<AssistantUsageMetricsRepository> _logger;
+
+    public AssistantUsageMetricsRepository(
+        BotDbContext context,
+        ILogger<AssistantUsageMetricsRepository> logger,
+        ILogger<Repository<AssistantUsageMetrics>> baseLogger)
+        : base(context, baseLogger)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<AssistantUsageMetrics> GetOrCreateAsync(
+        ulong guildId,
+        DateTime date,
+        CancellationToken cancellationToken = default)
+    {
+        // Normalize to date-only (remove time component)
+        var dateOnly = date.Date;
+
+        _logger.LogDebug(
+            "Getting or creating assistant usage metrics for guild {GuildId} on {Date}",
+            guildId, dateOnly);
+
+        var metrics = await DbSet
+            .FirstOrDefaultAsync(m => m.GuildId == guildId && m.Date == dateOnly, cancellationToken);
+
+        if (metrics != null)
+        {
+            _logger.LogDebug("Existing metrics found for guild {GuildId} on {Date}", guildId, dateOnly);
+            return metrics;
+        }
+
+        _logger.LogInformation("Creating new metrics record for guild {GuildId} on {Date}", guildId, dateOnly);
+
+        var now = DateTime.UtcNow;
+        metrics = new AssistantUsageMetrics
+        {
+            GuildId = guildId,
+            Date = dateOnly,
+            TotalQuestions = 0,
+            TotalInputTokens = 0,
+            TotalOutputTokens = 0,
+            TotalCachedTokens = 0,
+            TotalCacheWriteTokens = 0,
+            TotalCacheHits = 0,
+            TotalCacheMisses = 0,
+            TotalToolCalls = 0,
+            EstimatedCostUsd = 0m,
+            FailedRequests = 0,
+            AverageLatencyMs = 0,
+            UpdatedAt = now
+        };
+
+        await DbSet.AddAsync(metrics, cancellationToken);
+        await Context.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Created new metrics record for guild {GuildId} on {Date} with ID {Id}",
+            guildId, dateOnly, metrics.Id);
+
+        return metrics;
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<AssistantUsageMetrics>> GetRangeAsync(
+        ulong guildId,
+        DateTime startDate,
+        DateTime endDate,
+        CancellationToken cancellationToken = default)
+    {
+        // Normalize to date-only
+        var startDateOnly = startDate.Date;
+        var endDateOnly = endDate.Date;
+
+        _logger.LogDebug(
+            "Retrieving metrics for guild {GuildId} from {StartDate} to {EndDate}",
+            guildId, startDateOnly, endDateOnly);
+
+        var metrics = await DbSet
+            .AsNoTracking()
+            .Where(m => m.GuildId == guildId &&
+                       m.Date >= startDateOnly &&
+                       m.Date <= endDateOnly)
+            .OrderBy(m => m.Date)
+            .ToListAsync(cancellationToken);
+
+        _logger.LogDebug(
+            "Retrieved {Count} metrics records for guild {GuildId}",
+            metrics.Count, guildId);
+
+        return metrics;
+    }
+
+    /// <inheritdoc />
+    public async Task IncrementMetricsAsync(
+        ulong guildId,
+        DateTime date,
+        int inputTokens,
+        int outputTokens,
+        int cachedTokens,
+        int cacheWriteTokens,
+        bool cacheHit,
+        int toolCalls,
+        int latencyMs,
+        decimal cost,
+        CancellationToken cancellationToken = default)
+    {
+        var metrics = await GetOrCreateAsync(guildId, date, cancellationToken);
+
+        _logger.LogDebug(
+            "Incrementing metrics for guild {GuildId} on {Date}: +{InputTokens} input, +{OutputTokens} output, +{CachedTokens} cached",
+            guildId, date.Date, inputTokens, outputTokens, cachedTokens);
+
+        // Update metrics
+        metrics.TotalQuestions++;
+        metrics.TotalInputTokens += inputTokens;
+        metrics.TotalOutputTokens += outputTokens;
+        metrics.TotalCachedTokens += cachedTokens;
+        metrics.TotalCacheWriteTokens += cacheWriteTokens;
+        metrics.TotalToolCalls += toolCalls;
+        metrics.EstimatedCostUsd += cost;
+
+        if (cacheHit)
+        {
+            metrics.TotalCacheHits++;
+        }
+        else
+        {
+            metrics.TotalCacheMisses++;
+        }
+
+        // Calculate running average for latency
+        var totalRequests = metrics.TotalQuestions;
+        metrics.AverageLatencyMs = ((metrics.AverageLatencyMs * (totalRequests - 1)) + latencyMs) / totalRequests;
+
+        metrics.UpdatedAt = DateTime.UtcNow;
+        await Context.SaveChangesAsync(cancellationToken);
+
+        _logger.LogDebug(
+            "Updated metrics for guild {GuildId}: TotalQuestions={TotalQuestions}, TotalCost={TotalCost:C}",
+            guildId, metrics.TotalQuestions, metrics.EstimatedCostUsd);
+    }
+
+    /// <inheritdoc />
+    public async Task IncrementFailedRequestAsync(
+        ulong guildId,
+        DateTime date,
+        CancellationToken cancellationToken = default)
+    {
+        var metrics = await GetOrCreateAsync(guildId, date, cancellationToken);
+
+        metrics.FailedRequests++;
+        metrics.UpdatedAt = DateTime.UtcNow;
+
+        await Context.SaveChangesAsync(cancellationToken);
+
+        _logger.LogDebug(
+            "Incremented failed request count for guild {GuildId} on {Date}. Total failures: {FailedRequests}",
+            guildId, date.Date, metrics.FailedRequests);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> DeleteOlderThanAsync(
+        DateTime cutoffDate,
+        CancellationToken cancellationToken = default)
+    {
+        var cutoffDateOnly = cutoffDate.Date;
+
+        _logger.LogInformation(
+            "Deleting assistant usage metrics older than {CutoffDate}",
+            cutoffDateOnly);
+
+        var deletedCount = await DbSet
+            .Where(m => m.Date < cutoffDateOnly)
+            .ExecuteDeleteAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Deleted {Count} assistant usage metrics records older than {CutoffDate}",
+            deletedCount, cutoffDateOnly);
+
+        return deletedCount;
+    }
+
+    /// <summary>
+    /// Gets aggregated metrics across all guilds for a date range.
+    /// </summary>
+    /// <param name="startDate">Start date (inclusive, UTC).</param>
+    /// <param name="endDate">End date (inclusive, UTC).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Aggregated metrics.</returns>
+    public async Task<AggregatedUsageMetrics> GetAggregatedMetricsAsync(
+        DateTime startDate,
+        DateTime endDate,
+        CancellationToken cancellationToken = default)
+    {
+        var startDateOnly = startDate.Date;
+        var endDateOnly = endDate.Date;
+
+        _logger.LogDebug(
+            "Aggregating metrics from {StartDate} to {EndDate}",
+            startDateOnly, endDateOnly);
+
+        var result = await DbSet
+            .AsNoTracking()
+            .Where(m => m.Date >= startDateOnly && m.Date <= endDateOnly)
+            .GroupBy(m => 1) // Group all into single result
+            .Select(g => new AggregatedUsageMetrics
+            {
+                TotalGuilds = g.Select(m => m.GuildId).Distinct().Count(),
+                TotalQuestions = g.Sum(m => m.TotalQuestions),
+                TotalInputTokens = g.Sum(m => m.TotalInputTokens),
+                TotalOutputTokens = g.Sum(m => m.TotalOutputTokens),
+                TotalCachedTokens = g.Sum(m => m.TotalCachedTokens),
+                TotalToolCalls = g.Sum(m => m.TotalToolCalls),
+                TotalCost = g.Sum(m => m.EstimatedCostUsd),
+                TotalFailedRequests = g.Sum(m => m.FailedRequests),
+                CacheHitRate = g.Sum(m => m.TotalCacheHits + m.TotalCacheMisses) > 0
+                    ? (double)g.Sum(m => m.TotalCacheHits) / g.Sum(m => m.TotalCacheHits + m.TotalCacheMisses)
+                    : 0
+            })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        return result ?? new AggregatedUsageMetrics();
+    }
+}
+
+/// <summary>
+/// Aggregated usage metrics for reporting.
+/// </summary>
+public class AggregatedUsageMetrics
+{
+    public int TotalGuilds { get; set; }
+    public int TotalQuestions { get; set; }
+    public int TotalInputTokens { get; set; }
+    public int TotalOutputTokens { get; set; }
+    public int TotalCachedTokens { get; set; }
+    public int TotalToolCalls { get; set; }
+    public decimal TotalCost { get; set; }
+    public int TotalFailedRequests { get; set; }
+    public double CacheHitRate { get; set; }
+}

--- a/src/DiscordBot.Infrastructure/Services/AssistantGuildSettingsService.cs
+++ b/src/DiscordBot.Infrastructure/Services/AssistantGuildSettingsService.cs
@@ -1,0 +1,202 @@
+using DiscordBot.Core.Configuration;
+using DiscordBot.Core.Entities;
+using DiscordBot.Core.Interfaces;
+using DiscordBot.Infrastructure.Data.Repositories;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace DiscordBot.Infrastructure.Services;
+
+/// <summary>
+/// Service implementation for managing assistant guild settings.
+/// Handles configuration, enable/disable operations, and default settings creation.
+/// </summary>
+public class AssistantGuildSettingsService : IAssistantGuildSettingsService
+{
+    private readonly ILogger<AssistantGuildSettingsService> _logger;
+    private readonly AssistantGuildSettingsRepository _repository;
+    private readonly IOptions<AssistantOptions> _assistantOptions;
+
+    /// <summary>
+    /// Initializes a new instance of the AssistantGuildSettingsService.
+    /// </summary>
+    /// <param name="logger">Logger for diagnostic output.</param>
+    /// <param name="repository">Repository for guild settings data access.</param>
+    /// <param name="assistantOptions">Assistant configuration options.</param>
+    public AssistantGuildSettingsService(
+        ILogger<AssistantGuildSettingsService> logger,
+        AssistantGuildSettingsRepository repository,
+        IOptions<AssistantOptions> assistantOptions)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _assistantOptions = assistantOptions ?? throw new ArgumentNullException(nameof(assistantOptions));
+    }
+
+    /// <inheritdoc />
+    public async Task<AssistantGuildSettings> GetOrCreateSettingsAsync(
+        ulong guildId,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Getting or creating assistant settings for guild {GuildId}", guildId);
+
+        var settings = await _repository.GetByGuildIdAsync(guildId, cancellationToken);
+
+        if (settings != null)
+        {
+            return settings;
+        }
+
+        // Create new settings with defaults from options
+        _logger.LogInformation("Creating default assistant settings for guild {GuildId}", guildId);
+
+        var now = DateTime.UtcNow;
+        var newSettings = new AssistantGuildSettings
+        {
+            GuildId = guildId,
+            IsEnabled = _assistantOptions.Value.EnabledByDefaultForNewGuilds,
+            AllowedChannelIds = "[]",
+            RateLimitOverride = null,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        await _repository.AddAsync(newSettings, cancellationToken);
+
+        _logger.LogInformation(
+            "Created default assistant settings for guild {GuildId}. Enabled: {IsEnabled}",
+            guildId, newSettings.IsEnabled);
+
+        return newSettings;
+    }
+
+    /// <inheritdoc />
+    public async Task UpdateSettingsAsync(
+        AssistantGuildSettings settings,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Updating assistant settings for guild {GuildId}", settings.GuildId);
+
+        settings.UpdatedAt = DateTime.UtcNow;
+        await _repository.UpdateAsync(settings, cancellationToken);
+
+        _logger.LogInformation(
+            "Updated assistant settings for guild {GuildId}. Enabled: {IsEnabled}, RateLimit: {RateLimit}",
+            settings.GuildId, settings.IsEnabled, settings.RateLimitOverride);
+    }
+
+    /// <inheritdoc />
+    public async Task EnableAsync(
+        ulong guildId,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Enabling assistant for guild {GuildId}", guildId);
+
+        var settings = await GetOrCreateSettingsAsync(guildId, cancellationToken);
+
+        if (settings.IsEnabled)
+        {
+            _logger.LogDebug("Assistant already enabled for guild {GuildId}", guildId);
+            return;
+        }
+
+        settings.IsEnabled = true;
+        settings.UpdatedAt = DateTime.UtcNow;
+        await _repository.UpdateAsync(settings, cancellationToken);
+
+        _logger.LogInformation("Enabled assistant for guild {GuildId}", guildId);
+    }
+
+    /// <inheritdoc />
+    public async Task DisableAsync(
+        ulong guildId,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Disabling assistant for guild {GuildId}", guildId);
+
+        var settings = await _repository.GetByGuildIdAsync(guildId, cancellationToken);
+
+        if (settings == null)
+        {
+            _logger.LogDebug("No settings found for guild {GuildId}, nothing to disable", guildId);
+            return;
+        }
+
+        if (!settings.IsEnabled)
+        {
+            _logger.LogDebug("Assistant already disabled for guild {GuildId}", guildId);
+            return;
+        }
+
+        settings.IsEnabled = false;
+        settings.UpdatedAt = DateTime.UtcNow;
+        await _repository.UpdateAsync(settings, cancellationToken);
+
+        _logger.LogInformation("Disabled assistant for guild {GuildId}", guildId);
+    }
+
+    /// <summary>
+    /// Checks if the assistant is enabled for a guild.
+    /// </summary>
+    /// <param name="guildId">Discord guild ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if enabled globally and for the guild.</returns>
+    public async Task<bool> IsEnabledAsync(
+        ulong guildId,
+        CancellationToken cancellationToken = default)
+    {
+        // Check global setting first
+        if (!_assistantOptions.Value.GloballyEnabled)
+        {
+            return false;
+        }
+
+        var settings = await _repository.GetByGuildIdAsync(guildId, cancellationToken);
+        return settings?.IsEnabled ?? false;
+    }
+
+    /// <summary>
+    /// Checks if a channel is allowed for the assistant in a guild.
+    /// </summary>
+    /// <param name="guildId">Discord guild ID.</param>
+    /// <param name="channelId">Discord channel ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the channel is allowed (or no restrictions are set).</returns>
+    public async Task<bool> IsChannelAllowedAsync(
+        ulong guildId,
+        ulong channelId,
+        CancellationToken cancellationToken = default)
+    {
+        var settings = await _repository.GetByGuildIdAsync(guildId, cancellationToken);
+
+        if (settings == null)
+        {
+            return false; // No settings means not enabled
+        }
+
+        var allowedChannels = settings.GetAllowedChannelIdsList();
+
+        // Empty list means all channels are allowed
+        if (allowedChannels.Count == 0)
+        {
+            return true;
+        }
+
+        return allowedChannels.Contains(channelId);
+    }
+
+    /// <summary>
+    /// Gets the rate limit for a guild (guild override or global default).
+    /// </summary>
+    /// <param name="guildId">Discord guild ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The rate limit value.</returns>
+    public async Task<int> GetRateLimitAsync(
+        ulong guildId,
+        CancellationToken cancellationToken = default)
+    {
+        var settings = await _repository.GetByGuildIdAsync(guildId, cancellationToken);
+
+        return settings?.RateLimitOverride ?? _assistantOptions.Value.DefaultRateLimit;
+    }
+}

--- a/src/DiscordBot.Infrastructure/Services/LLM/Implementations/DocumentationTools.cs
+++ b/src/DiscordBot.Infrastructure/Services/LLM/Implementations/DocumentationTools.cs
@@ -1,0 +1,149 @@
+using System.Text.Json;
+using DiscordBot.Core.DTOs.LLM;
+
+namespace DiscordBot.Infrastructure.Services.LLM.Implementations;
+
+/// <summary>
+/// Static tool definitions for documentation access.
+/// Defines the schema and metadata for documentation-related tools.
+/// </summary>
+public static class DocumentationTools
+{
+    /// <summary>
+    /// Tool name for getting feature documentation.
+    /// </summary>
+    public const string GetFeatureDocumentation = "get_feature_documentation";
+
+    /// <summary>
+    /// Tool name for searching commands.
+    /// </summary>
+    public const string SearchCommands = "search_commands";
+
+    /// <summary>
+    /// Tool name for getting command details.
+    /// </summary>
+    public const string GetCommandDetails = "get_command_details";
+
+    /// <summary>
+    /// Tool name for listing all features.
+    /// </summary>
+    public const string ListFeatures = "list_features";
+
+    /// <summary>
+    /// Gets all documentation tool definitions.
+    /// </summary>
+    /// <returns>Collection of tool definitions.</returns>
+    public static IEnumerable<LlmToolDefinition> GetAllTools()
+    {
+        yield return CreateGetFeatureDocumentationTool();
+        yield return CreateSearchCommandsTool();
+        yield return CreateGetCommandDetailsTool();
+        yield return CreateListFeaturesTool();
+    }
+
+    /// <summary>
+    /// Creates the get_feature_documentation tool definition.
+    /// </summary>
+    private static LlmToolDefinition CreateGetFeatureDocumentationTool()
+    {
+        var schema = JsonDocument.Parse("""
+            {
+                "type": "object",
+                "properties": {
+                    "feature_name": {
+                        "type": "string",
+                        "description": "The name of the feature to get documentation for. Use lowercase with hyphens (e.g., 'soundboard', 'rat-watch', 'tts-support', 'reminder-system', 'member-directory')."
+                    }
+                },
+                "required": ["feature_name"]
+            }
+            """);
+
+        return new LlmToolDefinition
+        {
+            Name = GetFeatureDocumentation,
+            Description = "Retrieves comprehensive documentation for a specific bot feature. Returns markdown content including overview, configuration, usage instructions, and examples. Use this when users ask about how to use specific features.",
+            InputSchema = schema.RootElement.Clone()
+        };
+    }
+
+    /// <summary>
+    /// Creates the search_commands tool definition.
+    /// </summary>
+    private static LlmToolDefinition CreateSearchCommandsTool()
+    {
+        var schema = JsonDocument.Parse("""
+            {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Search keyword to find commands (e.g., 'moderation', 'sound', 'remind', 'ban')."
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Maximum number of results to return. Default is 10, maximum is 50.",
+                        "default": 10,
+                        "minimum": 1,
+                        "maximum": 50
+                    }
+                },
+                "required": ["query"]
+            }
+            """);
+
+        return new LlmToolDefinition
+        {
+            Name = SearchCommands,
+            Description = "Searches available slash commands by keyword. Returns matching commands with their descriptions, parameters, and permission requirements. Use this when users ask what commands are available or search for specific functionality.",
+            InputSchema = schema.RootElement.Clone()
+        };
+    }
+
+    /// <summary>
+    /// Creates the get_command_details tool definition.
+    /// </summary>
+    private static LlmToolDefinition CreateGetCommandDetailsTool()
+    {
+        var schema = JsonDocument.Parse("""
+            {
+                "type": "object",
+                "properties": {
+                    "command_name": {
+                        "type": "string",
+                        "description": "The command name without the leading slash (e.g., 'remind', 'play', 'ban', 'warn')."
+                    }
+                },
+                "required": ["command_name"]
+            }
+            """);
+
+        return new LlmToolDefinition
+        {
+            Name = GetCommandDetails,
+            Description = "Gets detailed information about a specific slash command including all parameters, their types, descriptions, default values, permission requirements, and usage examples. Use this when users ask how to use a specific command.",
+            InputSchema = schema.RootElement.Clone()
+        };
+    }
+
+    /// <summary>
+    /// Creates the list_features tool definition.
+    /// </summary>
+    private static LlmToolDefinition CreateListFeaturesTool()
+    {
+        var schema = JsonDocument.Parse("""
+            {
+                "type": "object",
+                "properties": {},
+                "required": []
+            }
+            """);
+
+        return new LlmToolDefinition
+        {
+            Name = ListFeatures,
+            Description = "Lists all available bot features with brief descriptions and availability status. Use this when users ask what the bot can do or want an overview of capabilities.",
+            InputSchema = schema.RootElement.Clone()
+        };
+    }
+}

--- a/src/DiscordBot.Infrastructure/Services/LLM/Implementations/UserGuildInfoTools.cs
+++ b/src/DiscordBot.Infrastructure/Services/LLM/Implementations/UserGuildInfoTools.cs
@@ -1,0 +1,120 @@
+using System.Text.Json;
+using DiscordBot.Core.DTOs.LLM;
+
+namespace DiscordBot.Infrastructure.Services.LLM.Implementations;
+
+/// <summary>
+/// Static tool definitions for user and guild information access.
+/// Defines the schema and metadata for user/guild info tools.
+/// </summary>
+public static class UserGuildInfoTools
+{
+    /// <summary>
+    /// Tool name for getting user profile information.
+    /// </summary>
+    public const string GetUserProfile = "get_user_profile";
+
+    /// <summary>
+    /// Tool name for getting guild information.
+    /// </summary>
+    public const string GetGuildInfo = "get_guild_info";
+
+    /// <summary>
+    /// Tool name for getting user roles in a guild.
+    /// </summary>
+    public const string GetUserRoles = "get_user_roles";
+
+    /// <summary>
+    /// Gets all user/guild info tool definitions.
+    /// </summary>
+    /// <returns>Collection of tool definitions.</returns>
+    public static IEnumerable<LlmToolDefinition> GetAllTools()
+    {
+        yield return CreateGetUserProfileTool();
+        yield return CreateGetGuildInfoTool();
+        yield return CreateGetUserRolesTool();
+    }
+
+    /// <summary>
+    /// Creates the get_user_profile tool definition.
+    /// </summary>
+    private static LlmToolDefinition CreateGetUserProfileTool()
+    {
+        var schema = JsonDocument.Parse("""
+            {
+                "type": "object",
+                "properties": {
+                    "user_id": {
+                        "type": "string",
+                        "description": "The Discord user ID (snowflake) to get profile information for. If not provided, returns info for the requesting user."
+                    },
+                    "include_roles": {
+                        "type": "boolean",
+                        "description": "Whether to include the user's roles in the current guild. Default is false.",
+                        "default": false
+                    }
+                },
+                "required": []
+            }
+            """);
+
+        return new LlmToolDefinition
+        {
+            Name = GetUserProfile,
+            Description = "Gets basic profile information for a Discord user including username, avatar URL, account creation date, and optionally their roles in the current guild. Use this when users ask about themselves or other users.",
+            InputSchema = schema.RootElement.Clone()
+        };
+    }
+
+    /// <summary>
+    /// Creates the get_guild_info tool definition.
+    /// </summary>
+    private static LlmToolDefinition CreateGetGuildInfoTool()
+    {
+        var schema = JsonDocument.Parse("""
+            {
+                "type": "object",
+                "properties": {
+                    "guild_id": {
+                        "type": "string",
+                        "description": "The Discord guild ID (snowflake) to get information for. If not provided, returns info for the current guild."
+                    }
+                },
+                "required": []
+            }
+            """);
+
+        return new LlmToolDefinition
+        {
+            Name = GetGuildInfo,
+            Description = "Gets information about a Discord guild (server) including name, icon, creation date, member count, and owner. Use this when users ask about the server or its configuration.",
+            InputSchema = schema.RootElement.Clone()
+        };
+    }
+
+    /// <summary>
+    /// Creates the get_user_roles tool definition.
+    /// </summary>
+    private static LlmToolDefinition CreateGetUserRolesTool()
+    {
+        var schema = JsonDocument.Parse("""
+            {
+                "type": "object",
+                "properties": {
+                    "user_id": {
+                        "type": "string",
+                        "description": "The Discord user ID (snowflake) to get roles for. If not provided, returns roles for the requesting user."
+                    }
+                },
+                "required": []
+            }
+            """);
+
+        return new LlmToolDefinition
+        {
+            Name = GetUserRoles,
+            Description = "Gets all roles for a user in the current guild, including role names, colors, and hierarchy positions. Use this when users ask about their permissions, roles, or what they can access.",
+            InputSchema = schema.RootElement.Clone()
+        };
+    }
+}

--- a/src/DiscordBot.Infrastructure/Services/LLM/PromptTemplate.cs
+++ b/src/DiscordBot.Infrastructure/Services/LLM/PromptTemplate.cs
@@ -1,0 +1,143 @@
+using System.Text.RegularExpressions;
+using DiscordBot.Core.Interfaces.LLM;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+
+namespace DiscordBot.Infrastructure.Services.LLM;
+
+/// <summary>
+/// Loads and renders prompt templates with variable substitution.
+/// Supports file caching for improved performance.
+/// </summary>
+public partial class PromptTemplate : IPromptTemplate
+{
+    private readonly ILogger<PromptTemplate> _logger;
+    private readonly IMemoryCache _cache;
+    private readonly TimeSpan _cacheDuration = TimeSpan.FromMinutes(5);
+
+    // Regex to match {{variable}} placeholders
+    [GeneratedRegex(@"\{\{(\w+)\}\}", RegexOptions.Compiled)]
+    private static partial Regex PlaceholderRegex();
+
+    /// <summary>
+    /// Initializes a new instance of the PromptTemplate class.
+    /// </summary>
+    /// <param name="logger">Logger for diagnostic output.</param>
+    /// <param name="cache">Memory cache for template caching.</param>
+    public PromptTemplate(ILogger<PromptTemplate> logger, IMemoryCache cache)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+    }
+
+    /// <inheritdoc />
+    public async Task<string> LoadAsync(string filePath, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        var cacheKey = $"prompt_template:{filePath}";
+
+        if (_cache.TryGetValue(cacheKey, out string? cachedContent) && cachedContent != null)
+        {
+            _logger.LogDebug("Loaded template from cache: {FilePath}", filePath);
+            return cachedContent;
+        }
+
+        _logger.LogDebug("Loading template from disk: {FilePath}", filePath);
+
+        // Resolve relative paths from application root
+        var fullPath = Path.IsPathRooted(filePath)
+            ? filePath
+            : Path.Combine(AppContext.BaseDirectory, filePath);
+
+        // Also check relative to working directory if not found
+        if (!File.Exists(fullPath))
+        {
+            var workingDirPath = Path.Combine(Directory.GetCurrentDirectory(), filePath);
+            if (File.Exists(workingDirPath))
+            {
+                fullPath = workingDirPath;
+            }
+        }
+
+        if (!File.Exists(fullPath))
+        {
+            _logger.LogError("Template file not found: {FilePath} (resolved to {FullPath})", filePath, fullPath);
+            throw new FileNotFoundException($"Template file not found: {filePath}", filePath);
+        }
+
+        try
+        {
+            var content = await File.ReadAllTextAsync(fullPath, cancellationToken);
+
+            // Cache the content
+            var cacheOptions = new MemoryCacheEntryOptions()
+                .SetAbsoluteExpiration(_cacheDuration)
+                .SetSize(content.Length); // Track memory size
+
+            _cache.Set(cacheKey, content, cacheOptions);
+
+            _logger.LogDebug(
+                "Loaded and cached template: {FilePath} ({Length} chars, cached for {Duration})",
+                filePath,
+                content.Length,
+                _cacheDuration);
+
+            return content;
+        }
+        catch (Exception ex) when (ex is not FileNotFoundException)
+        {
+            _logger.LogError(ex, "Failed to read template file: {FilePath}", filePath);
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    public string Render(string template, Dictionary<string, string> variables)
+    {
+        ArgumentNullException.ThrowIfNull(template);
+        variables ??= new Dictionary<string, string>();
+
+        if (variables.Count == 0)
+        {
+            _logger.LogDebug("No variables provided for template substitution");
+            return template;
+        }
+
+        var result = PlaceholderRegex().Replace(template, match =>
+        {
+            var variableName = match.Groups[1].Value;
+
+            if (variables.TryGetValue(variableName, out var value))
+            {
+                _logger.LogDebug("Substituting variable {{{VariableName}}}", variableName);
+                return value ?? string.Empty;
+            }
+
+            // Leave unmatched placeholders as-is (don't fail silently)
+            _logger.LogDebug("Variable not found, leaving placeholder: {{{VariableName}}}", variableName);
+            return match.Value;
+        });
+
+        var substitutionCount = variables.Keys.Count(v =>
+            template.Contains($"{{{{{v}}}}}", StringComparison.OrdinalIgnoreCase));
+
+        _logger.LogDebug(
+            "Rendered template with {SubstitutionCount}/{TotalVariables} variable substitutions",
+            substitutionCount,
+            variables.Count);
+
+        return result;
+    }
+
+    /// <summary>
+    /// Invalidates the cached template for a specific file path.
+    /// </summary>
+    /// <param name="filePath">The file path to invalidate.</param>
+    public void InvalidateCache(string filePath)
+    {
+        var cacheKey = $"prompt_template:{filePath}";
+        _cache.Remove(cacheKey);
+        _logger.LogDebug("Invalidated template cache: {FilePath}", filePath);
+    }
+}

--- a/src/DiscordBot.Infrastructure/Services/LLM/Providers/DocumentationToolProvider.cs
+++ b/src/DiscordBot.Infrastructure/Services/LLM/Providers/DocumentationToolProvider.cs
@@ -1,0 +1,417 @@
+using System.Text.Json;
+using DiscordBot.Core.Configuration;
+using DiscordBot.Core.DTOs.LLM;
+using DiscordBot.Core.Interfaces;
+using DiscordBot.Core.Interfaces.LLM;
+using DiscordBot.Infrastructure.Services.LLM.Implementations;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace DiscordBot.Infrastructure.Services.LLM.Providers;
+
+/// <summary>
+/// Tool provider for documentation access.
+/// Provides tools for reading feature documentation, searching commands, and listing features.
+/// </summary>
+public class DocumentationToolProvider : IToolProvider
+{
+    private readonly ILogger<DocumentationToolProvider> _logger;
+    private readonly ICommandMetadataService _commandMetadataService;
+    private readonly IOptions<AssistantOptions> _assistantOptions;
+    private readonly IOptions<ApplicationOptions> _applicationOptions;
+
+    /// <inheritdoc />
+    public string Name => "Documentation";
+
+    /// <inheritdoc />
+    public string Description => "Access bot documentation, command information, and feature guides";
+
+    // Feature name to documentation file mappings
+    private static readonly Dictionary<string, string> FeatureDocumentationMap = new(StringComparer.OrdinalIgnoreCase)
+    {
+        { "soundboard", "soundboard.md" },
+        { "rat-watch", "rat-watch.md" },
+        { "ratwatch", "rat-watch.md" },
+        { "tts", "tts-support.md" },
+        { "tts-support", "tts-support.md" },
+        { "text-to-speech", "tts-support.md" },
+        { "reminder", "reminder-system.md" },
+        { "reminder-system", "reminder-system.md" },
+        { "reminders", "reminder-system.md" },
+        { "member-directory", "member-directory.md" },
+        { "members", "member-directory.md" },
+        { "moderation", "authorization-policies.md" },
+        { "welcome", "welcome-system.md" },
+        { "welcome-system", "welcome-system.md" },
+        { "scheduled-messages", "scheduled-messages.md" },
+        { "schedule", "scheduled-messages.md" },
+        { "consent", "consent-privacy.md" },
+        { "privacy", "consent-privacy.md" },
+        { "commands", "commands-page.md" },
+        { "settings", "settings-page.md" },
+        { "audio", "audio-dependencies.md" },
+        { "performance", "bot-performance-dashboard.md" },
+        { "audit", "audit-log-system.md" },
+        { "audit-log", "audit-log-system.md" }
+    };
+
+    // Feature metadata for listing
+    private static readonly List<FeatureInfo> AllFeatures = new()
+    {
+        new("Soundboard", "Audio", "Upload and play audio clips in voice channels.", "soundboard"),
+        new("Text-to-Speech", "Audio", "Send text-to-speech messages to voice channels using Azure Cognitive Services.", "tts-support"),
+        new("Rat Watch", "Accountability", "Community accountability system with voting, tracking, and leaderboards.", "rat-watch"),
+        new("Reminders", "Productivity", "Personal reminders with natural language time parsing.", "reminder-system"),
+        new("Scheduled Messages", "Automation", "Schedule one-time or recurring messages to channels.", "scheduled-messages"),
+        new("Member Directory", "Management", "Browse and search guild members with filtering.", "member-directory"),
+        new("Moderation", "Administration", "User moderation tools including warn, mute, kick, and ban.", "authorization-policies"),
+        new("Welcome System", "Engagement", "Automated welcome messages for new members.", "welcome-system"),
+        new("Commands", "Core", "Slash command system with module organization.", "commands-page"),
+        new("Performance Dashboard", "Monitoring", "Real-time bot performance and health metrics.", "bot-performance-dashboard"),
+        new("Audit Logs", "Security", "Track administrative actions and changes.", "audit-log-system"),
+        new("Consent & Privacy", "Privacy", "User consent management for data collection features.", "consent-privacy")
+    };
+
+    /// <summary>
+    /// Initializes a new instance of the DocumentationToolProvider.
+    /// </summary>
+    /// <param name="logger">Logger for diagnostic output.</param>
+    /// <param name="commandMetadataService">Service for command metadata.</param>
+    /// <param name="assistantOptions">Assistant configuration options.</param>
+    /// <param name="applicationOptions">Application configuration options.</param>
+    public DocumentationToolProvider(
+        ILogger<DocumentationToolProvider> logger,
+        ICommandMetadataService commandMetadataService,
+        IOptions<AssistantOptions> assistantOptions,
+        IOptions<ApplicationOptions> applicationOptions)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _commandMetadataService = commandMetadataService ?? throw new ArgumentNullException(nameof(commandMetadataService));
+        _assistantOptions = assistantOptions ?? throw new ArgumentNullException(nameof(assistantOptions));
+        _applicationOptions = applicationOptions ?? throw new ArgumentNullException(nameof(applicationOptions));
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<LlmToolDefinition> GetTools()
+    {
+        return DocumentationTools.GetAllTools();
+    }
+
+    /// <inheritdoc />
+    public async Task<ToolExecutionResult> ExecuteToolAsync(
+        string toolName,
+        JsonElement input,
+        ToolContext context,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Executing documentation tool {ToolName}", toolName);
+
+        try
+        {
+            return toolName.ToLowerInvariant() switch
+            {
+                "get_feature_documentation" => await ExecuteGetFeatureDocumentationAsync(input, context, cancellationToken),
+                "search_commands" => await ExecuteSearchCommandsAsync(input, cancellationToken),
+                "get_command_details" => await ExecuteGetCommandDetailsAsync(input, cancellationToken),
+                "list_features" => ExecuteListFeatures(context),
+                _ => throw new NotSupportedException($"Tool '{toolName}' is not supported by this provider")
+            };
+        }
+        catch (NotSupportedException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error executing documentation tool {ToolName}", toolName);
+            return ToolExecutionResult.CreateError($"Error executing tool: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Executes the get_feature_documentation tool.
+    /// </summary>
+    private async Task<ToolExecutionResult> ExecuteGetFeatureDocumentationAsync(
+        JsonElement input,
+        ToolContext context,
+        CancellationToken cancellationToken)
+    {
+        if (!input.TryGetProperty("feature_name", out var featureNameElement))
+        {
+            return ToolExecutionResult.CreateError("Missing required parameter: feature_name");
+        }
+
+        var featureName = featureNameElement.GetString();
+        if (string.IsNullOrWhiteSpace(featureName))
+        {
+            return ToolExecutionResult.CreateError("Parameter feature_name cannot be empty");
+        }
+
+        _logger.LogDebug("Getting documentation for feature: {FeatureName}", featureName);
+
+        // Map feature name to documentation file
+        if (!FeatureDocumentationMap.TryGetValue(featureName, out var fileName))
+        {
+            // Try with .md extension
+            fileName = $"{featureName}.md";
+        }
+
+        var docPath = Path.Combine(_assistantOptions.Value.DocumentationBasePath, fileName);
+
+        // Resolve path
+        var fullPath = Path.IsPathRooted(docPath)
+            ? docPath
+            : Path.Combine(Directory.GetCurrentDirectory(), docPath);
+
+        if (!File.Exists(fullPath))
+        {
+            _logger.LogWarning("Documentation file not found: {Path}", fullPath);
+            return CreateJsonResult(new
+            {
+                error = true,
+                message = $"Documentation for feature '{featureName}' not found. Available features can be listed using list_features tool."
+            });
+        }
+
+        try
+        {
+            var content = await File.ReadAllTextAsync(fullPath, cancellationToken);
+
+            // Generate guild-specific URLs in the content
+            var baseUrl = GetBaseUrl();
+            if (!string.IsNullOrEmpty(baseUrl) && context.GuildId > 0)
+            {
+                content = content
+                    .Replace("{BASE_URL}", baseUrl)
+                    .Replace("{GUILD_ID}", context.GuildId.ToString());
+            }
+
+            _logger.LogDebug("Successfully loaded documentation for {FeatureName} ({Length} chars)", featureName, content.Length);
+
+            return CreateJsonResult(new
+            {
+                feature = featureName,
+                content,
+                available = true,
+                last_updated = File.GetLastWriteTimeUtc(fullPath).ToString("o")
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error reading documentation file: {Path}", fullPath);
+            return ToolExecutionResult.CreateError($"Error reading documentation: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Executes the search_commands tool.
+    /// </summary>
+    private async Task<ToolExecutionResult> ExecuteSearchCommandsAsync(
+        JsonElement input,
+        CancellationToken cancellationToken)
+    {
+        if (!input.TryGetProperty("query", out var queryElement))
+        {
+            return ToolExecutionResult.CreateError("Missing required parameter: query");
+        }
+
+        var query = queryElement.GetString();
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return ToolExecutionResult.CreateError("Parameter query cannot be empty");
+        }
+
+        var limit = 10;
+        if (input.TryGetProperty("limit", out var limitElement))
+        {
+            limit = Math.Clamp(limitElement.GetInt32(), 1, 50);
+        }
+
+        _logger.LogDebug("Searching commands with query: {Query}, limit: {Limit}", query, limit);
+
+        var modules = await _commandMetadataService.GetAllModulesAsync(cancellationToken);
+
+        var matchingCommands = modules
+            .SelectMany(m => m.Commands)
+            .Where(c =>
+                c.Name.Contains(query, StringComparison.OrdinalIgnoreCase) ||
+                c.FullName.Contains(query, StringComparison.OrdinalIgnoreCase) ||
+                c.Description.Contains(query, StringComparison.OrdinalIgnoreCase) ||
+                c.ModuleName.Contains(query, StringComparison.OrdinalIgnoreCase))
+            .Take(limit)
+            .Select(c => new
+            {
+                name = c.FullName,
+                description = c.Description,
+                module = c.ModuleName,
+                parameters = c.Parameters.Count,
+                preconditions = c.Preconditions.Select(p => p.Name).ToList()
+            })
+            .ToList();
+
+        var totalMatches = modules
+            .SelectMany(m => m.Commands)
+            .Count(c =>
+                c.Name.Contains(query, StringComparison.OrdinalIgnoreCase) ||
+                c.FullName.Contains(query, StringComparison.OrdinalIgnoreCase) ||
+                c.Description.Contains(query, StringComparison.OrdinalIgnoreCase) ||
+                c.ModuleName.Contains(query, StringComparison.OrdinalIgnoreCase));
+
+        _logger.LogDebug("Found {Count} commands matching '{Query}'", matchingCommands.Count, query);
+
+        return CreateJsonResult(new
+        {
+            results = matchingCommands,
+            total_matches = totalMatches,
+            limited_to = limit
+        });
+    }
+
+    /// <summary>
+    /// Executes the get_command_details tool.
+    /// </summary>
+    private async Task<ToolExecutionResult> ExecuteGetCommandDetailsAsync(
+        JsonElement input,
+        CancellationToken cancellationToken)
+    {
+        if (!input.TryGetProperty("command_name", out var commandNameElement))
+        {
+            return ToolExecutionResult.CreateError("Missing required parameter: command_name");
+        }
+
+        var commandName = commandNameElement.GetString();
+        if (string.IsNullOrWhiteSpace(commandName))
+        {
+            return ToolExecutionResult.CreateError("Parameter command_name cannot be empty");
+        }
+
+        // Remove leading slash if present
+        commandName = commandName.TrimStart('/');
+
+        _logger.LogDebug("Getting details for command: {CommandName}", commandName);
+
+        var modules = await _commandMetadataService.GetAllModulesAsync(cancellationToken);
+
+        var command = modules
+            .SelectMany(m => m.Commands)
+            .FirstOrDefault(c =>
+                c.Name.Equals(commandName, StringComparison.OrdinalIgnoreCase) ||
+                c.FullName.Equals(commandName, StringComparison.OrdinalIgnoreCase));
+
+        if (command == null)
+        {
+            _logger.LogDebug("Command not found: {CommandName}", commandName);
+            return CreateJsonResult(new
+            {
+                error = true,
+                message = $"Command '{commandName}' not found. Use search_commands to find available commands."
+            });
+        }
+
+        _logger.LogDebug("Found command {CommandName} in module {Module}", command.FullName, command.ModuleName);
+
+        return CreateJsonResult(new
+        {
+            name = command.FullName,
+            description = command.Description,
+            module = command.ModuleName,
+            parameters = command.Parameters.Select(p => new
+            {
+                name = p.Name,
+                type = p.Type,
+                required = p.IsRequired,
+                description = p.Description,
+                @default = p.DefaultValue
+            }).ToList(),
+            preconditions = command.Preconditions.Select(p => new
+            {
+                name = p.Name,
+                configuration = p.Configuration
+            }).ToList(),
+            examples = GenerateCommandExamples(command.FullName, command.Parameters.Select(p => (p.Name, p.IsRequired)).ToList())
+        });
+    }
+
+    /// <summary>
+    /// Executes the list_features tool.
+    /// </summary>
+    private ToolExecutionResult ExecuteListFeatures(ToolContext context)
+    {
+        _logger.LogDebug("Listing all features");
+
+        var baseUrl = GetBaseUrl();
+        var features = AllFeatures.Select(f => new
+        {
+            name = f.Name,
+            category = f.Category,
+            description = f.Description,
+            enabled = true,
+            availability = "All guilds",
+            documentation_url = !string.IsNullOrEmpty(baseUrl)
+                ? $"{baseUrl}/docs/articles/{f.DocumentationFile}"
+                : null
+        }).ToList();
+
+        return CreateJsonResult(new
+        {
+            features,
+            total_count = features.Count
+        });
+    }
+
+    /// <summary>
+    /// Gets the base URL for generating links.
+    /// </summary>
+    private string? GetBaseUrl()
+    {
+        return _assistantOptions.Value.BaseUrl ?? _applicationOptions.Value.BaseUrl;
+    }
+
+    /// <summary>
+    /// Generates example usage for a command.
+    /// </summary>
+    private static List<string> GenerateCommandExamples(string commandName, List<(string Name, bool IsRequired)> parameters)
+    {
+        var examples = new List<string>();
+
+        // Basic example with required parameters only
+        var requiredParams = parameters.Where(p => p.IsRequired).ToList();
+        if (requiredParams.Any())
+        {
+            var basicExample = $"/{commandName} " + string.Join(" ", requiredParams.Select(p => $"{p.Name}:<value>"));
+            examples.Add(basicExample);
+        }
+        else
+        {
+            examples.Add($"/{commandName}");
+        }
+
+        // Full example with all parameters
+        if (parameters.Any() && parameters.Count > requiredParams.Count)
+        {
+            var fullExample = $"/{commandName} " + string.Join(" ", parameters.Select(p => $"{p.Name}:<value>"));
+            examples.Add(fullExample);
+        }
+
+        return examples;
+    }
+
+    /// <summary>
+    /// Creates a JSON result from an object.
+    /// </summary>
+    private static ToolExecutionResult CreateJsonResult(object data)
+    {
+        var jsonString = JsonSerializer.Serialize(data, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+            WriteIndented = false
+        });
+        var jsonElement = JsonDocument.Parse(jsonString).RootElement.Clone();
+        return ToolExecutionResult.CreateSuccess(jsonElement);
+    }
+
+    /// <summary>
+    /// Internal record for feature information.
+    /// </summary>
+    private record FeatureInfo(string Name, string Category, string Description, string DocumentationFile);
+}

--- a/src/DiscordBot.Infrastructure/Services/LLM/ToolRegistry.cs
+++ b/src/DiscordBot.Infrastructure/Services/LLM/ToolRegistry.cs
@@ -1,0 +1,248 @@
+using System.Text.Json;
+using DiscordBot.Core.DTOs.LLM;
+using DiscordBot.Core.Interfaces.LLM;
+using Microsoft.Extensions.Logging;
+
+namespace DiscordBot.Infrastructure.Services.LLM;
+
+/// <summary>
+/// Central registry for managing tool providers with enable/disable capability.
+/// Routes tool execution to the appropriate provider.
+/// </summary>
+public class ToolRegistry : IToolRegistry
+{
+    private readonly ILogger<ToolRegistry> _logger;
+    private readonly Dictionary<string, ProviderEntry> _providers = new(StringComparer.OrdinalIgnoreCase);
+    private readonly object _lock = new();
+
+    /// <summary>
+    /// Initializes a new instance of the ToolRegistry.
+    /// </summary>
+    /// <param name="logger">Logger for diagnostic output.</param>
+    public ToolRegistry(ILogger<ToolRegistry> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public void RegisterProvider(IToolProvider provider, bool enabled = true)
+    {
+        ArgumentNullException.ThrowIfNull(provider);
+
+        lock (_lock)
+        {
+            if (_providers.ContainsKey(provider.Name))
+            {
+                _logger.LogWarning(
+                    "Provider {ProviderName} is already registered. Skipping duplicate registration",
+                    provider.Name);
+                return;
+            }
+
+            _providers[provider.Name] = new ProviderEntry(provider, enabled);
+
+            _logger.LogInformation(
+                "Registered tool provider {ProviderName} ({Description}) with {ToolCount} tools. Enabled: {Enabled}",
+                provider.Name,
+                provider.Description,
+                provider.GetTools().Count(),
+                enabled);
+        }
+    }
+
+    /// <inheritdoc />
+    public void EnableProvider(string providerName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerName);
+
+        lock (_lock)
+        {
+            if (!_providers.TryGetValue(providerName, out var entry))
+            {
+                throw new InvalidOperationException($"Provider '{providerName}' not found in registry");
+            }
+
+            if (entry.IsEnabled)
+            {
+                _logger.LogDebug("Provider {ProviderName} is already enabled", providerName);
+                return;
+            }
+
+            entry.IsEnabled = true;
+            _logger.LogInformation("Enabled tool provider {ProviderName}", providerName);
+        }
+    }
+
+    /// <inheritdoc />
+    public void DisableProvider(string providerName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerName);
+
+        lock (_lock)
+        {
+            if (!_providers.TryGetValue(providerName, out var entry))
+            {
+                throw new InvalidOperationException($"Provider '{providerName}' not found in registry");
+            }
+
+            if (!entry.IsEnabled)
+            {
+                _logger.LogDebug("Provider {ProviderName} is already disabled", providerName);
+                return;
+            }
+
+            entry.IsEnabled = false;
+            _logger.LogInformation("Disabled tool provider {ProviderName}", providerName);
+        }
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<LlmToolDefinition> GetEnabledTools()
+    {
+        lock (_lock)
+        {
+            var tools = _providers.Values
+                .Where(e => e.IsEnabled)
+                .SelectMany(e => e.Provider.GetTools())
+                .ToList();
+
+            _logger.LogDebug(
+                "Retrieved {ToolCount} tools from {ProviderCount} enabled providers",
+                tools.Count,
+                _providers.Values.Count(e => e.IsEnabled));
+
+            return tools;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<ToolExecutionResult> ExecuteToolAsync(
+        string toolName,
+        JsonElement input,
+        ToolContext context,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(toolName);
+        ArgumentNullException.ThrowIfNull(context);
+
+        _logger.LogDebug(
+            "Executing tool {ToolName} for user {UserId} in guild {GuildId}",
+            toolName,
+            context.UserId,
+            context.GuildId);
+
+        // Find the first enabled provider that has this tool
+        IToolProvider? targetProvider = null;
+
+        lock (_lock)
+        {
+            foreach (var entry in _providers.Values.Where(e => e.IsEnabled))
+            {
+                if (entry.Provider.GetTools().Any(t =>
+                    t.Name.Equals(toolName, StringComparison.OrdinalIgnoreCase)))
+                {
+                    targetProvider = entry.Provider;
+                    break;
+                }
+            }
+        }
+
+        if (targetProvider == null)
+        {
+            _logger.LogWarning(
+                "Tool {ToolName} not found in any enabled provider",
+                toolName);
+            throw new NotSupportedException($"Tool '{toolName}' not found in any enabled provider");
+        }
+
+        _logger.LogDebug(
+            "Routing tool {ToolName} to provider {ProviderName}",
+            toolName,
+            targetProvider.Name);
+
+        try
+        {
+            var result = await targetProvider.ExecuteToolAsync(toolName, input, context, cancellationToken);
+
+            if (result.Success)
+            {
+                _logger.LogDebug(
+                    "Tool {ToolName} executed successfully via provider {ProviderName}",
+                    toolName,
+                    targetProvider.Name);
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "Tool {ToolName} execution failed via provider {ProviderName}: {Error}",
+                    toolName,
+                    targetProvider.Name,
+                    result.ErrorMessage);
+            }
+
+            return result;
+        }
+        catch (Exception ex) when (ex is not NotSupportedException)
+        {
+            _logger.LogError(ex,
+                "Tool {ToolName} execution threw exception via provider {ProviderName}",
+                toolName,
+                targetProvider.Name);
+
+            return ToolExecutionResult.CreateError($"Tool execution failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Gets the names of all registered providers.
+    /// </summary>
+    /// <returns>Collection of provider names.</returns>
+    public IEnumerable<string> GetProviderNames()
+    {
+        lock (_lock)
+        {
+            return _providers.Keys.ToList();
+        }
+    }
+
+    /// <summary>
+    /// Checks if a provider is registered.
+    /// </summary>
+    /// <param name="providerName">Name of the provider to check.</param>
+    /// <returns>True if the provider is registered, false otherwise.</returns>
+    public bool IsProviderRegistered(string providerName)
+    {
+        lock (_lock)
+        {
+            return _providers.ContainsKey(providerName);
+        }
+    }
+
+    /// <summary>
+    /// Checks if a provider is enabled.
+    /// </summary>
+    /// <param name="providerName">Name of the provider to check.</param>
+    /// <returns>True if the provider is enabled, false if disabled or not registered.</returns>
+    public bool IsProviderEnabled(string providerName)
+    {
+        lock (_lock)
+        {
+            return _providers.TryGetValue(providerName, out var entry) && entry.IsEnabled;
+        }
+    }
+
+    /// <summary>
+    /// Internal class to track provider registration state.
+    /// </summary>
+    private class ProviderEntry
+    {
+        public IToolProvider Provider { get; }
+        public bool IsEnabled { get; set; }
+
+        public ProviderEntry(IToolProvider provider, bool isEnabled)
+        {
+            Provider = provider;
+            IsEnabled = isEnabled;
+        }
+    }
+}

--- a/tests/DiscordBot.Tests/Services/LLM/DocumentationToolProviderTests.cs
+++ b/tests/DiscordBot.Tests/Services/LLM/DocumentationToolProviderTests.cs
@@ -1,0 +1,438 @@
+using System.Text.Json;
+using DiscordBot.Core.Configuration;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.DTOs.LLM;
+using DiscordBot.Core.Interfaces;
+using DiscordBot.Infrastructure.Services.LLM.Implementations;
+using DiscordBot.Infrastructure.Services.LLM.Providers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace DiscordBot.Tests.Services.LLM;
+
+/// <summary>
+/// Unit tests for <see cref="DocumentationToolProvider"/>.
+/// Tests cover tool definitions, command search, and feature documentation retrieval.
+/// </summary>
+public class DocumentationToolProviderTests
+{
+    private readonly Mock<ILogger<DocumentationToolProvider>> _mockLogger;
+    private readonly Mock<ICommandMetadataService> _mockCommandMetadataService;
+    private readonly Mock<IOptions<AssistantOptions>> _mockAssistantOptions;
+    private readonly Mock<IOptions<ApplicationOptions>> _mockApplicationOptions;
+    private readonly DocumentationToolProvider _provider;
+
+    public DocumentationToolProviderTests()
+    {
+        _mockLogger = new Mock<ILogger<DocumentationToolProvider>>();
+        _mockCommandMetadataService = new Mock<ICommandMetadataService>();
+        _mockAssistantOptions = new Mock<IOptions<AssistantOptions>>();
+        _mockApplicationOptions = new Mock<IOptions<ApplicationOptions>>();
+
+        _mockAssistantOptions.Setup(o => o.Value).Returns(new AssistantOptions
+        {
+            DocumentationBasePath = "docs/articles",
+            BaseUrl = "https://test.example.com"
+        });
+
+        _mockApplicationOptions.Setup(o => o.Value).Returns(new ApplicationOptions
+        {
+            BaseUrl = "https://test.example.com"
+        });
+
+        _provider = new DocumentationToolProvider(
+            _mockLogger.Object,
+            _mockCommandMetadataService.Object,
+            _mockAssistantOptions.Object,
+            _mockApplicationOptions.Object);
+    }
+
+    #region Provider Properties Tests
+
+    [Fact]
+    public void Name_ReturnsDocumentation()
+    {
+        _provider.Name.Should().Be("Documentation");
+    }
+
+    [Fact]
+    public void Description_IsNotEmpty()
+    {
+        _provider.Description.Should().NotBeEmpty();
+    }
+
+    #endregion
+
+    #region GetTools Tests
+
+    [Fact]
+    public void GetTools_ReturnsFourTools()
+    {
+        // Act
+        var tools = _provider.GetTools().ToList();
+
+        // Assert
+        tools.Should().HaveCount(4);
+    }
+
+    [Fact]
+    public void GetTools_ContainsGetFeatureDocumentation()
+    {
+        // Act
+        var tools = _provider.GetTools().ToList();
+
+        // Assert
+        tools.Should().Contain(t => t.Name == DocumentationTools.GetFeatureDocumentation);
+    }
+
+    [Fact]
+    public void GetTools_ContainsSearchCommands()
+    {
+        // Act
+        var tools = _provider.GetTools().ToList();
+
+        // Assert
+        tools.Should().Contain(t => t.Name == DocumentationTools.SearchCommands);
+    }
+
+    [Fact]
+    public void GetTools_ContainsGetCommandDetails()
+    {
+        // Act
+        var tools = _provider.GetTools().ToList();
+
+        // Assert
+        tools.Should().Contain(t => t.Name == DocumentationTools.GetCommandDetails);
+    }
+
+    [Fact]
+    public void GetTools_ContainsListFeatures()
+    {
+        // Act
+        var tools = _provider.GetTools().ToList();
+
+        // Assert
+        tools.Should().Contain(t => t.Name == DocumentationTools.ListFeatures);
+    }
+
+    [Fact]
+    public void GetTools_AllToolsHaveValidSchema()
+    {
+        // Act
+        var tools = _provider.GetTools().ToList();
+
+        // Assert
+        foreach (var tool in tools)
+        {
+            tool.InputSchema.ValueKind.Should().Be(JsonValueKind.Object);
+            tool.Description.Should().NotBeEmpty();
+        }
+    }
+
+    #endregion
+
+    #region SearchCommands Tests
+
+    [Fact]
+    public async Task SearchCommands_ReturnsMatchingCommands()
+    {
+        // Arrange
+        var modules = new List<CommandModuleDto>
+        {
+            new()
+            {
+                Name = "TestModule",
+                DisplayName = "Test",
+                Commands = new List<CommandInfoDto>
+                {
+                    new()
+                    {
+                        Name = "ping",
+                        FullName = "ping",
+                        Description = "Test ping command",
+                        ModuleName = "TestModule",
+                        Parameters = new List<CommandParameterDto>(),
+                        Preconditions = new List<PreconditionDto>()
+                    },
+                    new()
+                    {
+                        Name = "ban",
+                        FullName = "ban",
+                        Description = "Ban a user",
+                        ModuleName = "TestModule",
+                        Parameters = new List<CommandParameterDto>(),
+                        Preconditions = new List<PreconditionDto>
+                        {
+                            new() { Name = "RequireAdmin", Configuration = "Requires admin" }
+                        }
+                    }
+                }
+            }
+        };
+
+        _mockCommandMetadataService
+            .Setup(s => s.GetAllModulesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(modules);
+
+        var input = CreateJsonElement(new { query = "ping", limit = 10 });
+        var context = CreateToolContext();
+
+        // Act
+        var result = await _provider.ExecuteToolAsync(
+            DocumentationTools.SearchCommands, input, context);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Data.Should().NotBeNull();
+        result.Data!.Value.GetProperty("results").GetArrayLength().Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task SearchCommands_ReturnsMissingParameterError()
+    {
+        // Arrange - Empty input (no query parameter)
+        var input = CreateJsonElement(new { });
+        var context = CreateToolContext();
+
+        // Act
+        var result = await _provider.ExecuteToolAsync(
+            DocumentationTools.SearchCommands, input, context);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("query");
+    }
+
+    [Fact]
+    public async Task SearchCommands_RespectsLimit()
+    {
+        // Arrange
+        var commands = Enumerable.Range(1, 20).Select(i => new CommandInfoDto
+        {
+            Name = $"command{i}",
+            FullName = $"command{i}",
+            Description = "Test command",
+            ModuleName = "TestModule",
+            Parameters = new List<CommandParameterDto>(),
+            Preconditions = new List<PreconditionDto>()
+        }).ToList();
+
+        var modules = new List<CommandModuleDto>
+        {
+            new()
+            {
+                Name = "TestModule",
+                Commands = commands
+            }
+        };
+
+        _mockCommandMetadataService
+            .Setup(s => s.GetAllModulesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(modules);
+
+        var input = CreateJsonElement(new { query = "command", limit = 5 });
+        var context = CreateToolContext();
+
+        // Act
+        var result = await _provider.ExecuteToolAsync(
+            DocumentationTools.SearchCommands, input, context);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Data!.Value.GetProperty("results").GetArrayLength().Should().Be(5);
+        result.Data!.Value.GetProperty("limited_to").GetInt32().Should().Be(5);
+    }
+
+    #endregion
+
+    #region GetCommandDetails Tests
+
+    [Fact]
+    public async Task GetCommandDetails_ReturnsCommandDetails()
+    {
+        // Arrange
+        var modules = new List<CommandModuleDto>
+        {
+            new()
+            {
+                Name = "ReminderModule",
+                Commands = new List<CommandInfoDto>
+                {
+                    new()
+                    {
+                        Name = "remind",
+                        FullName = "remind",
+                        Description = "Set a reminder",
+                        ModuleName = "ReminderModule",
+                        Parameters = new List<CommandParameterDto>
+                        {
+                            new() { Name = "time", Type = "string", IsRequired = true, Description = "When" },
+                            new() { Name = "message", Type = "string", IsRequired = true, Description = "What" }
+                        },
+                        Preconditions = new List<PreconditionDto>()
+                    }
+                }
+            }
+        };
+
+        _mockCommandMetadataService
+            .Setup(s => s.GetAllModulesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(modules);
+
+        var input = CreateJsonElement(new { command_name = "remind" });
+        var context = CreateToolContext();
+
+        // Act
+        var result = await _provider.ExecuteToolAsync(
+            DocumentationTools.GetCommandDetails, input, context);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Data.Should().NotBeNull();
+        result.Data!.Value.GetProperty("name").GetString().Should().Be("remind");
+        result.Data!.Value.GetProperty("module").GetString().Should().Be("ReminderModule");
+    }
+
+    [Fact]
+    public async Task GetCommandDetails_ReturnsErrorForUnknownCommand()
+    {
+        // Arrange
+        _mockCommandMetadataService
+            .Setup(s => s.GetAllModulesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CommandModuleDto>());
+
+        var input = CreateJsonElement(new { command_name = "nonexistent" });
+        var context = CreateToolContext();
+
+        // Act
+        var result = await _provider.ExecuteToolAsync(
+            DocumentationTools.GetCommandDetails, input, context);
+
+        // Assert
+        result.Success.Should().BeTrue(); // Tool succeeds but returns error in data
+        result.Data!.Value.TryGetProperty("error", out var error).Should().BeTrue();
+        error.GetBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetCommandDetails_StripsLeadingSlash()
+    {
+        // Arrange
+        var modules = new List<CommandModuleDto>
+        {
+            new()
+            {
+                Name = "GeneralModule",
+                Commands = new List<CommandInfoDto>
+                {
+                    new()
+                    {
+                        Name = "ping",
+                        FullName = "ping",
+                        Description = "Ping the bot",
+                        ModuleName = "GeneralModule",
+                        Parameters = new List<CommandParameterDto>(),
+                        Preconditions = new List<PreconditionDto>()
+                    }
+                }
+            }
+        };
+
+        _mockCommandMetadataService
+            .Setup(s => s.GetAllModulesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(modules);
+
+        var input = CreateJsonElement(new { command_name = "/ping" });
+        var context = CreateToolContext();
+
+        // Act
+        var result = await _provider.ExecuteToolAsync(
+            DocumentationTools.GetCommandDetails, input, context);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Data!.Value.GetProperty("name").GetString().Should().Be("ping");
+    }
+
+    #endregion
+
+    #region ListFeatures Tests
+
+    [Fact]
+    public async Task ListFeatures_ReturnsAllFeatures()
+    {
+        // Arrange
+        var input = CreateJsonElement(new { });
+        var context = CreateToolContext();
+
+        // Act
+        var result = await _provider.ExecuteToolAsync(
+            DocumentationTools.ListFeatures, input, context);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Data.Should().NotBeNull();
+        result.Data!.Value.GetProperty("features").GetArrayLength().Should().BeGreaterThan(0);
+        result.Data!.Value.GetProperty("total_count").GetInt32().Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task ListFeatures_IncludesDocumentationUrls()
+    {
+        // Arrange
+        var input = CreateJsonElement(new { });
+        var context = CreateToolContext();
+
+        // Act
+        var result = await _provider.ExecuteToolAsync(
+            DocumentationTools.ListFeatures, input, context);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        var features = result.Data!.Value.GetProperty("features");
+        features[0].TryGetProperty("documentation_url", out var url).Should().BeTrue();
+        url.GetString().Should().Contain("https://test.example.com");
+    }
+
+    #endregion
+
+    #region UnsupportedTool Tests
+
+    [Fact]
+    public async Task ExecuteToolAsync_ThrowsOnUnsupportedTool()
+    {
+        // Arrange
+        var input = CreateJsonElement(new { });
+        var context = CreateToolContext();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotSupportedException>(() =>
+            _provider.ExecuteToolAsync("unsupported_tool", input, context));
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static ToolContext CreateToolContext()
+    {
+        return new ToolContext
+        {
+            UserId = 123456789,
+            GuildId = 987654321,
+            ChannelId = 111222333,
+            MessageId = 444555666,
+            UserRoles = new List<string> { "Member" }
+        };
+    }
+
+    private static JsonElement CreateJsonElement(object obj)
+    {
+        var json = JsonSerializer.Serialize(obj);
+        return JsonDocument.Parse(json).RootElement.Clone();
+    }
+
+    #endregion
+}

--- a/tests/DiscordBot.Tests/Services/LLM/ToolRegistryTests.cs
+++ b/tests/DiscordBot.Tests/Services/LLM/ToolRegistryTests.cs
@@ -1,0 +1,340 @@
+using System.Text.Json;
+using DiscordBot.Core.DTOs.LLM;
+using DiscordBot.Core.Interfaces.LLM;
+using DiscordBot.Infrastructure.Services.LLM;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace DiscordBot.Tests.Services.LLM;
+
+/// <summary>
+/// Unit tests for <see cref="ToolRegistry"/>.
+/// Tests cover provider registration, enable/disable, tool retrieval, and tool execution.
+/// </summary>
+public class ToolRegistryTests
+{
+    private readonly Mock<ILogger<ToolRegistry>> _mockLogger;
+    private readonly ToolRegistry _registry;
+
+    public ToolRegistryTests()
+    {
+        _mockLogger = new Mock<ILogger<ToolRegistry>>();
+        _registry = new ToolRegistry(_mockLogger.Object);
+    }
+
+    #region Registration Tests
+
+    [Fact]
+    public void RegisterProvider_RegistersProviderSuccessfully()
+    {
+        // Arrange
+        var provider = CreateMockProvider("TestProvider", "Test Description", "test_tool");
+
+        // Act
+        _registry.RegisterProvider(provider.Object);
+
+        // Assert
+        _registry.IsProviderRegistered("TestProvider").Should().BeTrue();
+        _registry.IsProviderEnabled("TestProvider").Should().BeTrue();
+    }
+
+    [Fact]
+    public void RegisterProvider_RegistersDisabledProvider()
+    {
+        // Arrange
+        var provider = CreateMockProvider("TestProvider", "Test Description", "test_tool");
+
+        // Act
+        _registry.RegisterProvider(provider.Object, enabled: false);
+
+        // Assert
+        _registry.IsProviderRegistered("TestProvider").Should().BeTrue();
+        _registry.IsProviderEnabled("TestProvider").Should().BeFalse();
+    }
+
+    [Fact]
+    public void RegisterProvider_IgnoresDuplicateRegistration()
+    {
+        // Arrange
+        var provider = CreateMockProvider("TestProvider", "Test Description", "test_tool");
+
+        // Act
+        _registry.RegisterProvider(provider.Object);
+        _registry.RegisterProvider(provider.Object); // Duplicate
+
+        // Assert - Should not throw and only register once
+        _registry.GetProviderNames().Count(n => n == "TestProvider").Should().Be(1);
+    }
+
+    [Fact]
+    public void RegisterProvider_ThrowsOnNullProvider()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => _registry.RegisterProvider(null!));
+    }
+
+    #endregion
+
+    #region Enable/Disable Tests
+
+    [Fact]
+    public void EnableProvider_EnablesDisabledProvider()
+    {
+        // Arrange
+        var provider = CreateMockProvider("TestProvider", "Test Description", "test_tool");
+        _registry.RegisterProvider(provider.Object, enabled: false);
+
+        // Act
+        _registry.EnableProvider("TestProvider");
+
+        // Assert
+        _registry.IsProviderEnabled("TestProvider").Should().BeTrue();
+    }
+
+    [Fact]
+    public void DisableProvider_DisablesEnabledProvider()
+    {
+        // Arrange
+        var provider = CreateMockProvider("TestProvider", "Test Description", "test_tool");
+        _registry.RegisterProvider(provider.Object, enabled: true);
+
+        // Act
+        _registry.DisableProvider("TestProvider");
+
+        // Assert
+        _registry.IsProviderEnabled("TestProvider").Should().BeFalse();
+    }
+
+    [Fact]
+    public void EnableProvider_ThrowsOnUnknownProvider()
+    {
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => _registry.EnableProvider("UnknownProvider"));
+    }
+
+    [Fact]
+    public void DisableProvider_ThrowsOnUnknownProvider()
+    {
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => _registry.DisableProvider("UnknownProvider"));
+    }
+
+    [Fact]
+    public void EnableProvider_IsCaseInsensitive()
+    {
+        // Arrange
+        var provider = CreateMockProvider("TestProvider", "Test Description", "test_tool");
+        _registry.RegisterProvider(provider.Object, enabled: false);
+
+        // Act
+        _registry.EnableProvider("TESTPROVIDER");
+
+        // Assert
+        _registry.IsProviderEnabled("TestProvider").Should().BeTrue();
+    }
+
+    #endregion
+
+    #region GetEnabledTools Tests
+
+    [Fact]
+    public void GetEnabledTools_ReturnsToolsFromEnabledProviders()
+    {
+        // Arrange
+        var provider1 = CreateMockProvider("Provider1", "Description 1", "tool1");
+        var provider2 = CreateMockProvider("Provider2", "Description 2", "tool2");
+
+        _registry.RegisterProvider(provider1.Object, enabled: true);
+        _registry.RegisterProvider(provider2.Object, enabled: true);
+
+        // Act
+        var tools = _registry.GetEnabledTools().ToList();
+
+        // Assert
+        tools.Should().HaveCount(2);
+        tools.Select(t => t.Name).Should().Contain("tool1");
+        tools.Select(t => t.Name).Should().Contain("tool2");
+    }
+
+    [Fact]
+    public void GetEnabledTools_ExcludesDisabledProviders()
+    {
+        // Arrange
+        var provider1 = CreateMockProvider("Provider1", "Description 1", "tool1");
+        var provider2 = CreateMockProvider("Provider2", "Description 2", "tool2");
+
+        _registry.RegisterProvider(provider1.Object, enabled: true);
+        _registry.RegisterProvider(provider2.Object, enabled: false);
+
+        // Act
+        var tools = _registry.GetEnabledTools().ToList();
+
+        // Assert
+        tools.Should().HaveCount(1);
+        tools.Single().Name.Should().Be("tool1");
+    }
+
+    [Fact]
+    public void GetEnabledTools_ReturnsEmptyWhenNoProviders()
+    {
+        // Act
+        var tools = _registry.GetEnabledTools().ToList();
+
+        // Assert
+        tools.Should().BeEmpty();
+    }
+
+    #endregion
+
+    #region ExecuteToolAsync Tests
+
+    [Fact]
+    public async Task ExecuteToolAsync_ExecutesToolSuccessfully()
+    {
+        // Arrange
+        var expectedResult = ToolExecutionResult.CreateSuccess(CreateJsonElement(new { success = true }));
+        var provider = CreateMockProvider("TestProvider", "Description", "test_tool", expectedResult);
+        _registry.RegisterProvider(provider.Object);
+
+        var context = CreateToolContext();
+        var input = CreateJsonElement(new { });
+
+        // Act
+        var result = await _registry.ExecuteToolAsync("test_tool", input, context);
+
+        // Assert
+        result.Success.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ExecuteToolAsync_ThrowsWhenToolNotFound()
+    {
+        // Arrange
+        var provider = CreateMockProvider("TestProvider", "Description", "tool1");
+        _registry.RegisterProvider(provider.Object);
+
+        var context = CreateToolContext();
+        var input = CreateJsonElement(new { });
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotSupportedException>(() =>
+            _registry.ExecuteToolAsync("nonexistent_tool", input, context));
+    }
+
+    [Fact]
+    public async Task ExecuteToolAsync_DoesNotExecuteFromDisabledProvider()
+    {
+        // Arrange
+        var provider = CreateMockProvider("TestProvider", "Description", "test_tool");
+        _registry.RegisterProvider(provider.Object, enabled: false);
+
+        var context = CreateToolContext();
+        var input = CreateJsonElement(new { });
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotSupportedException>(() =>
+            _registry.ExecuteToolAsync("test_tool", input, context));
+    }
+
+    [Fact]
+    public async Task ExecuteToolAsync_ReturnsErrorOnException()
+    {
+        // Arrange
+        var provider = new Mock<IToolProvider>();
+        provider.Setup(p => p.Name).Returns("TestProvider");
+        provider.Setup(p => p.Description).Returns("Test");
+        provider.Setup(p => p.GetTools()).Returns(new[]
+        {
+            new LlmToolDefinition { Name = "test_tool", Description = "Test" }
+        });
+        provider.Setup(p => p.ExecuteToolAsync(It.IsAny<string>(), It.IsAny<JsonElement>(), It.IsAny<ToolContext>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Test error"));
+
+        _registry.RegisterProvider(provider.Object);
+
+        var context = CreateToolContext();
+        var input = CreateJsonElement(new { });
+
+        // Act
+        var result = await _registry.ExecuteToolAsync("test_tool", input, context);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Test error");
+    }
+
+    [Fact]
+    public async Task ExecuteToolAsync_IsCaseInsensitiveForToolName()
+    {
+        // Arrange
+        var expectedResult = ToolExecutionResult.CreateSuccess(CreateJsonElement(new { success = true }));
+        var provider = CreateMockProvider("TestProvider", "Description", "test_tool", expectedResult);
+        _registry.RegisterProvider(provider.Object);
+
+        var context = CreateToolContext();
+        var input = CreateJsonElement(new { });
+
+        // Act
+        var result = await _registry.ExecuteToolAsync("TEST_TOOL", input, context);
+
+        // Assert
+        result.Success.Should().BeTrue();
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static Mock<IToolProvider> CreateMockProvider(
+        string name,
+        string description,
+        string toolName,
+        ToolExecutionResult? executionResult = null)
+    {
+        var provider = new Mock<IToolProvider>();
+        provider.Setup(p => p.Name).Returns(name);
+        provider.Setup(p => p.Description).Returns(description);
+        provider.Setup(p => p.GetTools()).Returns(new[]
+        {
+            new LlmToolDefinition
+            {
+                Name = toolName,
+                Description = $"Tool: {toolName}",
+                InputSchema = CreateJsonElement(new { type = "object" })
+            }
+        });
+
+        if (executionResult != null)
+        {
+            provider.Setup(p => p.ExecuteToolAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<JsonElement>(),
+                    It.IsAny<ToolContext>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(executionResult);
+        }
+
+        return provider;
+    }
+
+    private static ToolContext CreateToolContext()
+    {
+        return new ToolContext
+        {
+            UserId = 123456789,
+            GuildId = 987654321,
+            ChannelId = 111222333,
+            MessageId = 444555666,
+            UserRoles = new List<string> { "Member" }
+        };
+    }
+
+    private static JsonElement CreateJsonElement(object obj)
+    {
+        var json = JsonSerializer.Serialize(obj);
+        return JsonDocument.Parse(json).RootElement.Clone();
+    }
+
+    #endregion
+}

--- a/tests/DiscordBot.Tests/Services/LLM/UserGuildInfoToolProviderTests.cs
+++ b/tests/DiscordBot.Tests/Services/LLM/UserGuildInfoToolProviderTests.cs
@@ -1,0 +1,303 @@
+using System.Text.Json;
+using Discord;
+using Discord.WebSocket;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.DTOs.LLM;
+using DiscordBot.Core.Interfaces;
+using DiscordBot.Infrastructure.Services.LLM.Implementations;
+using DiscordBot.Bot.Services.LLM.Providers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace DiscordBot.Tests.Services.LLM;
+
+/// <summary>
+/// Unit tests for <see cref="UserGuildInfoToolProvider"/>.
+/// Tests cover tool definitions, user profile retrieval, guild info, and role lookup.
+/// </summary>
+public class UserGuildInfoToolProviderTests
+{
+    private readonly Mock<ILogger<UserGuildInfoToolProvider>> _mockLogger;
+    private readonly Mock<DiscordSocketClient> _mockDiscordClient;
+    private readonly Mock<IGuildService> _mockGuildService;
+    private readonly UserGuildInfoToolProvider _provider;
+
+    public UserGuildInfoToolProviderTests()
+    {
+        _mockLogger = new Mock<ILogger<UserGuildInfoToolProvider>>();
+        _mockDiscordClient = new Mock<DiscordSocketClient>();
+        _mockGuildService = new Mock<IGuildService>();
+
+        _provider = new UserGuildInfoToolProvider(
+            _mockLogger.Object,
+            _mockDiscordClient.Object,
+            _mockGuildService.Object);
+    }
+
+    #region Provider Properties Tests
+
+    [Fact]
+    public void Name_ReturnsUserGuildInfo()
+    {
+        _provider.Name.Should().Be("UserGuildInfo");
+    }
+
+    [Fact]
+    public void Description_IsNotEmpty()
+    {
+        _provider.Description.Should().NotBeEmpty();
+    }
+
+    #endregion
+
+    #region GetTools Tests
+
+    [Fact]
+    public void GetTools_ReturnsThreeTools()
+    {
+        // Act
+        var tools = _provider.GetTools().ToList();
+
+        // Assert
+        tools.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void GetTools_ContainsGetUserProfile()
+    {
+        // Act
+        var tools = _provider.GetTools().ToList();
+
+        // Assert
+        tools.Should().Contain(t => t.Name == UserGuildInfoTools.GetUserProfile);
+    }
+
+    [Fact]
+    public void GetTools_ContainsGetGuildInfo()
+    {
+        // Act
+        var tools = _provider.GetTools().ToList();
+
+        // Assert
+        tools.Should().Contain(t => t.Name == UserGuildInfoTools.GetGuildInfo);
+    }
+
+    [Fact]
+    public void GetTools_ContainsGetUserRoles()
+    {
+        // Act
+        var tools = _provider.GetTools().ToList();
+
+        // Assert
+        tools.Should().Contain(t => t.Name == UserGuildInfoTools.GetUserRoles);
+    }
+
+    [Fact]
+    public void GetTools_AllToolsHaveValidSchema()
+    {
+        // Act
+        var tools = _provider.GetTools().ToList();
+
+        // Assert
+        foreach (var tool in tools)
+        {
+            tool.InputSchema.ValueKind.Should().Be(JsonValueKind.Object);
+            tool.Description.Should().NotBeEmpty();
+        }
+    }
+
+    #endregion
+
+    #region GetGuildInfo Tests (using database fallback)
+
+    [Fact]
+    public async Task GetGuildInfo_ReturnsGuildFromDatabase_WhenNotConnected()
+    {
+        // Arrange
+        var guildId = 987654321UL;
+        var guildDto = new GuildDto
+        {
+            Id = guildId,
+            Name = "Test Guild",
+            IconUrl = "https://cdn.example.com/icon.png",
+            MemberCount = 100,
+            IsActive = true
+        };
+
+        _mockGuildService
+            .Setup(s => s.GetGuildByIdAsync(guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(guildDto);
+
+        var input = CreateJsonElement(new { });
+        var context = CreateToolContext(guildId: guildId);
+
+        // Act
+        var result = await _provider.ExecuteToolAsync(
+            UserGuildInfoTools.GetGuildInfo, input, context);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Data.Should().NotBeNull();
+        result.Data!.Value.GetProperty("name").GetString().Should().Be("Test Guild");
+        result.Data!.Value.GetProperty("bot_connected").GetBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetGuildInfo_ReturnsErrorForNoGuildContext()
+    {
+        // Arrange
+        var input = CreateJsonElement(new { });
+        var context = CreateToolContext(guildId: 0); // No guild context
+
+        // Act
+        var result = await _provider.ExecuteToolAsync(
+            UserGuildInfoTools.GetGuildInfo, input, context);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("guild context");
+    }
+
+    [Fact]
+    public async Task GetGuildInfo_ReturnsErrorForUnknownGuild()
+    {
+        // Arrange
+        var guildId = 987654321UL;
+
+        _mockGuildService
+            .Setup(s => s.GetGuildByIdAsync(guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GuildDto?)null);
+
+        var input = CreateJsonElement(new { });
+        var context = CreateToolContext(guildId: guildId);
+
+        // Act
+        var result = await _provider.ExecuteToolAsync(
+            UserGuildInfoTools.GetGuildInfo, input, context);
+
+        // Assert
+        result.Success.Should().BeTrue(); // Tool succeeds but returns error in data
+        result.Data!.Value.TryGetProperty("error", out var error).Should().BeTrue();
+        error.GetBoolean().Should().BeTrue();
+    }
+
+    #endregion
+
+    #region GetUserRoles Tests
+
+    [Fact]
+    public async Task GetUserRoles_ReturnsErrorForNoGuildContext()
+    {
+        // Arrange
+        var input = CreateJsonElement(new { });
+        var context = CreateToolContext(guildId: 0); // No guild context
+
+        // Act
+        var result = await _provider.ExecuteToolAsync(
+            UserGuildInfoTools.GetUserRoles, input, context);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("guild context");
+    }
+
+    [Fact]
+    public async Task GetUserRoles_ReturnsErrorForUnknownGuild()
+    {
+        // Arrange
+        var input = CreateJsonElement(new { });
+        var context = CreateToolContext();
+
+        // Act
+        var result = await _provider.ExecuteToolAsync(
+            UserGuildInfoTools.GetUserRoles, input, context);
+
+        // Assert
+        result.Success.Should().BeTrue(); // Tool succeeds but returns error in data
+        result.Data!.Value.TryGetProperty("error", out var error).Should().BeTrue();
+    }
+
+    #endregion
+
+    #region UnsupportedTool Tests
+
+    [Fact]
+    public async Task ExecuteToolAsync_ThrowsOnUnsupportedTool()
+    {
+        // Arrange
+        var input = CreateJsonElement(new { });
+        var context = CreateToolContext();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotSupportedException>(() =>
+            _provider.ExecuteToolAsync("unsupported_tool", input, context));
+    }
+
+    #endregion
+
+    #region Input Parsing Tests
+
+    [Fact]
+    public async Task GetUserProfile_UsesContextUserIdWhenNotProvided()
+    {
+        // Arrange - Note: The mock Discord client won't return a user, so we expect an error result
+        // but the point is that it uses the context user ID
+        var input = CreateJsonElement(new { }); // No user_id in input
+        var context = CreateToolContext(userId: 123456789);
+
+        // Act
+        var result = await _provider.ExecuteToolAsync(
+            UserGuildInfoTools.GetUserProfile, input, context);
+
+        // Assert - Tool returns error for unknown user, which is expected
+        // The important thing is it doesn't throw and attempted to look up context.UserId
+        result.Data!.Value.TryGetProperty("error", out _).Should().BeTrue();
+        result.Data!.Value.TryGetProperty("message", out var msg).Should().BeTrue();
+        msg.GetString().Should().Contain("123456789");
+    }
+
+    [Fact]
+    public async Task GetUserProfile_UsesProvidedUserId()
+    {
+        // Arrange
+        var providedUserId = 999888777UL;
+        var input = CreateJsonElement(new { user_id = providedUserId.ToString() });
+        var context = CreateToolContext(userId: 123456789); // Different from provided
+
+        // Act
+        var result = await _provider.ExecuteToolAsync(
+            UserGuildInfoTools.GetUserProfile, input, context);
+
+        // Assert - Should try to look up the provided user ID, not the context one
+        result.Data!.Value.TryGetProperty("message", out var msg).Should().BeTrue();
+        msg.GetString().Should().Contain("999888777");
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static ToolContext CreateToolContext(
+        ulong userId = 123456789,
+        ulong guildId = 987654321,
+        ulong channelId = 111222333)
+    {
+        return new ToolContext
+        {
+            UserId = userId,
+            GuildId = guildId,
+            ChannelId = channelId,
+            MessageId = 444555666,
+            UserRoles = new List<string> { "Member" }
+        };
+    }
+
+    private static JsonElement CreateJsonElement(object obj)
+    {
+        var json = JsonSerializer.Serialize(obj);
+        return JsonDocument.Parse(json).RootElement.Clone();
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Implements ToolRegistry for central tool provider management with enable/disable functionality
- Implements PromptTemplate for loading and rendering prompt templates with variable substitution
- Creates DocumentationTools static class and DocumentationToolProvider for bot documentation access
- Creates UserGuildInfoTools static class and UserGuildInfoToolProvider for Discord user/guild information
- Implements AssistantGuildSettingsRepository, AssistantUsageMetricsRepository, and AssistantInteractionLogRepository
- Implements AssistantGuildSettingsService for managing guild-level assistant configuration
- Adds comprehensive unit tests for ToolRegistry, DocumentationToolProvider, and UserGuildInfoToolProvider (49 tests total)

## Test plan
- [x] All 49 unit tests pass
- [x] Build succeeds with no errors or warnings
- [ ] Manual verification of tool execution in assistant context
- [ ] Integration testing with actual Discord guild/user data

Closes #1061

🤖 Generated with [Claude Code](https://claude.com/claude-code)