### PR TITLE
feat: Add Reminders and ScheduledMessages to global search (#1160)

### DIFF
--- a/src/DiscordBot.Bot/Pages/Search.cshtml
+++ b/src/DiscordBot.Bot/Pages/Search.cshtml
@@ -28,7 +28,9 @@
                                              Model.ViewModel.Commands.Count +
                                              Model.ViewModel.AuditLogs.Count +
                                              Model.ViewModel.MessageLogs.Count +
-                                             Model.ViewModel.Pages.Count;
+                                             Model.ViewModel.Pages.Count +
+                                             Model.ViewModel.Reminders.Count +
+                                             Model.ViewModel.ScheduledMessages.Count;
                         }
                         Found @totalResults result@(totalResults != 1 ? "s" : "") for <span class="font-semibold text-text-primary">"@Model.ViewModel.SearchTerm"</span>
                     </p>
@@ -627,6 +629,145 @@
                                     @if (!string.IsNullOrEmpty(msg.Subtitle))
                                     {
                                         <p class="text-sm text-text-secondary"><highlight text="@msg.Subtitle" search-term="@Model.ViewModel.SearchTerm" /></p>
+                                    }
+                                    @if (!string.IsNullOrEmpty(msg.Description))
+                                    {
+                                        <p class="text-xs text-text-tertiary">@msg.Description</p>
+                                    }
+                                </div>
+                            </a>
+                        }
+                    </div>
+                </div>
+            }
+
+            <!-- Reminders Section (Admin+ only) -->
+            @if (Model.ViewModel.CanViewUsers && Model.ViewModel.Reminders.Any())
+            {
+                <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden">
+                    <!-- Section Header -->
+                    <div class="px-6 py-4 border-b border-border-primary bg-bg-tertiary">
+                        <div class="flex items-center justify-between">
+                            <div class="flex items-center gap-3">
+                                <svg class="w-5 h-5 text-text-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+                                </svg>
+                                <h2 class="text-lg font-semibold text-text-primary">Reminders</h2>
+                                @{
+                                    var remindersCountBadge = new BadgeViewModel
+                                    {
+                                        Text = Model.ViewModel.Reminders.Count.ToString(),
+                                        Variant = BadgeVariant.Default,
+                                        Size = BadgeSize.Small
+                                    };
+                                }
+                                <partial name="Shared/Components/_Badge" model="remindersCountBadge" />
+                            </div>
+                            @if (Model.ViewModel.TotalReminders > Model.ViewModel.Reminders.Count && !string.IsNullOrEmpty(Model.ViewModel.RemindersViewAllUrl))
+                            {
+                                <a href="@Model.ViewModel.RemindersViewAllUrl" class="text-sm font-medium text-accent-blue hover:text-accent-blue-hover transition-colors">
+                                    View all @Model.ViewModel.TotalReminders results →
+                                </a>
+                            }
+                        </div>
+                    </div>
+
+                    <!-- Reminder Results List -->
+                    <div class="divide-y divide-border-primary">
+                        @foreach (var reminder in Model.ViewModel.Reminders)
+                        {
+                            <a href="@reminder.Url" class="block px-6 py-4 hover:bg-bg-hover transition-colors">
+                                <div class="flex flex-col gap-2">
+                                    <div class="flex items-center gap-3 flex-wrap">
+                                        <span class="font-semibold text-text-primary text-sm"><highlight text="@reminder.Title" search-term="@Model.ViewModel.SearchTerm" max-length="50" /></span>
+                                        @if (!string.IsNullOrEmpty(reminder.BadgeText))
+                                        {
+                                            var reminderBadgeVariant = reminder.BadgeVariant switch
+                                            {
+                                                "warning" => BadgeVariant.Warning,
+                                                "success" => BadgeVariant.Success,
+                                                "danger" => BadgeVariant.Error,
+                                                "secondary" => BadgeVariant.Default,
+                                                _ => BadgeVariant.Default
+                                            };
+                                            var reminderBadge = new BadgeViewModel
+                                            {
+                                                Text = reminder.BadgeText,
+                                                Variant = reminderBadgeVariant,
+                                                Size = BadgeSize.Small
+                                            };
+                                            <partial name="Shared/Components/_Badge" model="reminderBadge" />
+                                        }
+                                    </div>
+                                    @if (!string.IsNullOrEmpty(reminder.Subtitle))
+                                    {
+                                        <p class="text-sm text-text-secondary">@reminder.Subtitle</p>
+                                    }
+                                    @if (!string.IsNullOrEmpty(reminder.Description))
+                                    {
+                                        <p class="text-xs text-text-tertiary">@reminder.Description</p>
+                                    }
+                                </div>
+                            </a>
+                        }
+                    </div>
+                </div>
+            }
+
+            <!-- Scheduled Messages Section (Admin+ only) -->
+            @if (Model.ViewModel.CanViewUsers && Model.ViewModel.ScheduledMessages.Any())
+            {
+                <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden">
+                    <!-- Section Header -->
+                    <div class="px-6 py-4 border-b border-border-primary bg-bg-tertiary">
+                        <div class="flex items-center justify-between">
+                            <div class="flex items-center gap-3">
+                                <svg class="w-5 h-5 text-text-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                </svg>
+                                <h2 class="text-lg font-semibold text-text-primary">Scheduled Messages</h2>
+                                @{
+                                    var scheduledMessagesCountBadge = new BadgeViewModel
+                                    {
+                                        Text = Model.ViewModel.ScheduledMessages.Count.ToString(),
+                                        Variant = BadgeVariant.Default,
+                                        Size = BadgeSize.Small
+                                    };
+                                }
+                                <partial name="Shared/Components/_Badge" model="scheduledMessagesCountBadge" />
+                            </div>
+                            @if (Model.ViewModel.TotalScheduledMessages > Model.ViewModel.ScheduledMessages.Count && !string.IsNullOrEmpty(Model.ViewModel.ScheduledMessagesViewAllUrl))
+                            {
+                                <a href="@Model.ViewModel.ScheduledMessagesViewAllUrl" class="text-sm font-medium text-accent-blue hover:text-accent-blue-hover transition-colors">
+                                    View all @Model.ViewModel.TotalScheduledMessages results →
+                                </a>
+                            }
+                        </div>
+                    </div>
+
+                    <!-- Scheduled Message Results List -->
+                    <div class="divide-y divide-border-primary">
+                        @foreach (var msg in Model.ViewModel.ScheduledMessages)
+                        {
+                            <a href="@msg.Url" class="block px-6 py-4 hover:bg-bg-hover transition-colors">
+                                <div class="flex flex-col gap-2">
+                                    <div class="flex items-center gap-3 flex-wrap">
+                                        <span class="font-semibold text-text-primary text-sm"><highlight text="@msg.Title" search-term="@Model.ViewModel.SearchTerm" max-length="50" /></span>
+                                        @if (!string.IsNullOrEmpty(msg.BadgeText))
+                                        {
+                                            var scheduledMsgBadgeVariant = msg.BadgeVariant == "success" ? BadgeVariant.Success : BadgeVariant.Default;
+                                            var scheduledMsgBadge = new BadgeViewModel
+                                            {
+                                                Text = msg.BadgeText,
+                                                Variant = scheduledMsgBadgeVariant,
+                                                Size = BadgeSize.Small
+                                            };
+                                            <partial name="Shared/Components/_Badge" model="scheduledMsgBadge" />
+                                        }
+                                    </div>
+                                    @if (!string.IsNullOrEmpty(msg.Subtitle))
+                                    {
+                                        <p class="text-sm text-text-secondary">@msg.Subtitle</p>
                                     }
                                     @if (!string.IsNullOrEmpty(msg.Description))
                                     {

--- a/src/DiscordBot.Bot/Pages/Search.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Search.cshtml.cs
@@ -107,7 +107,15 @@ public class SearchModel : PageModel
 
             Pages = unifiedResult.Pages.Items,
             TotalPages = unifiedResult.Pages.TotalCount,
-            PagesViewAllUrl = unifiedResult.Pages.ViewAllUrl
+            PagesViewAllUrl = unifiedResult.Pages.ViewAllUrl,
+
+            Reminders = unifiedResult.Reminders.Items,
+            TotalReminders = unifiedResult.Reminders.TotalCount,
+            RemindersViewAllUrl = unifiedResult.Reminders.ViewAllUrl,
+
+            ScheduledMessages = unifiedResult.ScheduledMessages.Items,
+            TotalScheduledMessages = unifiedResult.ScheduledMessages.TotalCount,
+            ScheduledMessagesViewAllUrl = unifiedResult.ScheduledMessages.ViewAllUrl
         };
 
         _logger.LogInformation("Search completed. Found {TotalResults} total results across all categories",

--- a/src/DiscordBot.Bot/ViewModels/Pages/SearchResultsViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Pages/SearchResultsViewModel.cs
@@ -109,6 +109,36 @@ public class SearchResultsViewModel
     public string? PagesViewAllUrl { get; set; }
 
     /// <summary>
+    /// Gets or sets the reminder search results (Admin+ only).
+    /// </summary>
+    public IReadOnlyList<SearchResultItemDto> Reminders { get; set; } = Array.Empty<SearchResultItemDto>();
+
+    /// <summary>
+    /// Gets or sets the total number of reminders matching the search.
+    /// </summary>
+    public int TotalReminders { get; set; }
+
+    /// <summary>
+    /// Gets the "View all" URL for reminders category.
+    /// </summary>
+    public string? RemindersViewAllUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets the scheduled message search results (Admin+ only).
+    /// </summary>
+    public IReadOnlyList<SearchResultItemDto> ScheduledMessages { get; set; } = Array.Empty<SearchResultItemDto>();
+
+    /// <summary>
+    /// Gets or sets the total number of scheduled messages matching the search.
+    /// </summary>
+    public int TotalScheduledMessages { get; set; }
+
+    /// <summary>
+    /// Gets the "View all" URL for scheduled messages category.
+    /// </summary>
+    public string? ScheduledMessagesViewAllUrl { get; set; }
+
+    /// <summary>
     /// Gets whether there are any search results across all categories.
     /// </summary>
     public bool HasResults =>
@@ -118,7 +148,9 @@ public class SearchResultsViewModel
         Commands.Any() ||
         AuditLogs.Any() ||
         MessageLogs.Any() ||
-        Pages.Any();
+        Pages.Any() ||
+        Reminders.Any() ||
+        ScheduledMessages.Any();
 }
 
 /// <summary>

--- a/src/DiscordBot.Core/DTOs/SearchDtos.cs
+++ b/src/DiscordBot.Core/DTOs/SearchDtos.cs
@@ -71,6 +71,16 @@ public class UnifiedSearchResultDto
     public SearchCategoryResult Pages { get; set; } = new();
 
     /// <summary>
+    /// Gets or sets the results for the Reminders category.
+    /// </summary>
+    public SearchCategoryResult Reminders { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the results for the ScheduledMessages category.
+    /// </summary>
+    public SearchCategoryResult ScheduledMessages { get; set; } = new();
+
+    /// <summary>
     /// Gets a value indicating whether any results were found across all categories.
     /// </summary>
     public bool HasResults =>
@@ -80,7 +90,9 @@ public class UnifiedSearchResultDto
         Commands.Items.Count > 0 ||
         AuditLogs.Items.Count > 0 ||
         MessageLogs.Items.Count > 0 ||
-        Pages.Items.Count > 0;
+        Pages.Items.Count > 0 ||
+        Reminders.Items.Count > 0 ||
+        ScheduledMessages.Items.Count > 0;
 
     /// <summary>
     /// Gets the total number of results across all categories.
@@ -92,7 +104,9 @@ public class UnifiedSearchResultDto
         Commands.Items.Count +
         AuditLogs.Items.Count +
         MessageLogs.Items.Count +
-        Pages.Items.Count;
+        Pages.Items.Count +
+        Reminders.Items.Count +
+        ScheduledMessages.Items.Count;
 }
 
 /// <summary>

--- a/src/DiscordBot.Core/Enums/SearchCategory.cs
+++ b/src/DiscordBot.Core/Enums/SearchCategory.cs
@@ -38,5 +38,15 @@ public enum SearchCategory
     /// <summary>
     /// Admin UI page search results.
     /// </summary>
-    Pages
+    Pages,
+
+    /// <summary>
+    /// Reminder search results.
+    /// </summary>
+    Reminders,
+
+    /// <summary>
+    /// Scheduled message search results.
+    /// </summary>
+    ScheduledMessages
 }


### PR DESCRIPTION
## Summary

This PR adds two new search categories to the global search system: **Reminders** and **Scheduled Messages**.

### Implementation Details

- Added `Reminders` and `ScheduledMessages` categories to the `SearchCategory` enum with XML documentation
- Updated `UnifiedSearchResultDto` with new category properties and updated computed properties (`HasResults`, `TotalResultCount`)
- Added `SearchRemindersAsync` and `SearchScheduledMessagesAsync` methods to `SearchService` following existing patterns
- Both new categories are Admin+ only (restricted via `IsAdminCategory` and `DetermineCategoriesToSearch`)
- Updated `SearchResultsViewModel` with new category properties for the Search page
- Updated `Search.cshtml.cs` to map new categories to the view model
- Updated `Search.cshtml` with new UI sections using bell icon (Reminders) and clock icon (Scheduled Messages)

### Search Features

**Reminders:**
- Searchable by message content and user ID
- Shows status badges (Pending/Delivered/Failed/Cancelled)
- Links to guild-specific reminders management page

**Scheduled Messages:**
- Searchable by content, title, and channel ID
- Shows Active/Disabled status
- Links to guild-specific scheduled messages page

### Technical Notes

- Both search methods use DbContext with filtered queries for performance (EF.Functions.Like for SQL-side filtering)
- No global "view all" links since both features are guild-scoped
- Follow existing search patterns for consistency

## Review Status

- Code Review: APPROVED (after 1 fix iteration)
- UI Review: SKIPPED (no screenshot requested)
- Review iterations: 2
- Unresolved items: None (minor optimization suggestions logged but not required)

Closes #1160

🤖 Generated with [Claude Code](https://claude.com/claude-code)