### PR TITLE
fix: Remove redundant Members navigation from Guild Details page (#1255)

### DIFF
--- a/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml
@@ -19,14 +19,6 @@
         },
         new TabItemViewModel
         {
-            Id = "members",
-            Label = "Members",
-            ShortLabel = "Members",
-            IconPathOutline = "M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z",
-            IconPathSolid = "M8.25 6.75a3.75 3.75 0 117.5 0 3.75 3.75 0 01-7.5 0zM15.75 9.75a3 3 0 116 0 3 3 0 01-6 0zM2.25 9.75a3 3 0 116 0 3 3 0 01-6 0zM6.31 15.117A6.745 6.745 0 0112 12a6.745 6.745 0 016.709 7.498.75.75 0 01-.372.568A12.696 12.696 0 0112 21.75c-2.305 0-4.47-.612-6.337-1.684a.75.75 0 01-.372-.568 6.787 6.787 0 011.019-4.38z"
-        },
-        new TabItemViewModel
-        {
             Id = "messages",
             Label = "Messages",
             ShortLabel = "Msgs",
@@ -228,55 +220,6 @@
                 }
             </div>
         }
-    </div>
-
-    <!-- Members Tab -->
-    <div data-tab-panel-for="guildDetails" data-tab-id="members" role="tabpanel" aria-labelledby="guildDetails-tab-members" hidden>
-        <div class="bg-bg-secondary border border-border-primary rounded-lg p-4 sm:p-6">
-            <div class="flex items-center justify-between mb-4">
-                <h3 class="text-lg font-semibold text-text-primary">Member Directory</h3>
-                <a asp-page="Members/Index" asp-route-guildId="@guild.Id" class="text-sm text-accent-blue hover:text-accent-blue/80 transition-colors">
-                    View All →
-                </a>
-            </div>
-
-            <div class="grid grid-cols-2 md:grid-cols-3 gap-3 sm:gap-4">
-                <!-- Total Members -->
-                <div class="bg-bg-primary rounded-lg p-3 sm:p-4">
-                    <div class="flex items-center gap-2 mb-1">
-                        <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
-                        </svg>
-                        <span class="text-xs text-text-tertiary font-medium">Total Members</span>
-                    </div>
-                    <p class="text-2xl font-bold text-text-primary">@guild.MemberCount.ToString("N0")</p>
-                </div>
-
-                <!-- Quick Actions -->
-                <div class="bg-bg-primary rounded-lg p-3 sm:p-4 col-span-2 md:col-span-2">
-                    <div class="flex items-center gap-2 mb-2">
-                        <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-                        </svg>
-                        <span class="text-xs text-text-tertiary font-medium">Quick Actions</span>
-                    </div>
-                    <div class="flex flex-wrap gap-2">
-                        <a asp-page="Members/Index" asp-route-guildId="@guild.Id" class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-bg-secondary rounded-md text-text-secondary hover:text-text-primary hover:bg-bg-tertiary transition-colors">
-                            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-                            </svg>
-                            Search Members
-                        </a>
-                        <a asp-page="Members/Index" asp-route-guildId="@guild.Id" asp-route-sortBy="JoinedAt" asp-route-sortDescending="true" class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-bg-secondary rounded-md text-text-secondary hover:text-text-primary hover:bg-bg-tertiary transition-colors">
-                            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-                            </svg>
-                            Recent Joins
-                        </a>
-                    </div>
-                </div>
-            </div>
-        </div>
     </div>
 
     <!-- Messages Tab -->

--- a/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml.cs
@@ -282,13 +282,6 @@ public class DetailsModel : PageModel
                 },
                 new()
                 {
-                    Label = "Members",
-                    Url = $"/Guilds/Members?guildId={guild.Id}",
-                    Icon = "M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z",
-                    Style = HeaderActionStyle.Secondary
-                },
-                new()
-                {
                     Label = "Edit Settings",
                     Url = $"/Guilds/Edit?id={guild.Id}",
                     Icon = "M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z",


### PR DESCRIPTION
## Summary
Removes redundant "Members" navigation from the Guild Details page, consolidating member directory access to the primary navigation bar only.

### Changes
- Removed "Members" button from Details page header actions
- Removed "Members" tab from in-page TabPanel
- Removed "Members" tab content panel section
- Primary navigation bar "Members" tab remains as single access point

### Testing
- Verified Details page loads without Members tab/button
- Confirmed Members page still accessible via primary navigation
- UI follows design system standards

Closes #1255

🤖 Generated with [Claude Code](https://claude.com/claude-code)