### PR TITLE
Task: Create Command page ViewModels

### DIFF
--- a/src/DiscordBot.Bot/ViewModels/Components/CommandBreadcrumbViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Components/CommandBreadcrumbViewModel.cs
@@ -1,0 +1,26 @@
+// src/DiscordBot.Bot/ViewModels/Components/CommandBreadcrumbViewModel.cs
+namespace DiscordBot.Bot.ViewModels.Components;
+
+/// <summary>
+/// ViewModel for Commands page breadcrumb navigation component.
+/// Generates breadcrumb path: Home / Commands / [Active Tab].
+/// </summary>
+public record CommandBreadcrumbViewModel
+{
+    /// <summary>
+    /// Currently active tab identifier (command-list, execution-logs, analytics).
+    /// </summary>
+    public string ActiveTab { get; init; } = "command-list";
+
+    /// <summary>
+    /// Gets the display name for the current active tab.
+    /// </summary>
+    /// <returns>Human-readable tab name for breadcrumb display.</returns>
+    public string GetTabDisplayName() => ActiveTab switch
+    {
+        "command-list" => "Command List",
+        "execution-logs" => "Execution Logs",
+        "analytics" => "Analytics",
+        _ => "Command List"
+    };
+}

--- a/src/DiscordBot.Bot/ViewModels/Components/CommandHeaderViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Components/CommandHeaderViewModel.cs
@@ -1,0 +1,23 @@
+// src/DiscordBot.Bot/ViewModels/Components/CommandHeaderViewModel.cs
+namespace DiscordBot.Bot.ViewModels.Components;
+
+/// <summary>
+/// ViewModel for Commands page header component with dynamic subtitle based on active tab.
+/// </summary>
+public record CommandHeaderViewModel
+{
+    /// <summary>
+    /// Main page title. Defaults to "Commands".
+    /// </summary>
+    public string Title { get; init; } = "Commands";
+
+    /// <summary>
+    /// Optional subtitle text displayed below the title. Dynamic based on active tab.
+    /// </summary>
+    public string Subtitle { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Currently active tab identifier (command-list, execution-logs, analytics).
+    /// </summary>
+    public string ActiveTab { get; init; } = "command-list";
+}


### PR DESCRIPTION
## Summary
Creates two ViewModel classes to support the unified Commands page with tabbed navigation:
- **CommandHeaderViewModel**: Page header with dynamic subtitle based on active tab
- **CommandBreadcrumbViewModel**: Tab-based breadcrumb navigation with display name mapping

## Changes
- Added `src/DiscordBot.Bot/ViewModels/Components/CommandHeaderViewModel.cs`
- Added `src/DiscordBot.Bot/ViewModels/Components/CommandBreadcrumbViewModel.cs`

## Technical Details
- Follows existing Guild ViewModel patterns (record types, init-only properties)
- Default tab: "command-list"
- Supports three tabs: command-list, execution-logs, analytics
- Full XML documentation comments included
- Clean build with 0 errors

## Related Issues
Part of #1219 - Unified layout with tabbed navigation

## Testing
- [x] Solution builds successfully
- [x] Both ViewModel files created in correct location
- [x] Namespace matches existing pattern
- [x] Classes use `record` keyword with `init` accessors
- [x] XML documentation present for all members
- [x] Default values specified appropriately

## Next Steps
These ViewModels will be consumed by:
- Task #1225 - Create Command page shared components
- Task #1226 - Refactor Commands PageModel
- Task #1227 - Refactor Commands view

Closes #1224

🤖 Generated with [Claude Code](https://claude.com/claude-code)