### PR TITLE
fix(user-purge): Use Set<ApplicationUser>() instead of OfType<ApplicationUser>()

### DIFF
--- a/src/DiscordBot.Bot/Services/UserPurgeService.cs
+++ b/src/DiscordBot.Bot/Services/UserPurgeService.cs
@@ -355,8 +355,7 @@ public class UserPurgeService : IUserPurgeService
             };
 
             // Check for linked ApplicationUser
-            var applicationUser = await _dbContext.Users
-                .OfType<ApplicationUser>()
+            var applicationUser = await _dbContext.Set<ApplicationUser>()
                 .FirstOrDefaultAsync(u => u.DiscordUserId == discordUserId, cancellationToken);
 
             if (applicationUser != null)
@@ -404,8 +403,7 @@ public class UserPurgeService : IUserPurgeService
             _logger.LogDebug("Checking if Discord user {DiscordUserId} can be purged", discordUserId);
 
             // Check if user has a linked ApplicationUser account
-            var applicationUser = await _dbContext.Users
-                .OfType<ApplicationUser>()
+            var applicationUser = await _dbContext.Set<ApplicationUser>()
                 .FirstOrDefaultAsync(u => u.DiscordUserId == discordUserId, cancellationToken);
 
             if (applicationUser == null)


### PR DESCRIPTION
## Summary
- Replace invalid `OfType<ApplicationUser>()` calls with `Set<ApplicationUser>()` in `UserPurgeService`
- `BotDbContext.Users` shadows `IdentityDbContext<ApplicationUser>.Users` with the Discord `User` entity
- Since `User` and `ApplicationUser` are unrelated types, `OfType<ApplicationUser>()` cannot be translated to SQL
- Add unit tests for `CanPurgeUserAsync` to prevent regression

## Test plan
- [x] Verify `CanPurgeUserAsync_ReturnsTrue_WhenNoLinkedApplicationUser` passes
- [x] Verify `CanPurgeUserAsync_ReturnsTrue_WhenLinkedApplicationUserHasNoAdminRole` passes
- [ ] Navigate to `/Admin/UserPurge`, enter a Discord user ID, and verify no 500 error

Closes #1173

🤖 Generated with [Claude Code](https://claude.com/claude-code)