### PR TITLE
fix: Command autocomplete stores display text instead of ID (#1257)

### DIFF
--- a/src/DiscordBot.Bot/Pages/Commands/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Commands/Index.cshtml
@@ -227,7 +227,7 @@
                 Placeholder = "Search by command name...",
                 Endpoint = "/api/autocomplete/commands",
                 InitialValue = Model.CommandName,
-                InitialDisplayText = Model.CommandName,
+                InitialDisplayText = Model.CommandDisplayText,
                 NoResultsMessage = "No commands found"
             };
         }


### PR DESCRIPTION
## Summary

Fixes a bug where the command autocomplete would display only the command name (e.g., `ping`) instead of the formatted display text (e.g., `/ping - Check the bot's latency`) when reloading the Commands/Index page with an active command filter.

## Changes

- **Added `CommandDisplayText` property** to the Commands/Index PageModel to store formatted display text separately from the filter value
- **Added `GetCommandDisplayTextAsync` helper method** that looks up command metadata by name and returns formatted text
- **Updated `OnGetAsync`** to populate `CommandDisplayText` when a command filter is active
- **Changed autocomplete `InitialDisplayText`** to use `CommandDisplayText` instead of `CommandName`

## Technical Details

The autocomplete component now properly separates concerns:
- The form value (`CommandName`) remains the command ID for filtering (e.g., `ping`)
- The display text (`CommandDisplayText`) shows formatted user-facing text (e.g., `/ping - Check the bot's latency`)
- On page reload with an active filter, users see the formatted text while the filter value remains correct

## Testing

- Manual testing verified the autocomplete displays formatted text on page reload
- Code review approved by @cpike5

Closes #1257

🤖 Generated with [Claude Code](https://claude.com/claude-code)