### PR TITLE
feat: Create ViewModels and partial components for guild layout system (#1190)

### DIFF
--- a/src/DiscordBot.Bot/Configuration/GuildNavigationConfig.cs
+++ b/src/DiscordBot.Bot/Configuration/GuildNavigationConfig.cs
@@ -1,0 +1,102 @@
+// src/DiscordBot.Bot/Configuration/GuildNavigationConfig.cs
+using DiscordBot.Bot.ViewModels.Components;
+
+namespace DiscordBot.Bot.Configuration;
+
+/// <summary>
+/// Provides static configuration for guild navigation tabs.
+/// </summary>
+public static class GuildNavigationConfig
+{
+    /// <summary>
+    /// Gets the list of navigation tabs for guild pages.
+    /// </summary>
+    /// <returns>Read-only list of guild navigation items.</returns>
+    public static IReadOnlyList<GuildNavItem> GetTabs()
+    {
+        return new List<GuildNavItem>
+        {
+            new()
+            {
+                Id = "overview",
+                Label = "Overview",
+                PageName = "/Guilds/Details",
+                Order = 1,
+                IconOutline = "M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6",
+                IconSolid = "M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z"
+            },
+            new()
+            {
+                Id = "members",
+                Label = "Members",
+                PageName = "/Guilds/Members",
+                Order = 2,
+                IconOutline = "M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z",
+                IconSolid = "M9 6a3 3 0 11-6 0 3 3 0 016 0zM17 6a3 3 0 11-6 0 3 3 0 016 0zM12.93 17c.046-.327.07-.66.07-1a6.97 6.97 0 00-1.5-4.33A5 5 0 0119 16v1h-6.07zM6 11a5 5 0 015 5v1H1v-1a5 5 0 015-5z"
+            },
+            new()
+            {
+                Id = "moderation",
+                Label = "Moderation",
+                PageName = "/Guilds/ModerationSettings",
+                Order = 3,
+                IconOutline = "M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z",
+                IconSolid = "M20.618 5.984A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016zM9 11l2 2 4-4"
+            },
+            new()
+            {
+                Id = "messages",
+                Label = "Messages",
+                PageName = "/Guilds/ScheduledMessages",
+                Order = 4,
+                IconOutline = "M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z",
+                IconSolid = "M2 5a2 2 0 012-2h7a2 2 0 012 2v4a2 2 0 01-2 2H9l-3 3v-3H4a2 2 0 01-2-2V5zm15 0a2 2 0 012 2v4a2 2 0 01-2 2h-1v3l-3-3h-2a2 2 0 01-2-2V7a2 2 0 012-2h6z"
+            },
+            new()
+            {
+                Id = "audio",
+                Label = "Audio",
+                PageName = "/Guilds/Soundboard",
+                Order = 5,
+                IconOutline = "M15.536 8.464a5 5 0 010 7.072m2.828-9.9a9 9 0 010 12.728M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z",
+                IconSolid = "M9.383 3.076A1 1 0 0110 4v12a1 1 0 01-1.707.707L4.586 13H2a1 1 0 01-1-1V8a1 1 0 011-1h2.586l3.707-3.707a1 1 0 011.09-.217zM14.657 2.929a1 1 0 011.414 0A9.972 9.972 0 0119 10a9.972 9.972 0 01-2.929 7.071 1 1 0 01-1.414-1.414A7.971 7.971 0 0017 10c0-2.21-.894-4.208-2.343-5.657a1 1 0 010-1.414zm-2.829 2.828a1 1 0 011.415 0A5.983 5.983 0 0115 10a5.984 5.984 0 01-1.757 4.243 1 1 0 01-1.415-1.415A3.984 3.984 0 0013 10a3.983 3.983 0 00-1.172-2.828 1 1 0 010-1.415z"
+            },
+            new()
+            {
+                Id = "ratwatch",
+                Label = "Rat Watch",
+                PageName = "/Guilds/RatWatch",
+                Order = 6,
+                IconOutline = "M15 12a3 3 0 11-6 0 3 3 0 016 0z M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z",
+                IconSolid = "M10 12a2 2 0 100-4 2 2 0 000 4z M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10z"
+            },
+            new()
+            {
+                Id = "reminders",
+                Label = "Reminders",
+                PageName = "/Guilds/Reminders",
+                Order = 7,
+                IconOutline = "M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9",
+                IconSolid = "M10 2a6 6 0 00-6 6v3.586l-.707.707A1 1 0 004 14h12a1 1 0 00.707-1.707L16 11.586V8a6 6 0 00-6-6zM10 18a3 3 0 01-3-3h6a3 3 0 01-3 3z"
+            },
+            new()
+            {
+                Id = "welcome",
+                Label = "Welcome",
+                PageName = "/Guilds/Welcome",
+                Order = 8,
+                IconOutline = "M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z",
+                IconSolid = "M8 9a3 3 0 100-6 3 3 0 000 6zM8 11a6 6 0 016 6H2a6 6 0 016-6zM16 7a1 1 0 10-2 0v1h-1a1 1 0 100 2h1v1a1 1 0 102 0v-1h1a1 1 0 100-2h-1V7z"
+            },
+            new()
+            {
+                Id = "assistant",
+                Label = "Assistant",
+                PageName = "/Guilds/AssistantSettings",
+                Order = 9,
+                IconOutline = "M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z",
+                IconSolid = "M11 3a1 1 0 10-2 0v1a1 1 0 102 0V3zM15.657 5.757a1 1 0 00-1.414-1.414l-.707.707a1 1 0 001.414 1.414l.707-.707zM18 10a1 1 0 01-1 1h-1a1 1 0 110-2h1a1 1 0 011 1zM5.05 6.464A1 1 0 106.464 5.05l-.707-.707a1 1 0 00-1.414 1.414l.707.707zM5 10a1 1 0 01-1 1H3a1 1 0 110-2h1a1 1 0 011 1zM8 16v-1h4v1a2 2 0 11-4 0zM12 14c.015-.34.208-.646.477-.859a4 4 0 10-4.954 0c.27.213.462.519.476.859h4.002z"
+            }
+        };
+    }
+}

--- a/src/DiscordBot.Bot/Pages/Guilds/GuildPageModelBase.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/GuildPageModelBase.cs
@@ -1,0 +1,110 @@
+// src/DiscordBot.Bot/Pages/Guilds/GuildPageModelBase.cs
+using DiscordBot.Bot.Configuration;
+using DiscordBot.Bot.ViewModels.Components;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace DiscordBot.Bot.Pages.Guilds;
+
+/// <summary>
+/// Abstract base class for guild-related pages that use the standardized guild layout.
+/// Provides helper properties and methods for building breadcrumbs and navigation.
+/// </summary>
+public abstract class GuildPageModelBase : PageModel
+{
+    /// <summary>
+    /// Breadcrumb navigation for the page.
+    /// </summary>
+    public GuildBreadcrumbViewModel Breadcrumb { get; set; } = new();
+
+    /// <summary>
+    /// Guild header information including guild icon, title, and actions.
+    /// </summary>
+    public GuildHeaderViewModel Header { get; set; } = new();
+
+    /// <summary>
+    /// Guild navigation bar with tabs.
+    /// </summary>
+    public GuildNavBarViewModel Navigation { get; set; } = new();
+
+    /// <summary>
+    /// Builds a basic breadcrumb with Home > Servers > Guild Name.
+    /// </summary>
+    /// <param name="guildId">Discord guild ID.</param>
+    /// <param name="guildName">Guild name.</param>
+    /// <returns>Breadcrumb view model.</returns>
+    protected GuildBreadcrumbViewModel BuildBasicBreadcrumb(ulong guildId, string guildName)
+    {
+        return new GuildBreadcrumbViewModel
+        {
+            Items = new List<BreadcrumbItem>
+            {
+                new() { Label = "Home", Url = "/" },
+                new() { Label = "Servers", Url = "/Guilds" },
+                new() { Label = guildName, Url = $"/Guilds/Details?id={guildId}", IsCurrent = true }
+            }
+        };
+    }
+
+    /// <summary>
+    /// Builds a breadcrumb with Home > Servers > Guild Name > Page Name.
+    /// </summary>
+    /// <param name="guildId">Discord guild ID.</param>
+    /// <param name="guildName">Guild name.</param>
+    /// <param name="pageName">Current page name.</param>
+    /// <returns>Breadcrumb view model.</returns>
+    protected GuildBreadcrumbViewModel BuildPageBreadcrumb(ulong guildId, string guildName, string pageName)
+    {
+        return new GuildBreadcrumbViewModel
+        {
+            Items = new List<BreadcrumbItem>
+            {
+                new() { Label = "Home", Url = "/" },
+                new() { Label = "Servers", Url = "/Guilds" },
+                new() { Label = guildName, Url = $"/Guilds/Details?id={guildId}" },
+                new() { Label = pageName, IsCurrent = true }
+            }
+        };
+    }
+
+    /// <summary>
+    /// Builds navigation bar with all tabs.
+    /// </summary>
+    /// <param name="guildId">Discord guild ID.</param>
+    /// <param name="activeTabId">ID of the currently active tab.</param>
+    /// <returns>Navigation bar view model.</returns>
+    protected GuildNavBarViewModel BuildNavigation(ulong guildId, string activeTabId)
+    {
+        return new GuildNavBarViewModel
+        {
+            GuildId = guildId,
+            ActiveTab = activeTabId,
+            Tabs = GuildNavigationConfig.GetTabs().ToList()
+        };
+    }
+
+    /// <summary>
+    /// Builds a basic guild header with title and description.
+    /// </summary>
+    /// <param name="guildId">Discord guild ID.</param>
+    /// <param name="guildName">Guild name.</param>
+    /// <param name="guildIconUrl">URL to guild icon (optional).</param>
+    /// <param name="pageTitle">Page title to display.</param>
+    /// <param name="pageDescription">Optional page description.</param>
+    /// <returns>Header view model.</returns>
+    protected GuildHeaderViewModel BuildHeader(
+        ulong guildId,
+        string guildName,
+        string? guildIconUrl,
+        string pageTitle,
+        string? pageDescription = null)
+    {
+        return new GuildHeaderViewModel
+        {
+            GuildId = guildId,
+            GuildName = guildName,
+            GuildIconUrl = guildIconUrl,
+            PageTitle = pageTitle,
+            PageDescription = pageDescription
+        };
+    }
+}

--- a/src/DiscordBot.Bot/Pages/Shared/Components/_GuildBreadcrumb.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/Components/_GuildBreadcrumb.cshtml
@@ -1,0 +1,31 @@
+@model DiscordBot.Bot.ViewModels.Components.GuildBreadcrumbViewModel
+
+@if (Model.Items?.Any() == true)
+{
+    <nav aria-label="Breadcrumb" class="mb-6">
+        <ol class="flex items-center gap-2 text-sm">
+            @foreach (var item in Model.Items)
+            {
+                <li class="flex items-center gap-2">
+                    @if (!item.IsCurrent && !string.IsNullOrEmpty(item.Url))
+                    {
+                        <a href="@item.Url" class="text-text-secondary hover:text-accent-blue transition-colors">
+                            @item.Label
+                        </a>
+                    }
+                    else
+                    {
+                        <span class="text-text-primary font-medium">@item.Label</span>
+                    }
+
+                    @if (!item.IsCurrent)
+                    {
+                        <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                        </svg>
+                    }
+                </li>
+            }
+        </ol>
+    </nav>
+}

--- a/src/DiscordBot.Bot/Pages/Shared/Components/_GuildHeader.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/Components/_GuildHeader.cshtml
@@ -1,0 +1,86 @@
+@model DiscordBot.Bot.ViewModels.Components.GuildHeaderViewModel
+@{
+    var hasActions = Model.Actions?.Any() == true;
+}
+
+<div class="mb-8">
+    <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+        <!-- Left: Icon + Title + Description -->
+        <div class="flex items-center gap-4">
+            <!-- Guild Icon -->
+            @if (!string.IsNullOrEmpty(Model.GuildIconUrl))
+            {
+                <img src="@Model.GuildIconUrl"
+                     alt="@Model.GuildName"
+                     class="w-12 h-12 rounded-full flex-shrink-0" />
+            }
+            else
+            {
+                <div class="w-12 h-12 rounded-full bg-gradient-to-br from-accent-blue to-accent-orange flex items-center justify-center text-white font-bold text-lg flex-shrink-0">
+                    @(Model.GuildName.Length >= 2 ? Model.GuildName[..2].ToUpper() : Model.GuildName.ToUpper())
+                </div>
+            }
+
+            <!-- Title + Description -->
+            <div>
+                <h1 class="text-2xl font-bold text-text-primary">@Model.PageTitle</h1>
+                @if (!string.IsNullOrEmpty(Model.PageDescription))
+                {
+                    <p class="mt-1 text-sm text-text-secondary">@Model.PageDescription</p>
+                }
+            </div>
+        </div>
+
+        <!-- Right: Action Buttons -->
+        @if (hasActions)
+        {
+            <div class="flex items-center gap-2">
+                @foreach (var action in Model.Actions!)
+                {
+                    @if (action.Style == DiscordBot.Bot.ViewModels.Components.HeaderActionStyle.Primary)
+                    {
+                        <a href="@action.Url"
+                           @(action.OpenInNewTab ? "target=\"_blank\" rel=\"noopener noreferrer\"" : "")
+                           class="px-4 py-2 bg-accent-orange text-white font-medium text-sm rounded-lg hover:bg-accent-orange-hover transition-colors inline-flex items-center gap-2">
+                            @if (!string.IsNullOrEmpty(action.Icon))
+                            {
+                                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@action.Icon" />
+                                </svg>
+                            }
+                            <span>@action.Label</span>
+                        </a>
+                    }
+                    else if (action.Style == DiscordBot.Bot.ViewModels.Components.HeaderActionStyle.Secondary)
+                    {
+                        <a href="@action.Url"
+                           @(action.OpenInNewTab ? "target=\"_blank\" rel=\"noopener noreferrer\"" : "")
+                           class="px-3 py-2 text-sm font-medium text-text-secondary hover:text-accent-blue bg-bg-secondary border border-border-primary rounded-lg hover:border-border-focus transition-colors inline-flex items-center gap-2">
+                            @if (!string.IsNullOrEmpty(action.Icon))
+                            {
+                                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@action.Icon" />
+                                </svg>
+                            }
+                            <span>@action.Label</span>
+                        </a>
+                    }
+                    else if (action.Style == DiscordBot.Bot.ViewModels.Components.HeaderActionStyle.Link)
+                    {
+                        <a href="@action.Url"
+                           @(action.OpenInNewTab ? "target=\"_blank\" rel=\"noopener noreferrer\"" : "")
+                           class="text-sm font-medium text-accent-blue hover:text-accent-blue-hover transition-colors inline-flex items-center gap-1">
+                            @if (!string.IsNullOrEmpty(action.Icon))
+                            {
+                                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@action.Icon" />
+                                </svg>
+                            }
+                            <span>@action.Label</span>
+                        </a>
+                    }
+                }
+            </div>
+        }
+    </div>
+</div>

--- a/src/DiscordBot.Bot/Pages/Shared/Components/_GuildNavBar.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/Components/_GuildNavBar.cshtml
@@ -1,0 +1,64 @@
+@model DiscordBot.Bot.ViewModels.Components.GuildNavBarViewModel
+@{
+    var orderedTabs = Model.Tabs.OrderBy(t => t.Order).ToList();
+    var activeTab = orderedTabs.FirstOrDefault(t => t.Id == Model.ActiveTab);
+}
+
+<div class="guild-nav-container mb-6" id="guildNavContainer">
+    <!-- Desktop: Horizontal tabs -->
+    <nav class="guild-nav-tabs hidden sm:flex" id="guildNavTabs" role="tablist" aria-label="Guild sections">
+        @foreach (var tab in orderedTabs)
+        {
+            var isActive = Model.ActiveTab == tab.Id;
+
+            <a asp-page="@tab.PageName"
+               asp-route-guildId="@Model.GuildId"
+               class="guild-nav-tab @(isActive ? "active" : "")"
+               role="tab"
+               aria-selected="@(isActive ? "true" : "false")">
+                @if (isActive && !string.IsNullOrEmpty(tab.IconSolid))
+                {
+                    <svg class="tab-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                        <path d="@tab.IconSolid" />
+                    </svg>
+                }
+                else if (!string.IsNullOrEmpty(tab.IconOutline))
+                {
+                    <svg class="tab-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@tab.IconOutline" />
+                    </svg>
+                }
+                <span>@tab.Label</span>
+            </a>
+        }
+    </nav>
+
+    <!-- Mobile: Dropdown -->
+    <div class="guild-nav-dropdown sm:hidden">
+        <button type="button"
+                id="guildNavDropdownToggle"
+                class="guild-nav-dropdown-button"
+                aria-haspopup="true"
+                aria-expanded="false">
+            <span id="guildNavSelectedText">@(activeTab?.Label ?? "Navigation")</span>
+            <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            </svg>
+        </button>
+        <div id="guildNavDropdownMenu"
+             class="hidden guild-nav-dropdown-menu"
+             role="region"
+             aria-label="Guild navigation menu">
+            @foreach (var tab in orderedTabs)
+            {
+                var isActive = Model.ActiveTab == tab.Id;
+
+                <a asp-page="@tab.PageName"
+                   asp-route-guildId="@Model.GuildId"
+                   class="guild-nav-dropdown-item @(isActive ? "active" : "")">
+                    @tab.Label
+                </a>
+            }
+        </div>
+    </div>
+</div>

--- a/src/DiscordBot.Bot/Pages/Shared/_GuildLayout.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/_GuildLayout.cshtml
@@ -1,0 +1,24 @@
+@using DiscordBot.Bot.ViewModels.Components
+@{
+    Layout = "_Layout.cshtml";
+}
+
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <!-- Breadcrumb Navigation -->
+    @await Html.PartialAsync("Components/_GuildBreadcrumb", (GuildBreadcrumbViewModel)Model.Breadcrumb)
+
+    <!-- Guild Header -->
+    @await Html.PartialAsync("Components/_GuildHeader", (GuildHeaderViewModel)Model.Header)
+
+    <!-- Guild Navigation Bar -->
+    @await Html.PartialAsync("Components/_GuildNavBar", (GuildNavBarViewModel)Model.Navigation)
+
+    <!-- Page Content -->
+    <div class="guild-page-content">
+        @RenderBody()
+    </div>
+</div>
+
+@section Scripts {
+    <script src="~/js/guild-nav.js" asp-append-version="true"></script>
+}

--- a/src/DiscordBot.Bot/ViewModels/Components/GuildBreadcrumbViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Components/GuildBreadcrumbViewModel.cs
@@ -1,0 +1,34 @@
+// src/DiscordBot.Bot/ViewModels/Components/GuildBreadcrumbViewModel.cs
+namespace DiscordBot.Bot.ViewModels.Components;
+
+/// <summary>
+/// ViewModel for guild breadcrumb navigation component.
+/// </summary>
+public record GuildBreadcrumbViewModel
+{
+    /// <summary>
+    /// List of breadcrumb items to display.
+    /// </summary>
+    public List<BreadcrumbItem> Items { get; init; } = new();
+}
+
+/// <summary>
+/// Represents a single item in the breadcrumb navigation.
+/// </summary>
+public record BreadcrumbItem
+{
+    /// <summary>
+    /// Display text for the breadcrumb item.
+    /// </summary>
+    public string Label { get; init; } = string.Empty;
+
+    /// <summary>
+    /// URL to navigate to. Null for the current page.
+    /// </summary>
+    public string? Url { get; init; }
+
+    /// <summary>
+    /// Whether this is the current page (last item in breadcrumb).
+    /// </summary>
+    public bool IsCurrent { get; init; }
+}

--- a/src/DiscordBot.Bot/ViewModels/Components/GuildHeaderViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Components/GuildHeaderViewModel.cs
@@ -1,0 +1,90 @@
+// src/DiscordBot.Bot/ViewModels/Components/GuildHeaderViewModel.cs
+namespace DiscordBot.Bot.ViewModels.Components;
+
+/// <summary>
+/// ViewModel for guild header component displaying guild info, page title, and action buttons.
+/// </summary>
+public record GuildHeaderViewModel
+{
+    /// <summary>
+    /// Discord guild ID (Snowflake).
+    /// </summary>
+    public ulong GuildId { get; init; }
+
+    /// <summary>
+    /// Guild name.
+    /// </summary>
+    public string GuildName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// URL to guild icon image. If null, displays initials fallback.
+    /// </summary>
+    public string? GuildIconUrl { get; init; }
+
+    /// <summary>
+    /// Main page title displayed in the header.
+    /// </summary>
+    public string PageTitle { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Optional description text displayed below the title.
+    /// </summary>
+    public string? PageDescription { get; init; }
+
+    /// <summary>
+    /// Optional list of action buttons to display in the header.
+    /// </summary>
+    public List<HeaderAction>? Actions { get; init; }
+}
+
+/// <summary>
+/// Represents an action button in the guild header.
+/// </summary>
+public record HeaderAction
+{
+    /// <summary>
+    /// Button label text.
+    /// </summary>
+    public string Label { get; init; } = string.Empty;
+
+    /// <summary>
+    /// URL to navigate to when clicked.
+    /// </summary>
+    public string Url { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Optional SVG icon path or CSS class.
+    /// </summary>
+    public string? Icon { get; init; }
+
+    /// <summary>
+    /// Visual style of the button.
+    /// </summary>
+    public HeaderActionStyle Style { get; init; } = HeaderActionStyle.Secondary;
+
+    /// <summary>
+    /// Whether to open the link in a new tab.
+    /// </summary>
+    public bool OpenInNewTab { get; init; }
+}
+
+/// <summary>
+/// Visual styles for header action buttons.
+/// </summary>
+public enum HeaderActionStyle
+{
+    /// <summary>
+    /// Orange accent button with solid background.
+    /// </summary>
+    Primary,
+
+    /// <summary>
+    /// Bordered button with secondary background.
+    /// </summary>
+    Secondary,
+
+    /// <summary>
+    /// Text link style.
+    /// </summary>
+    Link
+}

--- a/src/DiscordBot.Bot/ViewModels/Components/GuildNavBarViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Components/GuildNavBarViewModel.cs
@@ -1,0 +1,59 @@
+// src/DiscordBot.Bot/ViewModels/Components/GuildNavBarViewModel.cs
+namespace DiscordBot.Bot.ViewModels.Components;
+
+/// <summary>
+/// ViewModel for guild navigation bar component with tab navigation.
+/// </summary>
+public record GuildNavBarViewModel
+{
+    /// <summary>
+    /// Discord guild ID (Snowflake).
+    /// </summary>
+    public ulong GuildId { get; init; }
+
+    /// <summary>
+    /// ID of the currently active tab.
+    /// </summary>
+    public string ActiveTab { get; init; } = string.Empty;
+
+    /// <summary>
+    /// List of navigation tabs to display.
+    /// </summary>
+    public List<GuildNavItem> Tabs { get; init; } = new();
+}
+
+/// <summary>
+/// Represents a single navigation tab item.
+/// </summary>
+public record GuildNavItem
+{
+    /// <summary>
+    /// Unique identifier for the tab (e.g., "overview", "members").
+    /// </summary>
+    public string Id { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Display label for the tab.
+    /// </summary>
+    public string Label { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Full Razor page path to navigate to (e.g., "/Guilds/Details").
+    /// </summary>
+    public string PageName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// SVG path for outline icon (used when tab is not active).
+    /// </summary>
+    public string? IconOutline { get; init; }
+
+    /// <summary>
+    /// SVG path for solid icon (used when tab is active).
+    /// </summary>
+    public string? IconSolid { get; init; }
+
+    /// <summary>
+    /// Display order for the tab.
+    /// </summary>
+    public int Order { get; init; }
+}

--- a/src/DiscordBot.Bot/wwwroot/css/site.css
+++ b/src/DiscordBot.Bot/wwwroot/css/site.css
@@ -3282,3 +3282,152 @@
     transition: none;
   }
 }
+
+/* ============================================
+   GUILD NAVIGATION COMPONENTS
+   ============================================ */
+
+/* Guild Navigation Tabs (Desktop) */
+.guild-nav-container {
+  position: relative;
+}
+
+.guild-nav-tabs {
+  display: flex;
+  gap: 0.25rem;
+  padding: 0.25rem;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-primary);
+  border-radius: 0.75rem;
+  overflow-x: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.guild-nav-tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.guild-nav-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  background: transparent;
+  border-radius: 0.5rem;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: all 0.15s ease-out;
+}
+
+.guild-nav-tab:hover {
+  color: var(--color-text-primary);
+  background: var(--color-bg-hover);
+}
+
+.guild-nav-tab:focus-visible {
+  outline: 2px solid var(--color-accent-blue);
+  outline-offset: 2px;
+}
+
+.guild-nav-tab.active {
+  color: var(--color-text-primary);
+  background: var(--color-bg-tertiary);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.guild-nav-tab .tab-icon {
+  width: 1.125rem;
+  height: 1.125rem;
+  flex-shrink: 0;
+}
+
+.guild-nav-tab.active .tab-icon {
+  color: var(--color-accent-blue);
+}
+
+/* Guild Navigation Dropdown (Mobile) */
+.guild-nav-dropdown {
+  position: relative;
+}
+
+.guild-nav-dropdown-button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text-primary);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-primary);
+  border-radius: 0.75rem;
+  transition: all 0.15s ease-out;
+}
+
+.guild-nav-dropdown-button:hover {
+  border-color: var(--color-border-focus);
+}
+
+.guild-nav-dropdown-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  margin-top: 0.5rem;
+  background: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border-primary);
+  border-radius: 0.75rem;
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  overflow: hidden;
+  z-index: var(--z-popover);
+}
+
+.guild-nav-dropdown-item {
+  display: block;
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+  color: var(--color-text-primary);
+  text-decoration: none;
+  transition: background 0.15s ease-out;
+}
+
+.guild-nav-dropdown-item:hover {
+  background: var(--color-bg-hover);
+}
+
+.guild-nav-dropdown-item:focus-visible {
+  outline: 2px solid var(--color-accent-blue);
+  outline-offset: -2px;
+}
+
+.guild-nav-dropdown-item.active {
+  background: var(--color-bg-hover);
+  font-weight: 600;
+}
+
+/* Mobile responsive */
+@media (max-width: 640px) {
+  .guild-nav-tab {
+    padding: 0.5rem 0.875rem;
+    font-size: 0.8125rem;
+  }
+
+  .guild-nav-tab .tab-icon {
+    width: 1rem;
+    height: 1rem;
+  }
+}
+
+/* Reduced motion support */
+@media (prefers-reduced-motion: reduce) {
+  .guild-nav-tab,
+  .guild-nav-dropdown-button,
+  .guild-nav-dropdown-item {
+    transition: none;
+  }
+}

--- a/src/DiscordBot.Bot/wwwroot/js/guild-nav.js
+++ b/src/DiscordBot.Bot/wwwroot/js/guild-nav.js
@@ -1,0 +1,33 @@
+// Guild Navigation Dropdown Toggle
+// Handles mobile dropdown for guild navigation tabs
+
+document.addEventListener('DOMContentLoaded', function() {
+    const dropdownToggle = document.getElementById('guildNavDropdownToggle');
+    const dropdownMenu = document.getElementById('guildNavDropdownMenu');
+
+    if (dropdownToggle && dropdownMenu) {
+        // Toggle dropdown on button click
+        dropdownToggle.addEventListener('click', function(e) {
+            e.stopPropagation();
+            const isHidden = dropdownMenu.classList.toggle('hidden');
+            dropdownToggle.setAttribute('aria-expanded', !isHidden);
+        });
+
+        // Close dropdown on click outside
+        document.addEventListener('click', function(e) {
+            if (!e.target.closest('.guild-nav-dropdown')) {
+                dropdownMenu.classList.add('hidden');
+                dropdownToggle.setAttribute('aria-expanded', 'false');
+            }
+        });
+
+        // Close dropdown on Escape key
+        document.addEventListener('keydown', function(e) {
+            if (e.key === 'Escape' && !dropdownMenu.classList.contains('hidden')) {
+                dropdownMenu.classList.add('hidden');
+                dropdownToggle.setAttribute('aria-expanded', 'false');
+                dropdownToggle.focus();
+            }
+        });
+    }
+});


### PR DESCRIPTION
## Summary

- Created foundational infrastructure for standardized guild page layouts
- Added ViewModels (`GuildBreadcrumbViewModel`, `GuildHeaderViewModel`, `GuildNavBarViewModel`) with proper records and enums
- Implemented `GuildNavigationConfig` with 9 navigation tabs including Hero Icons
- Built partial components (`_GuildBreadcrumb`, `_GuildHeader`, `_GuildNavBar`) with accessibility support
- Created `_GuildLayout.cshtml` shared layout integrating all components
- Added JavaScript for mobile dropdown with keyboard navigation
- Added CSS styles with focus states, reduced motion support, and design system tokens
- Optional `GuildPageModelBase` for common guild page functionality

Closes #1190

## Test plan

- [ ] Build passes with `dotnet build`
- [ ] Create a test page using `_GuildLayout` and verify all components render
- [ ] Test desktop navigation tabs (>=640px viewport)
- [ ] Test mobile dropdown (<640px viewport)
- [ ] Verify active tab indicator works correctly
- [ ] Test keyboard navigation (Tab, Escape for dropdown)
- [ ] Verify screen reader compatibility with ARIA labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)