### PR TITLE
fix: Remove dead Overview tab from Guild Details page

### DIFF
--- a/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml
@@ -11,14 +11,6 @@
     {
         new TabItemViewModel
         {
-            Id = "overview",
-            Label = "Overview",
-            ShortLabel = "Overview",
-            IconPathOutline = "M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z M15 12a3 3 0 11-6 0 3 3 0 016 0z",
-            IconPathSolid = "M11.078 2.25c-.917 0-1.699.663-1.855 1.567L9.05 4.889c-.02.12-.115.26-.297.348a7.493 7.493 0 00-.986.57c-.166.115-.334.126-.45.083L6.3 5.508a1.875 1.875 0 00-2.282.819l-.922 1.597a1.875 1.875 0 00.432 2.385l.84.692c.095.078.17.229.154.43a7.598 7.598 0 000 1.139c.015.2-.059.352-.153.43l-.841.692a1.875 1.875 0 00-.432 2.385l.922 1.597a1.875 1.875 0 002.282.818l1.019-.382c.115-.043.283-.031.45.082.312.214.641.405.985.57.182.088.277.228.297.35l.178 1.071c.151.904.933 1.567 1.85 1.567h1.844c.916 0 1.699-.663 1.85-1.567l.178-1.072c.02-.12.114-.26.297-.349.344-.165.673-.356.985-.57.167-.114.335-.125.45-.082l1.02.382a1.875 1.875 0 002.28-.819l.923-1.597a1.875 1.875 0 00-.432-2.385l-.84-.692c-.095-.078-.17-.229-.154-.43a7.614 7.614 0 000-1.139c-.016-.2.059-.352.153-.43l.84-.692c.708-.582.891-1.59.433-2.385l-.922-1.597a1.875 1.875 0 00-2.282-.818l-1.02.382c-.114.043-.282.031-.449-.083a7.49 7.49 0 00-.985-.57c-.183-.087-.277-.227-.297-.348l-.179-1.072a1.875 1.875 0 00-1.85-1.567h-1.843zM12 15.75a3.75 3.75 0 100-7.5 3.75 3.75 0 000 7.5z"
-        },
-        new TabItemViewModel
-        {
             Id = "messages",
             Label = "Messages",
             ShortLabel = "Msgs",
@@ -61,7 +53,7 @@
     {
         Id = "guildDetails",
         Tabs = tabs,
-        ActiveTabId = "overview",
+        ActiveTabId = "messages",
         NavigationMode = TabNavigationMode.InPage,
         PersistenceMode = TabPersistenceMode.UrlHash,
         AriaLabel = "Guild details navigation"
@@ -170,60 +162,8 @@
 
     <!-- Tab Panel Content -->
 
-    <!-- Overview Tab -->
-    <div data-tab-panel-for="guildDetails" data-tab-id="overview" role="tabpanel" aria-labelledby="guildDetails-tab-overview">
-        @if (guild.Settings.HasSettings)
-        {
-            <div class="bg-bg-secondary border border-border-primary rounded-lg p-4 sm:p-6">
-                <h3 class="text-lg font-semibold text-text-primary mb-4">Guild Settings</h3>
-                <div class="space-y-3">
-                    @if (!string.IsNullOrEmpty(guild.Settings.WelcomeChannel))
-                    {
-                        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 sm:gap-4 text-sm">
-                            <span class="text-text-secondary">Welcome Channel</span>
-                            <span class="text-text-primary font-medium truncate">#@guild.Settings.WelcomeChannel</span>
-                        </div>
-                    }
-                    @if (!string.IsNullOrEmpty(guild.Settings.LogChannel))
-                    {
-                        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 sm:gap-4 text-sm">
-                            <span class="text-text-secondary">Log Channel</span>
-                            <span class="text-text-primary font-medium truncate">#@guild.Settings.LogChannel</span>
-                        </div>
-                    }
-                    @if (guild.Settings.AutoModEnabled)
-                    {
-                        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 sm:gap-4 text-sm">
-                            <span class="text-text-secondary">Auto-Moderation</span>
-                            <span class="text-success font-medium">Enabled</span>
-                        </div>
-                    }
-                </div>
-            </div>
-        }
-        else
-        {
-            <div class="bg-bg-secondary border border-border-primary rounded-lg p-8 text-center">
-                <svg class="w-12 h-12 text-text-tertiary mx-auto mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                </svg>
-                <p class="text-text-secondary mb-3">No custom settings configured yet</p>
-                @if (guild.CanEdit)
-                {
-                    <a asp-page="Edit" asp-route-id="@guild.Id" class="btn btn-primary inline-flex items-center gap-2">
-                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                        </svg>
-                        Configure Settings
-                    </a>
-                }
-            </div>
-        }
-    </div>
-
     <!-- Messages Tab -->
-    <div data-tab-panel-for="guildDetails" data-tab-id="messages" role="tabpanel" aria-labelledby="guildDetails-tab-messages" hidden>
+    <div data-tab-panel-for="guildDetails" data-tab-id="messages" role="tabpanel" aria-labelledby="guildDetails-tab-messages">
         <div class="bg-bg-secondary border border-border-primary rounded-lg p-4 sm:p-6">
             <div class="flex items-center justify-between mb-4">
                 <h3 class="text-lg font-semibold text-text-primary">Scheduled Messages</h3>


### PR DESCRIPTION
## Summary
- Removes the non-functional Overview tab from the Guild Details page
- The Overview tab was intended for work that was changed/cancelled and never removed
- Sets Messages as the new default active tab

## Changes
- Removed Overview tab definition from the tabs list
- Removed Overview tab content panel
- Changed `ActiveTabId` from "overview" to "messages"
- Removed `hidden` attribute from Messages tab (now the default)

## Test plan
- [ ] Navigate to Guild Details page and verify Overview tab is no longer visible
- [ ] Verify Messages tab is now the default active tab
- [ ] Verify all other tabs (Rat Watch, Reminders, Activity) still function correctly
- [ ] Verify the build succeeds with no new errors

Closes #1293

🤖 Generated with [Claude Code](https://claude.com/claude-code)