### PR TITLE
feat(config): Add CPU metrics configuration to PerformanceMetricsOptions

### DIFF
--- a/docs/articles/bot-performance-dashboard.md
+++ b/docs/articles/bot-performance-dashboard.md
@@ -2228,6 +2228,8 @@ Performance metrics configuration is managed through the `PerformanceMetricsOpti
 |----------|------|---------|-------------|
 | `LatencyRetentionHours` | int | 24 | Hours of latency history to retain in circular buffer |
 | `LatencySampleIntervalSeconds` | int | 30 | Interval between latency samples |
+| `CpuSampleIntervalSeconds` | int | 5 | Interval between CPU samples |
+| `CpuRetentionHours` | int | 24 | Hours of CPU history to retain in memory |
 | `ConnectionEventRetentionDays` | int | 30 | Days of connection events to retain |
 | `CommandAggregationCacheTtlMinutes` | int | 5 | Cache TTL for aggregated command metrics |
 | `SlowQueryThresholdMs` | int | 100 | Threshold for flagging slow database queries |

--- a/src/DiscordBot.Core/Configuration/PerformanceMetricsOptions.cs
+++ b/src/DiscordBot.Core/Configuration/PerformanceMetricsOptions.cs
@@ -66,4 +66,16 @@ public class PerformanceMetricsOptions
     /// Default is 100.
     /// </summary>
     public int MaxApiCategories { get; set; } = 100;
+
+    /// <summary>
+    /// Gets or sets the interval (in seconds) at which CPU samples are recorded.
+    /// Default is 5 seconds.
+    /// </summary>
+    public int CpuSampleIntervalSeconds { get; set; } = 5;
+
+    /// <summary>
+    /// Gets or sets the duration (in hours) for which CPU history is retained in memory.
+    /// Default is 24 hours.
+    /// </summary>
+    public int CpuRetentionHours { get; set; } = 24;
 }


### PR DESCRIPTION
## Summary
- Add `CpuSampleIntervalSeconds` property with default of 5 seconds
- Add `CpuRetentionHours` property with default of 24 hours
- Add XML documentation to both properties
- Update bot-performance-dashboard.md with new configuration options

## Test plan
- [x] Build succeeds
- [x] Tests pass (pre-existing failures unrelated to this change)
- [ ] Verify options bind correctly at runtime

Closes #730

🤖 Generated with [Claude Code](https://claude.com/claude-code)