### PR TITLE
feat: Add upcoming reminders list to Reminders dashboard widget (#1298)

### DIFF
--- a/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml
@@ -342,6 +342,30 @@
                         <p class='text-2xl font-bold " + (Model.RemindersFailed > 0 ? "text-error" : "text-text-primary") + @"'>{Model.RemindersFailed}</p>
                     </div>
                 </div>";
+
+                if (Model.UpcomingReminders.Any())
+                {
+                    remindersBody += @"
+                <div class='space-y-2 mt-6'>
+                    <h3 class='text-xs font-semibold text-text-tertiary uppercase tracking-wide mb-4'>Upcoming</h3>";
+
+                    foreach (var reminder in Model.UpcomingReminders)
+                    {
+                        var triggerAtUtcIso = reminder.TriggerAtUtcIso;
+
+                        remindersBody += $@"
+                    <div class='flex items-start gap-3 p-2 rounded-lg hover:bg-bg-tertiary transition-colors'>
+                        <div class='flex-1 min-w-0'>
+                            <p class='text-sm font-medium text-text-primary preview-trigger' data-preview-type='user' data-user-id='{reminder.UserId}' data-context-guild-id='{guild.Id}'>{System.Net.WebUtility.HtmlEncode(reminder.Username)}</p>
+                            <p class='text-xs text-text-secondary truncate mt-0.5'>{System.Net.WebUtility.HtmlEncode(reminder.MessagePreview)}</p>
+                            <p class='text-xs text-text-tertiary mt-1' data-utc='{triggerAtUtcIso}' data-format='datetime-relative'></p>
+                        </div>
+                    </div>";
+                    }
+
+                    remindersBody += @"
+                </div>";
+                }
             }
             else
             {

--- a/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml.cs
@@ -173,6 +173,11 @@ public class DetailsModel : PageModel
     public int RemindersFailed { get; set; }
 
     /// <summary>
+    /// Gets the upcoming reminders for this guild (up to 5).
+    /// </summary>
+    public List<UpcomingReminderDto> UpcomingReminders { get; set; } = new();
+
+    /// <summary>
     /// Gets the total count of guild members.
     /// </summary>
     public int MembersTotalCount { get; set; }
@@ -274,6 +279,9 @@ public class DetailsModel : PageModel
         RemindersPending = remindersPending;
         RemindersDeliveredToday = remindersDeliveredToday;
         RemindersFailed = remindersFailed;
+
+        // Fetch upcoming reminders
+        UpcomingReminders = (await _reminderRepository.GetUpcomingAsync(guildId, 5, cancellationToken)).ToList();
 
         // Fetch member stats
         var memberCountQuery = new GuildMemberQueryDto { IsActive = true };

--- a/src/DiscordBot.Core/DTOs/ReminderDtos.cs
+++ b/src/DiscordBot.Core/DTOs/ReminderDtos.cs
@@ -1,0 +1,38 @@
+namespace DiscordBot.Core.DTOs;
+
+/// <summary>
+/// Data transfer object representing an upcoming reminder.
+/// </summary>
+public class UpcomingReminderDto
+{
+    /// <summary>
+    /// Gets or sets the unique identifier for this reminder.
+    /// </summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Discord user snowflake ID who set the reminder.
+    /// </summary>
+    public ulong UserId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the username of the user who set the reminder.
+    /// Falls back to UserId as string if username is not available.
+    /// </summary>
+    public string Username { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the reminder message preview (truncated to 50 characters).
+    /// </summary>
+    public string MessagePreview { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the UTC timestamp when the reminder should be triggered.
+    /// </summary>
+    public DateTime TriggerAt { get; set; }
+
+    /// <summary>
+    /// Gets the trigger time in ISO format for client-side timezone conversion.
+    /// </summary>
+    public string TriggerAtUtcIso => DateTime.SpecifyKind(TriggerAt, DateTimeKind.Utc).ToString("o");
+}

--- a/src/DiscordBot.Core/Interfaces/IReminderRepository.cs
+++ b/src/DiscordBot.Core/Interfaces/IReminderRepository.cs
@@ -1,3 +1,4 @@
+using DiscordBot.Core.DTOs;
 using DiscordBot.Core.Entities;
 using DiscordBot.Core.Enums;
 
@@ -76,5 +77,18 @@ public interface IReminderRepository : IRepository<Reminder>
     /// <returns>A tuple containing total, pending, delivered today, and failed counts.</returns>
     Task<(int TotalCount, int PendingCount, int DeliveredTodayCount, int FailedCount)> GetGuildStatsAsync(
         ulong guildId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets upcoming pending reminders for a specific guild.
+    /// Returns reminders where Status is Pending and TriggerAt is in the future, ordered by TriggerAt ascending.
+    /// </summary>
+    /// <param name="guildId">Discord guild ID to get upcoming reminders for.</param>
+    /// <param name="count">Maximum number of upcoming reminders to return.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Collection of upcoming reminder DTOs with user information.</returns>
+    Task<IEnumerable<UpcomingReminderDto>> GetUpcomingAsync(
+        ulong guildId,
+        int count,
         CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
## Summary

Added upcoming reminders list to the Reminders dashboard widget on the Guild Details page. The widget now displays the next 5 pending reminders with username (with hover preview), message preview (truncated to 50 characters), and relative trigger time.

### Implementation Details
- Added `UpcomingReminderDto` for data transfer
- Added `GetUpcomingAsync` method to `IReminderRepository`
- Implemented repository method with efficient left-join query to handle cases where User record doesn't exist
- Follows the existing Members widget pattern for UI consistency
- Usernames include hover preview support for user context

## Files Changed
- `src/DiscordBot.Core/DTOs/ReminderDtos.cs` (created)
- `src/DiscordBot.Core/Interfaces/IReminderRepository.cs`
- `src/DiscordBot.Infrastructure/Data/Repositories/ReminderRepository.cs`
- `src/DiscordBot.Bot/Pages/Guilds/Details.cshtml.cs`
- `src/DiscordBot.Bot/Pages/Guilds/Details.cshtml`

## Review Status
- Code Review: APPROVED (after 2 fix iterations)
- Unresolved items: None

Closes #1298

🤖 Generated with [Claude Code](https://claude.com/claude-code)