### PR TITLE
fix(ui): Chart.js labels visible in both light and dark themes

### DIFF
--- a/src/DiscordBot.Bot/wwwroot/js/command-analytics.js
+++ b/src/DiscordBot.Bot/wwwroot/js/command-analytics.js
@@ -4,14 +4,39 @@
 (function () {
     'use strict';
 
+    function getDesignToken(name) {
+        return getComputedStyle(document.documentElement)
+            .getPropertyValue(`--color-${name}`).trim();
+    }
+
+    function initColors() {
+        return {
+            accentOrange: getDesignToken('accent-orange') || '#cb4e1b',
+            accentBlue: getDesignToken('accent-blue') || '#098ecf',
+            success: getDesignToken('success') || '#10b981',
+            warning: getDesignToken('warning') || '#f59e0b',
+            info: getDesignToken('info') || '#06b6d4',
+            error: getDesignToken('error') || '#ef4444',
+            bgPrimary: getDesignToken('bg-primary') || '#1d2022',
+            bgSecondary: getDesignToken('bg-secondary') || '#262a2d',
+            bgTertiary: getDesignToken('bg-tertiary') || '#2f3336',
+            textPrimary: getDesignToken('text-primary') || '#d7d3d0',
+            textSecondary: getDesignToken('text-secondary') || '#a8a5a3',
+            textTertiary: getDesignToken('text-tertiary') || '#7a7876',
+            borderPrimary: getDesignToken('border-primary') || '#3f4447',
+        };
+    }
+
+    let colors = initColors();
+
     // Design system chart colors
     const CHART_COLORS = [
-        '#cb4e1b',  // accent-orange
-        '#098ecf',  // accent-blue
-        '#10b981',  // success
-        '#f59e0b',  // warning
-        '#06b6d4',  // info
-        '#ef4444',  // error
+        colors.accentOrange,
+        colors.accentBlue,
+        colors.success,
+        colors.warning,
+        colors.info,
+        colors.error,
         '#8b5cf6',  // purple
         '#ec4899',  // pink
         '#14b8a6',  // teal
@@ -19,18 +44,18 @@
     ];
 
     const BG_COLORS = {
-        primary: '#1d2022',
-        secondary: '#262a2d',
-        tertiary: '#2f3336',
+        primary: colors.bgPrimary,
+        secondary: colors.bgSecondary,
+        tertiary: colors.bgTertiary,
     };
 
     const TEXT_COLORS = {
-        primary: '#d7d3d0',
-        secondary: '#a8a5a3',
-        tertiary: '#7a7876',
+        primary: colors.textPrimary,
+        secondary: colors.textSecondary,
+        tertiary: colors.textTertiary,
     };
 
-    const BORDER_COLOR = '#3f4447';
+    const BORDER_COLOR = colors.borderPrimary;
 
     // Chart instance references
     let usageOverTimeChart = null;
@@ -113,7 +138,7 @@
 
             ctx.save();
             ctx.font = 'bold 32px ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto';
-            ctx.fillStyle = TEXT_COLORS.primary;
+            ctx.fillStyle = getDesignToken('text-primary') || '#d7d3d0';
             ctx.textAlign = 'center';
             ctx.textBaseline = 'middle';
             ctx.fillText(text, centerX, centerY);


### PR DESCRIPTION
## Summary
- Fixes Chart.js chart labels being invisible in light theme on Command Analytics page
- Replaces hardcoded dark theme hex colors with CSS custom property reads at runtime
- Follows the established pattern from `engagement-analytics.js`

Closes #1172

## Test plan
- [ ] Navigate to `/CommandLogs/Analytics`
- [ ] Verify charts display correctly in dark theme (baseline)
- [ ] Switch to light theme via profile settings
- [ ] Verify axis labels (X and Y) are visible in light theme
- [ ] Verify Success Rate chart legend text is visible
- [ ] Verify doughnut chart center percentage text is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)