### PR TITLE
feat(assistant): Add Claude API integration with agentic loop

### DIFF
--- a/src/DiscordBot.Bot/Extensions/AssistantServiceExtensions.cs
+++ b/src/DiscordBot.Bot/Extensions/AssistantServiceExtensions.cs
@@ -1,0 +1,62 @@
+using Anthropic;
+using Anthropic.Core;
+using DiscordBot.Core.Configuration;
+using DiscordBot.Core.Interfaces.LLM;
+using DiscordBot.Infrastructure.Services.LLM;
+using DiscordBot.Infrastructure.Services.LLM.Anthropic;
+using DiscordBot.Infrastructure.Services.LLM.Providers;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DiscordBot.Bot.Extensions;
+
+/// <summary>
+/// Extension methods for registering AI assistant services.
+/// </summary>
+public static class AssistantServiceExtensions
+{
+    /// <summary>
+    /// Adds AI assistant services including LLM client, agent runner, and tool registry.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configuration">The configuration.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddAssistant(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        // Register configuration
+        services.Configure<AnthropicOptions>(
+            configuration.GetSection(AnthropicOptions.SectionName));
+
+        // Get API key from configuration
+        var apiKey = configuration.GetValue<string>("Anthropic:ApiKey");
+
+        // Only register Anthropic services if API key is configured
+        if (!string.IsNullOrEmpty(apiKey))
+        {
+            // Register Anthropic client as singleton (thread-safe, expensive to create)
+            // The SDK reads from ANTHROPIC_API_KEY environment variable by default,
+            // but we can pass options to configure it explicitly
+            services.AddSingleton<AnthropicClient>(sp =>
+            {
+                var clientOptions = new ClientOptions { ApiKey = apiKey };
+                return new AnthropicClient(clientOptions);
+            });
+
+            // Register LLM client implementation
+            services.AddSingleton<ILlmClient, AnthropicLlmClient>();
+        }
+
+        // Register tool registry as singleton (manages tool providers)
+        services.AddSingleton<IToolRegistry, ToolRegistry>();
+
+        // Register built-in tool providers
+        services.AddSingleton<IToolProvider, DocumentationToolProvider>();
+
+        // Register agent runner (depends on ILlmClient and ILogger)
+        services.AddScoped<IAgentRunner, AgentRunner>();
+
+        return services;
+    }
+}

--- a/src/DiscordBot.Bot/Program.cs
+++ b/src/DiscordBot.Bot/Program.cs
@@ -165,6 +165,9 @@ try
     // Voice and audio
     builder.Services.AddVoiceSupport(builder.Configuration);
 
+    // AI Assistant (LLM integration)
+    builder.Services.AddAssistant(builder.Configuration);
+
     // Analytics and metrics
     builder.Services.AddAnalytics(builder.Configuration);
 

--- a/src/DiscordBot.Core/Configuration/AnthropicOptions.cs
+++ b/src/DiscordBot.Core/Configuration/AnthropicOptions.cs
@@ -1,0 +1,72 @@
+namespace DiscordBot.Core.Configuration;
+
+/// <summary>
+/// Configuration options for Anthropic Claude API integration.
+/// </summary>
+public class AnthropicOptions
+{
+    /// <summary>
+    /// The configuration section name for binding.
+    /// </summary>
+    public const string SectionName = "Anthropic";
+
+    /// <summary>
+    /// Gets or sets the Anthropic API key.
+    /// This should be configured via user secrets, never in appsettings.json.
+    /// </summary>
+    /// <remarks>
+    /// Required for Claude API access. If not configured, the Anthropic LLM client will be disabled.
+    /// Set via user secrets: dotnet user-secrets set "Anthropic:ApiKey" "your-api-key-here"
+    /// </remarks>
+    public string? ApiKey { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default Claude model to use.
+    /// Default is "claude-sonnet-4-20250514".
+    /// </summary>
+    /// <remarks>
+    /// Available models: claude-opus-4-20250514, claude-sonnet-4-20250514, claude-haiku-4-20250514.
+    /// Model names may change with new releases. Check Anthropic documentation for current model names.
+    /// </remarks>
+    public string DefaultModel { get; set; } = "claude-sonnet-4-20250514";
+
+    /// <summary>
+    /// Gets or sets the maximum number of retry attempts for transient failures.
+    /// Default is 3.
+    /// </summary>
+    /// <remarks>
+    /// Retries use exponential backoff. Set to 0 to disable retries.
+    /// Only retries on transient errors (rate limits, timeouts, 5xx errors).
+    /// </remarks>
+    public int MaxRetries { get; set; } = 3;
+
+    /// <summary>
+    /// Gets or sets the request timeout in seconds.
+    /// Default is 300 seconds (5 minutes).
+    /// </summary>
+    /// <remarks>
+    /// Claude API calls can take time for large context windows or complex tool use.
+    /// Adjust based on your use case and expected response times.
+    /// </remarks>
+    public int TimeoutSeconds { get; set; } = 300;
+
+    /// <summary>
+    /// Gets or sets the base delay in milliseconds for exponential backoff.
+    /// Default is 1000ms (1 second).
+    /// </summary>
+    /// <remarks>
+    /// Delay formula: baseDelay * (2 ^ retryAttempt).
+    /// Example with base 1000ms: 1s, 2s, 4s for attempts 0, 1, 2.
+    /// </remarks>
+    public int RetryBaseDelayMs { get; set; } = 1000;
+
+    /// <summary>
+    /// Gets or sets whether to enable automatic prompt caching by default.
+    /// Default is true.
+    /// </summary>
+    /// <remarks>
+    /// Prompt caching can significantly reduce costs for repeated requests with similar prompts.
+    /// Individual requests can override this setting via LlmRequest.EnablePromptCaching.
+    /// </remarks>
+    public bool EnablePromptCachingByDefault { get; set; } = true;
+}

--- a/src/DiscordBot.Infrastructure/DiscordBot.Infrastructure.csproj
+++ b/src/DiscordBot.Infrastructure/DiscordBot.Infrastructure.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Anthropic" Version="12.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.*" />

--- a/src/DiscordBot.Infrastructure/Services/LLM/AgentRunner.cs
+++ b/src/DiscordBot.Infrastructure/Services/LLM/AgentRunner.cs
@@ -1,0 +1,347 @@
+using System.Text.Json;
+using DiscordBot.Core.DTOs.LLM;
+using DiscordBot.Core.DTOs.LLM.Enums;
+using DiscordBot.Core.Interfaces.LLM;
+using Microsoft.Extensions.Logging;
+
+namespace DiscordBot.Infrastructure.Services.LLM;
+
+/// <summary>
+/// Orchestrates the agentic loop (tool use cycles).
+/// Manages conversation history and iterates until a final response is generated.
+/// </summary>
+public class AgentRunner : IAgentRunner
+{
+    private readonly ILlmClient _llmClient;
+    private readonly ILogger<AgentRunner> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the AgentRunner.
+    /// </summary>
+    /// <param name="llmClient">LLM client for making completion requests.</param>
+    /// <param name="logger">Logger for diagnostic output.</param>
+    public AgentRunner(ILlmClient llmClient, ILogger<AgentRunner> logger)
+    {
+        _llmClient = llmClient ?? throw new ArgumentNullException(nameof(llmClient));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<AgentRunResult> RunAsync(
+        string userMessage,
+        AgentContext context,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(userMessage);
+        ArgumentNullException.ThrowIfNull(context);
+
+        _logger.LogDebug(
+            "Starting agent run for user {UserId} in guild {GuildId}. Max iterations: {MaxIterations}",
+            context.ExecutionContext.UserId,
+            context.ExecutionContext.GuildId,
+            context.MaxToolCallIterations);
+
+        // Initialize conversation history with the user's message
+        var conversationHistory = new List<LlmMessage>
+        {
+            new()
+            {
+                Role = LlmRole.User,
+                Content = userMessage
+            }
+        };
+
+        // Initialize token usage tracking
+        var totalUsage = new LlmUsage();
+        var totalToolCalls = 0;
+        var loopCount = 0;
+
+        // Build the initial LLM request
+        var request = new LlmRequest
+        {
+            SystemPrompt = context.SystemPrompt,
+            Messages = conversationHistory,
+            Tools = context.ToolRegistry?.GetEnabledTools().ToList(),
+            MaxTokens = context.MaxTokens,
+            Temperature = context.Temperature,
+            EnablePromptCaching = true
+        };
+
+        _logger.LogDebug(
+            "Initial request configured with {ToolCount} tools, MaxTokens: {MaxTokens}, Temperature: {Temperature}",
+            request.Tools?.Count ?? 0,
+            context.MaxTokens,
+            context.Temperature);
+
+        // Agentic loop
+        while (loopCount < context.MaxToolCallIterations)
+        {
+            loopCount++;
+
+            _logger.LogDebug(
+                "Agent loop iteration {Iteration}/{MaxIterations}",
+                loopCount,
+                context.MaxToolCallIterations);
+
+            // Call the LLM
+            var response = await _llmClient.CompleteAsync(request, cancellationToken);
+
+            // Check for LLM failure
+            if (!response.Success)
+            {
+                _logger.LogError(
+                    "LLM completion failed on iteration {Iteration}: {Error}",
+                    loopCount,
+                    response.ErrorMessage);
+
+                return new AgentRunResult
+                {
+                    Success = false,
+                    ErrorMessage = response.ErrorMessage ?? "LLM completion failed",
+                    LoopCount = loopCount,
+                    TotalToolCalls = totalToolCalls,
+                    TotalUsage = totalUsage
+                };
+            }
+
+            // Accumulate token usage
+            totalUsage.InputTokens += response.Usage.InputTokens;
+            totalUsage.OutputTokens += response.Usage.OutputTokens;
+            totalUsage.CachedTokens += response.Usage.CachedTokens;
+            totalUsage.CacheWriteTokens += response.Usage.CacheWriteTokens;
+
+            if (response.Usage.EstimatedCost.HasValue)
+            {
+                totalUsage.EstimatedCost = (totalUsage.EstimatedCost ?? 0) + response.Usage.EstimatedCost.Value;
+            }
+
+            _logger.LogDebug(
+                "LLM response received. StopReason: {StopReason}, InputTokens: {InputTokens}, OutputTokens: {OutputTokens}, CachedTokens: {CachedTokens}",
+                response.StopReason,
+                response.Usage.InputTokens,
+                response.Usage.OutputTokens,
+                response.Usage.CachedTokens);
+
+            // Handle stop reason
+            switch (response.StopReason)
+            {
+                case LlmStopReason.EndTurn:
+                    // Final response reached
+                    _logger.LogInformation(
+                        "Agent run completed successfully. Iterations: {Iterations}, ToolCalls: {ToolCalls}, TotalTokens: {TotalTokens}",
+                        loopCount,
+                        totalToolCalls,
+                        totalUsage.TotalTokens);
+
+                    return new AgentRunResult
+                    {
+                        Success = true,
+                        Response = response.Content ?? string.Empty,
+                        LoopCount = loopCount,
+                        TotalToolCalls = totalToolCalls,
+                        TotalUsage = totalUsage
+                    };
+
+                case LlmStopReason.ToolUse:
+                    // LLM wants to use tools
+                    if (response.ToolCalls == null || response.ToolCalls.Count == 0)
+                    {
+                        _logger.LogWarning(
+                            "StopReason is ToolUse but no tool calls provided. Treating as error");
+
+                        return new AgentRunResult
+                        {
+                            Success = false,
+                            ErrorMessage = "LLM indicated tool use but provided no tool calls",
+                            LoopCount = loopCount,
+                            TotalToolCalls = totalToolCalls,
+                            TotalUsage = totalUsage
+                        };
+                    }
+
+                    if (context.ToolRegistry == null)
+                    {
+                        _logger.LogWarning(
+                            "LLM requested tool use but no ToolRegistry is configured");
+
+                        return new AgentRunResult
+                        {
+                            Success = false,
+                            ErrorMessage = "Tool use requested but no ToolRegistry configured",
+                            LoopCount = loopCount,
+                            TotalToolCalls = totalToolCalls,
+                            TotalUsage = totalUsage
+                        };
+                    }
+
+                    _logger.LogDebug(
+                        "Processing {ToolCallCount} tool calls",
+                        response.ToolCalls.Count);
+
+                    // Add assistant message with tool calls to conversation history
+                    conversationHistory.Add(new LlmMessage
+                    {
+                        Role = LlmRole.Assistant,
+                        Content = response.Content ?? string.Empty,
+                        ToolCalls = response.ToolCalls
+                    });
+
+                    // Execute each tool call
+                    var toolResults = new List<LlmToolResult>();
+
+                    foreach (var toolCall in response.ToolCalls)
+                    {
+                        totalToolCalls++;
+
+                        _logger.LogDebug(
+                            "Executing tool {ToolName} (ID: {ToolCallId})",
+                            toolCall.Name,
+                            toolCall.Id);
+
+                        try
+                        {
+                            var executionResult = await context.ToolRegistry.ExecuteToolAsync(
+                                toolCall.Name,
+                                toolCall.Input,
+                                context.ExecutionContext,
+                                cancellationToken);
+
+                            // Convert ToolExecutionResult to LlmToolResult
+                            JsonElement contentElement;
+                            if (executionResult.Success && executionResult.Data.HasValue)
+                            {
+                                contentElement = executionResult.Data.Value;
+                            }
+                            else if (!executionResult.Success)
+                            {
+                                // Convert error message to JSON
+                                contentElement = JsonSerializer.SerializeToElement(new
+                                {
+                                    error = executionResult.ErrorMessage ?? "Unknown error"
+                                });
+                            }
+                            else
+                            {
+                                // Success but no data
+                                contentElement = JsonSerializer.SerializeToElement(new
+                                {
+                                    success = true
+                                });
+                            }
+
+                            toolResults.Add(new LlmToolResult
+                            {
+                                ToolCallId = toolCall.Id,
+                                Content = contentElement,
+                                IsError = !executionResult.Success
+                            });
+
+                            if (executionResult.Success)
+                            {
+                                _logger.LogDebug(
+                                    "Tool {ToolName} executed successfully",
+                                    toolCall.Name);
+                            }
+                            else
+                            {
+                                _logger.LogWarning(
+                                    "Tool {ToolName} execution failed: {Error}",
+                                    toolCall.Name,
+                                    executionResult.ErrorMessage);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogError(ex,
+                                "Exception executing tool {ToolName}",
+                                toolCall.Name);
+
+                            // Return error result for this tool
+                            var errorElement = JsonSerializer.SerializeToElement(new
+                            {
+                                error = $"Tool execution exception: {ex.Message}"
+                            });
+
+                            toolResults.Add(new LlmToolResult
+                            {
+                                ToolCallId = toolCall.Id,
+                                Content = errorElement,
+                                IsError = true
+                            });
+                        }
+                    }
+
+                    // Add tool results as a user message
+                    conversationHistory.Add(new LlmMessage
+                    {
+                        Role = LlmRole.User,
+                        ToolResults = toolResults
+                    });
+
+                    // Update the request for the next iteration
+                    request.Messages = conversationHistory;
+
+                    _logger.LogDebug(
+                        "Tool execution cycle complete. Continuing to next iteration");
+
+                    break;
+
+                case LlmStopReason.MaxTokens:
+                    _logger.LogWarning(
+                        "Agent run stopped due to max tokens limit. Returning partial response");
+
+                    return new AgentRunResult
+                    {
+                        Success = true,
+                        Response = response.Content ?? string.Empty,
+                        LoopCount = loopCount,
+                        TotalToolCalls = totalToolCalls,
+                        TotalUsage = totalUsage,
+                        ErrorMessage = "Response truncated due to max tokens limit"
+                    };
+
+                case LlmStopReason.Error:
+                    _logger.LogError(
+                        "LLM returned error stop reason: {Error}",
+                        response.ErrorMessage);
+
+                    return new AgentRunResult
+                    {
+                        Success = false,
+                        ErrorMessage = response.ErrorMessage ?? "LLM returned error stop reason",
+                        LoopCount = loopCount,
+                        TotalToolCalls = totalToolCalls,
+                        TotalUsage = totalUsage
+                    };
+
+                default:
+                    _logger.LogWarning(
+                        "Unexpected stop reason: {StopReason}",
+                        response.StopReason);
+
+                    return new AgentRunResult
+                    {
+                        Success = false,
+                        ErrorMessage = $"Unexpected stop reason: {response.StopReason}",
+                        LoopCount = loopCount,
+                        TotalToolCalls = totalToolCalls,
+                        TotalUsage = totalUsage
+                    };
+            }
+        }
+
+        // Exceeded max iterations
+        _logger.LogWarning(
+            "Agent run exceeded maximum iterations ({MaxIterations}). Returning incomplete result",
+            context.MaxToolCallIterations);
+
+        return new AgentRunResult
+        {
+            Success = false,
+            ErrorMessage = $"Exceeded maximum tool call iterations ({context.MaxToolCallIterations})",
+            LoopCount = loopCount,
+            TotalToolCalls = totalToolCalls,
+            TotalUsage = totalUsage
+        };
+    }
+}

--- a/src/DiscordBot.Infrastructure/Services/LLM/Anthropic/AnthropicLlmClient.cs
+++ b/src/DiscordBot.Infrastructure/Services/LLM/Anthropic/AnthropicLlmClient.cs
@@ -1,0 +1,262 @@
+using Anthropic;
+using Anthropic.Models.Messages;
+using DiscordBot.Core.Configuration;
+using DiscordBot.Core.DTOs.LLM;
+using DiscordBot.Core.DTOs.LLM.Enums;
+using DiscordBot.Core.Interfaces.LLM;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace DiscordBot.Infrastructure.Services.LLM.Anthropic;
+
+/// <summary>
+/// Anthropic Claude API client implementation of ILlmClient.
+/// Uses the official Anthropic package and handles API calls, retry logic, and message mapping.
+/// </summary>
+public class AnthropicLlmClient : ILlmClient
+{
+    private readonly AnthropicClient _client;
+    private readonly IOptions<AnthropicOptions> _options;
+    private readonly ILogger<AnthropicLlmClient> _logger;
+
+    public AnthropicLlmClient(
+        AnthropicClient client,
+        IOptions<AnthropicOptions> options,
+        ILogger<AnthropicLlmClient> logger)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public string ProviderName => "Anthropic";
+
+    /// <inheritdoc />
+    public bool SupportsToolUse => true;
+
+    /// <inheritdoc />
+    public bool SupportsPromptCaching => true;
+
+    /// <inheritdoc />
+    public async Task<LlmResponse> CompleteAsync(
+        LlmRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var options = _options.Value;
+
+        // Validate API key
+        if (string.IsNullOrEmpty(options.ApiKey))
+        {
+            _logger.LogError("Anthropic API key is not configured");
+            return new LlmResponse
+            {
+                Success = false,
+                StopReason = LlmStopReason.Error,
+                ErrorMessage = "Anthropic API key is not configured"
+            };
+        }
+
+        // Build the message request parameters
+        var messageParams = BuildMessageParams(request);
+
+        // Execute with retry logic
+        for (int attempt = 0; attempt <= options.MaxRetries; attempt++)
+        {
+            try
+            {
+                // Create timeout cancellation token source
+                using var timeoutCts = new CancellationTokenSource(
+                    TimeSpan.FromSeconds(options.TimeoutSeconds));
+
+                // Combine timeout with caller's cancellation token
+                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+                    cancellationToken, timeoutCts.Token);
+
+                _logger.LogDebug(
+                    "Sending Anthropic completion request (attempt {Attempt}/{MaxAttempts})",
+                    attempt + 1,
+                    options.MaxRetries + 1);
+
+                // Call Anthropic API using the official SDK
+                var response = await _client.Messages.Create(
+                    messageParams,
+                    cancellationToken: linkedCts.Token);
+
+                _logger.LogInformation(
+                    "Anthropic completion successful. Tokens: {InputTokens} in, {OutputTokens} out, {CachedTokens} cached",
+                    response.Usage.InputTokens,
+                    response.Usage.OutputTokens,
+                    response.Usage.CacheReadInputTokens ?? 0);
+
+                // Map response to LlmResponse
+                return AnthropicMessageMapper.ToLlmResponse(response);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Caller cancelled the operation - don't retry
+                _logger.LogWarning("Anthropic completion request was cancelled");
+                return new LlmResponse
+                {
+                    Success = false,
+                    StopReason = LlmStopReason.Error,
+                    ErrorMessage = "Request was cancelled"
+                };
+            }
+            catch (OperationCanceledException)
+            {
+                // Timeout occurred
+                _logger.LogWarning(
+                    "Anthropic completion request timed out after {TimeoutSeconds} seconds (attempt {Attempt}/{MaxAttempts})",
+                    options.TimeoutSeconds,
+                    attempt + 1,
+                    options.MaxRetries + 1);
+
+                if (attempt >= options.MaxRetries)
+                {
+                    return new LlmResponse
+                    {
+                        Success = false,
+                        StopReason = LlmStopReason.Error,
+                        ErrorMessage = $"Request timed out after {options.TimeoutSeconds} seconds"
+                    };
+                }
+
+                await DelayForRetry(attempt, options.RetryBaseDelayMs, cancellationToken);
+            }
+            catch (Exception ex) when (IsTransientError(ex))
+            {
+                // Transient error - retry with exponential backoff
+                _logger.LogWarning(
+                    ex,
+                    "Transient error calling Anthropic API (attempt {Attempt}/{MaxAttempts}): {ErrorMessage}",
+                    attempt + 1,
+                    options.MaxRetries + 1,
+                    ex.Message);
+
+                if (attempt >= options.MaxRetries)
+                {
+                    return new LlmResponse
+                    {
+                        Success = false,
+                        StopReason = LlmStopReason.Error,
+                        ErrorMessage = $"Request failed after {options.MaxRetries + 1} attempts: {ex.Message}"
+                    };
+                }
+
+                await DelayForRetry(attempt, options.RetryBaseDelayMs, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                // Permanent error - don't retry
+                _logger.LogError(
+                    ex,
+                    "Permanent error calling Anthropic API: {ErrorMessage}",
+                    ex.Message);
+
+                return new LlmResponse
+                {
+                    Success = false,
+                    StopReason = LlmStopReason.Error,
+                    ErrorMessage = ex.Message
+                };
+            }
+        }
+
+        // Should never reach here, but satisfy compiler
+        return new LlmResponse
+        {
+            Success = false,
+            StopReason = LlmStopReason.Error,
+            ErrorMessage = "Unknown error occurred"
+        };
+    }
+
+    /// <summary>
+    /// Builds MessageCreateParams from LlmRequest.
+    /// </summary>
+    private MessageCreateParams BuildMessageParams(LlmRequest request)
+    {
+        var options = _options.Value;
+
+        // Determine the model to use - Model class has static properties for known models
+        var modelName = !string.IsNullOrEmpty(request.Model)
+            ? request.Model
+            : options.DefaultModel;
+
+        // Build base params with object initializer (all init-only properties set here)
+        var messageParams = new MessageCreateParams
+        {
+            Model = modelName,
+            MaxTokens = request.MaxTokens,
+            Messages = AnthropicMessageMapper.ToAnthropicMessages(request),
+            // Set system prompt if provided
+            System = !string.IsNullOrEmpty(request.SystemPrompt)
+                ? (request.EnablePromptCaching && options.EnablePromptCachingByDefault
+                    ? AnthropicMessageMapper.CreateCachedSystemMessage(request.SystemPrompt)
+                    : AnthropicMessageMapper.CreateSystemMessage(request.SystemPrompt))
+                : null,
+            // Set tools if provided
+            Tools = request.Tools?.Any() == true
+                ? AnthropicMessageMapper.ToAnthropicTools(request.Tools)
+                : null
+        };
+
+        return messageParams;
+    }
+
+    /// <summary>
+    /// Determines if an exception represents a transient error that should be retried.
+    /// </summary>
+    private static bool IsTransientError(Exception ex)
+    {
+        // Check exception type and message for known transient errors
+        var message = ex.Message.ToLowerInvariant();
+
+        // Rate limits
+        if (message.Contains("rate limit") || message.Contains("429"))
+        {
+            return true;
+        }
+
+        // Timeouts
+        if (message.Contains("timeout") || message.Contains("timed out"))
+        {
+            return true;
+        }
+
+        // Server errors (5xx)
+        if (message.Contains("500") || message.Contains("502") ||
+            message.Contains("503") || message.Contains("504"))
+        {
+            return true;
+        }
+
+        // Network errors
+        if (ex is HttpRequestException or TaskCanceledException)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Delays for retry with exponential backoff.
+    /// </summary>
+    private async Task DelayForRetry(
+        int attempt,
+        int baseDelayMs,
+        CancellationToken cancellationToken)
+    {
+        // Exponential backoff: baseDelay * (2 ^ attempt)
+        var delayMs = baseDelayMs * (int)Math.Pow(2, attempt);
+
+        _logger.LogDebug(
+            "Retrying Anthropic API call in {DelayMs}ms (attempt {Attempt})",
+            delayMs,
+            attempt + 1);
+
+        await Task.Delay(delayMs, cancellationToken);
+    }
+}

--- a/src/DiscordBot.Infrastructure/Services/LLM/Anthropic/AnthropicMessageMapper.cs
+++ b/src/DiscordBot.Infrastructure/Services/LLM/Anthropic/AnthropicMessageMapper.cs
@@ -1,0 +1,277 @@
+using System.Text.Json;
+using Anthropic;
+using Anthropic.Models.Messages;
+using DiscordBot.Core.DTOs.LLM;
+using DiscordBot.Core.DTOs.LLM.Enums;
+
+namespace DiscordBot.Infrastructure.Services.LLM.Anthropic;
+
+/// <summary>
+/// Maps between provider-agnostic LLM DTOs and Anthropic SDK types.
+/// Uses the official Anthropic package (12.2.0+).
+/// </summary>
+public static class AnthropicMessageMapper
+{
+    /// <summary>
+    /// Converts LlmRequest messages to Anthropic MessageParam format.
+    /// </summary>
+    /// <param name="request">The LLM request containing messages to convert.</param>
+    /// <returns>List of Anthropic MessageParam objects.</returns>
+    public static List<MessageParam> ToAnthropicMessages(LlmRequest request)
+    {
+        var messages = new List<MessageParam>();
+
+        foreach (var msg in request.Messages)
+        {
+            switch (msg.Role)
+            {
+                case LlmRole.User:
+                    messages.Add(CreateUserMessage(msg));
+                    break;
+
+                case LlmRole.Assistant:
+                    messages.Add(CreateAssistantMessage(msg));
+                    break;
+
+                case LlmRole.System:
+                    // System messages are handled separately in Anthropic API
+                    // They should be passed as System parameter, not in messages array
+                    throw new ArgumentException(
+                        "System role messages should be set via LlmRequest.SystemPrompt, not in Messages list.");
+
+                default:
+                    throw new ArgumentException($"Unsupported role: {msg.Role}");
+            }
+        }
+
+        return messages;
+    }
+
+    /// <summary>
+    /// Creates a user message, handling both text content and tool results.
+    /// </summary>
+    private static MessageParam CreateUserMessage(LlmMessage msg)
+    {
+        var contentBlocks = new List<ContentBlockParam>();
+
+        // Add text content if present
+        if (!string.IsNullOrEmpty(msg.Content))
+        {
+            contentBlocks.Add(new TextBlockParam { Text = msg.Content });
+        }
+
+        // Add tool results if present
+        if (msg.ToolResults?.Any() == true)
+        {
+            foreach (var toolResult in msg.ToolResults)
+            {
+                contentBlocks.Add(new ToolResultBlockParam
+                {
+                    ToolUseID = toolResult.ToolCallId,
+                    Content = toolResult.Content.GetRawText(),
+                    IsError = toolResult.IsError
+                });
+            }
+        }
+
+        return new MessageParam
+        {
+            Role = Role.User,
+            Content = contentBlocks
+        };
+    }
+
+    /// <summary>
+    /// Creates an assistant message, handling both text content and tool calls.
+    /// </summary>
+    private static MessageParam CreateAssistantMessage(LlmMessage msg)
+    {
+        var contentBlocks = new List<ContentBlockParam>();
+
+        // Add text content if present
+        if (!string.IsNullOrEmpty(msg.Content))
+        {
+            contentBlocks.Add(new TextBlockParam { Text = msg.Content });
+        }
+
+        // Add tool use blocks if present
+        if (msg.ToolCalls?.Any() == true)
+        {
+            foreach (var toolCall in msg.ToolCalls)
+            {
+                // Deserialize JsonElement to IReadOnlyDictionary<string, JsonElement> for the Input property
+                var inputDict = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(
+                    toolCall.Input.GetRawText()) ?? new Dictionary<string, JsonElement>();
+
+                contentBlocks.Add(new ToolUseBlockParam
+                {
+                    ID = toolCall.Id,
+                    Name = toolCall.Name,
+                    Input = inputDict
+                });
+            }
+        }
+
+        return new MessageParam
+        {
+            Role = Role.Assistant,
+            Content = contentBlocks
+        };
+    }
+
+    /// <summary>
+    /// Converts LLM tool definitions to Anthropic Tool format.
+    /// </summary>
+    /// <param name="tools">The tool definitions to convert.</param>
+    /// <returns>List of Anthropic Tool objects.</returns>
+    public static List<ToolUnion> ToAnthropicTools(List<LlmToolDefinition> tools)
+    {
+        return tools.Select(t =>
+        {
+            // Parse the input schema JSON to extract properties and required fields
+            var schemaDoc = JsonDocument.Parse(t.InputSchema.GetRawText());
+            var schemaRoot = schemaDoc.RootElement;
+
+            var properties = new Dictionary<string, JsonElement>();
+            List<string>? required = null;
+
+            if (schemaRoot.TryGetProperty("properties", out var propsElement))
+            {
+                foreach (var prop in propsElement.EnumerateObject())
+                {
+                    properties[prop.Name] = prop.Value.Clone();
+                }
+            }
+
+            if (schemaRoot.TryGetProperty("required", out var reqElement))
+            {
+                required = reqElement.EnumerateArray()
+                    .Select(e => e.GetString()!)
+                    .ToList();
+            }
+
+            var tool = new Tool
+            {
+                Name = t.Name,
+                Description = t.Description,
+                InputSchema = new InputSchema
+                {
+                    Properties = properties,
+                    Required = required
+                }
+            };
+
+            return (ToolUnion)tool;
+        }).ToList();
+    }
+
+    /// <summary>
+    /// Converts Anthropic Message response to provider-agnostic LlmResponse.
+    /// </summary>
+    /// <param name="response">The Anthropic message response.</param>
+    /// <returns>Provider-agnostic LLM response.</returns>
+    public static LlmResponse ToLlmResponse(Message response)
+    {
+        // Map stop reason - compare values since StopReason is an ApiEnum
+        LlmStopReason stopReason;
+        if (response.StopReason == StopReason.EndTurn)
+            stopReason = LlmStopReason.EndTurn;
+        else if (response.StopReason == StopReason.ToolUse)
+            stopReason = LlmStopReason.ToolUse;
+        else if (response.StopReason == StopReason.MaxTokens)
+            stopReason = LlmStopReason.MaxTokens;
+        else if (response.StopReason == StopReason.StopSequence)
+            stopReason = LlmStopReason.EndTurn;
+        else
+            stopReason = LlmStopReason.Error;
+
+        // Extract text content and tool calls from content blocks
+        string? textContent = null;
+        List<LlmToolCall>? toolCalls = null;
+
+        if (response.Content?.Any() == true)
+        {
+            var textBlocks = new List<string>();
+            var toolUseBlocks = new List<LlmToolCall>();
+
+            foreach (var block in response.Content)
+            {
+                if (block.Value is TextBlock textBlock)
+                {
+                    textBlocks.Add(textBlock.Text);
+                }
+                else if (block.Value is ToolUseBlock toolUseBlock)
+                {
+                    // Convert the Input dictionary back to JsonElement
+                    var inputJson = JsonSerializer.Serialize(toolUseBlock.Input);
+                    var inputElement = JsonDocument.Parse(inputJson).RootElement;
+
+                    toolUseBlocks.Add(new LlmToolCall
+                    {
+                        Id = toolUseBlock.ID,
+                        Name = toolUseBlock.Name,
+                        Input = inputElement.Clone()
+                    });
+                }
+            }
+
+            if (textBlocks.Any())
+            {
+                textContent = string.Join("\n", textBlocks);
+            }
+
+            if (toolUseBlocks.Any())
+            {
+                toolCalls = toolUseBlocks;
+            }
+        }
+
+        // Map usage information (cast long to int for our DTOs)
+        var usage = new LlmUsage
+        {
+            InputTokens = (int)response.Usage.InputTokens,
+            OutputTokens = (int)response.Usage.OutputTokens,
+            CachedTokens = (int)(response.Usage.CacheReadInputTokens ?? 0),
+            CacheWriteTokens = (int)(response.Usage.CacheCreationInputTokens ?? 0)
+        };
+
+        return new LlmResponse
+        {
+            Success = true,
+            Content = textContent,
+            StopReason = stopReason,
+            ToolCalls = toolCalls,
+            Usage = usage
+        };
+    }
+
+    /// <summary>
+    /// Creates a system message with cache control for prompt caching.
+    /// </summary>
+    /// <param name="systemPrompt">The system prompt text.</param>
+    /// <returns>List of TextBlockParam with cache control enabled.</returns>
+    public static List<TextBlockParam> CreateCachedSystemMessage(string systemPrompt)
+    {
+        return new List<TextBlockParam>
+        {
+            new TextBlockParam
+            {
+                Text = systemPrompt,
+                CacheControl = new CacheControlEphemeral()
+            }
+        };
+    }
+
+    /// <summary>
+    /// Creates a system message without cache control.
+    /// </summary>
+    /// <param name="systemPrompt">The system prompt text.</param>
+    /// <returns>List of TextBlockParam.</returns>
+    public static List<TextBlockParam> CreateSystemMessage(string systemPrompt)
+    {
+        return new List<TextBlockParam>
+        {
+            new TextBlockParam { Text = systemPrompt }
+        };
+    }
+}

--- a/tests/DiscordBot.Tests/Infrastructure/LLM/AgentRunnerTests.cs
+++ b/tests/DiscordBot.Tests/Infrastructure/LLM/AgentRunnerTests.cs
@@ -1,0 +1,861 @@
+using System.Text.Json;
+using DiscordBot.Core.DTOs.LLM;
+using DiscordBot.Core.DTOs.LLM.Enums;
+using DiscordBot.Core.Interfaces.LLM;
+using DiscordBot.Infrastructure.Services.LLM;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace DiscordBot.Tests.Infrastructure.LLM;
+
+/// <summary>
+/// Unit tests for AgentRunner.
+/// Tests the agentic loop orchestration, tool use cycles, and error handling.
+/// </summary>
+public class AgentRunnerTests
+{
+    private readonly Mock<ILlmClient> _mockLlmClient;
+    private readonly Mock<ILogger<AgentRunner>> _mockLogger;
+    private readonly AgentRunner _agentRunner;
+
+    public AgentRunnerTests()
+    {
+        _mockLlmClient = new Mock<ILlmClient>();
+        _mockLogger = new Mock<ILogger<AgentRunner>>();
+        _agentRunner = new AgentRunner(_mockLlmClient.Object, _mockLogger.Object);
+    }
+
+    #region Happy Path Tests
+
+    [Fact]
+    public async Task RunAsync_WithSuccessfulResponse_ReturnsSuccess()
+    {
+        // Arrange
+        const string userMessage = "Hello, agent!";
+        var context = new AgentContext
+        {
+            SystemPrompt = "You are a helpful assistant.",
+            ExecutionContext = new ToolContext { UserId = 123, GuildId = 456 },
+            MaxTokens = 1024,
+            Temperature = 0.7,
+            MaxToolCallIterations = 5
+        };
+
+        var llmResponse = new LlmResponse
+        {
+            Success = true,
+            Content = "Hello! I'm ready to help.",
+            StopReason = LlmStopReason.EndTurn,
+            Usage = new LlmUsage
+            {
+                InputTokens = 50,
+                OutputTokens = 20,
+                CachedTokens = 0,
+                CacheWriteTokens = 0
+            }
+        };
+
+        _mockLlmClient.Setup(c => c.CompleteAsync(It.IsAny<LlmRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(llmResponse);
+
+        // Act
+        var result = await _agentRunner.RunAsync(userMessage, context);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Success.Should().BeTrue();
+        result.Response.Should().Be("Hello! I'm ready to help.");
+        result.LoopCount.Should().Be(1);
+        result.TotalToolCalls.Should().Be(0);
+        result.TotalUsage.InputTokens.Should().Be(50);
+        result.TotalUsage.OutputTokens.Should().Be(20);
+        result.ErrorMessage.Should().BeNullOrEmpty();
+    }
+
+    #endregion
+
+    #region Tool Use Tests
+
+    [Fact]
+    public async Task RunAsync_WithToolUse_ExecutesToolsAndContinues()
+    {
+        // Arrange
+        const string userMessage = "What are the user roles?";
+
+        var toolRegistry = new Mock<IToolRegistry>();
+        var context = new AgentContext
+        {
+            SystemPrompt = "You are a helpful assistant.",
+            ToolRegistry = toolRegistry.Object,
+            ExecutionContext = new ToolContext { UserId = 123, GuildId = 456 },
+            MaxTokens = 1024,
+            Temperature = 0.7,
+            MaxToolCallIterations = 5
+        };
+
+        var toolDef = new LlmToolDefinition
+        {
+            Name = "get_roles",
+            Description = "Get user roles",
+            InputSchema = JsonDocument.Parse("""{"properties": {}, "required": []}""").RootElement
+        };
+
+        toolRegistry.Setup(t => t.GetEnabledTools())
+            .Returns(new[] { toolDef });
+
+        // First response: tool use
+        var toolCall = new LlmToolCall
+        {
+            Id = "call-1",
+            Name = "get_roles",
+            Input = JsonDocument.Parse("""{}""").RootElement
+        };
+
+        var toolUseResponse = new LlmResponse
+        {
+            Success = true,
+            Content = "I'll check the roles for you.",
+            StopReason = LlmStopReason.ToolUse,
+            ToolCalls = new List<LlmToolCall> { toolCall },
+            Usage = new LlmUsage { InputTokens = 50, OutputTokens = 30 }
+        };
+
+        // Second response: final answer
+        var finalResponse = new LlmResponse
+        {
+            Success = true,
+            Content = "The user has admin and moderator roles.",
+            StopReason = LlmStopReason.EndTurn,
+            Usage = new LlmUsage { InputTokens = 100, OutputTokens = 25 }
+        };
+
+        _mockLlmClient.SetupSequence(c => c.CompleteAsync(It.IsAny<LlmRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(toolUseResponse)
+            .ReturnsAsync(finalResponse);
+
+        var toolResult = JsonDocument.Parse("""{"roles": ["admin", "moderator"]}""").RootElement;
+        toolRegistry.Setup(t => t.ExecuteToolAsync("get_roles", It.IsAny<JsonElement>(), It.IsAny<ToolContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ToolExecutionResult.CreateSuccess(toolResult));
+
+        // Act
+        var result = await _agentRunner.RunAsync(userMessage, context);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Success.Should().BeTrue();
+        result.Response.Should().Be("The user has admin and moderator roles.");
+        result.LoopCount.Should().Be(2);
+        result.TotalToolCalls.Should().Be(1);
+        result.TotalUsage.InputTokens.Should().Be(150); // 50 + 100
+        result.TotalUsage.OutputTokens.Should().Be(55); // 30 + 25
+
+        // Verify tool was executed
+        toolRegistry.Verify(
+            t => t.ExecuteToolAsync("get_roles", It.IsAny<JsonElement>(), It.IsAny<ToolContext>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_WithMultipleToolCalls_ExecutesAllTools()
+    {
+        // Arrange
+        const string userMessage = "Get user info and roles";
+
+        var toolRegistry = new Mock<IToolRegistry>();
+        var context = new AgentContext
+        {
+            SystemPrompt = "You are a helpful assistant.",
+            ToolRegistry = toolRegistry.Object,
+            ExecutionContext = new ToolContext { UserId = 123, GuildId = 456 },
+            MaxToolCallIterations = 5
+        };
+
+        var toolDef1 = new LlmToolDefinition
+        {
+            Name = "get_user_info",
+            Description = "Get user information",
+            InputSchema = JsonDocument.Parse("""{"properties": {}, "required": []}""").RootElement
+        };
+
+        var toolDef2 = new LlmToolDefinition
+        {
+            Name = "get_roles",
+            Description = "Get user roles",
+            InputSchema = JsonDocument.Parse("""{"properties": {}, "required": []}""").RootElement
+        };
+
+        toolRegistry.Setup(t => t.GetEnabledTools())
+            .Returns(new[] { toolDef1, toolDef2 });
+
+        // Response with multiple tool calls
+        var toolCall1 = new LlmToolCall
+        {
+            Id = "call-1",
+            Name = "get_user_info",
+            Input = JsonDocument.Parse("""{}""").RootElement
+        };
+
+        var toolCall2 = new LlmToolCall
+        {
+            Id = "call-2",
+            Name = "get_roles",
+            Input = JsonDocument.Parse("""{}""").RootElement
+        };
+
+        var multiToolResponse = new LlmResponse
+        {
+            Success = true,
+            Content = "I'll fetch both pieces of information.",
+            StopReason = LlmStopReason.ToolUse,
+            ToolCalls = new List<LlmToolCall> { toolCall1, toolCall2 },
+            Usage = new LlmUsage { InputTokens = 50, OutputTokens = 30 }
+        };
+
+        var finalResponse = new LlmResponse
+        {
+            Success = true,
+            Content = "User info and roles retrieved.",
+            StopReason = LlmStopReason.EndTurn,
+            Usage = new LlmUsage { InputTokens = 150, OutputTokens = 25 }
+        };
+
+        _mockLlmClient.SetupSequence(c => c.CompleteAsync(It.IsAny<LlmRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(multiToolResponse)
+            .ReturnsAsync(finalResponse);
+
+        toolRegistry.Setup(t => t.ExecuteToolAsync("get_user_info", It.IsAny<JsonElement>(), It.IsAny<ToolContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ToolExecutionResult.CreateSuccess(JsonDocument.Parse("""{"username": "testuser"}""").RootElement));
+
+        toolRegistry.Setup(t => t.ExecuteToolAsync("get_roles", It.IsAny<JsonElement>(), It.IsAny<ToolContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ToolExecutionResult.CreateSuccess(JsonDocument.Parse("""{"roles": ["admin"]}""").RootElement));
+
+        // Act
+        var result = await _agentRunner.RunAsync(userMessage, context);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.LoopCount.Should().Be(2);
+        result.TotalToolCalls.Should().Be(2);
+
+        // Verify both tools were executed
+        toolRegistry.Verify(
+            t => t.ExecuteToolAsync("get_user_info", It.IsAny<JsonElement>(), It.IsAny<ToolContext>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        toolRegistry.Verify(
+            t => t.ExecuteToolAsync("get_roles", It.IsAny<JsonElement>(), It.IsAny<ToolContext>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    #endregion
+
+    #region Token Usage Tests
+
+    [Fact]
+    public async Task RunAsync_AccumulatesTokenUsage_AcrossIterations()
+    {
+        // Arrange
+        const string userMessage = "Test message";
+
+        var toolRegistry = new Mock<IToolRegistry>();
+        var context = new AgentContext
+        {
+            SystemPrompt = "You are a helpful assistant.",
+            ToolRegistry = toolRegistry.Object,
+            ExecutionContext = new ToolContext { UserId = 123, GuildId = 456 },
+            MaxToolCallIterations = 5
+        };
+
+        var toolDef = new LlmToolDefinition
+        {
+            Name = "test_tool",
+            Description = "Test tool",
+            InputSchema = JsonDocument.Parse("""{"properties": {}, "required": []}""").RootElement
+        };
+
+        toolRegistry.Setup(t => t.GetEnabledTools())
+            .Returns(new[] { toolDef });
+
+        // First response with tool use
+        var toolResponse = new LlmResponse
+        {
+            Success = true,
+            Content = "Calling tool",
+            StopReason = LlmStopReason.ToolUse,
+            ToolCalls = new List<LlmToolCall>
+            {
+                new() { Id = "call-1", Name = "test_tool", Input = JsonDocument.Parse("""{}""").RootElement }
+            },
+            Usage = new LlmUsage
+            {
+                InputTokens = 100,
+                OutputTokens = 50,
+                CachedTokens = 10,
+                CacheWriteTokens = 20
+            }
+        };
+
+        // Second response with final answer
+        var finalResponse = new LlmResponse
+        {
+            Success = true,
+            Content = "Done",
+            StopReason = LlmStopReason.EndTurn,
+            Usage = new LlmUsage
+            {
+                InputTokens = 200,
+                OutputTokens = 75,
+                CachedTokens = 5,
+                CacheWriteTokens = 0
+            }
+        };
+
+        _mockLlmClient.SetupSequence(c => c.CompleteAsync(It.IsAny<LlmRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(toolResponse)
+            .ReturnsAsync(finalResponse);
+
+        toolRegistry.Setup(t => t.ExecuteToolAsync("test_tool", It.IsAny<JsonElement>(), It.IsAny<ToolContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ToolExecutionResult.CreateSuccess(JsonDocument.Parse("""{"result": "ok"}""").RootElement));
+
+        // Act
+        var result = await _agentRunner.RunAsync(userMessage, context);
+
+        // Assert
+        result.TotalUsage.InputTokens.Should().Be(300); // 100 + 200
+        result.TotalUsage.OutputTokens.Should().Be(125); // 50 + 75
+        result.TotalUsage.CachedTokens.Should().Be(15); // 10 + 5
+        result.TotalUsage.CacheWriteTokens.Should().Be(20); // 20 + 0
+    }
+
+    [Fact]
+    public async Task RunAsync_AccumulatesEstimatedCost_AcrossIterations()
+    {
+        // Arrange
+        const string userMessage = "Test message";
+        var context = new AgentContext
+        {
+            SystemPrompt = "You are a helpful assistant.",
+            ExecutionContext = new ToolContext { UserId = 123, GuildId = 456 },
+            MaxToolCallIterations = 5
+        };
+
+        var response1 = new LlmResponse
+        {
+            Success = true,
+            Content = "Response 1",
+            StopReason = LlmStopReason.EndTurn,
+            Usage = new LlmUsage
+            {
+                InputTokens = 100,
+                OutputTokens = 50,
+                EstimatedCost = 0.01m
+            }
+        };
+
+        var response2 = new LlmResponse
+        {
+            Success = true,
+            Content = "Response 2",
+            StopReason = LlmStopReason.EndTurn,
+            Usage = new LlmUsage
+            {
+                InputTokens = 50,
+                OutputTokens = 25,
+                EstimatedCost = 0.005m
+            }
+        };
+
+        _mockLlmClient.Setup(c => c.CompleteAsync(It.IsAny<LlmRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response1);
+
+        // Act - First call
+        var result1 = await _agentRunner.RunAsync(userMessage, context);
+
+        // Assert
+        result1.TotalUsage.EstimatedCost.Should().Be(0.01m);
+    }
+
+    #endregion
+
+    #region Error Handling Tests
+
+    [Fact]
+    public async Task RunAsync_WithLlmFailure_ReturnsError()
+    {
+        // Arrange
+        const string userMessage = "Test message";
+        var context = new AgentContext
+        {
+            SystemPrompt = "You are a helpful assistant.",
+            ExecutionContext = new ToolContext { UserId = 123, GuildId = 456 }
+        };
+
+        var failureResponse = new LlmResponse
+        {
+            Success = false,
+            ErrorMessage = "LLM service unavailable"
+        };
+
+        _mockLlmClient.Setup(c => c.CompleteAsync(It.IsAny<LlmRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(failureResponse);
+
+        // Act
+        var result = await _agentRunner.RunAsync(userMessage, context);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Be("LLM service unavailable");
+        result.LoopCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task RunAsync_WithToolUseButNoToolCalls_ReturnsError()
+    {
+        // Arrange
+        const string userMessage = "Test message";
+
+        var toolRegistry = new Mock<IToolRegistry>();
+        var context = new AgentContext
+        {
+            SystemPrompt = "You are a helpful assistant.",
+            ToolRegistry = toolRegistry.Object,
+            ExecutionContext = new ToolContext { UserId = 123, GuildId = 456 }
+        };
+
+        toolRegistry.Setup(t => t.GetEnabledTools())
+            .Returns(new List<LlmToolDefinition>());
+
+        // LLM says it wants to use tools but provides no tool calls
+        var invalidResponse = new LlmResponse
+        {
+            Success = true,
+            StopReason = LlmStopReason.ToolUse,
+            ToolCalls = null, // No tool calls!
+            Usage = new LlmUsage()
+        };
+
+        _mockLlmClient.Setup(c => c.CompleteAsync(It.IsAny<LlmRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(invalidResponse);
+
+        // Act
+        var result = await _agentRunner.RunAsync(userMessage, context);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("tool calls");
+    }
+
+    [Fact]
+    public async Task RunAsync_WithToolUseButNoRegistry_ReturnsError()
+    {
+        // Arrange
+        const string userMessage = "Test message";
+        var context = new AgentContext
+        {
+            SystemPrompt = "You are a helpful assistant.",
+            ToolRegistry = null, // No registry
+            ExecutionContext = new ToolContext { UserId = 123, GuildId = 456 }
+        };
+
+        var toolUseResponse = new LlmResponse
+        {
+            Success = true,
+            StopReason = LlmStopReason.ToolUse,
+            ToolCalls = new List<LlmToolCall>
+            {
+                new() { Id = "call-1", Name = "tool", Input = JsonDocument.Parse("""{}""").RootElement }
+            },
+            Usage = new LlmUsage()
+        };
+
+        _mockLlmClient.Setup(c => c.CompleteAsync(It.IsAny<LlmRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(toolUseResponse);
+
+        // Act
+        var result = await _agentRunner.RunAsync(userMessage, context);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("ToolRegistry");
+    }
+
+    [Fact]
+    public async Task RunAsync_WithToolExecutionException_RecordsErrorAndContinues()
+    {
+        // Arrange
+        const string userMessage = "Test message";
+
+        var toolRegistry = new Mock<IToolRegistry>();
+        var context = new AgentContext
+        {
+            SystemPrompt = "You are a helpful assistant.",
+            ToolRegistry = toolRegistry.Object,
+            ExecutionContext = new ToolContext { UserId = 123, GuildId = 456 },
+            MaxToolCallIterations = 5
+        };
+
+        var toolDef = new LlmToolDefinition
+        {
+            Name = "failing_tool",
+            Description = "A tool that fails",
+            InputSchema = JsonDocument.Parse("""{"properties": {}, "required": []}""").RootElement
+        };
+
+        toolRegistry.Setup(t => t.GetEnabledTools())
+            .Returns(new[] { toolDef });
+
+        // First response: tool use
+        var toolUseResponse = new LlmResponse
+        {
+            Success = true,
+            StopReason = LlmStopReason.ToolUse,
+            ToolCalls = new List<LlmToolCall>
+            {
+                new() { Id = "call-1", Name = "failing_tool", Input = JsonDocument.Parse("""{}""").RootElement }
+            },
+            Usage = new LlmUsage { InputTokens = 50, OutputTokens = 30 }
+        };
+
+        // Final response after tool fails
+        var finalResponse = new LlmResponse
+        {
+            Success = true,
+            Content = "Tool failed, proceeding anyway.",
+            StopReason = LlmStopReason.EndTurn,
+            Usage = new LlmUsage { InputTokens = 100, OutputTokens = 25 }
+        };
+
+        _mockLlmClient.SetupSequence(c => c.CompleteAsync(It.IsAny<LlmRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(toolUseResponse)
+            .ReturnsAsync(finalResponse);
+
+        // Tool throws an exception
+        toolRegistry.Setup(t => t.ExecuteToolAsync("failing_tool", It.IsAny<JsonElement>(), It.IsAny<ToolContext>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Tool execution failed"));
+
+        // Act
+        var result = await _agentRunner.RunAsync(userMessage, context);
+
+        // Assert - Agent continues despite tool failure
+        result.Success.Should().BeTrue();
+        result.LoopCount.Should().Be(2);
+        result.TotalToolCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task RunAsync_WithMaxTokensStopReason_ReturnsTruncatedResponse()
+    {
+        // Arrange
+        const string userMessage = "Test message";
+        var context = new AgentContext
+        {
+            SystemPrompt = "You are a helpful assistant.",
+            ExecutionContext = new ToolContext { UserId = 123, GuildId = 456 },
+            MaxTokens = 100
+        };
+
+        var truncatedResponse = new LlmResponse
+        {
+            Success = true,
+            Content = "This response was truncated due to max tokens...",
+            StopReason = LlmStopReason.MaxTokens,
+            Usage = new LlmUsage { InputTokens = 50, OutputTokens = 100 }
+        };
+
+        _mockLlmClient.Setup(c => c.CompleteAsync(It.IsAny<LlmRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(truncatedResponse);
+
+        // Act
+        var result = await _agentRunner.RunAsync(userMessage, context);
+
+        // Assert
+        result.Success.Should().BeTrue(); // Still successful, but truncated
+        result.Response.Should().Be("This response was truncated due to max tokens...");
+        result.ErrorMessage.Should().Contain("max tokens");
+    }
+
+    [Fact]
+    public async Task RunAsync_WithErrorStopReason_ReturnsError()
+    {
+        // Arrange
+        const string userMessage = "Test message";
+        var context = new AgentContext
+        {
+            SystemPrompt = "You are a helpful assistant.",
+            ExecutionContext = new ToolContext { UserId = 123, GuildId = 456 }
+        };
+
+        var errorResponse = new LlmResponse
+        {
+            Success = true,
+            StopReason = LlmStopReason.Error,
+            ErrorMessage = "Internal LLM error occurred",
+            Usage = new LlmUsage()
+        };
+
+        _mockLlmClient.Setup(c => c.CompleteAsync(It.IsAny<LlmRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(errorResponse);
+
+        // Act
+        var result = await _agentRunner.RunAsync(userMessage, context);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Be("Internal LLM error occurred");
+    }
+
+    #endregion
+
+    #region Iteration Limit Tests
+
+    [Fact]
+    public async Task RunAsync_ExceedsMaxIterations_ReturnsError()
+    {
+        // Arrange
+        const string userMessage = "Test message";
+
+        var toolRegistry = new Mock<IToolRegistry>();
+        var context = new AgentContext
+        {
+            SystemPrompt = "You are a helpful assistant.",
+            ToolRegistry = toolRegistry.Object,
+            ExecutionContext = new ToolContext { UserId = 123, GuildId = 456 },
+            MaxToolCallIterations = 2 // Very low limit
+        };
+
+        var toolDef = new LlmToolDefinition
+        {
+            Name = "test_tool",
+            Description = "Test tool",
+            InputSchema = JsonDocument.Parse("""{"properties": {}, "required": []}""").RootElement
+        };
+
+        toolRegistry.Setup(t => t.GetEnabledTools())
+            .Returns(new[] { toolDef });
+
+        // Every response wants more tools (infinite loop scenario)
+        var toolUseResponse = new LlmResponse
+        {
+            Success = true,
+            StopReason = LlmStopReason.ToolUse,
+            ToolCalls = new List<LlmToolCall>
+            {
+                new() { Id = "call-1", Name = "test_tool", Input = JsonDocument.Parse("""{}""").RootElement }
+            },
+            Usage = new LlmUsage { InputTokens = 50, OutputTokens = 30 }
+        };
+
+        _mockLlmClient.Setup(c => c.CompleteAsync(It.IsAny<LlmRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(toolUseResponse);
+
+        toolRegistry.Setup(t => t.ExecuteToolAsync("test_tool", It.IsAny<JsonElement>(), It.IsAny<ToolContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ToolExecutionResult.CreateSuccess(JsonDocument.Parse("""{"result": "ok"}""").RootElement));
+
+        // Act
+        var result = await _agentRunner.RunAsync(userMessage, context);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("maximum tool call iterations");
+        result.LoopCount.Should().Be(2);
+    }
+
+    #endregion
+
+    #region Input Validation Tests
+
+    [Fact]
+    public async Task RunAsync_WithNullUserMessage_ThrowsArgumentException()
+    {
+        // Arrange
+        var context = new AgentContext { SystemPrompt = "Test" };
+
+        // Act & Assert
+        // ArgumentNullException is a subclass of ArgumentException
+        await Assert.ThrowsAnyAsync<ArgumentException>(() => _agentRunner.RunAsync(null!, context));
+    }
+
+    [Fact]
+    public async Task RunAsync_WithEmptyUserMessage_ThrowsArgumentException()
+    {
+        // Arrange
+        var context = new AgentContext { SystemPrompt = "Test" };
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(() => _agentRunner.RunAsync("", context));
+    }
+
+    [Fact]
+    public async Task RunAsync_WithNullContext_ThrowsArgumentNullException()
+    {
+        // Arrange
+        const string userMessage = "Test message";
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(() => _agentRunner.RunAsync(userMessage, null!));
+    }
+
+    #endregion
+
+    #region Constructor Tests
+
+    [Fact]
+    public void Constructor_WithNullLlmClient_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new AgentRunner(null!, _mockLogger.Object));
+    }
+
+    [Fact]
+    public void Constructor_WithNullLogger_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new AgentRunner(_mockLlmClient.Object, null!));
+    }
+
+    #endregion
+
+    #region Tool Execution Error Scenarios
+
+    [Fact]
+    public async Task RunAsync_WithToolExecutionError_IncludesErrorInResults()
+    {
+        // Arrange
+        const string userMessage = "Test message";
+
+        var toolRegistry = new Mock<IToolRegistry>();
+        var context = new AgentContext
+        {
+            SystemPrompt = "You are a helpful assistant.",
+            ToolRegistry = toolRegistry.Object,
+            ExecutionContext = new ToolContext { UserId = 123, GuildId = 456 },
+            MaxToolCallIterations = 5
+        };
+
+        var toolDef = new LlmToolDefinition
+        {
+            Name = "error_tool",
+            Description = "Tool that returns error",
+            InputSchema = JsonDocument.Parse("""{"properties": {}, "required": []}""").RootElement
+        };
+
+        toolRegistry.Setup(t => t.GetEnabledTools())
+            .Returns(new[] { toolDef });
+
+        // First response: tool use
+        var toolUseResponse = new LlmResponse
+        {
+            Success = true,
+            StopReason = LlmStopReason.ToolUse,
+            ToolCalls = new List<LlmToolCall>
+            {
+                new() { Id = "call-1", Name = "error_tool", Input = JsonDocument.Parse("""{}""").RootElement }
+            },
+            Usage = new LlmUsage { InputTokens = 50, OutputTokens = 30 }
+        };
+
+        // Final response
+        var finalResponse = new LlmResponse
+        {
+            Success = true,
+            Content = "Tool failed.",
+            StopReason = LlmStopReason.EndTurn,
+            Usage = new LlmUsage { InputTokens = 100, OutputTokens = 25 }
+        };
+
+        _mockLlmClient.SetupSequence(c => c.CompleteAsync(It.IsAny<LlmRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(toolUseResponse)
+            .ReturnsAsync(finalResponse);
+
+        // Tool returns error
+        toolRegistry.Setup(t => t.ExecuteToolAsync("error_tool", It.IsAny<JsonElement>(), It.IsAny<ToolContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ToolExecutionResult.CreateError("Tool execution failed"));
+
+        // Act
+        var result = await _agentRunner.RunAsync(userMessage, context);
+
+        // Assert - Agent continues despite tool error
+        result.Success.Should().BeTrue();
+        result.TotalToolCalls.Should().Be(1);
+    }
+
+    #endregion
+
+    #region Conversation History Tests
+
+    [Fact]
+    public async Task RunAsync_BuildsCorrectConversationHistory()
+    {
+        // Arrange
+        const string userMessage = "Initial message";
+
+        var toolRegistry = new Mock<IToolRegistry>();
+        var context = new AgentContext
+        {
+            SystemPrompt = "You are a helpful assistant.",
+            ToolRegistry = toolRegistry.Object,
+            ExecutionContext = new ToolContext { UserId = 123, GuildId = 456 },
+            MaxToolCallIterations = 5
+        };
+
+        var toolDef = new LlmToolDefinition
+        {
+            Name = "test_tool",
+            Description = "Test tool",
+            InputSchema = JsonDocument.Parse("""{"properties": {}, "required": []}""").RootElement
+        };
+
+        toolRegistry.Setup(t => t.GetEnabledTools())
+            .Returns(new[] { toolDef });
+
+        // First response: tool use
+        var toolCall = new LlmToolCall
+        {
+            Id = "call-1",
+            Name = "test_tool",
+            Input = JsonDocument.Parse("""{"param": "value"}""").RootElement
+        };
+
+        var toolUseResponse = new LlmResponse
+        {
+            Success = true,
+            Content = "Using tool",
+            StopReason = LlmStopReason.ToolUse,
+            ToolCalls = new List<LlmToolCall> { toolCall },
+            Usage = new LlmUsage { InputTokens = 50, OutputTokens = 30 }
+        };
+
+        var finalResponse = new LlmResponse
+        {
+            Success = true,
+            Content = "Final answer",
+            StopReason = LlmStopReason.EndTurn,
+            Usage = new LlmUsage { InputTokens = 100, OutputTokens = 25 }
+        };
+
+        LlmRequest? capturedRequest = null;
+        _mockLlmClient.Setup(c => c.CompleteAsync(It.IsAny<LlmRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<LlmRequest, CancellationToken>((req, _) => capturedRequest = req)
+            .ReturnsAsync(toolUseResponse);
+
+        _mockLlmClient.SetupSequence(c => c.CompleteAsync(It.IsAny<LlmRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(toolUseResponse)
+            .ReturnsAsync(finalResponse);
+
+        toolRegistry.Setup(t => t.ExecuteToolAsync("test_tool", It.IsAny<JsonElement>(), It.IsAny<ToolContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ToolExecutionResult.CreateSuccess(JsonDocument.Parse("""{"result": "ok"}""").RootElement));
+
+        // Act
+        var result = await _agentRunner.RunAsync(userMessage, context);
+
+        // Assert
+        result.Success.Should().BeTrue();
+
+        // Verify the second request includes the tool results
+        var secondCall = _mockLlmClient.Invocations[1];
+        var secondRequest = (LlmRequest)secondCall.Arguments[0];
+        secondRequest.Messages.Should().HaveCountGreaterThan(1);
+    }
+
+    #endregion
+}

--- a/tests/DiscordBot.Tests/Infrastructure/LLM/AnthropicMessageMapperTests.cs
+++ b/tests/DiscordBot.Tests/Infrastructure/LLM/AnthropicMessageMapperTests.cs
@@ -1,0 +1,755 @@
+using System.Text.Json;
+using Anthropic.Models.Messages;
+using DiscordBot.Core.DTOs.LLM;
+using DiscordBot.Core.DTOs.LLM.Enums;
+using DiscordBot.Infrastructure.Services.LLM.Anthropic;
+using FluentAssertions;
+
+namespace DiscordBot.Tests.Infrastructure.LLM;
+
+/// <summary>
+/// Unit tests for AnthropicMessageMapper.
+/// Tests conversion between provider-agnostic LLM DTOs and Anthropic SDK types.
+/// </summary>
+public class AnthropicMessageMapperTests
+{
+    #region ToAnthropicMessages Tests
+
+    [Fact]
+    public void ToAnthropicMessages_WithUserMessage_ConvertsCorrectly()
+    {
+        // Arrange
+        var request = new LlmRequest
+        {
+            Messages = new List<LlmMessage>
+            {
+                new()
+                {
+                    Role = LlmRole.User,
+                    Content = "Hello, assistant!"
+                }
+            }
+        };
+
+        // Act
+        var anthropicMessages = AnthropicMessageMapper.ToAnthropicMessages(request);
+
+        // Assert
+        anthropicMessages.Should().HaveCount(1);
+        anthropicMessages[0].Role.ToString().Should().Contain("user");
+        anthropicMessages[0].Content.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ToAnthropicMessages_WithAssistantMessage_ConvertsCorrectly()
+    {
+        // Arrange
+        var request = new LlmRequest
+        {
+            Messages = new List<LlmMessage>
+            {
+                new()
+                {
+                    Role = LlmRole.Assistant,
+                    Content = "Hello! How can I help?"
+                }
+            }
+        };
+
+        // Act
+        var anthropicMessages = AnthropicMessageMapper.ToAnthropicMessages(request);
+
+        // Assert
+        anthropicMessages.Should().HaveCount(1);
+        anthropicMessages[0].Role.ToString().Should().Contain("assistant");
+        anthropicMessages[0].Content.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ToAnthropicMessages_WithToolCalls_ConvertsCorrectly()
+    {
+        // Arrange
+        var toolInput = JsonDocument.Parse("""{"user_id": "123", "role": "admin"}""").RootElement;
+
+        var request = new LlmRequest
+        {
+            Messages = new List<LlmMessage>
+            {
+                new()
+                {
+                    Role = LlmRole.Assistant,
+                    Content = "I'll check the user roles.",
+                    ToolCalls = new List<LlmToolCall>
+                    {
+                        new()
+                        {
+                            Id = "tool-call-1",
+                            Name = "get_user_roles",
+                            Input = toolInput
+                        }
+                    }
+                }
+            }
+        };
+
+        // Act
+        var anthropicMessages = AnthropicMessageMapper.ToAnthropicMessages(request);
+
+        // Assert
+        anthropicMessages.Should().HaveCount(1);
+        anthropicMessages[0].Role.ToString().Should().Contain("assistant");
+        anthropicMessages[0].Content.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ToAnthropicMessages_WithToolResults_ConvertsCorrectly()
+    {
+        // Arrange
+        var resultContent = JsonDocument.Parse("""{"roles": ["admin", "moderator"]}""").RootElement;
+
+        var request = new LlmRequest
+        {
+            Messages = new List<LlmMessage>
+            {
+                new()
+                {
+                    Role = LlmRole.User,
+                    Content = "Here are the results.",
+                    ToolResults = new List<LlmToolResult>
+                    {
+                        new()
+                        {
+                            ToolCallId = "tool-call-1",
+                            Content = resultContent,
+                            IsError = false
+                        }
+                    }
+                }
+            }
+        };
+
+        // Act
+        var anthropicMessages = AnthropicMessageMapper.ToAnthropicMessages(request);
+
+        // Assert
+        anthropicMessages.Should().HaveCount(1);
+        anthropicMessages[0].Role.ToString().Should().Contain("user");
+        anthropicMessages[0].Content.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ToAnthropicMessages_WithErrorToolResult_ConvertsCorrectly()
+    {
+        // Arrange
+        var errorContent = JsonDocument.Parse("""{"error": "Tool not found"}""").RootElement;
+
+        var request = new LlmRequest
+        {
+            Messages = new List<LlmMessage>
+            {
+                new()
+                {
+                    Role = LlmRole.User,
+                    ToolResults = new List<LlmToolResult>
+                    {
+                        new()
+                        {
+                            ToolCallId = "tool-call-1",
+                            Content = errorContent,
+                            IsError = true
+                        }
+                    }
+                }
+            }
+        };
+
+        // Act
+        var anthropicMessages = AnthropicMessageMapper.ToAnthropicMessages(request);
+
+        // Assert
+        anthropicMessages.Should().HaveCount(1);
+        anthropicMessages[0].Role.ToString().Should().Contain("user");
+    }
+
+    [Fact]
+    public void ToAnthropicMessages_WithSystemMessage_ThrowsArgumentException()
+    {
+        // Arrange
+        var request = new LlmRequest
+        {
+            Messages = new List<LlmMessage>
+            {
+                new()
+                {
+                    Role = LlmRole.System,
+                    Content = "You are helpful."
+                }
+            }
+        };
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => AnthropicMessageMapper.ToAnthropicMessages(request));
+    }
+
+    [Fact]
+    public void ToAnthropicMessages_WithMultipleMessages_ConvertsAll()
+    {
+        // Arrange
+        var request = new LlmRequest
+        {
+            Messages = new List<LlmMessage>
+            {
+                new() { Role = LlmRole.User, Content = "Hello" },
+                new() { Role = LlmRole.Assistant, Content = "Hi there" },
+                new() { Role = LlmRole.User, Content = "How are you?" }
+            }
+        };
+
+        // Act
+        var anthropicMessages = AnthropicMessageMapper.ToAnthropicMessages(request);
+
+        // Assert
+        anthropicMessages.Should().HaveCount(3);
+        anthropicMessages[0].Role.ToString().Should().Contain("user");
+        anthropicMessages[1].Role.ToString().Should().Contain("assistant");
+        anthropicMessages[2].Role.ToString().Should().Contain("user");
+    }
+
+    [Fact]
+    public void ToAnthropicMessages_WithEmptyContentList_ReturnsEmpty()
+    {
+        // Arrange
+        var request = new LlmRequest { Messages = new List<LlmMessage>() };
+
+        // Act
+        var anthropicMessages = AnthropicMessageMapper.ToAnthropicMessages(request);
+
+        // Assert
+        anthropicMessages.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ToAnthropicMessages_WithOnlyToolResults_ConvertsCorrectly()
+    {
+        // Arrange
+        var resultContent = JsonDocument.Parse("""{"success": true}""").RootElement;
+
+        var request = new LlmRequest
+        {
+            Messages = new List<LlmMessage>
+            {
+                new()
+                {
+                    Role = LlmRole.User,
+                    ToolResults = new List<LlmToolResult>
+                    {
+                        new()
+                        {
+                            ToolCallId = "call-1",
+                            Content = resultContent,
+                            IsError = false
+                        }
+                    }
+                }
+            }
+        };
+
+        // Act
+        var anthropicMessages = AnthropicMessageMapper.ToAnthropicMessages(request);
+
+        // Assert
+        anthropicMessages.Should().HaveCount(1);
+        anthropicMessages[0].Role.ToString().Should().Contain("user");
+    }
+
+    [Fact]
+    public void ToAnthropicMessages_WithEmptyContent_StillConverts()
+    {
+        // Arrange
+        var request = new LlmRequest
+        {
+            Messages = new List<LlmMessage>
+            {
+                new()
+                {
+                    Role = LlmRole.User,
+                    Content = "" // Empty content
+                }
+            }
+        };
+
+        // Act
+        var anthropicMessages = AnthropicMessageMapper.ToAnthropicMessages(request);
+
+        // Assert
+        // Empty content should still create a message
+        anthropicMessages.Should().HaveCount(1);
+    }
+
+    #endregion
+
+    #region ToAnthropicTools Tests
+
+    [Fact]
+    public void ToAnthropicTools_ConvertsToolDefinitions_Correctly()
+    {
+        // Arrange
+        var inputSchema = JsonDocument.Parse("""
+        {
+            "properties": {
+                "user_id": {
+                    "type": "string",
+                    "description": "The user ID"
+                },
+                "role": {
+                    "type": "string",
+                    "description": "The role name"
+                }
+            },
+            "required": ["user_id", "role"]
+        }
+        """).RootElement;
+
+        var tools = new List<LlmToolDefinition>
+        {
+            new()
+            {
+                Name = "assign_role",
+                Description = "Assign a role to a user",
+                InputSchema = inputSchema
+            }
+        };
+
+        // Act
+        var anthropicTools = AnthropicMessageMapper.ToAnthropicTools(tools);
+
+        // Assert
+        anthropicTools.Should().HaveCount(1);
+        var tool = anthropicTools[0];
+        tool.Should().NotBeNull();
+        var typedTool = (Tool)tool.Value;
+        typedTool.Name.Should().Be("assign_role");
+        typedTool.Description.Should().Be("Assign a role to a user");
+    }
+
+    [Fact]
+    public void ToAnthropicTools_WithMultipleTools_ConvertsAll()
+    {
+        // Arrange
+        var schema1 = JsonDocument.Parse("""{"properties": {}, "required": []}""").RootElement;
+        var schema2 = JsonDocument.Parse("""{"properties": {}, "required": []}""").RootElement;
+
+        var tools = new List<LlmToolDefinition>
+        {
+            new() { Name = "tool1", Description = "First tool", InputSchema = schema1 },
+            new() { Name = "tool2", Description = "Second tool", InputSchema = schema2 }
+        };
+
+        // Act
+        var anthropicTools = AnthropicMessageMapper.ToAnthropicTools(tools);
+
+        // Assert
+        anthropicTools.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void ToAnthropicTools_WithNoRequiredFields_ConvertsCorrectly()
+    {
+        // Arrange
+        var inputSchema = JsonDocument.Parse("""
+        {
+            "properties": {
+                "optional_param": {
+                    "type": "string"
+                }
+            }
+        }
+        """).RootElement;
+
+        var tools = new List<LlmToolDefinition>
+        {
+            new()
+            {
+                Name = "optional_tool",
+                Description = "Tool with optional params",
+                InputSchema = inputSchema
+            }
+        };
+
+        // Act
+        var anthropicTools = AnthropicMessageMapper.ToAnthropicTools(tools);
+
+        // Assert
+        var tool = (Tool)anthropicTools[0].Value;
+        tool.Name.Should().Be("optional_tool");
+    }
+
+    [Fact]
+    public void ToAnthropicTools_WithComplexSchema_ConvertsCorrectly()
+    {
+        // Arrange
+        var inputSchema = JsonDocument.Parse("""
+        {
+            "properties": {
+                "filters": {
+                    "type": "object",
+                    "properties": {
+                        "status": { "type": "string" },
+                        "limit": { "type": "integer" }
+                    }
+                },
+                "sort_by": {
+                    "type": "string",
+                    "enum": ["name", "date", "relevance"]
+                }
+            },
+            "required": ["filters"]
+        }
+        """).RootElement;
+
+        var tools = new List<LlmToolDefinition>
+        {
+            new()
+            {
+                Name = "search",
+                Description = "Search with filters",
+                InputSchema = inputSchema
+            }
+        };
+
+        // Act
+        var anthropicTools = AnthropicMessageMapper.ToAnthropicTools(tools);
+
+        // Assert
+        var tool = (Tool)anthropicTools[0].Value;
+        tool.Name.Should().Be("search");
+        tool.Description.Should().Be("Search with filters");
+    }
+
+    [Fact]
+    public void ToAnthropicTools_WithEmptyToolsList_ReturnsEmpty()
+    {
+        // Arrange
+        var tools = new List<LlmToolDefinition>();
+
+        // Act
+        var result = AnthropicMessageMapper.ToAnthropicTools(tools);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    #endregion
+
+    #region ToLlmResponse Tests
+
+    [Fact]
+    public void ToLlmResponse_MapsTextContent_Correctly()
+    {
+        // Arrange
+        var anthropicResponse = CreateMessage(
+            stopReason: StopReason.EndTurn,
+            content: new List<ContentBlock> { new TextBlock { Text = "Hello! I can help you with that.", Citations = null } },
+            inputTokens: 100,
+            outputTokens: 50
+        );
+
+        // Act
+        var llmResponse = AnthropicMessageMapper.ToLlmResponse(anthropicResponse);
+
+        // Assert
+        llmResponse.Success.Should().BeTrue();
+        llmResponse.Content.Should().Be("Hello! I can help you with that.");
+        llmResponse.StopReason.Should().Be(LlmStopReason.EndTurn);
+    }
+
+    [Fact]
+    public void ToLlmResponse_MapsToolUseBlocks_Correctly()
+    {
+        // Arrange
+        var toolInput = new Dictionary<string, JsonElement>
+        {
+            { "user_id", JsonDocument.Parse("\"123\"").RootElement },
+            { "role", JsonDocument.Parse("\"admin\"").RootElement }
+        };
+
+        var anthropicResponse = CreateMessage(
+            stopReason: StopReason.ToolUse,
+            content: new List<ContentBlock>
+            {
+                new TextBlock { Text = "I'll assign the role now.", Citations = null },
+                new ToolUseBlock { ID = "tool-call-1", Name = "assign_role", Input = toolInput }
+            },
+            inputTokens: 100,
+            outputTokens: 50
+        );
+
+        // Act
+        var llmResponse = AnthropicMessageMapper.ToLlmResponse(anthropicResponse);
+
+        // Assert
+        llmResponse.Success.Should().BeTrue();
+        llmResponse.StopReason.Should().Be(LlmStopReason.ToolUse);
+        llmResponse.ToolCalls.Should().NotBeNull();
+        llmResponse.ToolCalls.Should().HaveCount(1);
+        llmResponse.ToolCalls![0].Id.Should().Be("tool-call-1");
+        llmResponse.ToolCalls[0].Name.Should().Be("assign_role");
+    }
+
+    [Fact]
+    public void ToLlmResponse_WithMultipleTextBlocks_ConcatenatesContent()
+    {
+        // Arrange
+        var anthropicResponse = CreateMessage(
+            stopReason: StopReason.EndTurn,
+            content: new List<ContentBlock>
+            {
+                new TextBlock { Text = "First part. ", Citations = null },
+                new TextBlock { Text = "Second part.", Citations = null }
+            },
+            inputTokens: 100,
+            outputTokens: 50
+        );
+
+        // Act
+        var llmResponse = AnthropicMessageMapper.ToLlmResponse(anthropicResponse);
+
+        // Assert
+        llmResponse.Content.Should().Contain("First part");
+        llmResponse.Content.Should().Contain("Second part");
+    }
+
+    [Fact]
+    public void ToLlmResponse_MapsStopReason_EndTurn()
+    {
+        // Arrange
+        var response = CreateMessage(
+            stopReason: StopReason.EndTurn,
+            content: new List<ContentBlock> { new TextBlock { Text = "Done", Citations = null } },
+            inputTokens: 100,
+            outputTokens: 50
+        );
+
+        // Act
+        var llmResponse = AnthropicMessageMapper.ToLlmResponse(response);
+
+        // Assert
+        llmResponse.StopReason.Should().Be(LlmStopReason.EndTurn);
+    }
+
+    [Fact]
+    public void ToLlmResponse_MapsStopReason_ToolUse()
+    {
+        // Arrange
+        var response = CreateMessage(
+            stopReason: StopReason.ToolUse,
+            content: new List<ContentBlock>
+            {
+                new ToolUseBlock { ID = "call-1", Name = "tool", Input = new Dictionary<string, JsonElement>() }
+            },
+            inputTokens: 100,
+            outputTokens: 50
+        );
+
+        // Act
+        var llmResponse = AnthropicMessageMapper.ToLlmResponse(response);
+
+        // Assert
+        llmResponse.StopReason.Should().Be(LlmStopReason.ToolUse);
+    }
+
+    [Fact]
+    public void ToLlmResponse_MapsStopReason_MaxTokens()
+    {
+        // Arrange
+        var response = CreateMessage(
+            stopReason: StopReason.MaxTokens,
+            content: new List<ContentBlock> { new TextBlock { Text = "Truncated...", Citations = null } },
+            inputTokens: 100,
+            outputTokens: 1024
+        );
+
+        // Act
+        var llmResponse = AnthropicMessageMapper.ToLlmResponse(response);
+
+        // Assert
+        llmResponse.StopReason.Should().Be(LlmStopReason.MaxTokens);
+    }
+
+    [Fact]
+    public void ToLlmResponse_MapsStopReason_StopSequence()
+    {
+        // Arrange
+        var response = CreateMessage(
+            stopReason: StopReason.StopSequence,
+            content: new List<ContentBlock> { new TextBlock { Text = "Stopped", Citations = null } },
+            inputTokens: 100,
+            outputTokens: 50
+        );
+
+        // Act
+        var llmResponse = AnthropicMessageMapper.ToLlmResponse(response);
+
+        // Assert
+        llmResponse.StopReason.Should().Be(LlmStopReason.EndTurn);
+    }
+
+    [Fact]
+    public void ToLlmResponse_MapsUsage_Correctly()
+    {
+        // Arrange
+        var response = CreateMessage(
+            stopReason: StopReason.EndTurn,
+            content: new List<ContentBlock> { new TextBlock { Text = "Response", Citations = null } },
+            inputTokens: 250,
+            outputTokens: 75,
+            cacheReadInputTokens: 100,
+            cacheCreationInputTokens: 50
+        );
+
+        // Act
+        var llmResponse = AnthropicMessageMapper.ToLlmResponse(response);
+
+        // Assert
+        llmResponse.Usage.InputTokens.Should().Be(250);
+        llmResponse.Usage.OutputTokens.Should().Be(75);
+        llmResponse.Usage.CachedTokens.Should().Be(100);
+        llmResponse.Usage.CacheWriteTokens.Should().Be(50);
+    }
+
+    [Fact]
+    public void ToLlmResponse_WithNullCacheTokens_DefaultsToZero()
+    {
+        // Arrange
+        var response = CreateMessage(
+            stopReason: StopReason.EndTurn,
+            content: new List<ContentBlock> { new TextBlock { Text = "Response", Citations = null } },
+            inputTokens: 100,
+            outputTokens: 50,
+            cacheReadInputTokens: null,
+            cacheCreationInputTokens: null
+        );
+
+        // Act
+        var llmResponse = AnthropicMessageMapper.ToLlmResponse(response);
+
+        // Assert
+        llmResponse.Usage.CachedTokens.Should().Be(0);
+        llmResponse.Usage.CacheWriteTokens.Should().Be(0);
+    }
+
+    [Fact]
+    public void ToLlmResponse_WithEmptyContent_ReturnsNullContent()
+    {
+        // Arrange
+        var response = CreateMessage(
+            stopReason: StopReason.EndTurn,
+            content: new List<ContentBlock>(),
+            inputTokens: 100,
+            outputTokens: 50
+        );
+
+        // Act
+        var llmResponse = AnthropicMessageMapper.ToLlmResponse(response);
+
+        // Assert
+        llmResponse.Content.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToLlmResponse_WithMultipleToolCalls_MapsAll()
+    {
+        // Arrange
+        var anthropicResponse = CreateMessage(
+            stopReason: StopReason.ToolUse,
+            content: new List<ContentBlock>
+            {
+                new ToolUseBlock { ID = "call-1", Name = "tool1", Input = new Dictionary<string, JsonElement>() },
+                new ToolUseBlock { ID = "call-2", Name = "tool2", Input = new Dictionary<string, JsonElement>() }
+            },
+            inputTokens: 100,
+            outputTokens: 50
+        );
+
+        // Act
+        var llmResponse = AnthropicMessageMapper.ToLlmResponse(anthropicResponse);
+
+        // Assert
+        llmResponse.ToolCalls.Should().HaveCount(2);
+        llmResponse.ToolCalls![0].Name.Should().Be("tool1");
+        llmResponse.ToolCalls[1].Name.Should().Be("tool2");
+    }
+
+    #endregion
+
+    #region System Message Tests
+
+    [Fact]
+    public void CreateCachedSystemMessage_SetsCacheControl()
+    {
+        // Arrange
+        const string systemPrompt = "You are a helpful assistant.";
+
+        // Act
+        var result = AnthropicMessageMapper.CreateCachedSystemMessage(systemPrompt);
+
+        // Assert
+        result.Should().HaveCount(1);
+        var message = result[0];
+        message.Text.Should().Be(systemPrompt);
+        message.CacheControl.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void CreateSystemMessage_HasNoCacheControl()
+    {
+        // Arrange
+        const string systemPrompt = "You are a helpful assistant.";
+
+        // Act
+        var result = AnthropicMessageMapper.CreateSystemMessage(systemPrompt);
+
+        // Assert
+        result.Should().HaveCount(1);
+        var message = result[0];
+        message.Text.Should().Be(systemPrompt);
+        message.CacheControl.Should().BeNull();
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    /// <summary>
+    /// Creates a Message object with required members set to valid defaults.
+    /// </summary>
+    private static Message CreateMessage(
+        StopReason stopReason,
+        List<ContentBlock> content,
+        long inputTokens,
+        long outputTokens,
+        long? cacheReadInputTokens = null,
+        long? cacheCreationInputTokens = null)
+    {
+        return new Message
+        {
+            ID = "msg-test",
+            Model = "claude-3-5-sonnet-20241022",
+            Content = content,
+            StopReason = stopReason,
+            StopSequence = null,
+            Usage = new Usage
+            {
+                InputTokens = inputTokens,
+                OutputTokens = outputTokens,
+                CacheReadInputTokens = cacheReadInputTokens,
+                CacheCreationInputTokens = cacheCreationInputTokens,
+                CacheCreation = null,
+                ServerToolUse = null,
+                ServiceTier = null
+            }
+        };
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

- Implements Claude API client and agent runner for the AI assistant feature
- Adds AnthropicLlmClient with retry logic, timeout handling, and prompt caching
- Adds AgentRunner for agentic tool-use loops
- Adds comprehensive unit tests (47 tests)

## Changes

- `AnthropicLlmClient`: Implements `ILlmClient` with Claude API calls, exponential backoff retry, timeout handling
- `AnthropicMessageMapper`: Converts between LLM DTOs and Anthropic SDK types
- `AgentRunner`: Orchestrates agentic loop with tool execution cycles, conversation history, and token tracking
- `AnthropicOptions`: Configuration for API key, model, timeouts
- `AssistantServiceExtensions`: DI registration via `AddAssistant()`
- Unit tests for AgentRunner and AnthropicMessageMapper

## Test Plan

- [x] All 47 new unit tests pass
- [x] Full solution builds without errors
- [ ] Manual testing with configured API key

Closes #1062

🤖 Generated with [Claude Code](https://claude.com/claude-code)