### PR TITLE
feat: Add Ratwatch leaderboard to dashboard widget (#1297)

### DIFF
--- a/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml
@@ -194,7 +194,7 @@
             if (Model.RatWatchTotal > 0)
             {
                 ratWatchBody = $@"
-                <div class='grid grid-cols-2 md:grid-cols-4 gap-3 sm:gap-4'>
+                <div class='grid grid-cols-2 md:grid-cols-3 gap-3 sm:gap-4'>
                     <!-- Total -->
                     <div class='bg-bg-primary rounded-lg p-3 sm:p-4'>
                         <div class='flex items-center gap-2 mb-1'>
@@ -228,29 +228,45 @@
                         </div>
                         <p class='text-2xl font-bold text-success'>{Model.RatWatchCompleted}</p>
                     </div>
-
-                    <!-- Top Rat -->
-                    <div class='bg-bg-primary rounded-lg p-3 sm:p-4'>
-                        <div class='flex items-center gap-2 mb-1'>
-                            <svg class='w-4 h-4 text-error' fill='none' viewBox='0 0 24 24' stroke='currentColor'>
-                                <path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M17.657 18.657A8 8 0 016.343 7.343S7 9 9 10c0-2 .5-5 2.986-7C14 5 16.09 5.777 17.656 7.343A7.975 7.975 0 0120 13a7.975 7.975 0 01-2.343 5.657z' />
-                                <path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M9.879 16.121A3 3 0 1012.015 11L11 14H9c0 .768.293 1.536.879 2.121z' />
-                            </svg>
-                            <span class='text-xs text-text-tertiary font-medium'>Top Rat</span>
-                        </div>
-                        " + (!string.IsNullOrEmpty(Model.TopRatUsername)
-                            ? $"<p class='text-sm font-bold text-text-primary truncate' title='{System.Net.WebUtility.HtmlEncode(Model.TopRatUsername)}'>{System.Net.WebUtility.HtmlEncode(Model.TopRatUsername)}</p><p class='text-xs text-error'>{Model.TopRatGuiltyCount} guilty</p>"
-                            : "<p class='text-sm text-text-tertiary'>None yet</p>") + @"
-                    </div>
                 </div>";
+
+                if (Model.TopRatLeaderboard.Any())
+                {
+                    ratWatchBody += @"
+                <div class='space-y-2 mt-4'>
+                    <h3 class='text-xs font-semibold text-text-tertiary uppercase tracking-wide mb-3'>Top Rats</h3>";
+
+                    foreach (var entry in Model.TopRatLeaderboard)
+                    {
+                        var medalEmoji = entry.Rank switch
+                        {
+                            1 => "🥇",
+                            2 => "🥈",
+                            3 => "🥉",
+                            _ => $"#{entry.Rank}"
+                        };
+
+                        ratWatchBody += $@"
+                    <div class='flex items-center justify-between p-2 rounded-lg bg-bg-primary hover:bg-bg-tertiary transition-colors'>
+                        <div class='flex items-center gap-2 min-w-0 flex-1'>
+                            <span class='text-sm font-bold text-text-tertiary flex-shrink-0 w-6'>{medalEmoji}</span>
+                            <span class='text-sm font-medium text-text-primary truncate' title='{System.Net.WebUtility.HtmlEncode(entry.Username)}'>{System.Net.WebUtility.HtmlEncode(entry.Username)}</span>
+                        </div>
+                        <span class='text-sm font-bold text-error ml-2 flex-shrink-0'>{entry.GuiltyCount} guilty</span>
+                    </div>";
+                    }
+
+                    ratWatchBody += @"
+                </div>";
+                }
             }
             else
             {
                 ratWatchEmpty = new EmptyStateViewModel
                 {
                     Type = EmptyStateType.NoData,
-                    Title = "No Rat Watches yet",
-                    Description = "Use the \"Rat Watch\" context menu on messages in Discord to start accountability tracking.",
+                    Title = Model.RatWatchEnabled ? "No watches yet" : "Ratwatch is disabled",
+                    Description = Model.RatWatchEnabled ? "Use the \"Rat Watch\" context menu on messages in Discord to start accountability tracking." : "Enable Ratwatch in settings to start tracking.",
                     IconSvgPath = "M15 12a3 3 0 11-6 0 3 3 0 016 0z M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
                 };
             }

--- a/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml.cs
@@ -148,14 +148,9 @@ public class DetailsModel : PageModel
     public int RatWatchCompleted { get; set; }
 
     /// <summary>
-    /// Gets the top "rat" username for this guild (most guilty verdicts).
+    /// Gets the top leaderboard entries for this guild (up to 5).
     /// </summary>
-    public string? TopRatUsername { get; set; }
-
-    /// <summary>
-    /// Gets the guilty count for the top rat.
-    /// </summary>
-    public int TopRatGuiltyCount { get; set; }
+    public List<RatLeaderboardEntryDto> TopRatLeaderboard { get; set; } = new();
 
     /// <summary>
     /// Gets the total number of reminders for this guild.
@@ -268,14 +263,9 @@ public class DetailsModel : PageModel
         RatWatchPending = ratWatchList.Count(w => w.Status == RatWatchStatus.Pending || w.Status == RatWatchStatus.Voting);
         RatWatchCompleted = ratWatchList.Count(w => w.Status == RatWatchStatus.Guilty || w.Status == RatWatchStatus.NotGuilty);
 
-        // Get leaderboard for top rat
-        var leaderboard = await _ratWatchService.GetLeaderboardAsync(guildId, 1, cancellationToken);
-        var topRat = leaderboard.FirstOrDefault();
-        if (topRat != null)
-        {
-            TopRatUsername = topRat.Username;
-            TopRatGuiltyCount = topRat.GuiltyCount;
-        }
+        // Get leaderboard for top rats
+        var leaderboard = await _ratWatchService.GetLeaderboardAsync(guildId, 5, cancellationToken);
+        TopRatLeaderboard = leaderboard.ToList();
 
         // Fetch reminder stats
         var (remindersTotal, remindersPending, remindersDeliveredToday, remindersFailed) =


### PR DESCRIPTION
## Summary

Enhanced the Ratwatch dashboard widget to display a full leaderboard instead of just the top rat.

### Changes Made

- **Leaderboard Display**: Replaced single "Top Rat" stat box with a dedicated leaderboard section showing top 5 entries
- **Medal Emojis**: Added visual distinction for top 3 positions (🥇🥈🥉)
- **Layout Update**: Changed stat grid from 4 to 3 columns to accommodate the new leaderboard section
- **Improved Empty State**: Enhanced messaging to differentiate between "Ratwatch is disabled" and "No watches yet"

### Technical Details

- Modified `TopRatLeaderboard` property in Details.cshtml.cs to fetch top 5 entries instead of 1
- Updated the widget template to render full leaderboard with hover effects
- Maintained consistent styling with other dashboard widgets

## Review Status

- Code Review: ✅ APPROVED (1 iteration)
- UI Review: ✅ APPROVED
- Review iterations: 2 (initial + 1 fix cycle)
- Unresolved items: None (minor suggestions only)

Closes #1297

🤖 Generated with [Claude Code](https://claude.com/claude-code)