### PR TITLE
feat(core): Add ICpuHistoryService interface and CPU DTOs

### DIFF
--- a/src/DiscordBot.Core/DTOs/PerformanceMetricsDtos.cs
+++ b/src/DiscordBot.Core/DTOs/PerformanceMetricsDtos.cs
@@ -109,6 +109,83 @@ public record LatencyStatisticsDto
 }
 
 // ============================================================================
+// CPU History DTOs
+// ============================================================================
+
+/// <summary>
+/// CPU history data with samples and statistical analysis.
+/// </summary>
+public record CpuHistoryDto
+{
+    /// <summary>
+    /// Gets or sets the collection of CPU usage samples.
+    /// </summary>
+    public IReadOnlyList<CpuSampleDto> Samples { get; set; } = Array.Empty<CpuSampleDto>();
+
+    /// <summary>
+    /// Gets or sets the statistical summary of the CPU usage data.
+    /// </summary>
+    public CpuStatisticsDto Statistics { get; set; } = new();
+}
+
+/// <summary>
+/// A single CPU usage measurement sample.
+/// </summary>
+public record CpuSampleDto
+{
+    /// <summary>
+    /// Gets or sets the timestamp when the sample was recorded (UTC).
+    /// </summary>
+    public DateTime Timestamp { get; set; }
+
+    /// <summary>
+    /// Gets or sets the CPU usage percentage (0-100).
+    /// </summary>
+    public double CpuPercent { get; set; }
+}
+
+/// <summary>
+/// Statistical analysis of CPU usage samples.
+/// </summary>
+public record CpuStatisticsDto
+{
+    /// <summary>
+    /// Gets or sets the average CPU usage percentage.
+    /// </summary>
+    public double Average { get; set; }
+
+    /// <summary>
+    /// Gets or sets the minimum CPU usage percentage.
+    /// </summary>
+    public double Min { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum CPU usage percentage.
+    /// </summary>
+    public double Max { get; set; }
+
+    /// <summary>
+    /// Gets or sets the 50th percentile (median) CPU usage percentage.
+    /// </summary>
+    public double P50 { get; set; }
+
+    /// <summary>
+    /// Gets or sets the 95th percentile CPU usage percentage.
+    /// </summary>
+    public double P95 { get; set; }
+
+    /// <summary>
+    /// Gets or sets the 99th percentile CPU usage percentage.
+    /// </summary>
+    public double P99 { get; set; }
+
+    /// <summary>
+    /// Gets or sets the total number of samples included in this statistical analysis.
+    /// </summary>
+    public int SampleCount { get; set; }
+}
+
+// ============================================================================
 // Connection DTOs
 // ============================================================================
 

--- a/src/DiscordBot.Core/Interfaces/ICpuHistoryService.cs
+++ b/src/DiscordBot.Core/Interfaces/ICpuHistoryService.cs
@@ -1,0 +1,35 @@
+using DiscordBot.Core.DTOs;
+
+namespace DiscordBot.Core.Interfaces;
+
+/// <summary>
+/// Service interface for storing and analyzing CPU usage history.
+/// </summary>
+public interface ICpuHistoryService
+{
+    /// <summary>
+    /// Records a new CPU usage sample.
+    /// </summary>
+    /// <param name="cpuPercent">The CPU usage percentage (0-100).</param>
+    void RecordSample(double cpuPercent);
+
+    /// <summary>
+    /// Gets the most recently recorded CPU usage value.
+    /// </summary>
+    /// <returns>The current CPU usage percentage.</returns>
+    double GetCurrentCpu();
+
+    /// <summary>
+    /// Gets CPU usage samples for a specified number of hours.
+    /// </summary>
+    /// <param name="hours">The number of hours of history to retrieve (default: 24).</param>
+    /// <returns>A read-only list of CPU samples in chronological order.</returns>
+    IReadOnlyList<CpuSampleDto> GetSamples(int hours = 24);
+
+    /// <summary>
+    /// Gets statistical analysis of CPU usage samples over a specified number of hours.
+    /// </summary>
+    /// <param name="hours">The number of hours to analyze (default: 24).</param>
+    /// <returns>Statistical summary including average, min, max, and percentiles.</returns>
+    CpuStatisticsDto GetStatistics(int hours = 24);
+}


### PR DESCRIPTION
## Summary
- Add `ICpuHistoryService` interface for CPU usage history tracking
- Add `CpuSampleDto`, `CpuStatisticsDto`, and `CpuHistoryDto` records
- Follow established pattern from `ILatencyHistoryService`

Part of #642 - Implement accurate CPU metrics collection

## Test plan
- [x] Build succeeds with no new errors
- [ ] Interface is accessible from Infrastructure project for implementation

Closes #728

🤖 Generated with [Claude Code](https://claude.com/claude-code)