### PR TITLE
feat: Add NavTabs ViewModels and base partial (#1249)

### DIFF
--- a/src/DiscordBot.Bot/Pages/Shared/Components/_NavTabs.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/Components/_NavTabs.cshtml
@@ -1,0 +1,149 @@
+@model DiscordBot.Bot.ViewModels.Components.NavTabsViewModel
+@using DiscordBot.Bot.ViewModels.Components
+@{
+    var containerId = $"{Model.ContainerId}-container";
+    var navId = $"{Model.ContainerId}-nav";
+
+    string GetTabClass(NavTabItem tab)
+    {
+        var classes = "nav-tabs-item";
+        if (tab.Id == Model.ActiveTabId)
+        {
+            classes += " active";
+        }
+        if (tab.Disabled)
+        {
+            classes += " disabled";
+        }
+        return classes;
+    }
+
+    string GetStyleClass() => Model.StyleVariant switch
+    {
+        NavTabStyle.Pills => "nav-tabs-pills",
+        NavTabStyle.Bordered => "nav-tabs-bordered",
+        _ => "nav-tabs-underline"
+    };
+}
+
+@*
+    NavTabs Component
+    -----------------
+    Usage requires including the following in your page:
+
+    @section Styles {
+        <link rel="stylesheet" href="~/css/nav-tabs.css" asp-append-version="true" />
+    }
+
+    @section Scripts {
+        <script src="~/js/nav-tabs.js" asp-append-version="true"></script>
+    }
+
+    For in-page mode, create content panels like:
+    <div data-nav-panel-for="[containerId]" data-tab-id="[tabId]" hidden>
+        <!-- Tab content -->
+    </div>
+
+    For AJAX mode, add data-ajax-url to each NavTabItem's configuration.
+*@
+
+<div class="nav-tabs-container @GetStyleClass()"
+     id="@containerId"
+     data-nav-tabs
+     data-navigation-mode="@Model.NavigationMode.ToString().ToLowerInvariant()"
+     data-persistence-mode="@Model.PersistenceMode.ToString().ToLowerInvariant()"
+     data-container-id="@Model.ContainerId">
+    <nav class="nav-tabs-list"
+         id="@navId"
+         role="tablist"
+         aria-label="@Model.AriaLabel">
+        @foreach (var tab in Model.Tabs)
+        {
+            var isActive = tab.Id == Model.ActiveTabId;
+            var tabElementId = $"{Model.ContainerId}-tab-{tab.Id}";
+            var panelElementId = $"{Model.ContainerId}-panel-{tab.Id}";
+
+            if (Model.NavigationMode == NavMode.PageNavigation)
+            {
+                <a href="@(tab.Href ?? "#")"
+                   class="@GetTabClass(tab)"
+                   id="@tabElementId"
+                   role="tab"
+                   aria-selected="@(isActive ? "true" : "false")"
+                   aria-disabled="@(tab.Disabled ? "true" : null)"
+                   tabindex="@(isActive ? "0" : "-1")"
+                   data-tab-id="@tab.Id"
+                   data-icon-outline="@tab.IconPathOutline"
+                   data-icon-solid="@tab.IconPathSolid">
+                    @{ RenderTabContent(tab, isActive); }
+                </a>
+            }
+            else if (Model.NavigationMode == NavMode.Ajax)
+            {
+                <button type="button"
+                        class="@GetTabClass(tab)"
+                        id="@tabElementId"
+                        role="tab"
+                        aria-selected="@(isActive ? "true" : "false")"
+                        aria-controls="@panelElementId"
+                        tabindex="@(isActive ? "0" : "-1")"
+                        disabled="@(tab.Disabled ? true : null)"
+                        aria-disabled="@(tab.Disabled ? "true" : null)"
+                        data-tab-id="@tab.Id"
+                        data-ajax-url="@tab.Href"
+                        data-icon-outline="@tab.IconPathOutline"
+                        data-icon-solid="@tab.IconPathSolid">
+                    @{ RenderTabContent(tab, isActive); }
+                </button>
+            }
+            else
+            {
+                <button type="button"
+                        class="@GetTabClass(tab)"
+                        id="@tabElementId"
+                        role="tab"
+                        aria-selected="@(isActive ? "true" : "false")"
+                        aria-controls="@panelElementId"
+                        tabindex="@(isActive ? "0" : "-1")"
+                        disabled="@(tab.Disabled ? true : null)"
+                        aria-disabled="@(tab.Disabled ? "true" : null)"
+                        data-tab-id="@tab.Id"
+                        data-icon-outline="@tab.IconPathOutline"
+                        data-icon-solid="@tab.IconPathSolid">
+                    @{ RenderTabContent(tab, isActive); }
+                </button>
+            }
+        }
+    </nav>
+</div>
+
+@functions {
+    private void RenderTabContent(NavTabItem tab, bool isActive)
+    {
+        if (tab.HasIcon)
+        {
+            if (isActive && !string.IsNullOrEmpty(tab.IconPathSolid))
+            {
+                <svg class="nav-tabs-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                    <path d="@tab.IconPathSolid" />
+                </svg>
+            }
+            else
+            {
+                <svg class="nav-tabs-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@tab.IconPathOutline" />
+                </svg>
+            }
+        }
+
+        if (!string.IsNullOrEmpty(tab.ShortLabel))
+        {
+            <span class="tab-label-long">@tab.Label</span>
+            <span class="tab-label-short">@tab.ShortLabel</span>
+        }
+        else
+        {
+            <span>@tab.Label</span>
+        }
+    }
+}

--- a/src/DiscordBot.Bot/ViewModels/Components/NavTabsViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Components/NavTabsViewModel.cs
@@ -1,0 +1,163 @@
+namespace DiscordBot.Bot.ViewModels.Components;
+
+/// <summary>
+/// ViewModel for the unified navigation tabs component.
+/// Supports horizontal tab-style navigation with multiple modes (in-page, page navigation, AJAX)
+/// and style variants (underline, pills, bordered).
+/// </summary>
+public record NavTabsViewModel
+{
+    /// <summary>
+    /// Collection of navigation tabs to display.
+    /// </summary>
+    public IReadOnlyList<NavTabItem> Tabs { get; init; } = [];
+
+    /// <summary>
+    /// The ID of the currently active tab.
+    /// </summary>
+    public string ActiveTabId { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Visual style variant for the navigation tabs.
+    /// </summary>
+    public NavTabStyle StyleVariant { get; init; } = NavTabStyle.Underline;
+
+    /// <summary>
+    /// Navigation mode for the tabs.
+    /// </summary>
+    public NavMode NavigationMode { get; init; } = NavMode.InPage;
+
+    /// <summary>
+    /// Persistence mode for the active tab state.
+    /// </summary>
+    public NavPersistence PersistenceMode { get; init; } = NavPersistence.Hash;
+
+    /// <summary>
+    /// ARIA label for the navigation element for accessibility.
+    /// </summary>
+    public string AriaLabel { get; init; } = "Navigation";
+
+    /// <summary>
+    /// Unique identifier for this navigation instance. Used for generating
+    /// element IDs and managing multiple navigation components on the same page.
+    /// </summary>
+    public string ContainerId { get; init; } = "navTabs";
+}
+
+/// <summary>
+/// Represents a single navigation tab item.
+/// </summary>
+public record NavTabItem
+{
+    /// <summary>
+    /// Unique identifier for this tab. Used for activation and state management.
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Display label for the tab.
+    /// </summary>
+    public required string Label { get; init; }
+
+    /// <summary>
+    /// Optional shorter label to display on mobile devices.
+    /// If not provided, the full Label is used.
+    /// </summary>
+    public string? ShortLabel { get; init; }
+
+    /// <summary>
+    /// URL to navigate to when in page navigation mode.
+    /// Required when NavigationMode is PageNavigation.
+    /// </summary>
+    public string? Href { get; init; }
+
+    /// <summary>
+    /// Optional SVG icon path (outline version) to display before the label.
+    /// Use Heroicons-style 24x24 paths.
+    /// </summary>
+    public string? IconPathOutline { get; init; }
+
+    /// <summary>
+    /// Optional SVG icon path (solid version) to display when tab is active.
+    /// If not provided, IconPathOutline is used for both states.
+    /// </summary>
+    public string? IconPathSolid { get; init; }
+
+    /// <summary>
+    /// When true, this tab is disabled and cannot be selected.
+    /// </summary>
+    public bool Disabled { get; init; }
+
+    /// <summary>
+    /// Helper to check if this tab has an icon.
+    /// </summary>
+    public bool HasIcon => !string.IsNullOrEmpty(IconPathOutline);
+}
+
+/// <summary>
+/// Visual style variant for navigation tabs.
+/// </summary>
+public enum NavTabStyle
+{
+    /// <summary>
+    /// Tabs with an underline indicator on the active tab.
+    /// </summary>
+    Underline,
+
+    /// <summary>
+    /// Tabs styled as pills (rounded background on active tab).
+    /// </summary>
+    Pills,
+
+    /// <summary>
+    /// Tabs with visible borders around each tab.
+    /// </summary>
+    Bordered
+}
+
+/// <summary>
+/// Navigation mode for the navigation tabs component.
+/// </summary>
+public enum NavMode
+{
+    /// <summary>
+    /// Tabs switch content in-page via JavaScript (show/hide panels).
+    /// Tab content should be rendered with the component.
+    /// </summary>
+    InPage,
+
+    /// <summary>
+    /// Tabs link to separate pages (full page navigation).
+    /// Each tab's Href property must be set.
+    /// </summary>
+    PageNavigation,
+
+    /// <summary>
+    /// Tabs trigger AJAX requests to load content dynamically.
+    /// Tab content is fetched on demand.
+    /// </summary>
+    Ajax
+}
+
+/// <summary>
+/// Persistence mode for remembering the active tab.
+/// </summary>
+public enum NavPersistence
+{
+    /// <summary>
+    /// No persistence - tab resets to default on page reload.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// Persist active tab in URL hash (e.g., #overview).
+    /// Best for shareable URLs.
+    /// </summary>
+    Hash,
+
+    /// <summary>
+    /// Persist active tab in localStorage.
+    /// Best when URL should stay clean.
+    /// </summary>
+    LocalStorage
+}


### PR DESCRIPTION
## Summary

Created foundational ViewModels and base Razor partial for the unified navigation component system.

### Implementation Details

**ViewModels (`NavTabsViewModel.cs`)**:
- `NavTabsViewModel` - Main ViewModel with collection of tabs and configuration properties
  - `Tabs` - Collection of NavTabItem objects
  - `ActiveTabId` - Currently active tab identifier
  - `StyleVariant` - Visual style (Underline, Pills, Bordered)
  - `NavigationMode` - Behavior mode (InPage, PageNavigation, Ajax)
  - `PersistenceMode` - State persistence strategy (None, Hash, LocalStorage)
  - `AriaLabel` - Accessibility label for the navigation region
  - `ContainerId` - DOM identifier for JavaScript integration

- `NavTabItem` record - Individual tab configuration
  - Required: `Id`, `Label`
  - Optional: `ShortLabel`, `Href`, `IconPathOutline`, `IconPathSolid`, `Disabled`
  - Computed: `HasIcon` property

- Supporting enums for type-safe configuration

**Base Partial (`_NavTabs.cshtml`)**:
- Semantic HTML structure with proper ARIA attributes
- Support for all three navigation modes:
  - InPage: Client-side content switching
  - PageNavigation: Traditional hyperlinks
  - Ajax: Async content loading
- Icon rendering with outline/solid state swapping
- Short label support for mobile responsiveness
- Roving tabindex pattern for keyboard navigation
- Accessibility-first implementation

### Files Changed
- `src/DiscordBot.Bot/ViewModels/Components/NavTabsViewModel.cs` (created)
- `src/DiscordBot.Bot/Pages/Shared/Components/_NavTabs.cshtml` (created)

### Review Status
- Code Review: APPROVED (after 1 iteration - added `required` keyword to Id/Label)
- UI Review: APPROVED (after 1 fix - corrected tabindex on PageNavigation mode)
- Review iterations: 2
- Unresolved items: none

Closes #1249

🤖 Generated with [Claude Code](https://claude.com/claude-code)