### PR TITLE
feat: migrate GuildNavBar to unified TabPanel (#1261)

### DIFF
--- a/src/DiscordBot.Bot/Pages/Shared/_GuildLayout.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/_GuildLayout.cshtml
@@ -1,6 +1,10 @@
 @using DiscordBot.Bot.ViewModels.Components
 @{
     Layout = "_Layout";
+
+    GuildNavBarViewModel navModel = (GuildNavBarViewModel)Model.Navigation;
+    var orderedTabs = navModel.Tabs.OrderBy(t => t.Order).ToList();
+    var activeTab = orderedTabs.FirstOrDefault(t => t.Id == navModel.ActiveTab);
 }
 
 <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -11,7 +15,40 @@
     @await Html.PartialAsync("Components/_GuildHeader", (GuildHeaderViewModel)Model.Header)
 
     <!-- Guild Navigation Bar -->
-    @await Html.PartialAsync("Components/_GuildNavBar", (GuildNavBarViewModel)Model.Navigation)
+    <div class="guild-nav-container mb-6" id="guildNavContainer">
+        <!-- Desktop: Horizontal tabs using TabPanel -->
+        <div class="hidden sm:block">
+            @await Html.PartialAsync("Components/_TabPanel", GuildNavBarHelper.CreateGuildNavBar(navModel.GuildId, navModel.ActiveTab, navModel.Tabs))
+        </div>
+
+        <!-- Mobile: Dropdown -->
+        <div class="guild-nav-dropdown sm:hidden">
+            <button type="button"
+                    id="guildNavDropdownToggle"
+                    class="guild-nav-dropdown-button"
+                    aria-haspopup="true"
+                    aria-expanded="false">
+                <span id="guildNavSelectedText">@(activeTab?.Label ?? "Navigation")</span>
+                <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                </svg>
+            </button>
+            <div id="guildNavDropdownMenu"
+                 class="hidden guild-nav-dropdown-menu"
+                 role="region"
+                 aria-label="Guild navigation menu">
+                @foreach (var tab in orderedTabs)
+                {
+                    var isActive = navModel.ActiveTab == tab.Id;
+
+                    <a href="@tab.GetUrl(navModel.GuildId)"
+                       class="guild-nav-dropdown-item @(isActive ? "active" : "")">
+                        @tab.Label
+                    </a>
+                }
+            </div>
+        </div>
+    </div>
 
     <!-- Page Content -->
     <div class="guild-page-content">
@@ -20,10 +57,12 @@
 </div>
 
 @section Styles {
+    <link rel="stylesheet" href="~/css/tab-panel.css" asp-append-version="true" />
     @await RenderSectionAsync("Styles", required: false)
 }
 
 @section Scripts {
+    <script src="~/js/tab-panel.js" asp-append-version="true"></script>
     <script src="~/js/guild-nav.js" asp-append-version="true"></script>
     @await RenderSectionAsync("Scripts", required: false)
 }

--- a/src/DiscordBot.Bot/ViewModels/Components/GuildNavBarHelper.cs
+++ b/src/DiscordBot.Bot/ViewModels/Components/GuildNavBarHelper.cs
@@ -1,0 +1,44 @@
+namespace DiscordBot.Bot.ViewModels.Components;
+
+/// <summary>
+/// Helper methods for converting GuildNavBar components to unified TabPanel format.
+/// </summary>
+public static class GuildNavBarHelper
+{
+    /// <summary>
+    /// Creates a TabPanelViewModel configured for guild navigation bar.
+    /// Converts GuildNavItem list to TabPanel format with Pills style variant.
+    /// </summary>
+    /// <param name="guildId">Discord guild ID (Snowflake)</param>
+    /// <param name="activeTab">ID of the currently active tab</param>
+    /// <param name="navItems">Collection of guild navigation items</param>
+    /// <returns>Configured TabPanelViewModel ready for rendering</returns>
+    public static TabPanelViewModel CreateGuildNavBar(
+        ulong guildId,
+        string activeTab,
+        IEnumerable<GuildNavItem> navItems)
+    {
+        var tabs = navItems
+            .OrderBy(item => item.Order)
+            .Select(item => new TabItemViewModel
+            {
+                Id = item.Id,
+                Label = item.Label,
+                Href = item.GetUrl(guildId),
+                IconPathOutline = item.IconOutline,
+                IconPathSolid = item.IconSolid
+            })
+            .ToList();
+
+        return new TabPanelViewModel
+        {
+            Id = "guildNav",
+            Tabs = tabs,
+            ActiveTabId = activeTab,
+            StyleVariant = TabStyleVariant.Pills,
+            NavigationMode = TabNavigationMode.PageNavigation,
+            PersistenceMode = TabPersistenceMode.None,
+            AriaLabel = "Guild sections"
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Migrates the GuildNavBar component to use the unified TabPanel system while preserving mobile-specific dropdown navigation.

### Changes Made
- Created `GuildNavBarHelper.cs` static helper class to convert `GuildNavItem` collections into `TabPanelViewModel`
- Updated `_GuildLayout.cshtml` to use `_TabPanel` partial for desktop tabs with Pills style variant
- Desktop navigation now uses unified tab-panel.js for icon swapping and keyboard navigation
- Mobile dropdown remains guild-specific and unchanged (guild-nav.js still handles mobile interactions)
- Consistent with recent migrations (#1258, #1259, #1260)

### Implementation Details
- Desktop tabs use Pills variant matching the existing GuildNavBar visual design
- Tab configuration includes all guild navigation items (Overview, Members, Channels, Commands, etc.)
- Icon outline/solid swapping handled automatically via TabPanel component
- Keyboard navigation (arrow keys) enabled via tab-panel.js

### Review Status
- Code Review: ✅ APPROVED
- UI Review: ✅ APPROVED (after StyleVariant fix)
- Review iterations: 1
- Unresolved items: None

Closes #1261

🤖 Generated with [Claude Code](https://claude.com/claude-code)