### PR TITLE
feat: Add startup validation for required configuration settings

### DIFF
--- a/src/DiscordBot.Bot/Extensions/DiscordServiceExtensions.cs
+++ b/src/DiscordBot.Bot/Extensions/DiscordServiceExtensions.cs
@@ -23,8 +23,11 @@ public static class DiscordServiceExtensions
     /// <returns>The service collection for chaining.</returns>
     public static IServiceCollection AddDiscordBot(this IServiceCollection services, IConfiguration configuration)
     {
-        // Bind BotConfiguration from configuration
-        services.Configure<BotConfiguration>(configuration.GetSection(BotConfiguration.SectionName));
+        // Bind BotConfiguration from configuration with validation
+        services.AddOptions<BotConfiguration>()
+            .Bind(configuration.GetSection(BotConfiguration.SectionName))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
 
         // Register DiscordSocketClient as singleton with configuration
         services.AddSingleton(provider =>

--- a/src/DiscordBot.Bot/Services/BotConfiguration.cs
+++ b/src/DiscordBot.Bot/Services/BotConfiguration.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace DiscordBot.Bot.Services;
 
 /// <summary>
@@ -14,6 +16,7 @@ public class BotConfiguration
     /// Discord bot token for authentication.
     /// Should be stored in user secrets for security.
     /// </summary>
+    [Required(ErrorMessage = "Discord:Token is required. Set it via environment variable Discord__Token or user secrets.")]
     public string Token { get; set; } = string.Empty;
 
     /// <summary>

--- a/src/DiscordBot.Core/Configuration/DiscordOAuthOptions.cs
+++ b/src/DiscordBot.Core/Configuration/DiscordOAuthOptions.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace DiscordBot.Core.Configuration;
 
 /// <summary>
@@ -14,12 +16,14 @@ public class DiscordOAuthOptions
     /// Gets or sets the Discord OAuth client ID from the Discord Developer Portal.
     /// Required for Discord authentication. Default is empty string.
     /// </summary>
+    [Required(ErrorMessage = "Discord:OAuth:ClientId is required. Set it via environment variable Discord__OAuth__ClientId or user secrets.")]
     public string ClientId { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the Discord OAuth client secret from the Discord Developer Portal.
     /// Should be stored in user secrets or environment variables. Default is empty string.
     /// </summary>
+    [Required(ErrorMessage = "Discord:OAuth:ClientSecret is required. Set it via environment variable Discord__OAuth__ClientSecret or user secrets.")]
     public string ClientSecret { get; set; } = string.Empty;
 
     /// <summary>


### PR DESCRIPTION
## Summary

- Add startup validation for `Discord:Token`, `Discord:OAuth:ClientId`, and `Discord:OAuth:ClientSecret`
- Application now fails fast with clear error messages when required settings are missing
- Replaces cryptic `TaskCanceledException` during Kestrel binding with actionable `OptionsValidationException`

## Changes

1. **BotConfiguration.cs**: Added `[Required]` attribute to `Token` property with descriptive error message
2. **DiscordOAuthOptions.cs**: Added `[Required]` attributes to `ClientId` and `ClientSecret` with descriptive error messages
3. **DiscordServiceExtensions.cs**: Changed from `services.Configure<BotConfiguration>()` to `services.AddOptions<BotConfiguration>().ValidateDataAnnotations().ValidateOnStart()`
4. **IdentityServiceExtensions.cs**: Added `DiscordOAuthOptions` validation registration with `ValidateDataAnnotations().ValidateOnStart()`; removed conditional OAuth setup since it's now required

## Example Error (Before)

```
System.Threading.Tasks.TaskCanceledException: A task was canceled.
   at Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerImpl.BindAsync(CancellationToken cancellationToken)
```

## Example Error (After)

```
Microsoft.Extensions.Options.OptionsValidationException: 
DataAnnotation validation failed for 'BotConfiguration' members: 
'Token' with the error: 'Discord:Token is required. Set it via environment variable Discord__Token or user secrets.'
```

## Test plan

- [x] Build succeeds
- [x] Run existing tests (26 pre-existing failures unrelated to this change)
- [ ] Verify startup fails with clear message when `Discord:Token` is missing
- [ ] Verify startup fails with clear message when OAuth settings are missing
- [ ] Verify bot starts normally with proper configuration

Closes #1213

🤖 Generated with [Claude Code](https://claude.com/claude-code)