### PR TITLE
fix: Hide scrollbar on moderation history tabbed navigation (#1201)

### DIFF
--- a/src/DiscordBot.Bot/wwwroot/css/moderation.css
+++ b/src/DiscordBot.Bot/wwwroot/css/moderation.css
@@ -291,6 +291,12 @@
   border-bottom: 1px solid var(--color-border-primary, #3f4447);
   padding-bottom: 0;
   overflow-x: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.settings-tabs::-webkit-scrollbar {
+  display: none;
 }
 
 .settings-tab {


### PR DESCRIPTION
## Summary
Added cross-browser scrollbar hiding to the `.settings-tabs` container in the moderation history tabbed navigation, improving visual presentation while preserving horizontal scroll functionality for responsive layouts.

### Implementation Details
- Added `scrollbar-width: none` for Firefox
- Added `-ms-overflow-style: none` for IE/Edge
- Added `.settings-tabs::-webkit-scrollbar { display: none }` for Chrome/Safari/Opera
- Horizontal scroll functionality preserved for responsive layouts

### Files Changed
- `src/DiscordBot.Bot/wwwroot/css/moderation.css`

Closes #1201