### PR TITLE
fix(ui): Enable notification bell on all admin UI pages

### DIFF
--- a/src/DiscordBot.Bot/Pages/Shared/_Layout.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/_Layout.cshtml
@@ -85,6 +85,14 @@
     <script src="~/js/preview-popup.js" asp-append-version="true"></script>
     <!-- Theme Manager Module -->
     <script src="~/js/theme.js" asp-append-version="true"></script>
+    <!-- Global SignalR connection for notifications (idempotent - safe to call on all pages) -->
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            if (typeof DashboardHub !== 'undefined') {
+                DashboardHub.connect();
+            }
+        });
+    </script>
 
     @await RenderSectionAsync("Scripts", required: false)
 </body>


### PR DESCRIPTION
## Summary

- Add global `DashboardHub.connect()` call in `_Layout.cshtml` to establish SignalR connection on all admin pages
- Previously, notifications only worked on pages with page-specific scripts (dashboard, performance, soundboard, TTS)
- The `connect()` function is idempotent, so it won't cause duplicate connections on pages that also call it

## Test plan

- [ ] Navigate to admin UI pages without page-specific SignalR scripts (Commands, Guilds list, Audit Logs)
- [ ] Verify notification bell shows notifications (not "Loading...")
- [ ] Click notifications to verify mark as read/dismiss actions work
- [ ] Navigate to Performance Dashboard and verify it still works
- [ ] Check browser console - should see single "Connected successfully" message per page load

Closes #1215

🤖 Generated with [Claude Code](https://claude.com/claude-code)