### PR TITLE
feat: Migrate guild sub-pages to shared layout (#1193)

### DIFF
--- a/src/DiscordBot.Bot/Pages/Guilds/Analytics/Engagement.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Analytics/Engagement.cshtml
@@ -3,67 +3,10 @@
 @using DiscordBot.Bot.ViewModels.Components
 @{
     ViewData["Title"] = $"Engagement Metrics - {Model.ViewModel.GuildName}";
+    Layout = "_GuildLayout";
 }
 
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-    <!-- Breadcrumb Navigation -->
-    <nav aria-label="Breadcrumb" class="mb-6">
-        <ol class="flex items-center gap-2 text-sm flex-wrap">
-            <li>
-                <a asp-page="/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Home</a>
-            </li>
-            <li class="text-text-tertiary" aria-hidden="true">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <a asp-page="/Guilds/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Servers</a>
-            </li>
-            <li class="text-text-tertiary" aria-hidden="true">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <a asp-page="/Guilds/Details" asp-route-guildId="@Model.ViewModel.GuildId" class="text-text-secondary hover:text-accent-blue transition-colors">@Model.ViewModel.GuildName</a>
-            </li>
-            <li class="text-text-tertiary" aria-hidden="true">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <span class="text-text-primary font-medium" aria-current="page">Engagement Metrics</span>
-            </li>
-        </ol>
-    </nav>
-
-    <!-- Page Header -->
-    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
-        <div>
-            <h1 class="text-2xl font-bold text-text-primary">Engagement Metrics</h1>
-            <p class="mt-1 text-sm text-text-secondary">Message trends and member retention for @Model.ViewModel.GuildName</p>
-        </div>
-    </div>
-
-    <!-- Navigation Tabs -->
-    <div class="flex items-center gap-1 mb-6 border-b border-border-primary">
-        <a asp-page="Index" asp-route-guildId="@Model.ViewModel.GuildId"
-           class="px-4 py-3 text-sm font-medium border-b-2 border-transparent text-text-secondary hover:text-text-primary transition-colors">
-            Overview
-        </a>
-        <a asp-page="Moderation" asp-route-guildId="@Model.ViewModel.GuildId"
-           class="px-4 py-3 text-sm font-medium border-b-2 border-transparent text-text-secondary hover:text-text-primary transition-colors">
-            Moderation
-        </a>
-        <a asp-page="Engagement" asp-route-guildId="@Model.ViewModel.GuildId"
-           class="px-4 py-3 text-sm font-medium border-b-2 border-accent-blue text-text-primary">
-            Engagement
-        </a>
-    </div>
-
-    <!-- Display any errors -->
+<!-- Display any errors -->
     @if (TempData["ErrorMessage"] != null)
     {
         <div class="mb-6">

--- a/src/DiscordBot.Bot/Pages/Guilds/Analytics/Engagement.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/Analytics/Engagement.cshtml.cs
@@ -1,3 +1,5 @@
+using DiscordBot.Bot.Configuration;
+using DiscordBot.Bot.ViewModels.Components;
 using DiscordBot.Bot.ViewModels.Pages;
 using DiscordBot.Core.Interfaces;
 using Microsoft.AspNetCore.Authorization;
@@ -32,6 +34,21 @@ public class EngagementModel : PageModel
     /// The analytics view model with all chart data and metrics.
     /// </summary>
     public EngagementAnalyticsViewModel ViewModel { get; private set; } = new();
+
+    /// <summary>
+    /// Guild layout breadcrumb ViewModel.
+    /// </summary>
+    public GuildBreadcrumbViewModel Breadcrumb { get; set; } = new();
+
+    /// <summary>
+    /// Guild layout header ViewModel.
+    /// </summary>
+    public GuildHeaderViewModel Header { get; set; } = new();
+
+    /// <summary>
+    /// Guild layout navigation ViewModel.
+    /// </summary>
+    public GuildNavBarViewModel Navigation { get; set; } = new();
 
     /// <summary>
     /// Start date filter (bound from query string).
@@ -106,6 +123,35 @@ public class EngagementModel : PageModel
             _logger.LogInformation(
                 "Engagement analytics loaded successfully for guild {GuildId}. Total messages: {TotalMessages}, Active members: {ActiveMembers}",
                 guildId, summary.TotalMessages, summary.ActiveMembers);
+
+            // Populate guild layout ViewModels
+            Breadcrumb = new GuildBreadcrumbViewModel
+            {
+                Items = new List<BreadcrumbItem>
+                {
+                    new() { Label = "Home", Url = "/" },
+                    new() { Label = "Servers", Url = "/Guilds" },
+                    new() { Label = guild.Name, Url = $"/Guilds/Details/{guildId}" },
+                    new() { Label = "Analytics", Url = $"/Guilds/Analytics/{guildId}" },
+                    new() { Label = "Engagement", IsCurrent = true }
+                }
+            };
+
+            Header = new GuildHeaderViewModel
+            {
+                GuildId = guild.Id,
+                GuildName = guild.Name,
+                GuildIconUrl = guild.IconUrl,
+                PageTitle = "Engagement Metrics",
+                PageDescription = $"Message trends and member retention for {guild.Name}"
+            };
+
+            Navigation = new GuildNavBarViewModel
+            {
+                GuildId = guild.Id,
+                ActiveTab = "overview",
+                Tabs = GuildNavigationConfig.GetTabs().ToList()
+            };
         }
         catch (Exception ex)
         {

--- a/src/DiscordBot.Bot/Pages/Guilds/Analytics/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Analytics/Index.cshtml
@@ -3,67 +3,10 @@
 @using DiscordBot.Bot.ViewModels.Components
 @{
     ViewData["Title"] = $"Server Analytics - {Model.ViewModel.GuildName}";
+    Layout = "_GuildLayout";
 }
 
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-    <!-- Breadcrumb Navigation -->
-    <nav aria-label="Breadcrumb" class="mb-6">
-        <ol class="flex items-center gap-2 text-sm flex-wrap">
-            <li>
-                <a asp-page="/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Home</a>
-            </li>
-            <li class="text-text-tertiary" aria-hidden="true">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <a asp-page="/Guilds/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Servers</a>
-            </li>
-            <li class="text-text-tertiary" aria-hidden="true">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <a asp-page="/Guilds/Details" asp-route-guildId="@Model.ViewModel.GuildId" class="text-text-secondary hover:text-accent-blue transition-colors">@Model.ViewModel.GuildName</a>
-            </li>
-            <li class="text-text-tertiary" aria-hidden="true">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <span class="text-text-primary font-medium" aria-current="page">Analytics</span>
-            </li>
-        </ol>
-    </nav>
-
-    <!-- Page Header -->
-    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
-        <div>
-            <h1 class="text-2xl font-bold text-text-primary">Server Analytics</h1>
-            <p class="mt-1 text-sm text-text-secondary">Activity metrics and trends for @Model.ViewModel.GuildName</p>
-        </div>
-    </div>
-
-    <!-- Navigation Tabs -->
-    <div class="flex items-center gap-1 mb-6 border-b border-border-primary">
-        <a asp-page="Index" asp-route-guildId="@Model.ViewModel.GuildId"
-           class="px-4 py-3 text-sm font-medium border-b-2 border-accent-blue text-text-primary">
-            Overview
-        </a>
-        <a asp-page="Moderation" asp-route-guildId="@Model.ViewModel.GuildId"
-           class="px-4 py-3 text-sm font-medium border-b-2 border-transparent text-text-secondary hover:text-text-primary transition-colors">
-            Moderation
-        </a>
-        <a asp-page="Engagement" asp-route-guildId="@Model.ViewModel.GuildId"
-           class="px-4 py-3 text-sm font-medium border-b-2 border-transparent text-text-secondary hover:text-text-primary transition-colors">
-            Engagement
-        </a>
-    </div>
-
-    <!-- Display any errors -->
+<!-- Display any errors -->
     @if (TempData["ErrorMessage"] != null)
     {
         <div class="mb-6">

--- a/src/DiscordBot.Bot/Pages/Guilds/Analytics/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/Analytics/Index.cshtml.cs
@@ -1,4 +1,6 @@
 using Discord.WebSocket;
+using DiscordBot.Bot.Configuration;
+using DiscordBot.Bot.ViewModels.Components;
 using DiscordBot.Bot.ViewModels.Pages;
 using DiscordBot.Core.DTOs;
 using DiscordBot.Core.Interfaces;
@@ -40,6 +42,21 @@ public class IndexModel : PageModel
     /// The analytics view model with all chart data and metrics.
     /// </summary>
     public ServerAnalyticsViewModel ViewModel { get; private set; } = new();
+
+    /// <summary>
+    /// Guild layout breadcrumb ViewModel.
+    /// </summary>
+    public GuildBreadcrumbViewModel Breadcrumb { get; set; } = new();
+
+    /// <summary>
+    /// Guild layout header ViewModel.
+    /// </summary>
+    public GuildHeaderViewModel Header { get; set; } = new();
+
+    /// <summary>
+    /// Guild layout navigation ViewModel.
+    /// </summary>
+    public GuildNavBarViewModel Navigation { get; set; } = new();
 
     /// <summary>
     /// Start date filter (bound from query string).
@@ -117,6 +134,34 @@ public class IndexModel : PageModel
             _logger.LogInformation(
                 "Analytics loaded successfully for guild {GuildId}. Total members: {TotalMembers}, Messages (7d): {Messages7d}",
                 guildId, summary.TotalMembers, summary.Messages7d);
+
+            // Populate guild layout ViewModels
+            Breadcrumb = new GuildBreadcrumbViewModel
+            {
+                Items = new List<BreadcrumbItem>
+                {
+                    new() { Label = "Home", Url = "/" },
+                    new() { Label = "Servers", Url = "/Guilds" },
+                    new() { Label = guild.Name, Url = $"/Guilds/Details/{guildId}" },
+                    new() { Label = "Analytics", IsCurrent = true }
+                }
+            };
+
+            Header = new GuildHeaderViewModel
+            {
+                GuildId = guild.Id,
+                GuildName = guild.Name,
+                GuildIconUrl = guild.IconUrl,
+                PageTitle = "Server Analytics",
+                PageDescription = $"Activity metrics and trends for {guild.Name}"
+            };
+
+            Navigation = new GuildNavBarViewModel
+            {
+                GuildId = guild.Id,
+                ActiveTab = "overview",
+                Tabs = GuildNavigationConfig.GetTabs().ToList()
+            };
         }
         catch (Exception ex)
         {

--- a/src/DiscordBot.Bot/Pages/Guilds/Analytics/Moderation.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Analytics/Moderation.cshtml
@@ -3,67 +3,10 @@
 @using DiscordBot.Bot.ViewModels.Components
 @{
     ViewData["Title"] = $"Moderation Analytics - {Model.ViewModel.GuildName}";
+    Layout = "_GuildLayout";
 }
 
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-    <!-- Breadcrumb Navigation -->
-    <nav aria-label="Breadcrumb" class="mb-6">
-        <ol class="flex items-center gap-2 text-sm flex-wrap">
-            <li>
-                <a asp-page="/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Home</a>
-            </li>
-            <li class="text-text-tertiary" aria-hidden="true">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <a asp-page="/Guilds/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Servers</a>
-            </li>
-            <li class="text-text-tertiary" aria-hidden="true">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <a asp-page="/Guilds/Details" asp-route-guildId="@Model.ViewModel.GuildId" class="text-text-secondary hover:text-accent-blue transition-colors">@Model.ViewModel.GuildName</a>
-            </li>
-            <li class="text-text-tertiary" aria-hidden="true">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <span class="text-text-primary font-medium" aria-current="page">Moderation Analytics</span>
-            </li>
-        </ol>
-    </nav>
-
-    <!-- Page Header -->
-    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
-        <div>
-            <h1 class="text-2xl font-bold text-text-primary">Moderation Analytics</h1>
-            <p class="mt-1 text-sm text-text-secondary">Moderation metrics and trends for @Model.ViewModel.GuildName</p>
-        </div>
-    </div>
-
-    <!-- Navigation Tabs -->
-    <div class="flex items-center gap-1 mb-6 border-b border-border-primary">
-        <a asp-page="Index" asp-route-guildId="@Model.ViewModel.GuildId"
-           class="px-4 py-3 text-sm font-medium border-b-2 border-transparent text-text-secondary hover:text-text-primary transition-colors">
-            Overview
-        </a>
-        <a asp-page="Moderation" asp-route-guildId="@Model.ViewModel.GuildId"
-           class="px-4 py-3 text-sm font-medium border-b-2 border-accent-blue text-text-primary">
-            Moderation
-        </a>
-        <a asp-page="Engagement" asp-route-guildId="@Model.ViewModel.GuildId"
-           class="px-4 py-3 text-sm font-medium border-b-2 border-transparent text-text-secondary hover:text-text-primary transition-colors">
-            Engagement
-        </a>
-    </div>
-
-    <!-- Display any errors -->
+<!-- Display any errors -->
     @if (TempData["ErrorMessage"] != null)
     {
         <div class="mb-6">

--- a/src/DiscordBot.Bot/Pages/Guilds/Analytics/Moderation.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/Analytics/Moderation.cshtml.cs
@@ -1,4 +1,6 @@
 using Discord.WebSocket;
+using DiscordBot.Bot.Configuration;
+using DiscordBot.Bot.ViewModels.Components;
 using DiscordBot.Bot.ViewModels.Pages;
 using DiscordBot.Core.DTOs;
 using DiscordBot.Core.Interfaces;
@@ -37,6 +39,21 @@ public class ModerationModel : PageModel
     /// The moderation analytics view model with all chart data and metrics.
     /// </summary>
     public ModerationAnalyticsViewModel ViewModel { get; private set; } = new();
+
+    /// <summary>
+    /// Guild layout breadcrumb ViewModel.
+    /// </summary>
+    public GuildBreadcrumbViewModel Breadcrumb { get; set; } = new();
+
+    /// <summary>
+    /// Guild layout header ViewModel.
+    /// </summary>
+    public GuildHeaderViewModel Header { get; set; } = new();
+
+    /// <summary>
+    /// Guild layout navigation ViewModel.
+    /// </summary>
+    public GuildNavBarViewModel Navigation { get; set; } = new();
 
     /// <summary>
     /// Start date filter (bound from query string).
@@ -123,6 +140,35 @@ public class ModerationModel : PageModel
             _logger.LogInformation(
                 "Moderation analytics loaded successfully for guild {GuildId}. Total cases: {TotalCases}, Avg cases/day: {CasesPerDay:F1}",
                 guildId, summary.TotalCases, summary.CasesPerDay);
+
+            // Populate guild layout ViewModels
+            Breadcrumb = new GuildBreadcrumbViewModel
+            {
+                Items = new List<BreadcrumbItem>
+                {
+                    new() { Label = "Home", Url = "/" },
+                    new() { Label = "Servers", Url = "/Guilds" },
+                    new() { Label = guild.Name, Url = $"/Guilds/Details/{guildId}" },
+                    new() { Label = "Analytics", Url = $"/Guilds/Analytics/{guildId}" },
+                    new() { Label = "Moderation", IsCurrent = true }
+                }
+            };
+
+            Header = new GuildHeaderViewModel
+            {
+                GuildId = guild.Id,
+                GuildName = guild.Name,
+                GuildIconUrl = guild.IconUrl,
+                PageTitle = "Moderation Analytics",
+                PageDescription = $"Moderation metrics and trends for {guild.Name}"
+            };
+
+            Navigation = new GuildNavBarViewModel
+            {
+                GuildId = guild.Id,
+                ActiveTab = "overview",
+                Tabs = GuildNavigationConfig.GetTabs().ToList()
+            };
         }
         catch (Exception ex)
         {

--- a/src/DiscordBot.Bot/Pages/Guilds/AssistantMetrics.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/AssistantMetrics.cshtml
@@ -3,76 +3,11 @@
 @using DiscordBot.Bot.ViewModels.Components
 @{
     ViewData["Title"] = $"Assistant Metrics - {Model.Guild.Name}";
+    Layout = "_GuildLayout";
 }
 
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-    <!-- Breadcrumb Navigation -->
-    <nav aria-label="Breadcrumb" class="mb-6">
-        <ol class="flex items-center gap-2 text-sm">
-            <li>
-                <a asp-page="/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Home</a>
-            </li>
-            <li class="text-text-tertiary">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <a asp-page="Index" class="text-text-secondary hover:text-accent-blue transition-colors">Servers</a>
-            </li>
-            <li class="text-text-tertiary">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <a asp-page="Details" asp-route-guildId="@Model.Guild.Id" class="text-text-secondary hover:text-accent-blue transition-colors">@Model.Guild.Name</a>
-            </li>
-            <li class="text-text-tertiary">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <span class="text-text-primary font-medium">Assistant Metrics</span>
-            </li>
-        </ol>
-    </nav>
-
-    <!-- Page Header -->
-    <div class="mb-8">
-        <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-            <div class="flex items-center gap-4">
-                @if (!string.IsNullOrEmpty(Model.Guild.IconUrl))
-                {
-                    <img src="@Model.Guild.IconUrl" alt="@Model.Guild.Name" class="w-12 h-12 rounded-full flex-shrink-0" />
-                }
-                else
-                {
-                    <div class="w-12 h-12 rounded-full bg-gradient-to-br from-accent-blue to-accent-orange flex items-center justify-center text-white font-bold text-lg flex-shrink-0">
-                        @(Model.Guild.Name.Length >= 2 ? Model.Guild.Name[..2].ToUpper() : Model.Guild.Name.ToUpper())
-                    </div>
-                }
-                <div>
-                    <h1 class="text-2xl font-bold text-text-primary">Assistant Usage Metrics</h1>
-                    <p class="mt-1 text-sm text-text-secondary">Usage statistics for the last 30 days</p>
-                </div>
-            </div>
-            <div class="flex items-center gap-3">
-                <a asp-page="AssistantSettings" asp-route-guildId="@Model.Guild.Id"
-                   class="btn btn-secondary inline-flex items-center gap-2">
-                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                    </svg>
-                    Settings
-                </a>
-            </div>
-        </div>
-    </div>
-
-    <!-- Summary Cards -->
-    <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+<!-- Summary Cards -->
+<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
         <!-- Total Questions -->
         <div class="bg-bg-secondary border border-border-primary rounded-lg p-4">
             <div class="flex items-center gap-2 mb-1">

--- a/src/DiscordBot.Bot/Pages/Guilds/AssistantMetrics.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/AssistantMetrics.cshtml.cs
@@ -1,3 +1,5 @@
+using DiscordBot.Bot.Configuration;
+using DiscordBot.Bot.ViewModels.Components;
 using DiscordBot.Core.Entities;
 using DiscordBot.Core.Interfaces;
 using Microsoft.AspNetCore.Authorization;
@@ -37,6 +39,21 @@ public class AssistantMetricsModel : PageModel
     /// Guild information for display.
     /// </summary>
     public GuildViewModel Guild { get; set; } = new();
+
+    /// <summary>
+    /// Guild layout breadcrumb ViewModel.
+    /// </summary>
+    public GuildBreadcrumbViewModel Breadcrumb { get; set; } = new();
+
+    /// <summary>
+    /// Guild layout header ViewModel.
+    /// </summary>
+    public GuildHeaderViewModel Header { get; set; } = new();
+
+    /// <summary>
+    /// Guild layout navigation ViewModel.
+    /// </summary>
+    public GuildNavBarViewModel Navigation { get; set; } = new();
 
     /// <summary>
     /// Daily metrics for the last 30 days.
@@ -145,6 +162,39 @@ public class AssistantMetricsModel : PageModel
             // Calculate success rate
             var totalRequests = TotalQuestions + TotalFailedRequests;
             SuccessRate = totalRequests > 0 ? (double)TotalQuestions / totalRequests * 100 : 100;
+        }
+
+        // Populate guild layout ViewModels
+        var guildDto = await _guildService.GetGuildByIdAsync(GuildId, cancellationToken);
+        if (guildDto != null)
+        {
+            Breadcrumb = new GuildBreadcrumbViewModel
+            {
+                Items = new List<BreadcrumbItem>
+                {
+                    new() { Label = "Home", Url = "/" },
+                    new() { Label = "Servers", Url = "/Guilds" },
+                    new() { Label = guildDto.Name, Url = $"/Guilds/Details/{GuildId}" },
+                    new() { Label = "Assistant", Url = $"/Guilds/AssistantSettings/{GuildId}" },
+                    new() { Label = "Metrics", IsCurrent = true }
+                }
+            };
+
+            Header = new GuildHeaderViewModel
+            {
+                GuildId = guildDto.Id,
+                GuildName = guildDto.Name,
+                GuildIconUrl = guildDto.IconUrl,
+                PageTitle = "Assistant Usage Metrics",
+                PageDescription = $"AI assistant usage statistics for {guildDto.Name}"
+            };
+
+            Navigation = new GuildNavBarViewModel
+            {
+                GuildId = guildDto.Id,
+                ActiveTab = "assistant",
+                Tabs = GuildNavigationConfig.GetTabs().ToList()
+            };
         }
 
         return Page();

--- a/src/DiscordBot.Bot/Pages/Guilds/Edit.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Edit.cshtml
@@ -3,62 +3,10 @@
 @using DiscordBot.Bot.ViewModels.Components
 @{
     ViewData["Title"] = $"Edit {Model.ViewModel.Name}";
+    Layout = "_GuildLayout";
 }
 
-<div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-    <!-- Breadcrumb Navigation -->
-    <nav aria-label="Breadcrumb" class="mb-6">
-        <ol class="flex items-center gap-2 text-sm">
-            <li>
-                <a asp-page="/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Home</a>
-            </li>
-            <li class="text-text-tertiary">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <a asp-page="Index" class="text-text-secondary hover:text-accent-blue transition-colors">Servers</a>
-            </li>
-            <li class="text-text-tertiary">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <a asp-page="Details" asp-route-guildId="@Model.ViewModel.Id" class="text-text-secondary hover:text-accent-blue transition-colors">@Model.ViewModel.Name</a>
-            </li>
-            <li class="text-text-tertiary">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <span class="text-text-primary font-medium">Edit Settings</span>
-            </li>
-        </ol>
-    </nav>
-
-    <!-- Page Header -->
-    <div class="mb-8">
-        <div class="flex items-center gap-4">
-            @if (!string.IsNullOrEmpty(Model.ViewModel.IconUrl))
-            {
-                <img src="@Model.ViewModel.IconUrl" alt="@Model.ViewModel.Name" class="w-12 h-12 rounded-full flex-shrink-0" />
-            }
-            else
-            {
-                <div class="w-12 h-12 rounded-full bg-gradient-to-br from-accent-blue to-accent-orange flex items-center justify-center text-white font-bold text-lg flex-shrink-0">
-                    @(Model.ViewModel.Name.Length >= 2 ? Model.ViewModel.Name[..2].ToUpper() : Model.ViewModel.Name.ToUpper())
-                </div>
-            }
-            <div>
-                <h1 class="text-2xl font-bold text-text-primary">Edit Settings</h1>
-                <p class="mt-1 text-sm text-text-secondary">Configure bot settings for @Model.ViewModel.Name</p>
-            </div>
-        </div>
-    </div>
-
+<div class="max-w-3xl mx-auto">
     <!-- Success Message -->
     @if (!string.IsNullOrEmpty(Model.SuccessMessage))
     {

--- a/src/DiscordBot.Bot/Pages/Guilds/FlaggedEvents/Details.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/FlaggedEvents/Details.cshtml
@@ -4,87 +4,34 @@
 @using DiscordBot.Core.Enums
 @{
     ViewData["Title"] = $"Flagged Event Details - {Model.GuildName}";
+    Layout = "_GuildLayout";
 }
 
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-    <!-- Breadcrumb Navigation -->
-    <nav aria-label="Breadcrumb" class="mb-6">
-        <ol class="flex items-center gap-2 text-sm">
-            <li>
-                <a asp-page="/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Home</a>
-            </li>
-            <li class="text-text-tertiary">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <a asp-page="/Guilds/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Servers</a>
-            </li>
-            <li class="text-text-tertiary">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <a asp-page="/Guilds/Details" asp-route-guildId="@Model.GuildId" class="text-text-secondary hover:text-accent-blue transition-colors">@Model.GuildName</a>
-            </li>
-            <li class="text-text-tertiary">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <a asp-page="/Guilds/FlaggedEvents/Index" asp-route-guildId="@Model.GuildId" class="text-text-secondary hover:text-accent-blue transition-colors">Flagged Events</a>
-            </li>
-            <li class="text-text-tertiary">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <span class="text-text-primary font-medium">Event Details</span>
-            </li>
-        </ol>
-    </nav>
-
-    <!-- Page Header -->
-    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
-        <div class="flex items-center gap-3">
-            <a asp-page="/Guilds/FlaggedEvents/Index" asp-route-guildId="@Model.GuildId" class="text-text-secondary hover:text-text-primary transition-colors">
-                <svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
-                </svg>
-            </a>
-            <h1 class="text-2xl font-bold text-text-primary">Flagged Event Details</h1>
-        </div>
+<!-- Success Message -->
+@if (!string.IsNullOrEmpty(Model.SuccessMessage))
+{
+    <div class="mb-6">
+        <partial name="Shared/Components/_Alert" model="new AlertViewModel {
+            Variant = AlertVariant.Success,
+            Message = Model.SuccessMessage,
+            IsDismissible = true
+        }" />
     </div>
+}
 
-    <!-- Success Message -->
-    @if (!string.IsNullOrEmpty(Model.SuccessMessage))
-    {
-        <div class="mb-6">
-            <partial name="Shared/Components/_Alert" model="new AlertViewModel {
-                Variant = AlertVariant.Success,
-                Message = Model.SuccessMessage,
-                IsDismissible = true
-            }" />
-        </div>
-    }
+<!-- Error Message -->
+@if (!string.IsNullOrEmpty(Model.ErrorMessage))
+{
+    <div class="mb-6">
+        <partial name="Shared/Components/_Alert" model="new AlertViewModel {
+            Variant = AlertVariant.Error,
+            Message = Model.ErrorMessage,
+            IsDismissible = true
+        }" />
+    </div>
+}
 
-    <!-- Error Message -->
-    @if (!string.IsNullOrEmpty(Model.ErrorMessage))
-    {
-        <div class="mb-6">
-            <partial name="Shared/Components/_Alert" model="new AlertViewModel {
-                Variant = AlertVariant.Error,
-                Message = Model.ErrorMessage,
-                IsDismissible = true
-            }" />
-        </div>
-    }
-
-    <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+<div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <!-- Main Content Column -->
         <div class="lg:col-span-2 space-y-6">
             <!-- Event Summary Card -->

--- a/src/DiscordBot.Bot/Pages/Guilds/FlaggedEvents/Details.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/FlaggedEvents/Details.cshtml.cs
@@ -1,3 +1,5 @@
+using DiscordBot.Bot.Configuration;
+using DiscordBot.Bot.ViewModels.Components;
 using DiscordBot.Core.DTOs;
 using DiscordBot.Core.Interfaces;
 using Microsoft.AspNetCore.Authorization;
@@ -37,6 +39,21 @@ public class DetailsModel : PageModel
     /// The guild name for display.
     /// </summary>
     public string GuildName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Guild layout breadcrumb ViewModel.
+    /// </summary>
+    public GuildBreadcrumbViewModel Breadcrumb { get; set; } = new();
+
+    /// <summary>
+    /// Guild layout header ViewModel.
+    /// </summary>
+    public GuildHeaderViewModel Header { get; set; } = new();
+
+    /// <summary>
+    /// Guild layout navigation ViewModel.
+    /// </summary>
+    public GuildNavBarViewModel Navigation { get; set; } = new();
 
     /// <summary>
     /// The flagged event details.
@@ -106,6 +123,36 @@ public class DetailsModel : PageModel
 
         _logger.LogDebug("Retrieved flagged event {EventId} details with {HistoryCount} user history items",
             id, UserHistory.Count());
+
+        // Populate guild layout ViewModels
+        Breadcrumb = new GuildBreadcrumbViewModel
+        {
+            Items = new List<BreadcrumbItem>
+            {
+                new() { Label = "Home", Url = "/" },
+                new() { Label = "Servers", Url = "/Guilds" },
+                new() { Label = guild.Name, Url = $"/Guilds/Details/{guildId}" },
+                new() { Label = "Moderation", Url = $"/Guilds/{guildId}/FlaggedEvents" },
+                new() { Label = "Flagged Events", Url = $"/Guilds/{guildId}/FlaggedEvents" },
+                new() { Label = "Details", IsCurrent = true }
+            }
+        };
+
+        Header = new GuildHeaderViewModel
+        {
+            GuildId = guild.Id,
+            GuildName = guild.Name,
+            GuildIconUrl = guild.IconUrl,
+            PageTitle = "Flagged Event Details",
+            PageDescription = $"Event details for {guild.Name}"
+        };
+
+        Navigation = new GuildNavBarViewModel
+        {
+            GuildId = guild.Id,
+            ActiveTab = "moderation",
+            Tabs = GuildNavigationConfig.GetTabs().ToList()
+        };
 
         return Page();
     }

--- a/src/DiscordBot.Bot/Pages/Guilds/FlaggedEvents/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/FlaggedEvents/Index.cshtml
@@ -4,82 +4,32 @@
 @using DiscordBot.Core.Enums
 @{
     ViewData["Title"] = $"Flagged Events - {Model.GuildName}";
+    Layout = "_GuildLayout";
 }
 
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-    <!-- Breadcrumb Navigation -->
-    <nav aria-label="Breadcrumb" class="mb-6">
-        <ol class="flex items-center gap-2 text-sm">
-            <li>
-                <a asp-page="/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Home</a>
-            </li>
-            <li class="text-text-tertiary">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <a asp-page="/Guilds/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Servers</a>
-            </li>
-            <li class="text-text-tertiary">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <a asp-page="/Guilds/Details" asp-route-guildId="@Model.GuildId" class="text-text-secondary hover:text-accent-blue transition-colors">@Model.GuildName</a>
-            </li>
-            <li class="text-text-tertiary">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <span class="text-text-primary font-medium">Flagged Events</span>
-            </li>
-        </ol>
-    </nav>
-
-    <!-- Page Header -->
-    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
-        <div class="flex items-center gap-3">
-            <h1 class="text-2xl font-bold text-text-primary">Flagged Events</h1>
-            @{
-                var pendingCount = Model.Events.Count(e => e.Status == FlaggedEventStatus.Pending);
-            }
-            @if (pendingCount > 0)
-            {
-                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-sm font-medium bg-error text-white">
-                    @pendingCount pending
-                </span>
-            }
-        </div>
-        <p class="text-sm text-text-secondary">Auto-detected moderation events requiring review</p>
+<!-- Success Message -->
+@if (!string.IsNullOrEmpty(Model.SuccessMessage))
+{
+    <div class="mb-6">
+        <partial name="Shared/Components/_Alert" model="new AlertViewModel {
+            Variant = AlertVariant.Success,
+            Message = Model.SuccessMessage,
+            IsDismissible = true
+        }" />
     </div>
+}
 
-    <!-- Success Message -->
-    @if (!string.IsNullOrEmpty(Model.SuccessMessage))
-    {
-        <div class="mb-6">
-            <partial name="Shared/Components/_Alert" model="new AlertViewModel {
-                Variant = AlertVariant.Success,
-                Message = Model.SuccessMessage,
-                IsDismissible = true
-            }" />
-        </div>
-    }
-
-    <!-- Error Message -->
-    @if (!string.IsNullOrEmpty(Model.ErrorMessage))
-    {
-        <div class="mb-6">
-            <partial name="Shared/Components/_Alert" model="new AlertViewModel {
-                Variant = AlertVariant.Error,
-                Message = Model.ErrorMessage,
-                IsDismissible = true
-            }" />
-        </div>
-    }
+<!-- Error Message -->
+@if (!string.IsNullOrEmpty(Model.ErrorMessage))
+{
+    <div class="mb-6">
+        <partial name="Shared/Components/_Alert" model="new AlertViewModel {
+            Variant = AlertVariant.Error,
+            Message = Model.ErrorMessage,
+            IsDismissible = true
+        }" />
+    </div>
+}
 
     <!-- Filter Bar -->
     <div class="bg-bg-secondary border border-border-primary rounded-lg p-4 mb-6">

--- a/src/DiscordBot.Bot/Pages/Guilds/FlaggedEvents/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/FlaggedEvents/Index.cshtml.cs
@@ -1,3 +1,5 @@
+using DiscordBot.Bot.Configuration;
+using DiscordBot.Bot.ViewModels.Components;
 using DiscordBot.Core.DTOs;
 using DiscordBot.Core.Enums;
 using DiscordBot.Core.Interfaces;
@@ -38,6 +40,21 @@ public class IndexModel : PageModel
     /// The guild name for display.
     /// </summary>
     public string GuildName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Guild layout breadcrumb ViewModel.
+    /// </summary>
+    public GuildBreadcrumbViewModel Breadcrumb { get; set; } = new();
+
+    /// <summary>
+    /// Guild layout header ViewModel.
+    /// </summary>
+    public GuildHeaderViewModel Header { get; set; } = new();
+
+    /// <summary>
+    /// Guild layout navigation ViewModel.
+    /// </summary>
+    public GuildNavBarViewModel Navigation { get; set; } = new();
 
     /// <summary>
     /// The list of flagged events.
@@ -156,6 +173,35 @@ public class IndexModel : PageModel
 
         _logger.LogDebug("Retrieved {Count} flagged events for guild {GuildId} (page {Page} of {TotalPages})",
             Events.Count(), guildId, CurrentPage, TotalPages);
+
+        // Populate guild layout ViewModels
+        Breadcrumb = new GuildBreadcrumbViewModel
+        {
+            Items = new List<BreadcrumbItem>
+            {
+                new() { Label = "Home", Url = "/" },
+                new() { Label = "Servers", Url = "/Guilds" },
+                new() { Label = guild.Name, Url = $"/Guilds/Details/{guildId}" },
+                new() { Label = "Moderation", Url = $"/Guilds/{guildId}/FlaggedEvents" },
+                new() { Label = "Flagged Events", IsCurrent = true }
+            }
+        };
+
+        Header = new GuildHeaderViewModel
+        {
+            GuildId = guild.Id,
+            GuildName = guild.Name,
+            GuildIconUrl = guild.IconUrl,
+            PageTitle = "Flagged Events",
+            PageDescription = $"Auto-detected moderation events for {guild.Name}"
+        };
+
+        Navigation = new GuildNavBarViewModel
+        {
+            GuildId = guild.Id,
+            ActiveTab = "moderation",
+            Tabs = GuildNavigationConfig.GetTabs().ToList()
+        };
 
         return Page();
     }

--- a/src/DiscordBot.Bot/Pages/Guilds/Members/Moderation.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Members/Moderation.cshtml
@@ -3,39 +3,14 @@
 @using DiscordBot.Core.Enums
 @{
     ViewData["Title"] = $"{Model.ViewModel.DisplayName} - Moderation";
+    Layout = "_GuildLayout";
 }
 
 @section Styles {
     <link rel="stylesheet" href="~/css/moderation.css" asp-append-version="true" />
 }
 
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-    <!-- Breadcrumb Navigation -->
-    <nav class="text-sm text-text-secondary mb-6" aria-label="Breadcrumb">
-        <ol class="flex items-center gap-2">
-            <li><a asp-page="/Guilds/Index" class="hover:text-text-primary transition-colors">Servers</a></li>
-            <li aria-hidden="true">
-                <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li><a asp-page="/Guilds/Details" asp-route-guildId="@Model.GuildId" class="hover:text-text-primary transition-colors">@Model.ViewModel.GuildName</a></li>
-            <li aria-hidden="true">
-                <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li><a asp-page="/Guilds/Members/Index" asp-route-guildId="@Model.GuildId" class="hover:text-text-primary transition-colors">Members</a></li>
-            <li aria-hidden="true">
-                <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li class="text-text-primary font-medium" aria-current="page">@Model.ViewModel.DisplayName - Moderation</li>
-        </ol>
-    </nav>
-
-    <!-- User Header -->
+<!-- User Header (breadcrumb/header/nav now in layout) -->
     <div class="bg-bg-secondary border border-border-primary rounded-lg p-6 mb-6">
         <div class="flex flex-col md:flex-row md:items-start gap-6">
             <!-- Avatar and Basic Info -->
@@ -371,7 +346,6 @@
             </div>
         </div>
     </div>
-</div>
 
 @section Scripts {
     <script src="~/js/user-moderation-profile.js"></script>

--- a/src/DiscordBot.Bot/Pages/Guilds/Members/Moderation.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/Members/Moderation.cshtml.cs
@@ -1,5 +1,7 @@
 using Discord.WebSocket;
+using DiscordBot.Bot.Configuration;
 using DiscordBot.Bot.Extensions;
+using DiscordBot.Bot.ViewModels.Components;
 using DiscordBot.Bot.ViewModels.Pages;
 using DiscordBot.Core.Interfaces;
 using Microsoft.AspNetCore.Authorization;
@@ -60,6 +62,21 @@ public class ModerationModel : PageModel
     /// The view model containing all moderation profile data.
     /// </summary>
     public UserModerationProfileViewModel ViewModel { get; set; } = new();
+
+    /// <summary>
+    /// Guild layout breadcrumb ViewModel.
+    /// </summary>
+    public GuildBreadcrumbViewModel Breadcrumb { get; set; } = new();
+
+    /// <summary>
+    /// Guild layout header ViewModel.
+    /// </summary>
+    public GuildHeaderViewModel Header { get; set; } = new();
+
+    /// <summary>
+    /// Guild layout navigation ViewModel.
+    /// </summary>
+    public GuildNavBarViewModel Navigation { get; set; } = new();
 
     public async Task<IActionResult> OnGetAsync()
     {
@@ -126,6 +143,36 @@ public class ModerationModel : PageModel
 
         _logger.LogInformation("Loaded moderation profile for user {UserId} in guild {GuildId}: {CaseCount} cases, {NoteCount} notes, {TagCount} tags, {FlagCount} flags",
             UserId, GuildId, ViewModel.Cases.Count, ViewModel.Notes.Count, ViewModel.Tags.Count, ViewModel.FlaggedEvents.Count);
+
+        // Populate guild layout ViewModels
+        Breadcrumb = new GuildBreadcrumbViewModel
+        {
+            Items = new List<BreadcrumbItem>
+            {
+                new() { Label = "Home", Url = "/" },
+                new() { Label = "Servers", Url = "/Guilds" },
+                new() { Label = guild.Name, Url = $"/Guilds/Details/{GuildId}" },
+                new() { Label = "Members", Url = $"/Guilds/{GuildId}/Members" },
+                new() { Label = member.DisplayName, Url = $"/Guilds/{GuildId}/Members/{UserId}/Moderation" },
+                new() { Label = "Moderation", IsCurrent = true }
+            }
+        };
+
+        Header = new GuildHeaderViewModel
+        {
+            GuildId = guild.Id,
+            GuildName = guild.Name,
+            GuildIconUrl = guild.IconUrl,
+            PageTitle = $"Moderation Profile: {member.DisplayName}",
+            PageDescription = $"Moderation history and profile for {member.DisplayName}"
+        };
+
+        Navigation = new GuildNavBarViewModel
+        {
+            GuildId = guild.Id,
+            ActiveTab = "members",
+            Tabs = GuildNavigationConfig.GetTabs().ToList()
+        };
 
         return Page();
     }

--- a/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Analytics.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Analytics.cshtml
@@ -3,75 +3,10 @@
 @using DiscordBot.Bot.ViewModels.Components
 @{
     ViewData["Title"] = $"Rat Watch Analytics - {Model.ViewModel.GuildName}";
+    Layout = "_GuildLayout";
 }
 
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-    <!-- Breadcrumb Navigation -->
-    <nav aria-label="Breadcrumb" class="mb-6">
-        <ol class="flex items-center gap-2 text-sm flex-wrap">
-            <li>
-                <a asp-page="/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Home</a>
-            </li>
-            <li class="text-text-tertiary" aria-hidden="true">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <a asp-page="/Guilds/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Servers</a>
-            </li>
-            <li class="text-text-tertiary" aria-hidden="true">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <a asp-page="/Guilds/Details" asp-route-guildId="@Model.ViewModel.GuildId" class="text-text-secondary hover:text-accent-blue transition-colors">@Model.ViewModel.GuildName</a>
-            </li>
-            <li class="text-text-tertiary" aria-hidden="true">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <a asp-page="/Guilds/RatWatch/Index" asp-route-guildId="@Model.ViewModel.GuildId" class="text-text-secondary hover:text-accent-blue transition-colors">Rat Watch</a>
-            </li>
-            <li class="text-text-tertiary" aria-hidden="true">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <span class="text-text-primary font-medium" aria-current="page">Analytics</span>
-            </li>
-        </ol>
-    </nav>
-
-    <!-- Page Header -->
-    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
-        <div>
-            <h1 class="text-2xl font-bold text-text-primary">Rat Watch</h1>
-            <p class="mt-1 text-sm text-text-secondary">Accountability metrics and trends for @Model.ViewModel.GuildName</p>
-        </div>
-    </div>
-
-    <!-- Navigation Tabs -->
-    <div class="flex items-center gap-1 mb-6 border-b border-border-primary">
-        <a asp-page="Index" asp-route-guildId="@Model.ViewModel.GuildId"
-           class="px-4 py-3 text-sm font-medium border-b-2 border-transparent text-text-secondary hover:text-text-primary transition-colors">
-            Settings
-        </a>
-        <a asp-page="Analytics" asp-route-guildId="@Model.ViewModel.GuildId"
-           class="px-4 py-3 text-sm font-medium border-b-2 border-accent-orange text-text-primary">
-            Analytics
-        </a>
-        <a asp-page="Incidents" asp-route-guildId="@Model.ViewModel.GuildId"
-           class="px-4 py-3 text-sm font-medium border-b-2 border-transparent text-text-secondary hover:text-text-primary transition-colors">
-            Incidents
-        </a>
-    </div>
-
-    <!-- Display any errors -->
+<!-- Display any errors -->
     @if (TempData["ErrorMessage"] != null)
     {
         <div class="mb-6">
@@ -663,7 +598,6 @@
             }
         </div>
     </div>
-</div>
 
 @section Scripts {
     <!-- Chart.js Library -->

--- a/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Analytics.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Analytics.cshtml.cs
@@ -1,4 +1,6 @@
 using Discord.WebSocket;
+using DiscordBot.Bot.Configuration;
+using DiscordBot.Bot.ViewModels.Components;
 using DiscordBot.Bot.ViewModels.Pages;
 using DiscordBot.Core.DTOs;
 using DiscordBot.Core.Interfaces;
@@ -40,6 +42,21 @@ public class AnalyticsModel : PageModel
     /// The analytics view model with all chart data and metrics.
     /// </summary>
     public RatWatchAnalyticsViewModel ViewModel { get; private set; } = new();
+
+    /// <summary>
+    /// Guild layout breadcrumb ViewModel.
+    /// </summary>
+    public GuildBreadcrumbViewModel Breadcrumb { get; set; } = new();
+
+    /// <summary>
+    /// Guild layout header ViewModel.
+    /// </summary>
+    public GuildHeaderViewModel Header { get; set; } = new();
+
+    /// <summary>
+    /// Guild layout navigation ViewModel.
+    /// </summary>
+    public GuildNavBarViewModel Navigation { get; set; } = new();
 
     /// <summary>
     /// Start date filter (bound from query string).
@@ -131,6 +148,35 @@ public class AnalyticsModel : PageModel
             _logger.LogInformation(
                 "Analytics loaded successfully for guild {GuildId}. Total watches: {TotalWatches}, Guilty rate: {GuiltyRate:F2}%",
                 guildId, summary.TotalWatches, summary.GuiltyRate);
+
+            // Populate guild layout ViewModels
+            Breadcrumb = new GuildBreadcrumbViewModel
+            {
+                Items = new List<BreadcrumbItem>
+                {
+                    new() { Label = "Home", Url = "/" },
+                    new() { Label = "Servers", Url = "/Guilds" },
+                    new() { Label = guild.Name, Url = $"/Guilds/Details/{guildId}" },
+                    new() { Label = "Rat Watch", Url = $"/Guilds/RatWatch/{guildId}" },
+                    new() { Label = "Analytics", IsCurrent = true }
+                }
+            };
+
+            Header = new GuildHeaderViewModel
+            {
+                GuildId = guild.Id,
+                GuildName = guild.Name,
+                GuildIconUrl = guild.IconUrl,
+                PageTitle = "Rat Watch Analytics",
+                PageDescription = $"Usage metrics and accountability trends for {guild.Name}"
+            };
+
+            Navigation = new GuildNavBarViewModel
+            {
+                GuildId = guild.Id,
+                ActiveTab = "ratwatch",
+                Tabs = GuildNavigationConfig.GetTabs().ToList()
+            };
         }
         catch (Exception ex)
         {

--- a/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Incidents.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Incidents.cshtml
@@ -5,75 +5,10 @@
 @using DiscordBot.Core.Enums
 @{
     ViewData["Title"] = $"Rat Watch Incidents - {Model.ViewModel.GuildName}";
+    Layout = "_GuildLayout";
 }
 
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-    <!-- Breadcrumb Navigation -->
-    <nav aria-label="Breadcrumb" class="mb-6">
-        <ol class="flex items-center gap-2 text-sm">
-            <li>
-                <a asp-page="/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Home</a>
-            </li>
-            <li class="text-text-tertiary">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <a asp-page="/Guilds/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Servers</a>
-            </li>
-            <li class="text-text-tertiary">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <a asp-page="/Guilds/Details" asp-route-guildId="@Model.ViewModel.GuildId" class="text-text-secondary hover:text-accent-blue transition-colors">@Model.ViewModel.GuildName</a>
-            </li>
-            <li class="text-text-tertiary">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <a asp-page="/Guilds/RatWatch/Index" asp-route-guildId="@Model.ViewModel.GuildId" class="text-text-secondary hover:text-accent-blue transition-colors">Rat Watch</a>
-            </li>
-            <li class="text-text-tertiary">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <span class="text-text-primary font-medium">Incidents</span>
-            </li>
-        </ol>
-    </nav>
-
-    <!-- Page Header -->
-    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
-        <div>
-            <h1 class="text-2xl font-bold text-text-primary">Rat Watch</h1>
-            <p class="mt-1 text-sm text-text-secondary">Browse and search incidents for @Model.ViewModel.GuildName</p>
-        </div>
-    </div>
-
-    <!-- Navigation Tabs -->
-    <div class="flex items-center gap-1 mb-6 border-b border-border-primary">
-        <a asp-page="Index" asp-route-guildId="@Model.ViewModel.GuildId"
-           class="px-4 py-3 text-sm font-medium border-b-2 border-transparent text-text-secondary hover:text-text-primary transition-colors">
-            Settings
-        </a>
-        <a asp-page="Analytics" asp-route-guildId="@Model.ViewModel.GuildId"
-           class="px-4 py-3 text-sm font-medium border-b-2 border-transparent text-text-secondary hover:text-text-primary transition-colors">
-            Analytics
-        </a>
-        <a asp-page="Incidents" asp-route-guildId="@Model.ViewModel.GuildId"
-           class="px-4 py-3 text-sm font-medium border-b-2 border-accent-orange text-text-primary">
-            Incidents
-        </a>
-    </div>
-
-    <!-- Filter Panel -->
+<!-- Filter Panel -->
     <div class="bg-bg-secondary border border-border-primary rounded-lg mb-6">
         <button type="button"
                 id="filterToggle"
@@ -447,7 +382,6 @@
             </div>
         </div>
     </div>
-</div>
 
 <!-- Embedded incident data for CSV export -->
 @if (Model.ViewModel.TotalCount > 0)

--- a/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Incidents.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Incidents.cshtml.cs
@@ -1,3 +1,5 @@
+using DiscordBot.Bot.Configuration;
+using DiscordBot.Bot.ViewModels.Components;
 using DiscordBot.Bot.ViewModels.Pages;
 using DiscordBot.Core.DTOs;
 using DiscordBot.Core.Enums;
@@ -34,6 +36,21 @@ public class IncidentsModel : PageModel
     /// View model for display properties.
     /// </summary>
     public RatWatchIncidentsViewModel ViewModel { get; set; } = new();
+
+    /// <summary>
+    /// Guild layout breadcrumb ViewModel.
+    /// </summary>
+    public GuildBreadcrumbViewModel Breadcrumb { get; set; } = new();
+
+    /// <summary>
+    /// Guild layout header ViewModel.
+    /// </summary>
+    public GuildHeaderViewModel Header { get; set; } = new();
+
+    /// <summary>
+    /// Guild layout navigation ViewModel.
+    /// </summary>
+    public GuildNavBarViewModel Navigation { get; set; } = new();
 
     // Filter parameters bound from query string
     [BindProperty(SupportsGet = true)]
@@ -163,6 +180,35 @@ public class IncidentsModel : PageModel
             normalizedPage,
             normalizedPageSize,
             settings?.VotingDurationMinutes ?? 5);
+
+        // Populate guild layout ViewModels
+        Breadcrumb = new GuildBreadcrumbViewModel
+        {
+            Items = new List<BreadcrumbItem>
+            {
+                new() { Label = "Home", Url = "/" },
+                new() { Label = "Servers", Url = "/Guilds" },
+                new() { Label = guild.Name, Url = $"/Guilds/Details/{ulongGuildId}" },
+                new() { Label = "Rat Watch", Url = $"/Guilds/RatWatch/{ulongGuildId}" },
+                new() { Label = "Incidents", IsCurrent = true }
+            }
+        };
+
+        Header = new GuildHeaderViewModel
+        {
+            GuildId = guild.Id,
+            GuildName = guild.Name,
+            GuildIconUrl = guild.IconUrl,
+            PageTitle = "Rat Watch Incidents",
+            PageDescription = $"Browse and filter all Rat Watch incidents for {guild.Name}"
+        };
+
+        Navigation = new GuildNavBarViewModel
+        {
+            GuildId = guild.Id,
+            ActiveTab = "ratwatch",
+            Tabs = GuildNavigationConfig.GetTabs().ToList()
+        };
 
         return Page();
     }

--- a/src/DiscordBot.Bot/Pages/Guilds/ScheduledMessages/Create.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/ScheduledMessages/Create.cshtml
@@ -5,69 +5,22 @@
 @using DiscordBot.Core.Enums
 @{
     ViewData["Title"] = $"Create Scheduled Message - {Model.ViewModel.GuildName}";
+    Layout = "_GuildLayout";
 }
 
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-    <!-- Breadcrumb Navigation -->
-    <nav aria-label="Breadcrumb" class="mb-6">
-        <ol class="flex items-center gap-2 text-sm">
-            <li>
-                <a asp-page="/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Home</a>
-            </li>
-            <li class="text-text-tertiary">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <a asp-page="/Guilds/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Servers</a>
-            </li>
-            <li class="text-text-tertiary">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <a asp-page="/Guilds/Details" asp-route-guildId="@Model.ViewModel.GuildId" class="text-text-secondary hover:text-accent-blue transition-colors">@Model.ViewModel.GuildName</a>
-            </li>
-            <li class="text-text-tertiary">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <a asp-page="Index" asp-route-guildId="@Model.ViewModel.GuildId" class="text-text-secondary hover:text-accent-blue transition-colors">Scheduled Messages</a>
-            </li>
-            <li class="text-text-tertiary">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <span class="text-text-primary font-medium">Create</span>
-            </li>
-        </ol>
-    </nav>
-
-    <!-- Page Header -->
+<!-- Error Message -->
+@if (!string.IsNullOrEmpty(Model.ErrorMessage))
+{
     <div class="mb-6">
-        <h1 class="text-2xl font-bold text-text-primary">Create Scheduled Message</h1>
-        <p class="mt-1 text-sm text-text-secondary">Configure a new automated message to be sent at scheduled times</p>
+        <partial name="Shared/Components/_Alert" model="new AlertViewModel {
+            Variant = AlertVariant.Error,
+            Message = Model.ErrorMessage,
+            IsDismissible = true
+        }" />
     </div>
+}
 
-    <!-- Error Message -->
-    @if (!string.IsNullOrEmpty(Model.ErrorMessage))
-    {
-        <div class="mb-6">
-            <partial name="Shared/Components/_Alert" model="new AlertViewModel {
-                Variant = AlertVariant.Error,
-                Message = Model.ErrorMessage,
-                IsDismissible = true
-            }" />
-        </div>
-    }
-
-    <form method="post">
+<form method="post">
         <input type="hidden" name="Input.GuildId" value="@Model.Input.GuildId" />
         <input type="hidden" name="Input.UserTimezone" id="Input_UserTimezone" value="" />
         <div asp-validation-summary="ModelOnly" class="text-error text-sm mb-4"></div>

--- a/src/DiscordBot.Bot/Pages/Guilds/ScheduledMessages/Edit.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/ScheduledMessages/Edit.cshtml
@@ -5,87 +5,22 @@
 @using DiscordBot.Core.Enums
 @{
     ViewData["Title"] = $"Edit Scheduled Message - {Model.ViewModel.GuildName}";
+    Layout = "_GuildLayout";
 }
 
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-    <!-- Breadcrumb Navigation -->
-    <nav aria-label="Breadcrumb" class="mb-6">
-        <ol class="flex items-center gap-2 text-sm">
-            <li>
-                <a asp-page="/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Home</a>
-            </li>
-            <li class="text-text-tertiary">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <a asp-page="/Guilds/Index" class="text-text-secondary hover:text-accent-blue transition-colors">Servers</a>
-            </li>
-            <li class="text-text-tertiary">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <a asp-page="/Guilds/Details" asp-route-guildId="@Model.ViewModel.GuildId" class="text-text-secondary hover:text-accent-blue transition-colors">@Model.ViewModel.GuildName</a>
-            </li>
-            <li class="text-text-tertiary">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <a asp-page="Index" asp-route-guildId="@Model.ViewModel.GuildId" class="text-text-secondary hover:text-accent-blue transition-colors">Scheduled Messages</a>
-            </li>
-            <li class="text-text-tertiary">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                </svg>
-            </li>
-            <li>
-                <span class="text-text-primary font-medium">Edit</span>
-            </li>
-        </ol>
-    </nav>
-
-    <!-- Page Header -->
-    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
-        <div>
-            <h1 class="text-2xl font-bold text-text-primary">Edit Scheduled Message</h1>
-            <p class="mt-1 text-sm text-text-secondary">
-                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold @Model.GetStatusBadgeClass() mr-2">
-                    <span class="w-1.5 h-1.5 rounded-full @Model.GetStatusDotClass() mr-1.5"></span>
-                    @Model.GetStatusDisplay()
-                </span>
-                Created <span data-utc="@Model.CreatedAtUtcIso" data-format="date">...</span> &bull; Last modified <span data-utc="@Model.UpdatedAtUtcIso" data-format="date">...</span>
-            </p>
-        </div>
-        <button
-            type="button"
-            onclick="showDeleteModal()"
-            class="inline-flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium text-error bg-error/10 border border-error/30 rounded-md hover:bg-error/20 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-error focus-visible:ring-offset-2 focus-visible:ring-offset-bg-primary"
-        >
-            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-            </svg>
-            Delete
-        </button>
+<!-- Error Message -->
+@if (!string.IsNullOrEmpty(Model.ErrorMessage))
+{
+    <div class="mb-6">
+        <partial name="Shared/Components/_Alert" model="new AlertViewModel {
+            Variant = AlertVariant.Error,
+            Message = Model.ErrorMessage,
+            IsDismissible = true
+        }" />
     </div>
+}
 
-    <!-- Error Message -->
-    @if (!string.IsNullOrEmpty(Model.ErrorMessage))
-    {
-        <div class="mb-6">
-            <partial name="Shared/Components/_Alert" model="new AlertViewModel {
-                Variant = AlertVariant.Error,
-                Message = Model.ErrorMessage,
-                IsDismissible = true
-            }" />
-        </div>
-    }
-
-    <form method="post">
+<form method="post">
         <input type="hidden" name="Input.GuildId" value="@Model.Input.GuildId" />
         <input type="hidden" name="Input.UserTimezone" id="Input_UserTimezone" value="" />
         <div asp-validation-summary="ModelOnly" class="text-error text-sm mb-4"></div>


### PR DESCRIPTION
## Summary

Migrated 11 guild sub-pages to use the shared guild layout (`_GuildLayout.cshtml`), providing consistent breadcrumb navigation, guild headers, and tab navigation across all guild-related pages.

This completes the guild layout migration epic that began with #1190 (pilot pages) and #1192 (main settings pages).

## Pages Migrated

**Guild Analytics (3 pages):**
- `Analytics/Index.cshtml` - Guild analytics overview
- `Analytics/Engagement.cshtml` - Member engagement metrics
- `Analytics/Moderation.cshtml` - Moderation activity analytics

**Rat Watch (2 pages):**
- `RatWatch/Analytics.cshtml` - Rat Watch analytics and metrics
- `RatWatch/Incidents.cshtml` - Incident browser with filtering

**Member Management (1 page):**
- `Members/Moderation.cshtml` - Member moderation history

**Flagged Events (2 pages):**
- `FlaggedEvents/Index.cshtml` - Auto-moderation flagged events
- `FlaggedEvents/Details.cshtml` - Single flagged event details

**Scheduled Messages (2 pages):**
- `ScheduledMessages/Create.cshtml` - New scheduled message form
- `ScheduledMessages/Edit.cshtml` - Edit scheduled message form

**Guild Configuration (1 page):**
- `Edit.cshtml` - Guild settings editor

**Assistant (1 page):**
- `AssistantMetrics.cshtml` - AI assistant usage metrics

## Implementation Pattern

For each page:
1. Added layout ViewModels (Breadcrumb, Header, Navigation) to PageModel
2. Populated ViewModels in `OnGetAsync` with appropriate breadcrumb paths and active tabs
3. For forms with `OnPostAsync`, created `PopulateLayoutViewModelsAsync()` helper method
4. Changed `Layout` to `"_GuildLayout"` in `.cshtml`
5. Removed old breadcrumb/header/navigation HTML

## Tab Assignments

- Guild Analytics pages → "overview" tab
- Rat Watch pages → "ratwatch" tab
- Members page → "members" tab
- Flagged Events pages → "moderation" tab
- Scheduled Messages pages → "messages" tab
- Guild Edit → "overview" tab
- Assistant Metrics → "assistant" tab

## Test Plan

- [ ] All 11 pages render correctly with shared layout
- [ ] Breadcrumb navigation shows correct path for each page
- [ ] Guild header displays guild name and status
- [ ] Tab navigation shows correct active state
- [ ] Forms with validation errors repopulate layout correctly
- [ ] No visual regressions from layout migration

Closes #1193

🤖 Generated with [Claude Code](https://claude.com/claude-code)