### PR TITLE
feat: Add Members widget to Guild Details dashboard (#1295)

### DIFF
--- a/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml
@@ -348,6 +348,101 @@
             };
         }
         <partial name="Shared/Components/_DashboardWidget" model="remindersWidget" />
+
+        <!-- Members Widget -->
+        @{
+            string membersBody = "";
+            EmptyStateViewModel? membersEmpty = null;
+
+            if (Model.MembersTotalCount > 0)
+            {
+                membersBody = $@"
+                <div class='grid grid-cols-2 gap-3 sm:gap-4 mb-4'>
+                    <!-- Total Members -->
+                    <div class='bg-bg-primary rounded-lg p-3 sm:p-4'>
+                        <div class='flex items-center gap-2 mb-1'>
+                            <svg class='w-4 h-4 text-text-tertiary' fill='none' viewBox='0 0 24 24' stroke='currentColor'>
+                                <path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z' />
+                            </svg>
+                            <span class='text-xs text-text-tertiary font-medium'>Total Members</span>
+                        </div>
+                        <p class='text-2xl font-bold text-text-primary'>{Model.MembersTotalCount:N0}</p>
+                    </div>
+
+                    <!-- Active Today -->
+                    <div class='bg-bg-primary rounded-lg p-3 sm:p-4'>
+                        <div class='flex items-center gap-2 mb-1'>
+                            <svg class='w-4 h-4 text-success' fill='none' viewBox='0 0 24 24' stroke='currentColor'>
+                                <path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z' />
+                            </svg>
+                            <span class='text-xs text-text-tertiary font-medium'>Active Today</span>
+                        </div>
+                        <p class='text-2xl font-bold text-success'>{Model.MembersActiveToday:N0}</p>
+                    </div>
+                </div>";
+
+                if (Model.NewestMembers.Any())
+                {
+                    membersBody += @"
+                <div class='space-y-2'>
+                    <h3 class='text-xs font-semibold text-text-tertiary uppercase tracking-wide mb-4'>Newest Members</h3>";
+
+                    foreach (var member in Model.NewestMembers)
+                    {
+                        string? avatarUrl = null;
+                        if (!string.IsNullOrEmpty(member.AvatarHash))
+                        {
+                            var extension = member.AvatarHash.StartsWith("a_") ? "gif" : "png";
+                            avatarUrl = $"https://cdn.discordapp.com/avatars/{member.UserId}/{member.AvatarHash}.{extension}?size=80";
+                        }
+
+                        var avatarHtml = !string.IsNullOrEmpty(avatarUrl)
+                            ? $"<img src='{avatarUrl}' alt='{System.Net.WebUtility.HtmlEncode(member.DisplayName)}' class='w-10 h-10 rounded-full' />"
+                            : @"<div class='w-10 h-10 rounded-full bg-bg-tertiary flex items-center justify-center'>
+                                   <svg class='w-6 h-6 text-text-tertiary' fill='none' viewBox='0 0 24 24' stroke='currentColor'>
+                                       <path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z' />
+                                   </svg>
+                               </div>";
+
+                        var joinedDateUtcIso = DateTime.SpecifyKind(member.JoinedAt, DateTimeKind.Utc).ToString("o");
+                        var memberUrl = Url.Page("Members/Index", new { guildId = guild.Id, searchTerm = member.UserId.ToString() });
+
+                        membersBody += $@"
+                    <a href='{memberUrl}'
+                       class='flex items-center gap-3 p-2 rounded-lg hover:bg-bg-tertiary transition-colors'>
+                        {avatarHtml}
+                        <div class='flex-1 min-w-0'>
+                            <p class='text-sm font-medium text-text-primary truncate preview-trigger' data-preview-type='user' data-user-id='{member.UserId}' data-context-guild-id='{guild.Id}'>{System.Net.WebUtility.HtmlEncode(member.DisplayName)}</p>
+                            <p class='text-xs text-text-tertiary' data-utc='{joinedDateUtcIso}' data-format='date'></p>
+                        </div>
+                    </a>";
+                    }
+
+                    membersBody += @"
+                </div>";
+                }
+            }
+            else
+            {
+                membersEmpty = new EmptyStateViewModel
+                {
+                    Type = EmptyStateType.NoData,
+                    Title = "No members found",
+                    Description = "Member data will appear here after synchronization.",
+                    IconSvgPath = "M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+                };
+            }
+
+            var membersWidget = new DashboardWidgetViewModel
+            {
+                Title = "Members",
+                DetailUrl = Url.Page("Members/Index", new { guildId = guild.Id }),
+                BodyContent = membersBody,
+                EmptyState = membersEmpty,
+                ColSpan = 1
+            };
+        }
+        <partial name="Shared/Components/_DashboardWidget" model="membersWidget" />
     </div>
 
     <!-- Full-width Activity Section -->


### PR DESCRIPTION
## Summary
Added a Members widget to the Guild Details dashboard that displays:
- **Total member count** and **members active today** in a two-column stat grid
- **Newest 5 members** mini-list with:
  - Avatar images (with fallback icon for users without avatars)
  - Display names (clickable with preview popup support)
  - Join dates (converted to user's local timezone)
- Widget header links to full Members page
- Empty states handled gracefully when no member data exists

## Technical Details
- Added `IGuildMemberService` dependency injection to `DetailsModel`
- Added three new properties: `MembersTotalCount`, `MembersActiveToday`, `NewestMembers`
- Widget uses client-side timezone conversion for dates via `data-utc` and `data-format` attributes
- Member names include preview trigger support for hover popups
- Follows existing dashboard widget patterns exactly (same styling, structure, and behavior as other widgets)

## Files Changed
- `src/DiscordBot.Bot/Pages/Guilds/Details.cshtml.cs` - Added service dependency and member data loading
- `src/DiscordBot.Bot/Pages/Guilds/Details.cshtml` - Added Members widget markup

## Related Issues
Closes #1295

Part of parent issue #1292 (Guild Details Dashboard Rework)

🤖 Generated with [Claude Code](https://claude.com/claude-code)