### PR TITLE
feat(assistant): Add Discord message handler and consent updates

### DIFF
--- a/src/DiscordBot.Bot/Commands/ConsentModule.cs
+++ b/src/DiscordBot.Bot/Commands/ConsentModule.cs
@@ -93,8 +93,8 @@ public class ConsentModule : InteractionModuleBase<SocketInteractionContext>
             var successEmbed = new EmbedBuilder()
                 .WithTitle("✅ Consent Granted")
                 .WithDescription($"You have opted in to **{GetConsentTypeName(type).ToLower()}**. " +
-                               "Your messages in DMs with this bot and in mutual servers may now be logged.\n\n" +
-                               "You can revoke consent at any time with `/consent revoke`.")
+                               $"{GetConsentGrantDescription(type)}\n\n" +
+                               $"You can revoke consent at any time with `/consent revoke {type}`.")
                 .WithColor(Color.Green)
                 .WithCurrentTimestamp()
                 .Build();
@@ -177,9 +177,9 @@ public class ConsentModule : InteractionModuleBase<SocketInteractionContext>
             var successEmbed = new EmbedBuilder()
                 .WithTitle("✅ Consent Revoked")
                 .WithDescription($"You have opted out of **{GetConsentTypeName(type).ToLower()}**. " +
-                               "Your messages will no longer be logged.\n\n" +
-                               "**Note:** Previously logged messages are retained per our data retention policy.\n" +
-                               "Use `/consent delete-data` to request deletion of your data.")
+                               $"{GetConsentRevokeDescription(type)}\n\n" +
+                               "**Note:** Previously logged data is retained per our data retention policy.\n" +
+                               "Use `/privacy` for more information about data handling.")
                 .WithColor(Color.Green)
                 .WithCurrentTimestamp()
                 .Build();
@@ -306,7 +306,42 @@ public class ConsentModule : InteractionModuleBase<SocketInteractionContext>
         return type switch
         {
             ConsentType.MessageLogging => "Message Logging",
+            ConsentType.AssistantUsage => "AI Assistant Usage",
             _ => type.ToString()
+        };
+    }
+
+    /// <summary>
+    /// Gets a user-friendly description for a consent type when granting.
+    /// </summary>
+    /// <param name="type">The consent type.</param>
+    /// <returns>A user-friendly description.</returns>
+    private static string GetConsentGrantDescription(ConsentType type)
+    {
+        return type switch
+        {
+            ConsentType.MessageLogging =>
+                "Your messages in DMs with this bot and in mutual servers may now be logged.",
+            ConsentType.AssistantUsage =>
+                "You can now mention the bot to ask questions. Your questions and responses will be processed by Claude AI and logged for quality purposes.",
+            _ => "Your consent has been recorded."
+        };
+    }
+
+    /// <summary>
+    /// Gets a user-friendly description for a consent type when revoking.
+    /// </summary>
+    /// <param name="type">The consent type.</param>
+    /// <returns>A user-friendly description.</returns>
+    private static string GetConsentRevokeDescription(ConsentType type)
+    {
+        return type switch
+        {
+            ConsentType.MessageLogging =>
+                "Your messages will no longer be logged.",
+            ConsentType.AssistantUsage =>
+                "You will no longer be able to use the AI assistant feature by mentioning the bot.",
+            _ => "Your consent has been revoked."
         };
     }
 }

--- a/src/DiscordBot.Bot/Extensions/DiscordServiceExtensions.cs
+++ b/src/DiscordBot.Bot/Extensions/DiscordServiceExtensions.cs
@@ -83,6 +83,9 @@ public static class DiscordServiceExtensions
         // Register VoiceStateHandler for real-time voice channel member count updates
         services.AddSingleton<VoiceStateHandler>();
 
+        // Register AssistantMessageHandler for AI assistant mentions
+        services.AddSingleton<AssistantMessageHandler>();
+
         // Register member sync services
         services.AddSingleton<IMemberSyncQueue, MemberSyncQueue>();
         services.AddHostedService<MemberSyncService>();

--- a/src/DiscordBot.Bot/Handlers/AssistantMessageHandler.cs
+++ b/src/DiscordBot.Bot/Handlers/AssistantMessageHandler.cs
@@ -1,0 +1,261 @@
+using Discord;
+using Discord.WebSocket;
+using DiscordBot.Bot.Tracing;
+using DiscordBot.Core.Configuration;
+using DiscordBot.Core.Enums;
+using DiscordBot.Core.Interfaces;
+using Microsoft.Extensions.Options;
+
+namespace DiscordBot.Bot.Handlers;
+
+/// <summary>
+/// Handles Discord message events to detect bot mentions and process AI assistant requests.
+/// Acts as a thin wrapper around the AssistantService to bridge Discord.NET events.
+/// </summary>
+public class AssistantMessageHandler
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly DiscordSocketClient _client;
+    private readonly AssistantOptions _options;
+    private readonly ILogger<AssistantMessageHandler> _logger;
+
+    public AssistantMessageHandler(
+        IServiceScopeFactory scopeFactory,
+        DiscordSocketClient client,
+        IOptions<AssistantOptions> options,
+        ILogger<AssistantMessageHandler> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _client = client;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Handles the MessageReceived event from DiscordSocketClient.
+    /// Detects bot mentions and delegates to the AssistantService for processing.
+    /// </summary>
+    /// <param name="message">The received message.</param>
+    public async Task HandleMessageReceivedAsync(SocketMessage message)
+    {
+        // Ignore bot messages
+        if (message.Author.IsBot) return;
+
+        // Ignore DMs (guild-only feature)
+        if (message.Channel is not SocketGuildChannel guildChannel) return;
+
+        // Check if bot is mentioned
+        if (!message.MentionedUsers.Any(u => u.Id == _client.CurrentUser.Id)) return;
+
+        // Check if globally enabled
+        if (!_options.GloballyEnabled)
+        {
+            _logger.LogDebug("Assistant feature is globally disabled, ignoring mention in guild {GuildId}",
+                guildChannel.Guild.Id);
+            return;
+        }
+
+        var guildId = guildChannel.Guild.Id;
+        var channelId = message.Channel.Id;
+        var userId = message.Author.Id;
+        var messageId = message.Id;
+
+        using var activity = BotActivitySource.StartEventActivity(
+            "assistant.message.process",
+            guildId: guildId,
+            userId: userId);
+
+        try
+        {
+            // Extract question (remove bot mention)
+            var question = ExtractQuestion(message.Content);
+
+            if (string.IsNullOrWhiteSpace(question))
+            {
+                _logger.LogDebug("Empty question after removing mention in message {MessageId}", messageId);
+                return;
+            }
+
+            _logger.LogDebug("Processing assistant request from user {UserId} in guild {GuildId}: {Question}",
+                userId, guildId, question.Length > 100 ? question[..100] + "..." : question);
+
+            // Create scope to access scoped services from singleton
+            using var scope = _scopeFactory.CreateScope();
+            var assistantService = scope.ServiceProvider.GetRequiredService<IAssistantService>();
+            var consentRepository = scope.ServiceProvider.GetRequiredService<IUserConsentRepository>();
+
+            // Check if enabled for guild
+            if (!await assistantService.IsEnabledForGuildAsync(guildId))
+            {
+                _logger.LogDebug("Assistant is disabled for guild {GuildId}", guildId);
+                activity?.SetTag("assistant.guild_enabled", false);
+                BotActivitySource.SetSuccess(activity);
+                return;
+            }
+
+            activity?.SetTag("assistant.guild_enabled", true);
+
+            // Check if allowed in channel
+            if (!await assistantService.IsAllowedInChannelAsync(guildId, channelId))
+            {
+                _logger.LogDebug("Assistant is not allowed in channel {ChannelId} of guild {GuildId}",
+                    channelId, guildId);
+                activity?.SetTag("assistant.channel_allowed", false);
+                BotActivitySource.SetSuccess(activity);
+                return;
+            }
+
+            activity?.SetTag("assistant.channel_allowed", true);
+
+            // Check user consent if required
+            if (_options.RequireExplicitConsent)
+            {
+                var hasConsent = await consentRepository.GetActiveConsentAsync(userId, ConsentType.AssistantUsage);
+                if (hasConsent == null)
+                {
+                    _logger.LogDebug("User {UserId} has not granted AssistantUsage consent", userId);
+                    activity?.SetTag("assistant.consent_granted", false);
+
+                    // Send consent required message
+                    await SendConsentRequiredMessageAsync(message);
+                    BotActivitySource.SetSuccess(activity);
+                    return;
+                }
+            }
+
+            activity?.SetTag("assistant.consent_granted", true);
+
+            // Check rate limit
+            var rateLimitCheck = await assistantService.CheckRateLimitAsync(guildId, userId);
+            if (!rateLimitCheck.IsAllowed)
+            {
+                _logger.LogDebug("User {UserId} is rate limited in guild {GuildId}: {Message}",
+                    userId, guildId, rateLimitCheck.Message);
+                activity?.SetTag("assistant.rate_limited", true);
+
+                await message.Channel.SendMessageAsync(
+                    rateLimitCheck.Message ?? "You've reached your question limit. Please try again later.",
+                    messageReference: new MessageReference(messageId));
+
+                BotActivitySource.SetSuccess(activity);
+                return;
+            }
+
+            activity?.SetTag("assistant.rate_limited", false);
+
+            // Show typing indicator
+            IDisposable? typingState = null;
+            if (_options.ShowTypingIndicator)
+            {
+                typingState = message.Channel.EnterTypingState();
+            }
+
+            try
+            {
+                // Process question
+                var result = await assistantService.AskQuestionAsync(
+                    guildId, channelId, userId, messageId, question);
+
+                activity?.SetTag("assistant.success", result.Success);
+                activity?.SetTag("assistant.input_tokens", result.InputTokens);
+                activity?.SetTag("assistant.output_tokens", result.OutputTokens);
+                activity?.SetTag("assistant.cached_tokens", result.CachedTokens);
+                activity?.SetTag("assistant.tool_calls", result.ToolCalls);
+                activity?.SetTag("assistant.latency_ms", result.LatencyMs);
+                activity?.SetTag("assistant.cost_usd", result.EstimatedCostUsd);
+
+                if (result.Success && !string.IsNullOrWhiteSpace(result.Response))
+                {
+                    // Send response as reply
+                    await message.Channel.SendMessageAsync(
+                        result.Response,
+                        messageReference: new MessageReference(messageId));
+
+                    _logger.LogInformation(
+                        "Sent assistant response to user {UserId} in guild {GuildId}. " +
+                        "Tokens: {InputTokens} in / {OutputTokens} out / {CachedTokens} cached. " +
+                        "Cost: ${Cost:F4}. Latency: {LatencyMs}ms",
+                        userId, guildId,
+                        result.InputTokens, result.OutputTokens, result.CachedTokens,
+                        result.EstimatedCostUsd, result.LatencyMs);
+                }
+                else
+                {
+                    // Send error message
+                    await message.Channel.SendMessageAsync(
+                        _options.ErrorMessage,
+                        messageReference: new MessageReference(messageId));
+
+                    _logger.LogWarning(
+                        "Assistant request failed for user {UserId} in guild {GuildId}: {Error}",
+                        userId, guildId, result.ErrorMessage ?? "Unknown error");
+                }
+
+                BotActivitySource.SetSuccess(activity);
+            }
+            finally
+            {
+                typingState?.Dispose();
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to process assistant request for user {UserId} in guild {GuildId}",
+                userId, guildId);
+
+            BotActivitySource.RecordException(activity, ex);
+
+            // Send friendly error message
+            try
+            {
+                await message.Channel.SendMessageAsync(
+                    _options.ErrorMessage,
+                    messageReference: new MessageReference(messageId));
+            }
+            catch (Exception sendEx)
+            {
+                _logger.LogError(sendEx,
+                    "Failed to send error message for assistant request in guild {GuildId}",
+                    guildId);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Extracts the question from the message content by removing bot mentions.
+    /// </summary>
+    /// <param name="content">The message content.</param>
+    /// <returns>The extracted question text.</returns>
+    private string ExtractQuestion(string content)
+    {
+        // Remove both forms of bot mention: <@ID> and <@!ID>
+        var question = content
+            .Replace($"<@{_client.CurrentUser.Id}>", "")
+            .Replace($"<@!{_client.CurrentUser.Id}>", "")
+            .Trim();
+
+        return question;
+    }
+
+    /// <summary>
+    /// Sends a message to the user explaining that consent is required.
+    /// </summary>
+    /// <param name="message">The original message.</param>
+    private async Task SendConsentRequiredMessageAsync(SocketMessage message)
+    {
+        var embed = new EmbedBuilder()
+            .WithTitle("Consent Required")
+            .WithDescription(
+                "To use the AI assistant feature, you need to grant consent first.\n\n" +
+                "Run `/consent grant AssistantUsage` to enable this feature.\n\n" +
+                "Your questions and responses will be processed by Claude AI and logged for quality purposes.")
+            .WithColor(Color.Orange)
+            .WithCurrentTimestamp()
+            .Build();
+
+        await message.Channel.SendMessageAsync(
+            embed: embed,
+            messageReference: new MessageReference(message.Id));
+    }
+}

--- a/src/DiscordBot.Bot/Services/BotHostedService.cs
+++ b/src/DiscordBot.Bot/Services/BotHostedService.cs
@@ -27,6 +27,7 @@ public class BotHostedService : IHostedService
     private readonly MemberEventHandler _memberEventHandler;
     private readonly VoiceStateHandler _voiceStateHandler;
     private readonly AutoModerationHandler _autoModerationHandler;
+    private readonly AssistantMessageHandler _assistantMessageHandler;
     private readonly BusinessMetrics _businessMetrics;
     private readonly IDashboardUpdateService _dashboardUpdateService;
     private readonly IAuditLogQueue _auditLogQueue;
@@ -54,6 +55,7 @@ public class BotHostedService : IHostedService
         MemberEventHandler memberEventHandler,
         VoiceStateHandler voiceStateHandler,
         AutoModerationHandler autoModerationHandler,
+        AssistantMessageHandler assistantMessageHandler,
         BusinessMetrics businessMetrics,
         IDashboardUpdateService dashboardUpdateService,
         IAuditLogQueue auditLogQueue,
@@ -79,6 +81,7 @@ public class BotHostedService : IHostedService
         _memberEventHandler = memberEventHandler;
         _voiceStateHandler = voiceStateHandler;
         _autoModerationHandler = autoModerationHandler;
+        _assistantMessageHandler = assistantMessageHandler;
         _businessMetrics = businessMetrics;
         _dashboardUpdateService = dashboardUpdateService;
         _auditLogQueue = auditLogQueue;
@@ -134,6 +137,9 @@ public class BotHostedService : IHostedService
             // Wire auto-moderation handler for message and join monitoring
             _client.MessageReceived += _autoModerationHandler.HandleMessageReceivedAsync;
             _client.UserJoined += _autoModerationHandler.HandleUserJoinedAsync;
+
+            // Wire AI assistant handler for bot mentions
+            _client.MessageReceived += _assistantMessageHandler.HandleMessageReceivedAsync;
 
             // Wire welcome handler for new member joins
             _client.UserJoined += _welcomeHandler.HandleUserJoinedAsync;
@@ -236,6 +242,7 @@ public class BotHostedService : IHostedService
             _client.UserLeft -= _activityEventTrackingHandler.HandleUserLeftAsync;
             _client.MessageReceived -= _autoModerationHandler.HandleMessageReceivedAsync;
             _client.UserJoined -= _autoModerationHandler.HandleUserJoinedAsync;
+            _client.MessageReceived -= _assistantMessageHandler.HandleMessageReceivedAsync;
             _client.UserJoined -= _welcomeHandler.HandleUserJoinedAsync;
             _client.UserJoined -= _memberEventHandler.HandleUserJoinedAsync;
             _client.UserLeft -= _memberEventHandler.HandleUserLeftAsync;


### PR DESCRIPTION
## Summary
Implements Phase 4 of the AI assistant feature - Discord message handler and consent updates:

- **AssistantMessageHandler**: Detects bot mentions in messages, extracts questions, validates enablement/consent/rate limits, calls AssistantService, and posts responses as replies
- **BotHostedService**: Wired up handler to MessageReceived event for message processing
- **ConsentModule**: Updated to support `AssistantUsage` consent type with appropriate descriptions
- **DI Registration**: Added handler to DiscordServiceExtensions

## Changes
- Create `AssistantMessageHandler.cs` - Core message handler for bot mentions
- Update `BotHostedService.cs` - Wire handler to MessageReceived event
- Update `ConsentModule.cs` - Add AI Assistant Usage consent type support
- Update `DiscordServiceExtensions.cs` - Register handler in DI

## Test plan
- [ ] Mention bot with question → Receives response
- [ ] Mention bot without consent → Receives consent prompt
- [ ] Exceed rate limit → Receives rate limit message
- [ ] Disabled guild → No response
- [ ] Restricted channel → No response
- [ ] Typing indicator shown while waiting
- [ ] Errors show friendly message
- [ ] `/consent grant AssistantUsage` enables feature
- [ ] `/consent revoke AssistantUsage` disables feature
- [ ] `/consent status` shows AI Assistant Usage status

Closes #1063

🤖 Generated with [Claude Code](https://claude.com/claude-code)