### PR TITLE
feat: Migrate RatWatch tabs to unified TabPanel component (#1287)

### DIFF
--- a/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Analytics.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Analytics.cshtml
@@ -22,6 +22,34 @@
         </div>
     }
 
+    <!-- Rat Watch Navigation Tabs -->
+    <partial name="Shared/Components/_TabPanel" model='new TabPanelViewModel {
+        Id = "ratWatchTabs",
+        StyleVariant = TabStyleVariant.Underline,
+        NavigationMode = TabNavigationMode.PageNavigation,
+        Tabs = new List<TabItemViewModel>
+        {
+            new() {
+                Id = "settings",
+                Label = "Settings",
+                Href = $"/Guilds/RatWatch/{Model.ViewModel.GuildId}"
+            },
+            new() {
+                Id = "analytics",
+                Label = "Analytics",
+                Href = $"/Guilds/RatWatch/Analytics/{Model.ViewModel.GuildId}"
+            },
+            new() {
+                Id = "incidents",
+                Label = "Incidents",
+                Href = $"/Guilds/RatWatch/Incidents/{Model.ViewModel.GuildId}"
+            }
+        },
+        ActiveTabId = "analytics",
+        AriaLabel = "Rat Watch navigation",
+        ContainerClass = "mb-6"
+    }' />
+
     <!-- Filter Panel -->
     <div class="bg-bg-secondary border border-border-primary rounded-lg mb-6">
         <button type="button"

--- a/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Incidents.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Incidents.cshtml
@@ -8,6 +8,34 @@
     Layout = "_GuildLayout";
 }
 
+<!-- Rat Watch Navigation Tabs -->
+<partial name="Shared/Components/_TabPanel" model='new TabPanelViewModel {
+    Id = "ratWatchTabs",
+    StyleVariant = TabStyleVariant.Underline,
+    NavigationMode = TabNavigationMode.PageNavigation,
+    Tabs = new List<TabItemViewModel>
+    {
+        new() {
+            Id = "settings",
+            Label = "Settings",
+            Href = $"/Guilds/RatWatch/{Model.ViewModel.GuildId}"
+        },
+        new() {
+            Id = "analytics",
+            Label = "Analytics",
+            Href = $"/Guilds/RatWatch/Analytics/{Model.ViewModel.GuildId}"
+        },
+        new() {
+            Id = "incidents",
+            Label = "Incidents",
+            Href = $"/Guilds/RatWatch/Incidents/{Model.ViewModel.GuildId}"
+        }
+    },
+    ActiveTabId = "incidents",
+    AriaLabel = "Rat Watch navigation",
+    ContainerClass = "mb-6"
+}' />
+
 <!-- Filter Panel -->
     <div class="bg-bg-secondary border border-border-primary rounded-lg mb-6">
         <button type="button"

--- a/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/RatWatch/Index.cshtml
@@ -131,21 +131,33 @@
         </form>
     </div>
 
-    <!-- Navigation Tabs -->
-    <div class="flex items-center gap-1 mb-6 border-b border-border-primary">
-        <a asp-page="Index" asp-route-guildId="@Model.ViewModel.GuildId"
-           class="px-4 py-3 text-sm font-medium border-b-2 border-accent-orange text-text-primary">
-            Settings
-        </a>
-        <a asp-page="Analytics" asp-route-guildId="@Model.ViewModel.GuildId"
-           class="px-4 py-3 text-sm font-medium border-b-2 border-transparent text-text-secondary hover:text-text-primary transition-colors">
-            Analytics
-        </a>
-        <a asp-page="Incidents" asp-route-guildId="@Model.ViewModel.GuildId"
-           class="px-4 py-3 text-sm font-medium border-b-2 border-transparent text-text-secondary hover:text-text-primary transition-colors">
-            Incidents
-        </a>
-    </div>
+    <!-- Rat Watch Navigation Tabs -->
+    <partial name="Shared/Components/_TabPanel" model='new TabPanelViewModel {
+        Id = "ratWatchTabs",
+        StyleVariant = TabStyleVariant.Underline,
+        NavigationMode = TabNavigationMode.PageNavigation,
+        Tabs = new List<TabItemViewModel>
+        {
+            new() {
+                Id = "settings",
+                Label = "Settings",
+                Href = $"/Guilds/RatWatch/{Model.ViewModel.GuildId}"
+            },
+            new() {
+                Id = "analytics",
+                Label = "Analytics",
+                Href = $"/Guilds/RatWatch/Analytics/{Model.ViewModel.GuildId}"
+            },
+            new() {
+                Id = "incidents",
+                Label = "Incidents",
+                Href = $"/Guilds/RatWatch/Incidents/{Model.ViewModel.GuildId}"
+            }
+        },
+        ActiveTabId = "settings",
+        AriaLabel = "Rat Watch navigation",
+        ContainerClass = "mb-6"
+    }' />
 
     <!-- Summary Stats Cards -->
     @if (Model.ViewModel.AnalyticsSummary != null)


### PR DESCRIPTION
## Summary

Replaced custom inline tab navigation in RatWatch pages with the reusable `_TabPanel` partial component to maintain design system consistency.

### Changes Made

- **Index.cshtml**: Replaced custom inline tab styling with `_TabPanel` partial component
- **Analytics.cshtml**: Added `_TabPanel` navigation (previously had no tab navigation)
- **Incidents.cshtml**: Added `_TabPanel` navigation (previously had no tab navigation)

All three pages now use consistent TabPanel configuration:
- `TabStyleVariant.Underline` for standard design system styling
- `TabNavigationMode.PageNavigation` for cross-page navigation
- Proper `ActiveTabId` set for each page (settings, analytics, incidents)
- `AriaLabel = "Rat Watch navigation"` for accessibility
- `ContainerClass = "mb-6"` for consistent spacing

## Review Status

- Code Review: APPROVED
- UI Review: APPROVED
- Review iterations: 1 (passed first review)
- Unresolved items: none

Closes #1287

🤖 Generated with [Claude Code](https://claude.com/claude-code)