### PR TITLE
feat(tts): Update AzureTtsService for SynthesisMode (#1329)

### DIFF
--- a/src/DiscordBot.Core/Exceptions/SsmlValidationException.cs
+++ b/src/DiscordBot.Core/Exceptions/SsmlValidationException.cs
@@ -1,0 +1,30 @@
+namespace DiscordBot.Core.Exceptions;
+
+/// <summary>
+/// Exception thrown when SSML validation fails.
+/// </summary>
+public class SsmlValidationException : Exception
+{
+    /// <summary>
+    /// Gets the validation errors.
+    /// </summary>
+    public IReadOnlyList<string> Errors { get; }
+
+    /// <summary>
+    /// Gets the invalid SSML that caused the validation failure.
+    /// </summary>
+    public string InvalidSsml { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SsmlValidationException"/> class.
+    /// </summary>
+    /// <param name="message">The exception message.</param>
+    /// <param name="errors">The validation errors.</param>
+    /// <param name="invalidSsml">The invalid SSML.</param>
+    public SsmlValidationException(string message, IReadOnlyList<string> errors, string invalidSsml)
+        : base(message)
+    {
+        Errors = errors;
+        InvalidSsml = invalidSsml;
+    }
+}

--- a/src/DiscordBot.Core/Interfaces/ITtsService.cs
+++ b/src/DiscordBot.Core/Interfaces/ITtsService.cs
@@ -1,3 +1,4 @@
+using DiscordBot.Core.Enums;
 using DiscordBot.Core.Models;
 
 namespace DiscordBot.Core.Interfaces;
@@ -19,12 +20,49 @@ public interface ITtsService
     Task<Stream> SynthesizeSpeechAsync(string text, TtsOptions? options = null, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Synthesizes speech from text or SSML and returns the audio as a stream.
+    /// </summary>
+    /// <param name="input">The text or SSML to synthesize.</param>
+    /// <param name="options">TTS options (voice, speed, pitch, volume). Only used for PlainText mode.</param>
+    /// <param name="mode">The synthesis mode (PlainText, Ssml, or Auto).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A stream containing the synthesized audio in PCM format (48kHz, 16-bit, stereo).</returns>
+    /// <exception cref="ArgumentException">Thrown when input is null, empty, or exceeds max length.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when TTS service is not configured.</exception>
+    /// <exception cref="Exceptions.SsmlValidationException">Thrown when SSML validation fails.</exception>
+    Task<Stream> SynthesizeSpeechAsync(
+        string input,
+        TtsOptions? options,
+        SynthesisMode mode,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets available voices for the specified locale.
     /// </summary>
     /// <param name="locale">The locale to filter voices by (e.g., "en-US"). Pass null for all locales.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Collection of available voice information.</returns>
     Task<IEnumerable<VoiceInfo>> GetAvailableVoicesAsync(string? locale = "en-US", CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the capabilities for a specific voice.
+    /// </summary>
+    /// <param name="voiceName">Voice short name (e.g., "en-US-JennyNeural").</param>
+    /// <returns>Voice capabilities if known, null if voice is unknown.</returns>
+    Task<VoiceCapabilities?> GetVoiceCapabilitiesAsync(string voiceName);
+
+    /// <summary>
+    /// Gets all available style presets.
+    /// </summary>
+    /// <returns>Collection of style presets for voice configuration.</returns>
+    IEnumerable<StylePreset> GetStylePresets();
+
+    /// <summary>
+    /// Validates SSML markup.
+    /// </summary>
+    /// <param name="ssml">SSML markup to validate.</param>
+    /// <returns>Validation result with details about errors, warnings, and detected voices.</returns>
+    SsmlValidationResult ValidateSsml(string ssml);
 
     /// <summary>
     /// Checks if the TTS service is configured and available.

--- a/tests/DiscordBot.Tests/Bot/Services/AzureTtsServiceTests.cs
+++ b/tests/DiscordBot.Tests/Bot/Services/AzureTtsServiceTests.cs
@@ -1,5 +1,6 @@
 using DiscordBot.Bot.Services;
 using DiscordBot.Core.Configuration;
+using DiscordBot.Core.Interfaces;
 using DiscordBot.Core.Models;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
@@ -17,11 +18,17 @@ public class AzureTtsServiceTests : IDisposable
 {
     private readonly Mock<ILogger<AzureTtsService>> _mockLogger;
     private readonly Mock<IOptions<AzureSpeechOptions>> _mockOptions;
+    private readonly Mock<IVoiceCapabilityProvider> _mockVoiceCapabilityProvider;
+    private readonly Mock<IStylePresetProvider> _mockStylePresetProvider;
+    private readonly Mock<ISsmlValidator> _mockSsmlValidator;
 
     public AzureTtsServiceTests()
     {
         _mockLogger = new Mock<ILogger<AzureTtsService>>();
         _mockOptions = new Mock<IOptions<AzureSpeechOptions>>();
+        _mockVoiceCapabilityProvider = new Mock<IVoiceCapabilityProvider>();
+        _mockStylePresetProvider = new Mock<IStylePresetProvider>();
+        _mockSsmlValidator = new Mock<ISsmlValidator>();
     }
 
     public void Dispose()
@@ -33,7 +40,12 @@ public class AzureTtsServiceTests : IDisposable
     {
         var opts = options ?? new AzureSpeechOptions();
         _mockOptions.Setup(x => x.Value).Returns(opts);
-        return new AzureTtsService(_mockOptions.Object, _mockLogger.Object);
+        return new AzureTtsService(
+            _mockOptions.Object,
+            _mockLogger.Object,
+            _mockVoiceCapabilityProvider.Object,
+            _mockStylePresetProvider.Object,
+            _mockSsmlValidator.Object);
     }
 
     #region IsConfigured Property Tests


### PR DESCRIPTION
## Summary

This PR updates the `AzureTtsService` to support the new `SynthesisMode` parameter, enabling flexible handling of plain text, SSML, and automatic mode detection.

### Changes

**ITtsService Interface**
- Added 4 new methods:
  - `SynthesizeSpeechAsync(string input, TtsOptions? options, SynthesisMode mode, CancellationToken)` - new overload supporting SSML/Auto modes
  - `GetVoiceCapabilitiesAsync(string voiceName)` - returns voice capabilities
  - `GetStylePresets()` - returns available style presets
  - `ValidateSsml(string ssml)` - validates SSML markup

**AzureTtsService Implementation**
- Added constructor dependencies for `IVoiceCapabilityProvider`, `IStylePresetProvider`, `ISsmlValidator`
- Implemented new `SynthesizeSpeechAsync` overload handling PlainText, Ssml, and Auto modes
- Auto mode detects SSML by checking for `<speak>` tag
- SSML mode validates input and throws `SsmlValidationException` if invalid
- Refactored original method to delegate to new overload (eliminated code duplication)

**New Exception Type**
- Created `SsmlValidationException` in Core.Exceptions for validation failures

**Tests**
- Updated `AzureTtsServiceTests.cs` to mock the 3 new constructor dependencies

### Files Changed
1. `src/DiscordBot.Core/Exceptions/SsmlValidationException.cs` (new file)
2. `src/DiscordBot.Core/Interfaces/ITtsService.cs`
3. `src/DiscordBot.Bot/Services/AzureTtsService.cs`
4. `tests/DiscordBot.Tests/Bot/Services/AzureTtsServiceTests.cs`

### Review Status
- Code Review: APPROVED
- Review iterations: 2 (fixed backward compatibility issue with error messages)
- Unresolved items: None

Closes #1329

🤖 Generated with [Claude Code](https://claude.com/claude-code)