### PR TITLE
fix: Address preview popup, analytics, and alerts page issues

### DIFF
--- a/src/DiscordBot.Bot/Pages/Admin/Performance/Alerts.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/Alerts.cshtml.cs
@@ -14,6 +14,7 @@ namespace DiscordBot.Bot.Pages.Admin.Performance;
 public class AlertsModel : PageModel
 {
     private readonly IPerformanceAlertService _alertService;
+    private readonly IAuthorizationService _authorizationService;
     private readonly ILogger<AlertsModel> _logger;
 
     /// <summary>
@@ -25,18 +26,21 @@ public class AlertsModel : PageModel
     /// Gets a value indicating whether the current user can edit alert settings.
     /// Only Admin and SuperAdmin roles can modify alert configurations.
     /// </summary>
-    public bool CanEdit => User.IsInRole("Admin") || User.IsInRole("SuperAdmin");
+    public bool CanEdit { get; private set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AlertsModel"/> class.
     /// </summary>
     /// <param name="alertService">The performance alert service.</param>
+    /// <param name="authorizationService">The authorization service.</param>
     /// <param name="logger">The logger.</param>
     public AlertsModel(
         IPerformanceAlertService alertService,
+        IAuthorizationService authorizationService,
         ILogger<AlertsModel> logger)
     {
         _alertService = alertService;
+        _authorizationService = authorizationService;
         _logger = logger;
     }
 
@@ -47,6 +51,11 @@ public class AlertsModel : PageModel
     public async Task OnGetAsync(CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Alerts page accessed by user {UserId}", User.Identity?.Name);
+
+        // Check if user has Admin permission using policy-based authorization
+        var authResult = await _authorizationService.AuthorizeAsync(User, "RequireAdmin");
+        CanEdit = authResult.Succeeded;
+
         await LoadViewModelAsync(cancellationToken);
     }
 

--- a/src/DiscordBot.Bot/Pages/Guilds/Analytics/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Analytics/Index.cshtml
@@ -417,7 +417,10 @@
                                     <span class="inline-flex items-center justify-center w-8 h-8 rounded-full @rankBadgeClass font-bold text-sm">@rank</span>
                                 </td>
                                 <td class="px-5 py-4">
-                                    <p class="font-medium text-text-primary">@user.Username</p>
+                                    <span class="preview-trigger font-medium text-text-primary"
+                                          data-preview-type="user"
+                                          data-user-id="@user.UserId"
+                                          data-context-guild-id="@Model.ViewModel.GuildId">@user.Username</span>
                                 </td>
                                 <td class="px-5 py-4 text-text-primary font-medium">@user.MessageCount.ToString("N0")</td>
                                 <td class="px-5 py-4 text-text-secondary">@user.UniqueChannels</td>

--- a/src/DiscordBot.Bot/wwwroot/js/preview-popup.js
+++ b/src/DiscordBot.Bot/wwwroot/js/preview-popup.js
@@ -312,7 +312,7 @@ const PreviewPopup = (() => {
                     ${metaItems}
                 </div>
             </div>
-            <div class="preview-footer flex gap-2 p-3 border-t border-border-secondary bg-bg-secondary">
+            <div class="preview-footer flex items-center gap-2 p-3 border-t border-border-secondary bg-bg-secondary flex-wrap">
                 <a href="${profileUrl}" class="flex-1 min-w-0 px-3 py-1.5 text-xs font-medium text-white bg-accent-blue rounded hover:bg-accent-blue-hover transition-colors text-center whitespace-nowrap">
                     View Profile
                 </a>
@@ -384,7 +384,7 @@ const PreviewPopup = (() => {
                     ${metaItems}
                 </div>
             </div>
-            <div class="preview-footer flex gap-2 p-3 border-t border-border-secondary bg-bg-secondary">
+            <div class="preview-footer flex items-center gap-2 p-3 border-t border-border-secondary bg-bg-secondary flex-wrap">
                 <a href="/Guilds/Details?id=${data.guildId}" class="flex-1 min-w-0 px-3 py-1.5 text-xs font-medium text-white bg-accent-blue rounded hover:bg-accent-blue-hover transition-colors text-center whitespace-nowrap">
                     View Guild
                 </a>


### PR DESCRIPTION
## Summary

- **#783**: Fix user preview modal button alignment by adding `items-center` and `flex-wrap` classes to the footer container for proper vertical centering and graceful wrapping
- **#782**: Add user preview popups to Guild Analytics Index page for top contributors table
- **#1164**: Fix SuperAdmin cannot edit Alert tab by replacing `User.IsInRole()` with `IAuthorizationService.AuthorizeAsync()` for consistent policy-based authorization

## Test plan

- [ ] Verify preview modal buttons are vertically centered and wrap gracefully on small screens
- [ ] Verify top contributors in Guild Analytics show preview popup on hover
- [ ] Verify SuperAdmin users can edit alert settings on the Performance Alerts page
- [ ] Verify Admin users can edit alert settings on the Performance Alerts page
- [ ] Verify Moderator and Viewer users still have read-only access to alerts

Closes #782, closes #783, closes #1164

🤖 Generated with [Claude Code](https://claude.com/claude-code)