### PR TITLE
fix: Guild navigation tabs now properly hide on mobile (#1217)

### DIFF
--- a/src/DiscordBot.Bot/wwwroot/css/site.css
+++ b/src/DiscordBot.Bot/wwwroot/css/site.css
@@ -3412,6 +3412,10 @@
 
 /* Mobile responsive */
 @media (max-width: 640px) {
+  .guild-nav-tabs {
+    display: none;
+  }
+
   .guild-nav-tab {
     padding: 0.5rem 0.875rem;
     font-size: 0.8125rem;


### PR DESCRIPTION
## Summary
Fixed guild navigation mobile responsiveness by adding `display: none;` to `.guild-nav-tabs` within the mobile media query (max-width: 640px). The base CSS rule was setting `display: flex`, which overrode Tailwind's `hidden sm:flex` classes.

**Changes:**
- Added explicit `display: none` to `.guild-nav-tabs` in mobile breakpoint
- Ensures horizontal tabs hide on mobile (<640px) while dropdown selector displays
- Ensures horizontal tabs display on desktop (≥640px) while dropdown hides

**Result:**
- Mobile: Only dropdown selector visible
- Desktop: Only horizontal tabs visible

Closes #1217

## Review Status
- Code Review: APPROVED
- UI Review: APPROVED  
- Review iterations: 1 (passed on first review)
- Unresolved items: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)