### PR TITLE
feat: Add Activity dashboard widget with link to command logs

### DIFF
--- a/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml
@@ -756,9 +756,10 @@
 
             var activityWidget = new DashboardWidgetViewModel
             {
-                Title = "Recent Command Activity",
-                Subtitle = "Last 10 commands executed in this server",
-                DetailUrl = null, // No detail page for activity yet
+                Title = "Activity",
+                Subtitle = "Recent command activity",
+                IconSvgPath = "M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z",
+                DetailUrl = $"/Commands?tab=logs&GuildId={guild.Id}",
                 BodyContent = activityBody,
                 EmptyState = activityEmpty,
                 ColSpan = 2


### PR DESCRIPTION
## Summary
- Rename Activity widget title from "Recent Command Activity" to "Activity" for consistency with issue naming
- Add clock icon for visual consistency with other dashboard widgets
- Add DetailUrl linking to command logs filtered by guild (`/Commands?tab=logs&GuildId={guildId}`)

## Acceptance Criteria
- [x] Display recent activity feed (10 recent commands)
- [x] Full-width layout at bottom of dashboard
- [x] Appropriate item count for dashboard (10 items)
- [x] Header links to full activity view (command logs filtered by guild)
- [x] Empty state if no activity

## Test plan
- [ ] Navigate to Guild Details page and verify Activity widget displays at the bottom
- [ ] Verify widget shows clock icon and "Activity" title
- [ ] Click "View All →" link and verify it navigates to command logs filtered by the current guild
- [ ] Verify empty state displays when no commands have been executed

Closes #1300

🤖 Generated with [Claude Code](https://claude.com/claude-code)