### PR TITLE
fix(perf): Eliminate N+1 query pattern in ScheduledMessageExecutionService

### DIFF
--- a/src/DiscordBot.Core/Interfaces/IScheduledMessageService.cs
+++ b/src/DiscordBot.Core/Interfaces/IScheduledMessageService.cs
@@ -1,4 +1,5 @@
 using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Entities;
 using DiscordBot.Core.Enums;
 
 namespace DiscordBot.Core.Interfaces;
@@ -75,6 +76,16 @@ public interface IScheduledMessageService
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>True if execution was successful, false if the message was not found or execution failed.</returns>
     Task<bool> ExecuteScheduledMessageAsync(Guid id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Executes a scheduled message immediately by sending it to Discord and updating its state.
+    /// Updates LastExecutedAt and NextExecutionAt. Disables the message if frequency is Once.
+    /// This overload accepts a pre-loaded entity to avoid redundant database queries.
+    /// </summary>
+    /// <param name="message">The scheduled message entity to execute (must be a tracked entity for updates).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if execution was successful, false if execution failed.</returns>
+    Task<bool> ExecuteScheduledMessageAsync(ScheduledMessage message, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Validates a cron expression for correctness.


### PR DESCRIPTION
## Summary

- Eliminates N+1 query pattern in `ScheduledMessageExecutionService.Execute` that was causing poor performance
- Adds new overload `ExecuteScheduledMessageAsync(ScheduledMessage)` that accepts pre-loaded entities directly
- Refactors execution logic into private `ExecuteScheduledMessageCoreAsync` to avoid code duplication

## Problem

The execution service was:
1. Fetching all due messages from the database (1 query)
2. For each message, calling `ExecuteScheduledMessageAsync(message.Id)` which would re-fetch the same message (N queries)

This resulted in N+1 database queries per execution cycle.

## Solution

Pass the already-loaded `ScheduledMessage` entity directly to the new overload, reducing database queries from N+1 to 1 per execution cycle.

## Test plan

- [x] All existing `ScheduledMessage*` tests pass (106 passed, 1 skipped)
- [x] Build succeeds

Closes #785

🤖 Generated with [Claude Code](https://claude.com/claude-code)