### PR TITLE
feat(api): Add CPU metrics API endpoint

### DIFF
--- a/docs/articles/api-endpoints.md
+++ b/docs/articles/api-endpoints.md
@@ -22,6 +22,7 @@ The REST API provides programmatic access to bot status, guild management, and c
 | `/metrics` | GET | OpenTelemetry metrics (Prometheus format) |
 | `/api/metrics/health` | GET | Overall bot health status |
 | `/api/metrics/health/latency` | GET | Latency history with statistics |
+| `/api/metrics/health/cpu` | GET | CPU usage history with statistics |
 | `/api/metrics/health/connections` | GET | Connection event history |
 | `/api/metrics/commands/performance` | GET | Aggregated command performance metrics |
 | `/api/metrics/commands/slowest` | GET | Slowest commands by execution time |
@@ -242,7 +243,7 @@ The Performance Metrics API provides structured JSON endpoints for monitoring bo
 
 #### GET /api/metrics/health
 
-Returns overall bot health status including uptime, latency, and connection state.
+Returns overall bot health status including uptime, latency, CPU usage, and connection state.
 
 **Response: 200 OK**
 
@@ -250,7 +251,8 @@ Returns overall bot health status including uptime, latency, and connection stat
 {
   "status": "Healthy",
   "uptime": "2.15:34:22",
-  "latency": 45,
+  "latencyMs": 45,
+  "cpuUsagePercent": 12.5,
   "connectionState": "Connected",
   "timestamp": "2024-12-08T15:30:00Z"
 }
@@ -262,7 +264,8 @@ Returns overall bot health status including uptime, latency, and connection stat
 |-------|------|-------------|
 | `status` | string | Overall health status (Healthy, Degraded, Unhealthy) |
 | `uptime` | string | Bot uptime in TimeSpan format (d.hh:mm:ss) |
-| `latency` | int | Current gateway latency in milliseconds |
+| `latencyMs` | int | Current gateway latency in milliseconds |
+| `cpuUsagePercent` | double | Current CPU usage percentage (0-100) |
 | `connectionState` | string | Discord gateway connection state |
 | `timestamp` | string | ISO 8601 timestamp of the response |
 
@@ -326,6 +329,65 @@ GET /api/metrics/health/latency?hours=48
 | `statistics.p95` | double | 95th percentile latency |
 | `statistics.p99` | double | 99th percentile latency |
 | `timeRange` | object | Time range parameters of the query |
+
+---
+
+#### GET /api/metrics/health/cpu
+
+Returns CPU usage history with samples and statistical analysis.
+
+**Query Parameters:**
+
+| Parameter | Type | Required | Default | Range | Description |
+|-----------|------|----------|---------|-------|-------------|
+| `hours` | int | No | 24 | 1-720 | Time range for CPU history |
+
+**Example Request:**
+
+```bash
+GET /api/metrics/health/cpu?hours=24
+```
+
+**Response: 200 OK**
+
+```json
+{
+  "samples": [
+    {
+      "timestamp": "2024-12-08T15:30:00Z",
+      "cpuPercent": 12.5
+    },
+    {
+      "timestamp": "2024-12-08T15:29:55Z",
+      "cpuPercent": 10.2
+    }
+  ],
+  "statistics": {
+    "average": 11.3,
+    "min": 2.1,
+    "max": 45.6,
+    "p50": 10.5,
+    "p95": 35.2,
+    "p99": 42.1,
+    "sampleCount": 17280
+  }
+}
+```
+
+**Response Fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `samples` | array | CPU samples with timestamp and percentage |
+| `samples[].timestamp` | string | ISO 8601 timestamp when sample was recorded |
+| `samples[].cpuPercent` | double | CPU usage percentage (0-100) |
+| `statistics.average` | double | Average CPU usage percentage |
+| `statistics.min` | double | Minimum CPU usage observed |
+| `statistics.max` | double | Maximum CPU usage observed |
+| `statistics.p50` | double | 50th percentile (median) CPU usage |
+| `statistics.p95` | double | 95th percentile CPU usage |
+| `statistics.p99` | double | 99th percentile CPU usage |
+| `statistics.sampleCount` | int | Number of samples in the time range |
 
 ---
 

--- a/src/DiscordBot.Core/DTOs/PerformanceMetricsDtos.cs
+++ b/src/DiscordBot.Core/DTOs/PerformanceMetricsDtos.cs
@@ -25,6 +25,11 @@ public record PerformanceHealthDto
     public int LatencyMs { get; set; }
 
     /// <summary>
+    /// Gets or sets the current CPU usage percentage (0-100).
+    /// </summary>
+    public double CpuUsagePercent { get; set; }
+
+    /// <summary>
     /// Gets or sets the current connection state.
     /// </summary>
     public string ConnectionState { get; set; } = string.Empty;

--- a/tests/DiscordBot.Tests/Controllers/PerformanceMetricsControllerTests.cs
+++ b/tests/DiscordBot.Tests/Controllers/PerformanceMetricsControllerTests.cs
@@ -18,6 +18,7 @@ public class PerformanceMetricsControllerTests
 {
     private readonly Mock<IConnectionStateService> _mockConnectionStateService;
     private readonly Mock<ILatencyHistoryService> _mockLatencyHistoryService;
+    private readonly Mock<ICpuHistoryService> _mockCpuHistoryService;
     private readonly Mock<ICommandPerformanceAggregator> _mockCommandPerformanceAggregator;
     private readonly Mock<IApiRequestTracker> _mockApiRequestTracker;
     private readonly Mock<IDatabaseMetricsCollector> _mockDatabaseMetricsCollector;
@@ -31,6 +32,7 @@ public class PerformanceMetricsControllerTests
     {
         _mockConnectionStateService = new Mock<IConnectionStateService>();
         _mockLatencyHistoryService = new Mock<ILatencyHistoryService>();
+        _mockCpuHistoryService = new Mock<ICpuHistoryService>();
         _mockCommandPerformanceAggregator = new Mock<ICommandPerformanceAggregator>();
         _mockApiRequestTracker = new Mock<IApiRequestTracker>();
         _mockDatabaseMetricsCollector = new Mock<IDatabaseMetricsCollector>();
@@ -42,6 +44,7 @@ public class PerformanceMetricsControllerTests
         _controller = new PerformanceMetricsController(
             _mockConnectionStateService.Object,
             _mockLatencyHistoryService.Object,
+            _mockCpuHistoryService.Object,
             _mockCommandPerformanceAggregator.Object,
             _mockApiRequestTracker.Object,
             _mockDatabaseMetricsCollector.Object,


### PR DESCRIPTION
## Summary
- Added `cpuUsagePercent` property to `GET /api/metrics/health` response
- Added new `GET /api/metrics/health/cpu` endpoint for CPU history and statistics
- Updated API documentation with new endpoint details

## Changes
- **PerformanceHealthDto**: Added `CpuUsagePercent` property
- **PerformanceMetricsController**: 
  - Injected `ICpuHistoryService` 
  - Updated `GetHealth()` to include current CPU
  - Added `GetCpuHistory()` endpoint with hours parameter (1-720)
- **api-endpoints.md**: Added documentation for new endpoint

## Test Plan
- [x] Build passes with no errors
- [x] Existing controller tests pass (20 tests)
- [ ] Manual test: `GET /api/metrics/health` includes `cpuUsagePercent`
- [ ] Manual test: `GET /api/metrics/health/cpu` returns samples and statistics
- [ ] Manual test: `GET /api/metrics/health/cpu?hours=1` respects hours parameter
- [ ] Swagger documentation shows new endpoint

Closes #734

🤖 Generated with [Claude Code](https://claude.com/claude-code)