### PR TITLE
fix(api): Serialize Discord IDs as strings in Member Directory DTOs

### DIFF
--- a/src/DiscordBot.Core/DTOs/GuildMemberDto.cs
+++ b/src/DiscordBot.Core/DTOs/GuildMemberDto.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace DiscordBot.Core.DTOs;
 
 /// <summary>
@@ -7,7 +9,9 @@ public class GuildMemberDto
 {
     /// <summary>
     /// Gets or sets the Discord user snowflake ID.
+    /// Serialized as a string to prevent JavaScript precision loss for 64-bit integers.
     /// </summary>
+    [JsonNumberHandling(JsonNumberHandling.WriteAsString | JsonNumberHandling.AllowReadingFromString)]
     public ulong UserId { get; set; }
 
     /// <summary>
@@ -53,7 +57,9 @@ public class GuildMemberDto
 
     /// <summary>
     /// Gets or sets the list of role IDs assigned to this member.
+    /// Serialized as strings to prevent JavaScript precision loss for 64-bit integers.
     /// </summary>
+    [JsonNumberHandling(JsonNumberHandling.WriteAsString | JsonNumberHandling.AllowReadingFromString)]
     public List<ulong> RoleIds { get; set; } = new List<ulong>();
 
     /// <summary>

--- a/src/DiscordBot.Core/DTOs/GuildRoleDto.cs
+++ b/src/DiscordBot.Core/DTOs/GuildRoleDto.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace DiscordBot.Core.DTOs;
 
 /// <summary>
@@ -7,7 +9,9 @@ public class GuildRoleDto
 {
     /// <summary>
     /// Gets or sets the Discord role snowflake ID.
+    /// Serialized as a string to prevent JavaScript precision loss for 64-bit integers.
     /// </summary>
+    [JsonNumberHandling(JsonNumberHandling.WriteAsString | JsonNumberHandling.AllowReadingFromString)]
     public ulong Id { get; set; }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- Add `[JsonNumberHandling(WriteAsString | AllowReadingFromString)]` to `GuildMemberDto.UserId`
- Add `[JsonNumberHandling(WriteAsString | AllowReadingFromString)]` to `GuildMemberDto.RoleIds`
- Add `[JsonNumberHandling(WriteAsString | AllowReadingFromString)]` to `GuildRoleDto.Id`

This ensures Discord snowflake IDs (64-bit unsigned integers) are serialized as JSON strings, preventing JavaScript precision loss when IDs exceed `Number.MAX_SAFE_INTEGER` (2^53 - 1).

## Test plan

- [ ] Navigate to `/Guilds/{guildId}/Members`
- [ ] Click "View" on a member
- [ ] Verify in DevTools Network tab that `userId` in the API response is a quoted string, not a number
- [ ] Verify the member modal displays correct information
- [ ] Verify avatar images load correctly

Closes #1170

🤖 Generated with [Claude Code](https://claude.com/claude-code)