### PR TITLE
feat(assistant): Add admin UI pages for AI assistant management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,26 @@ dotnet user-secrets set "Identity:DefaultAdmin:Password" "InitialPassword123!"
 
 See [Identity Configuration](docs/articles/identity-configuration.md) for detailed authentication setup and troubleshooting.
 
+### Claude API Configuration (AI Assistant)
+
+The AI assistant feature uses Anthropic's Claude API. Configure via User Secrets:
+
+```bash
+cd src/DiscordBot.Bot
+dotnet user-secrets set "Assistant:ApiKey" "your-anthropic-api-key"
+dotnet user-secrets set "Assistant:Model" "claude-sonnet-4-20250514"  # Optional, defaults to claude-sonnet-4-20250514
+```
+
+#### Anthropic Console Setup
+
+1. Go to https://console.anthropic.com
+2. Create or select an organization
+3. Go to API Keys section
+4. Create a new API key
+5. Copy the key to user secrets as `Assistant:ApiKey`
+
+**Note:** The AI assistant requires users to grant consent via `/consent grant type:assistant` before responding to their questions. See [assistant-implementation-plan.md](docs/requirements/assistant-implementation-plan.md) for detailed feature documentation.
+
 ### Azure Speech Configuration (TTS)
 
 Azure Cognitive Services Speech is used for text-to-speech functionality. Configure via User Secrets:
@@ -113,6 +133,7 @@ The application uses the `IOptions<T>` pattern for strongly-typed configuration.
 |--------------|---------------------|---------|
 | `ApplicationOptions` | `Application` | App metadata (title, base URL, version) |
 | `AnalyticsRetentionOptions` | `AnalyticsRetention` | Analytics data retention settings |
+| `AssistantOptions` | `Assistant` | AI assistant settings (use user secrets for ApiKey) |
 | `AuditLogRetentionOptions` | `AuditLogRetention` | Audit log cleanup settings |
 | `AutoModerationOptions` | `AutoModeration` | Auto-moderation rules and thresholds |
 | `AzureSpeechOptions` | `AzureSpeech` | Azure TTS service settings (use user secrets for SubscriptionKey) |
@@ -363,6 +384,8 @@ The `preview-popup.js` module is loaded globally via `_Layout.cshtml`. See exist
 | Reminders | `/Guilds/{guildId:long}/Reminders` | Guild reminders management |
 | Soundboard | `/Guilds/Soundboard/{guildId:long}` | Guild soundboard management |
 | Audio Settings | `/Guilds/AudioSettings/{guildId:long}` | Guild audio configuration |
+| Assistant Settings | `/Guilds/AssistantSettings/{guildId:long}` | AI assistant configuration |
+| Assistant Metrics | `/Guilds/AssistantMetrics/{guildId:long}` | AI assistant usage metrics |
 | Text-to-Speech | `/Guilds/TextToSpeech/{guildId:long}` | Guild TTS message management |
 | TTS Portal | `/Portal/TTS/{guildId:long}` | TTS message composer for guild members (OAuth required) |
 | Public Leaderboard | `/Guilds/{guildId:long}/Leaderboard` | Public Rat Watch leaderboard (no auth) |

--- a/src/DiscordBot.Bot/Pages/Account/Privacy.cshtml
+++ b/src/DiscordBot.Bot/Pages/Account/Privacy.cshtml
@@ -309,6 +309,53 @@ else
         </div>
     }
 
+    <!-- AI Assistant Disclosure -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg shadow-lg mb-6">
+        <div class="flex items-center justify-between px-6 py-4 border-b border-border-primary">
+            <div>
+                <h3 class="text-lg font-semibold text-text-primary">AI Assistant</h3>
+                <p class="text-sm text-text-secondary mt-1">Information about AI-powered features</p>
+            </div>
+        </div>
+
+        <div class="p-6 space-y-4">
+            <div class="flex items-start gap-4 p-4 bg-bg-primary rounded-lg border border-border-secondary">
+                <div class="w-12 h-12 rounded-full bg-accent-blue/10 border border-accent-blue/20 flex items-center justify-center flex-shrink-0">
+                    <svg class="w-6 h-6 text-accent-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                </div>
+                <div class="flex-1">
+                    <h4 class="text-base font-semibold text-text-primary mb-1">Powered by Claude AI</h4>
+                    <p class="text-sm text-text-secondary mb-3">
+                        This bot uses Claude, an AI assistant by Anthropic, to answer questions about bot features.
+                        When you ask the bot a question (by mentioning it), your question is sent to Claude's API for processing.
+                    </p>
+                    <div class="space-y-2 text-sm text-text-secondary">
+                        <p><strong class="text-text-primary">Data Processed:</strong> Your question text and Discord user ID (for rate limiting)</p>
+                        <p><strong class="text-text-primary">Data Retained:</strong> Questions and responses are logged for debugging and usage metrics (30-day retention)</p>
+                        <p><strong class="text-text-primary">Third Party:</strong> Questions are processed by Anthropic's Claude API (<a href="https://www.anthropic.com/privacy" target="_blank" rel="noopener noreferrer" class="text-accent-blue hover:underline">Anthropic Privacy Policy</a>)</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="p-4 bg-warning-bg border border-warning-border rounded-md">
+                <div class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-warning flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20">
+                        <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
+                    </svg>
+                    <div class="text-sm text-warning">
+                        <p class="font-semibold mb-1">Consent Required</p>
+                        <p class="text-warning/90">
+                            You must grant consent via <code class="px-1.5 py-0.5 bg-warning/20 rounded font-mono text-xs">/consent grant type:assistant</code> before using the AI assistant.
+                            The assistant will not respond to your questions until consent is granted.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- Additional Info -->
     <div class="mt-6 p-4 bg-info-bg border border-info-border rounded-md">
         <div class="flex items-start gap-3">

--- a/src/DiscordBot.Bot/Pages/Guilds/AssistantMetrics.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/AssistantMetrics.cshtml
@@ -1,0 +1,287 @@
+@page "{guildId:long}"
+@model DiscordBot.Bot.Pages.Guilds.AssistantMetricsModel
+@using DiscordBot.Bot.ViewModels.Components
+@{
+    ViewData["Title"] = $"Assistant Metrics - {Model.Guild.Name}";
+}
+
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <!-- Breadcrumb Navigation -->
+    <nav aria-label="Breadcrumb" class="mb-6">
+        <ol class="flex items-center gap-2 text-sm">
+            <li>
+                <a asp-page="/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Home</a>
+            </li>
+            <li class="text-text-tertiary">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                </svg>
+            </li>
+            <li>
+                <a asp-page="Index" class="text-text-secondary hover:text-accent-blue transition-colors">Servers</a>
+            </li>
+            <li class="text-text-tertiary">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                </svg>
+            </li>
+            <li>
+                <a asp-page="Details" asp-route-id="@Model.Guild.Id" class="text-text-secondary hover:text-accent-blue transition-colors">@Model.Guild.Name</a>
+            </li>
+            <li class="text-text-tertiary">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                </svg>
+            </li>
+            <li>
+                <span class="text-text-primary font-medium">Assistant Metrics</span>
+            </li>
+        </ol>
+    </nav>
+
+    <!-- Page Header -->
+    <div class="mb-8">
+        <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+            <div class="flex items-center gap-4">
+                @if (!string.IsNullOrEmpty(Model.Guild.IconUrl))
+                {
+                    <img src="@Model.Guild.IconUrl" alt="@Model.Guild.Name" class="w-12 h-12 rounded-full flex-shrink-0" />
+                }
+                else
+                {
+                    <div class="w-12 h-12 rounded-full bg-gradient-to-br from-accent-blue to-accent-orange flex items-center justify-center text-white font-bold text-lg flex-shrink-0">
+                        @(Model.Guild.Name.Length >= 2 ? Model.Guild.Name[..2].ToUpper() : Model.Guild.Name.ToUpper())
+                    </div>
+                }
+                <div>
+                    <h1 class="text-2xl font-bold text-text-primary">Assistant Usage Metrics</h1>
+                    <p class="mt-1 text-sm text-text-secondary">Usage statistics for the last 30 days</p>
+                </div>
+            </div>
+            <div class="flex items-center gap-3">
+                <a asp-page="AssistantSettings" asp-route-guildId="@Model.Guild.Id"
+                   class="btn btn-secondary inline-flex items-center gap-2">
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                    </svg>
+                    Settings
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <!-- Summary Cards -->
+    <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+        <!-- Total Questions -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-4">
+            <div class="flex items-center gap-2 mb-1">
+                <svg class="w-5 h-5 text-accent-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <span class="text-xs text-text-tertiary font-medium">Total Questions</span>
+            </div>
+            <p class="text-2xl font-bold text-text-primary">@Model.TotalQuestions.ToString("N0")</p>
+        </div>
+
+        <!-- Total Cost -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-4">
+            <div class="flex items-center gap-2 mb-1">
+                <svg class="w-5 h-5 text-accent-orange" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <span class="text-xs text-text-tertiary font-medium">Est. Cost (USD)</span>
+            </div>
+            <p class="text-2xl font-bold text-text-primary">$@Model.TotalCost.ToString("F2")</p>
+        </div>
+
+        <!-- Average Latency -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-4">
+            <div class="flex items-center gap-2 mb-1">
+                <svg class="w-5 h-5 text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
+                </svg>
+                <span class="text-xs text-text-tertiary font-medium">Avg Latency</span>
+            </div>
+            <p class="text-2xl font-bold text-text-primary">
+                @if (Model.AverageLatencyMs >= 1000)
+                {
+                    <span>@((Model.AverageLatencyMs / 1000.0).ToString("F1"))s</span>
+                }
+                else
+                {
+                    <span>@Model.AverageLatencyMs<span class="text-sm font-normal text-text-tertiary">ms</span></span>
+                }
+            </p>
+        </div>
+
+        <!-- Cache Hit Rate -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-4">
+            <div class="flex items-center gap-2 mb-1">
+                <svg class="w-5 h-5 text-info" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4" />
+                </svg>
+                <span class="text-xs text-text-tertiary font-medium">Cache Hit Rate</span>
+            </div>
+            <p class="text-2xl font-bold text-text-primary">@Model.CacheHitRate.ToString("F1")<span class="text-sm font-normal text-text-tertiary">%</span></p>
+        </div>
+    </div>
+
+    <!-- Additional Stats Row -->
+    <div class="grid grid-cols-3 gap-4 mb-8">
+        <!-- Success Rate -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-4">
+            <div class="flex items-center gap-2 mb-1">
+                <svg class="w-5 h-5 @(Model.SuccessRate >= 95 ? "text-success" : Model.SuccessRate >= 80 ? "text-warning" : "text-error")" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <span class="text-xs text-text-tertiary font-medium">Success Rate</span>
+            </div>
+            <p class="text-xl font-bold text-text-primary">@Model.SuccessRate.ToString("F1")<span class="text-sm font-normal text-text-tertiary">%</span></p>
+            <p class="text-xs text-text-tertiary mt-1">@Model.TotalFailedRequests failed requests</p>
+        </div>
+
+        <!-- Tool Calls -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-4">
+            <div class="flex items-center gap-2 mb-1">
+                <svg class="w-5 h-5 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                </svg>
+                <span class="text-xs text-text-tertiary font-medium">Tool Calls</span>
+            </div>
+            <p class="text-xl font-bold text-text-primary">@Model.TotalToolCalls.ToString("N0")</p>
+            <p class="text-xs text-text-tertiary mt-1">Documentation lookups</p>
+        </div>
+
+        <!-- Cache Stats -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg p-4">
+            <div class="flex items-center gap-2 mb-1">
+                <svg class="w-5 h-5 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" />
+                </svg>
+                <span class="text-xs text-text-tertiary font-medium">Cache Stats</span>
+            </div>
+            <p class="text-xl font-bold text-text-primary">@Model.TotalCacheHits.ToString("N0") <span class="text-sm font-normal text-success">hits</span></p>
+            <p class="text-xs text-text-tertiary mt-1">@Model.TotalCacheMisses.ToString("N0") misses</p>
+        </div>
+    </div>
+
+    <!-- Daily Metrics Table -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden">
+        <div class="px-6 py-4 border-b border-border-primary">
+            <h3 class="text-lg font-semibold text-text-primary">Daily Breakdown</h3>
+            <p class="text-sm text-text-secondary mt-1">Detailed metrics for each day</p>
+        </div>
+
+        @if (Model.Metrics.Any())
+        {
+            <!-- Desktop Table -->
+            <div class="overflow-x-auto hidden md:block">
+                <table class="min-w-full divide-y divide-border-primary">
+                    <thead class="bg-bg-tertiary">
+                        <tr>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">Date</th>
+                            <th class="px-6 py-3 text-right text-xs font-medium text-text-secondary uppercase tracking-wider">Questions</th>
+                            <th class="px-6 py-3 text-right text-xs font-medium text-text-secondary uppercase tracking-wider">Cost</th>
+                            <th class="px-6 py-3 text-right text-xs font-medium text-text-secondary uppercase tracking-wider">Avg Latency</th>
+                            <th class="px-6 py-3 text-right text-xs font-medium text-text-secondary uppercase tracking-wider">Cache Hit</th>
+                            <th class="px-6 py-3 text-right text-xs font-medium text-text-secondary uppercase tracking-wider">Tool Calls</th>
+                            <th class="px-6 py-3 text-right text-xs font-medium text-text-secondary uppercase tracking-wider">Failed</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-border-primary">
+                        @foreach (var metric in Model.Metrics.OrderByDescending(m => m.Date))
+                        {
+                            var cacheTotal = metric.TotalCacheHits + metric.TotalCacheMisses;
+                            var cacheRate = cacheTotal > 0 ? (double)metric.TotalCacheHits / cacheTotal * 100 : 0;
+                            <tr class="hover:bg-bg-tertiary/50 transition-colors">
+                                <td class="px-6 py-4 whitespace-nowrap">
+                                    <span class="text-sm text-text-primary" data-utc="@metric.Date.ToString("o")" data-format="date">@metric.Date.ToString("MMM d")</span>
+                                </td>
+                                <td class="px-6 py-4 whitespace-nowrap text-right">
+                                    <span class="text-sm font-medium text-text-primary">@metric.TotalQuestions</span>
+                                </td>
+                                <td class="px-6 py-4 whitespace-nowrap text-right">
+                                    <span class="text-sm text-text-primary">$@metric.EstimatedCostUsd.ToString("F3")</span>
+                                </td>
+                                <td class="px-6 py-4 whitespace-nowrap text-right">
+                                    <span class="text-sm text-text-secondary">@metric.AverageLatencyMs<span class="text-text-tertiary">ms</span></span>
+                                </td>
+                                <td class="px-6 py-4 whitespace-nowrap text-right">
+                                    <span class="text-sm @(cacheRate >= 50 ? "text-success" : "text-text-secondary")">@cacheRate.ToString("F0")%</span>
+                                </td>
+                                <td class="px-6 py-4 whitespace-nowrap text-right">
+                                    <span class="text-sm text-text-secondary">@metric.TotalToolCalls</span>
+                                </td>
+                                <td class="px-6 py-4 whitespace-nowrap text-right">
+                                    @if (metric.FailedRequests > 0)
+                                    {
+                                        <span class="text-sm text-error">@metric.FailedRequests</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="text-sm text-text-tertiary">0</span>
+                                    }
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+
+            <!-- Mobile Card Layout -->
+            <div class="md:hidden divide-y divide-border-primary">
+                @foreach (var metric in Model.Metrics.OrderByDescending(m => m.Date).Take(10))
+                {
+                    var cacheTotal = metric.TotalCacheHits + metric.TotalCacheMisses;
+                    var cacheRate = cacheTotal > 0 ? (double)metric.TotalCacheHits / cacheTotal * 100 : 0;
+                    <div class="p-4 hover:bg-bg-tertiary/50 transition-colors">
+                        <div class="flex items-center justify-between mb-3">
+                            <span class="text-sm font-medium text-text-primary" data-utc="@metric.Date.ToString("o")" data-format="date">@metric.Date.ToString("MMM d, yyyy")</span>
+                            <span class="text-sm font-semibold text-accent-orange">$@metric.EstimatedCostUsd.ToString("F3")</span>
+                        </div>
+                        <div class="grid grid-cols-3 gap-2 text-xs">
+                            <div>
+                                <span class="text-text-tertiary block">Questions</span>
+                                <span class="text-text-primary font-medium">@metric.TotalQuestions</span>
+                            </div>
+                            <div>
+                                <span class="text-text-tertiary block">Latency</span>
+                                <span class="text-text-primary">@metric.AverageLatencyMs ms</span>
+                            </div>
+                            <div>
+                                <span class="text-text-tertiary block">Cache</span>
+                                <span class="@(cacheRate >= 50 ? "text-success" : "text-text-primary")">@cacheRate.ToString("F0")%</span>
+                            </div>
+                        </div>
+                    </div>
+                }
+            </div>
+        }
+        else
+        {
+            <div class="p-12 text-center">
+                <svg class="w-12 h-12 text-text-tertiary mx-auto mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+                </svg>
+                <p class="text-text-secondary mb-2">No usage data yet</p>
+                <p class="text-sm text-text-tertiary">Metrics will appear here once users start using the AI assistant.</p>
+            </div>
+        }
+    </div>
+
+    <!-- Cost Information -->
+    <div class="mt-6 p-4 bg-info-bg border border-info-border rounded-md">
+        <div class="flex items-start gap-3">
+            <svg class="w-5 h-5 text-info flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20">
+                <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd" />
+            </svg>
+            <div class="text-sm text-info">
+                <p class="font-semibold mb-1">About Cost Estimates</p>
+                <p class="text-info/90">
+                    Costs are estimated based on Claude API token usage. Actual costs may vary slightly. Cache hits reduce costs significantly by reusing previously computed context.
+                </p>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/DiscordBot.Bot/Pages/Guilds/AssistantMetrics.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/AssistantMetrics.cshtml.cs
@@ -1,0 +1,152 @@
+using DiscordBot.Core.Entities;
+using DiscordBot.Core.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace DiscordBot.Bot.Pages.Guilds;
+
+/// <summary>
+/// Page model for viewing AI assistant usage metrics for a guild.
+/// </summary>
+[Authorize(Policy = "RequireAdmin")]
+[Authorize(Policy = "GuildAccess")]
+public class AssistantMetricsModel : PageModel
+{
+    private readonly IAssistantService _assistantService;
+    private readonly IGuildService _guildService;
+    private readonly ILogger<AssistantMetricsModel> _logger;
+
+    public AssistantMetricsModel(
+        IAssistantService assistantService,
+        IGuildService guildService,
+        ILogger<AssistantMetricsModel> logger)
+    {
+        _assistantService = assistantService;
+        _guildService = guildService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Guild ID from route.
+    /// </summary>
+    [BindProperty(SupportsGet = true)]
+    public ulong GuildId { get; set; }
+
+    /// <summary>
+    /// Guild information for display.
+    /// </summary>
+    public GuildViewModel Guild { get; set; } = new();
+
+    /// <summary>
+    /// Daily metrics for the last 30 days.
+    /// </summary>
+    public List<AssistantUsageMetrics> Metrics { get; set; } = new();
+
+    /// <summary>
+    /// Total questions asked in the period.
+    /// </summary>
+    public int TotalQuestions { get; set; }
+
+    /// <summary>
+    /// Total cost in USD for the period.
+    /// </summary>
+    public decimal TotalCost { get; set; }
+
+    /// <summary>
+    /// Average response latency in ms.
+    /// </summary>
+    public int AverageLatencyMs { get; set; }
+
+    /// <summary>
+    /// Total cache hits.
+    /// </summary>
+    public int TotalCacheHits { get; set; }
+
+    /// <summary>
+    /// Total cache misses.
+    /// </summary>
+    public int TotalCacheMisses { get; set; }
+
+    /// <summary>
+    /// Cache hit rate as a percentage.
+    /// </summary>
+    public double CacheHitRate { get; set; }
+
+    /// <summary>
+    /// Total failed requests.
+    /// </summary>
+    public int TotalFailedRequests { get; set; }
+
+    /// <summary>
+    /// Success rate as a percentage.
+    /// </summary>
+    public double SuccessRate { get; set; }
+
+    /// <summary>
+    /// Total tool calls made.
+    /// </summary>
+    public int TotalToolCalls { get; set; }
+
+    /// <summary>
+    /// View model for guild display.
+    /// </summary>
+    public class GuildViewModel
+    {
+        public ulong Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string? IconUrl { get; set; }
+    }
+
+    public async Task<IActionResult> OnGetAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("User accessing assistant metrics page for guild {GuildId}", GuildId);
+
+        // Get guild info
+        var guild = await _guildService.GetGuildByIdAsync(GuildId, cancellationToken);
+        if (guild == null)
+        {
+            _logger.LogWarning("Guild {GuildId} not found", GuildId);
+            return NotFound();
+        }
+
+        Guild = new GuildViewModel
+        {
+            Id = guild.Id,
+            Name = guild.Name,
+            IconUrl = guild.IconUrl
+        };
+
+        // Get metrics for last 30 days
+        var endDate = DateTime.UtcNow.Date;
+        var startDate = endDate.AddDays(-30);
+
+        Metrics = (await _assistantService.GetUsageMetricsRangeAsync(
+            GuildId, startDate, endDate, cancellationToken)).ToList();
+
+        // Calculate summary statistics
+        if (Metrics.Any())
+        {
+            TotalQuestions = Metrics.Sum(m => m.TotalQuestions);
+            TotalCost = Metrics.Sum(m => m.EstimatedCostUsd);
+            TotalCacheHits = Metrics.Sum(m => m.TotalCacheHits);
+            TotalCacheMisses = Metrics.Sum(m => m.TotalCacheMisses);
+            TotalFailedRequests = Metrics.Sum(m => m.FailedRequests);
+            TotalToolCalls = Metrics.Sum(m => m.TotalToolCalls);
+
+            // Calculate weighted average latency
+            var totalLatencyWeight = Metrics.Sum(m => m.TotalQuestions * m.AverageLatencyMs);
+            AverageLatencyMs = TotalQuestions > 0 ? totalLatencyWeight / TotalQuestions : 0;
+
+            // Calculate cache hit rate
+            var totalCacheRequests = TotalCacheHits + TotalCacheMisses;
+            CacheHitRate = totalCacheRequests > 0 ? (double)TotalCacheHits / totalCacheRequests * 100 : 0;
+
+            // Calculate success rate
+            var totalRequests = TotalQuestions + TotalFailedRequests;
+            SuccessRate = totalRequests > 0 ? (double)TotalQuestions / totalRequests * 100 : 100;
+        }
+
+        return Page();
+    }
+}

--- a/src/DiscordBot.Bot/Pages/Guilds/AssistantSettings.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/AssistantSettings.cshtml
@@ -1,0 +1,305 @@
+@page "{guildId:long}"
+@model DiscordBot.Bot.Pages.Guilds.AssistantSettingsModel
+@using DiscordBot.Bot.ViewModels.Components
+@{
+    ViewData["Title"] = $"Assistant Settings - {Model.Guild.Name}";
+}
+
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <!-- Breadcrumb Navigation -->
+    <nav aria-label="Breadcrumb" class="mb-6">
+        <ol class="flex items-center gap-2 text-sm">
+            <li>
+                <a asp-page="/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Home</a>
+            </li>
+            <li class="text-text-tertiary">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                </svg>
+            </li>
+            <li>
+                <a asp-page="Index" class="text-text-secondary hover:text-accent-blue transition-colors">Servers</a>
+            </li>
+            <li class="text-text-tertiary">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                </svg>
+            </li>
+            <li>
+                <a asp-page="Details" asp-route-id="@Model.Guild.Id" class="text-text-secondary hover:text-accent-blue transition-colors">@Model.Guild.Name</a>
+            </li>
+            <li class="text-text-tertiary">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                </svg>
+            </li>
+            <li>
+                <span class="text-text-primary font-medium">Assistant Settings</span>
+            </li>
+        </ol>
+    </nav>
+
+    <!-- Page Header -->
+    <div class="mb-8">
+        <div class="flex items-center gap-4">
+            @if (!string.IsNullOrEmpty(Model.Guild.IconUrl))
+            {
+                <img src="@Model.Guild.IconUrl" alt="@Model.Guild.Name" class="w-12 h-12 rounded-full flex-shrink-0" />
+            }
+            else
+            {
+                <div class="w-12 h-12 rounded-full bg-gradient-to-br from-accent-blue to-accent-orange flex items-center justify-center text-white font-bold text-lg flex-shrink-0">
+                    @(Model.Guild.Name.Length >= 2 ? Model.Guild.Name[..2].ToUpper() : Model.Guild.Name.ToUpper())
+                </div>
+            }
+            <div>
+                <h1 class="text-2xl font-bold text-text-primary">AI Assistant Settings</h1>
+                <p class="mt-1 text-sm text-text-secondary">Configure the AI assistant for @Model.Guild.Name</p>
+            </div>
+        </div>
+    </div>
+
+    <!-- Global Status Warning -->
+    @if (!Model.GloballyEnabled)
+    {
+        <div class="mb-6">
+            @{
+                var globalDisabledAlert = new AlertViewModel {
+                    Variant = AlertVariant.Warning,
+                    Message = "The AI assistant is globally disabled. Guild-level settings will take effect once the feature is enabled globally."
+                };
+            }
+            <partial name="Shared/Components/_Alert" model="globalDisabledAlert" />
+        </div>
+    }
+
+    <!-- Success Message -->
+    @if (!string.IsNullOrEmpty(Model.SuccessMessage))
+    {
+        <div class="mb-6">
+            <partial name="Shared/Components/_Alert" model="new AlertViewModel {
+                Variant = AlertVariant.Success,
+                Message = Model.SuccessMessage,
+                IsDismissible = true
+            }" />
+        </div>
+    }
+
+    <!-- Error Message -->
+    @if (!string.IsNullOrEmpty(Model.ErrorMessage))
+    {
+        <div class="mb-6">
+            <partial name="Shared/Components/_Alert" model="new AlertViewModel {
+                Variant = AlertVariant.Error,
+                Message = Model.ErrorMessage,
+                IsDismissible = true
+            }" />
+        </div>
+    }
+
+    <form method="post">
+        <input type="hidden" name="Input.GuildId" value="@Model.Input.GuildId" />
+        <div asp-validation-summary="ModelOnly" class="text-error text-sm mb-4"></div>
+
+        <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
+            <!-- Configuration Form Column -->
+            <div class="lg:col-span-2 space-y-6">
+                <!-- Enable Assistant Toggle -->
+                <div class="bg-bg-secondary border border-border-primary rounded-lg p-6">
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <label for="Input_IsEnabled" class="text-sm font-semibold text-text-primary">Enable AI Assistant</label>
+                            <p class="text-xs text-text-secondary mt-1">Allow users to ask questions by mentioning the bot</p>
+                        </div>
+                        <label class="relative inline-flex items-center cursor-pointer">
+                            <input asp-for="Input.IsEnabled"
+                                   onchange="toggleAssistantEnabled()"
+                                   class="sr-only peer" />
+                            <div class="w-11 h-6 bg-bg-tertiary peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-border-focus/50 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-text-primary after:border-border-primary after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-accent-orange"></div>
+                        </label>
+                    </div>
+                </div>
+
+                <!-- Main Configuration Form -->
+                <div id="assistant-config-form" class="bg-bg-secondary border border-border-primary rounded-lg p-6 space-y-6 @(!Model.Input.IsEnabled ? "form-section-disabled" : "")">
+                    <!-- Channel Selection -->
+                    <div>
+                        <label class="block text-sm font-medium text-text-primary mb-2">Allowed Channels</label>
+                        <p class="text-xs text-text-secondary mb-3">Select channels where the assistant can respond. Leave empty to allow all channels.</p>
+
+                        <div class="max-h-64 overflow-y-auto border border-border-primary rounded-md bg-bg-primary">
+                            @if (Model.AvailableChannels.Any())
+                            {
+                                @foreach (var channel in Model.AvailableChannels)
+                                {
+                                    var prefix = channel.Type switch
+                                    {
+                                        "Announcement" => "megaphone",
+                                        _ => "hashtag"
+                                    };
+                                    <label class="flex items-center gap-3 px-4 py-2.5 hover:bg-bg-hover cursor-pointer border-b border-border-secondary last:border-b-0">
+                                        <input type="checkbox"
+                                               name="Input.AllowedChannelIds"
+                                               value="@channel.Id"
+                                               checked="@channel.IsSelected"
+                                               class="w-4 h-4 rounded border-border-primary text-accent-orange focus:ring-accent-orange focus:ring-offset-bg-primary" />
+                                        <svg class="w-4 h-4 text-text-tertiary flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                            @if (prefix == "megaphone")
+                                            {
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" />
+                                            }
+                                            else
+                                            {
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14" />
+                                            }
+                                        </svg>
+                                        <span class="text-sm text-text-primary">@channel.Name</span>
+                                        <span class="text-xs text-text-tertiary">@channel.Type</span>
+                                    </label>
+                                }
+                            }
+                            else
+                            {
+                                <div class="px-4 py-6 text-center text-text-secondary text-sm">
+                                    No text channels available
+                                </div>
+                            }
+                        </div>
+                        <p class="text-xs text-text-tertiary mt-2">
+                            @Model.AvailableChannels.Count(c => c.IsSelected) of @Model.AvailableChannels.Count channels selected
+                        </p>
+                    </div>
+
+                    <!-- Rate Limit Override -->
+                    <div>
+                        <label for="Input_RateLimitOverride" class="block text-sm font-medium text-text-primary mb-2">Rate Limit Override</label>
+                        <div class="relative max-w-xs">
+                            <input type="number"
+                                   asp-for="Input.RateLimitOverride"
+                                   placeholder="@Model.DefaultRateLimit (default)"
+                                   min="1"
+                                   max="100"
+                                   class="form-input w-full py-2.5 px-3 text-sm text-text-primary bg-bg-primary border border-border-primary rounded-md transition-colors placeholder-text-tertiary focus:outline-none focus:border-border-focus focus:ring-2 focus:ring-border-focus/20" />
+                        </div>
+                        <p class="text-xs text-text-secondary mt-1">
+                            Maximum questions per user per @Model.RateLimitWindowMinutes minute window. Leave empty to use the default (@Model.DefaultRateLimit).
+                        </p>
+                        <span asp-validation-for="Input.RateLimitOverride" class="text-error text-xs"></span>
+                    </div>
+                </div>
+
+                <!-- Form Actions -->
+                <div class="flex flex-col sm:flex-row gap-3">
+                    <button type="submit"
+                            class="btn btn-primary inline-flex items-center justify-center gap-2">
+                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+                        </svg>
+                        Save Settings
+                    </button>
+                    <a asp-page="Details" asp-route-id="@Model.Guild.Id"
+                       class="btn btn-secondary inline-flex items-center justify-center gap-2">
+                        Cancel
+                    </a>
+                    <a asp-page="AssistantMetrics" asp-route-guildId="@Model.Guild.Id"
+                       class="btn btn-glass inline-flex items-center justify-center gap-2 ml-auto">
+                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+                        </svg>
+                        View Metrics
+                    </a>
+                </div>
+            </div>
+
+            <!-- Help Panel Column -->
+            <div class="space-y-6">
+                <!-- How It Works -->
+                <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden">
+                    <div class="px-6 py-4 border-b border-border-primary">
+                        <h3 class="text-sm font-semibold text-text-primary flex items-center gap-2">
+                            <svg class="w-5 h-5 text-accent-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                            </svg>
+                            How It Works
+                        </h3>
+                    </div>
+                    <div class="p-6 space-y-4 text-sm text-text-secondary">
+                        <p>
+                            When enabled, users can ask questions by mentioning the bot:
+                        </p>
+                        <div class="bg-bg-primary border border-border-primary rounded-md p-3 font-mono text-xs">
+                            <span class="text-accent-blue">@@BotName</span> How do I use the soundboard?
+                        </div>
+                        <p>
+                            The bot uses AI to answer questions about its features and commands.
+                        </p>
+                    </div>
+                </div>
+
+                <!-- Consent Notice -->
+                <div class="bg-info-bg border border-info-border rounded-lg p-4">
+                    <div class="flex items-start gap-3">
+                        <svg class="w-5 h-5 text-info flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20">
+                            <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd" />
+                        </svg>
+                        <div class="text-sm text-info">
+                            <p class="font-semibold mb-1">User Consent Required</p>
+                            <p class="text-info/90">
+                                Users must grant consent via <code class="px-1 py-0.5 bg-info/20 rounded font-mono text-xs">/consent</code> before using the assistant. Questions and responses are logged for debugging.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Rate Limiting Info -->
+                <div class="bg-bg-secondary border border-border-primary rounded-lg p-4">
+                    <h4 class="text-sm font-semibold text-text-primary mb-2">Rate Limiting</h4>
+                    <p class="text-xs text-text-secondary">
+                        Rate limits prevent API cost abuse. Each user can ask @Model.DefaultRateLimit questions per @Model.RateLimitWindowMinutes minutes (by default).
+                        Admins can bypass this limit.
+                    </p>
+                </div>
+            </div>
+        </div>
+    </form>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+
+    <style>
+        .form-section-disabled {
+            position: relative;
+        }
+
+        .form-section-disabled::after {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background-color: rgba(29, 32, 34, 0.6);
+            border-radius: 0.5rem;
+            pointer-events: none;
+        }
+
+        .form-section-disabled > * {
+            pointer-events: none;
+        }
+    </style>
+
+    <script>
+        function toggleAssistantEnabled() {
+            const checkbox = document.getElementById('Input_IsEnabled');
+            const configForm = document.getElementById('assistant-config-form');
+
+            if (checkbox.checked) {
+                configForm.classList.remove('form-section-disabled');
+            } else {
+                configForm.classList.add('form-section-disabled');
+            }
+        }
+
+        document.addEventListener('DOMContentLoaded', function() {
+            toggleAssistantEnabled();
+        });
+    </script>
+}

--- a/src/DiscordBot.Bot/Pages/Guilds/AssistantSettings.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/AssistantSettings.cshtml.cs
@@ -1,0 +1,259 @@
+using Discord.WebSocket;
+using DiscordBot.Core.Configuration;
+using DiscordBot.Core.Entities;
+using DiscordBot.Core.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Options;
+using System.ComponentModel.DataAnnotations;
+
+namespace DiscordBot.Bot.Pages.Guilds;
+
+/// <summary>
+/// Page model for managing AI assistant configuration for a guild.
+/// </summary>
+[Authorize(Policy = "RequireAdmin")]
+[Authorize(Policy = "GuildAccess")]
+public class AssistantSettingsModel : PageModel
+{
+    private readonly IAssistantGuildSettingsService _settingsService;
+    private readonly IGuildService _guildService;
+    private readonly DiscordSocketClient _discordClient;
+    private readonly IOptions<AssistantOptions> _assistantOptions;
+    private readonly ILogger<AssistantSettingsModel> _logger;
+
+    public AssistantSettingsModel(
+        IAssistantGuildSettingsService settingsService,
+        IGuildService guildService,
+        DiscordSocketClient discordClient,
+        IOptions<AssistantOptions> assistantOptions,
+        ILogger<AssistantSettingsModel> logger)
+    {
+        _settingsService = settingsService;
+        _guildService = guildService;
+        _discordClient = discordClient;
+        _assistantOptions = assistantOptions;
+        _logger = logger;
+    }
+
+    [BindProperty]
+    public InputModel Input { get; set; } = new();
+
+    /// <summary>
+    /// Guild information for display.
+    /// </summary>
+    public GuildViewModel Guild { get; set; } = new();
+
+    /// <summary>
+    /// List of available text channels in the guild.
+    /// </summary>
+    public List<ChannelSelectItem> AvailableChannels { get; set; } = new();
+
+    /// <summary>
+    /// Default rate limit from configuration.
+    /// </summary>
+    public int DefaultRateLimit { get; set; }
+
+    /// <summary>
+    /// Rate limit window in minutes from configuration.
+    /// </summary>
+    public int RateLimitWindowMinutes { get; set; }
+
+    /// <summary>
+    /// Whether the assistant feature is globally enabled.
+    /// </summary>
+    public bool GloballyEnabled { get; set; }
+
+    /// <summary>
+    /// Error message to display.
+    /// </summary>
+    public string? ErrorMessage { get; set; }
+
+    /// <summary>
+    /// Success message from TempData.
+    /// </summary>
+    [TempData]
+    public string? SuccessMessage { get; set; }
+
+    /// <summary>
+    /// Input model for form binding.
+    /// </summary>
+    public class InputModel
+    {
+        public ulong GuildId { get; set; }
+
+        [Display(Name = "Enable AI Assistant")]
+        public bool IsEnabled { get; set; }
+
+        [Display(Name = "Allowed Channels")]
+        public List<string> AllowedChannelIds { get; set; } = new();
+
+        [Display(Name = "Rate Limit Override")]
+        [Range(1, 100, ErrorMessage = "Rate limit must be between 1 and 100")]
+        public int? RateLimitOverride { get; set; }
+    }
+
+    /// <summary>
+    /// View model for guild display.
+    /// </summary>
+    public class GuildViewModel
+    {
+        public ulong Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string? IconUrl { get; set; }
+    }
+
+    /// <summary>
+    /// Model for channel selection.
+    /// </summary>
+    public class ChannelSelectItem
+    {
+        public ulong Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public int Position { get; set; }
+        public string Type { get; set; } = "Text";
+        public bool IsSelected { get; set; }
+    }
+
+    public async Task<IActionResult> OnGetAsync(ulong guildId, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("User accessing assistant settings page for guild {GuildId}", guildId);
+
+        // Get guild info
+        var guild = await _guildService.GetGuildByIdAsync(guildId, cancellationToken);
+        if (guild == null)
+        {
+            _logger.LogWarning("Guild {GuildId} not found", guildId);
+            return NotFound();
+        }
+
+        Guild = new GuildViewModel
+        {
+            Id = guild.Id,
+            Name = guild.Name,
+            IconUrl = guild.IconUrl
+        };
+
+        // Get assistant settings
+        var settings = await _settingsService.GetOrCreateSettingsAsync(guildId, cancellationToken);
+        var allowedChannels = settings.GetAllowedChannelIdsList();
+
+        // Get available channels
+        AvailableChannels = GetTextChannels(guildId, allowedChannels);
+
+        // Load configuration defaults
+        DefaultRateLimit = _assistantOptions.Value.DefaultRateLimit;
+        RateLimitWindowMinutes = _assistantOptions.Value.RateLimitWindowMinutes;
+        GloballyEnabled = _assistantOptions.Value.GloballyEnabled;
+
+        // Populate form
+        Input = new InputModel
+        {
+            GuildId = guildId,
+            IsEnabled = settings.IsEnabled,
+            AllowedChannelIds = allowedChannels.Select(id => id.ToString()).ToList(),
+            RateLimitOverride = settings.RateLimitOverride
+        };
+
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("POST received for assistant settings - GuildId={GuildId}, IsEnabled={IsEnabled}",
+            Input.GuildId, Input.IsEnabled);
+
+        if (!ModelState.IsValid)
+        {
+            _logger.LogWarning("ModelState is invalid for guild {GuildId}. Errors: {Errors}",
+                Input.GuildId,
+                string.Join("; ", ModelState.Values.SelectMany(v => v.Errors).Select(e => e.ErrorMessage)));
+
+            await LoadViewModelAsync(Input.GuildId, cancellationToken);
+            return Page();
+        }
+
+        // Get current settings
+        var settings = await _settingsService.GetOrCreateSettingsAsync(Input.GuildId, cancellationToken);
+
+        // Update settings
+        settings.IsEnabled = Input.IsEnabled;
+        settings.RateLimitOverride = Input.RateLimitOverride;
+
+        // Parse channel IDs
+        var channelIds = new List<ulong>();
+        foreach (var channelIdStr in Input.AllowedChannelIds ?? new List<string>())
+        {
+            if (ulong.TryParse(channelIdStr, out var channelId))
+            {
+                channelIds.Add(channelId);
+            }
+        }
+        settings.SetAllowedChannelIdsList(channelIds);
+
+        // Save settings
+        await _settingsService.UpdateSettingsAsync(settings, cancellationToken);
+
+        _logger.LogInformation("Successfully updated assistant settings for guild {GuildId}", Input.GuildId);
+        SuccessMessage = "Assistant settings saved successfully.";
+
+        return RedirectToPage("AssistantSettings", new { guildId = Input.GuildId });
+    }
+
+    /// <summary>
+    /// Gets text channels from the Discord guild.
+    /// </summary>
+    private List<ChannelSelectItem> GetTextChannels(ulong guildId, List<ulong> selectedChannelIds)
+    {
+        var guild = _discordClient.GetGuild(guildId);
+        if (guild == null)
+        {
+            _logger.LogWarning("Could not fetch Discord guild {GuildId} from client", guildId);
+            return new List<ChannelSelectItem>();
+        }
+
+        var channels = new List<ChannelSelectItem>();
+
+        // Add text channels
+        foreach (var channel in guild.TextChannels.Where(c => c != null))
+        {
+            var type = channel is SocketNewsChannel ? "Announcement" : "Text";
+            channels.Add(new ChannelSelectItem
+            {
+                Id = channel.Id,
+                Name = channel.Name,
+                Position = channel.Position,
+                Type = type,
+                IsSelected = selectedChannelIds.Contains(channel.Id)
+            });
+        }
+
+        return channels.OrderBy(c => c.Position).ToList();
+    }
+
+    /// <summary>
+    /// Loads the view model for redisplay after validation error.
+    /// </summary>
+    private async Task LoadViewModelAsync(ulong guildId, CancellationToken cancellationToken)
+    {
+        var guild = await _guildService.GetGuildByIdAsync(guildId, cancellationToken);
+        if (guild != null)
+        {
+            Guild = new GuildViewModel
+            {
+                Id = guild.Id,
+                Name = guild.Name,
+                IconUrl = guild.IconUrl
+            };
+        }
+
+        var settings = await _settingsService.GetOrCreateSettingsAsync(guildId, cancellationToken);
+        var allowedChannels = settings.GetAllowedChannelIdsList();
+        AvailableChannels = GetTextChannels(guildId, allowedChannels);
+
+        DefaultRateLimit = _assistantOptions.Value.DefaultRateLimit;
+        RateLimitWindowMinutes = _assistantOptions.Value.RateLimitWindowMinutes;
+        GloballyEnabled = _assistantOptions.Value.GloballyEnabled;
+    }
+}

--- a/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml
@@ -232,6 +232,14 @@
                                     Audio
                                 </a>
 
+                                <a asp-page="AssistantSettings" asp-route-guildId="@guild.Id"
+                                   class="flex items-center gap-3 px-4 py-2.5 text-sm text-text-primary hover:bg-bg-hover transition-colors">
+                                    <svg class="w-5 h-5 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                    </svg>
+                                    AI Assistant
+                                </a>
+
                                 <div class="border-t border-border-primary my-1"></div>
 
                                 <a asp-page="Analytics/Index" asp-route-guildId="@guild.Id"


### PR DESCRIPTION
## Summary
- Adds **AssistantSettings** page for per-guild AI assistant configuration (enable/disable, channel restrictions, rate limit overrides)
- Adds **AssistantMetrics** page for viewing usage statistics (question counts, cost estimates, latency, cache hit rates)
- Adds AI Assistant link to guild dropdown menu in Details page
- Adds AI disclosure section to Privacy page (data processing, third-party info, consent requirement)
- Updates CLAUDE.md with Claude API configuration instructions

## Test plan
- [ ] Navigate to Guilds > [Server] > AI Assistant from dropdown
- [ ] Verify settings form loads with channel list
- [ ] Toggle enable/disable and save settings
- [ ] Navigate to metrics page via "View Metrics" button
- [ ] Verify metrics display (or empty state if no data)
- [ ] Check Privacy page shows AI Assistant disclosure section

Closes #1064

🤖 Generated with [Claude Code](https://claude.com/claude-code)