### PR TITLE
feat(tts): Add SSML request/response DTOs

### DIFF
--- a/src/DiscordBot.Core/DTOs/SsmlBuildRequest.cs
+++ b/src/DiscordBot.Core/DTOs/SsmlBuildRequest.cs
@@ -1,0 +1,84 @@
+namespace DiscordBot.Core.DTOs;
+
+/// <summary>
+/// Request DTO for building SSML from structured segments.
+/// </summary>
+public class SsmlBuildRequest
+{
+    /// <summary>
+    /// Gets or sets the language code for the SSML document.
+    /// </summary>
+    public string Language { get; init; } = "en-US";
+
+    /// <summary>
+    /// Gets or sets the segments that make up the SSML document.
+    /// </summary>
+    public required List<SsmlSegment> Segments { get; init; }
+}
+
+/// <summary>
+/// Represents a segment of SSML content with voice and style settings.
+/// </summary>
+public class SsmlSegment
+{
+    /// <summary>
+    /// Gets or sets the voice name for this segment.
+    /// </summary>
+    public required string VoiceName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the speaking style (e.g., "cheerful", "sad", "angry").
+    /// </summary>
+    public string? Style { get; init; }
+
+    /// <summary>
+    /// Gets or sets the style intensity (0.01-2.0).
+    /// </summary>
+    public double? StyleDegree { get; init; }
+
+    /// <summary>
+    /// Gets or sets the speaking rate (0.5-2.0).
+    /// </summary>
+    public double? Rate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the pitch adjustment (0.5-1.5).
+    /// </summary>
+    public double? Pitch { get; init; }
+
+    /// <summary>
+    /// Gets or sets the volume level (0.0-1.0).
+    /// </summary>
+    public double? Volume { get; init; }
+
+    /// <summary>
+    /// Gets or sets the plain text content for this segment.
+    /// </summary>
+    public required string Text { get; init; }
+
+    /// <summary>
+    /// Gets or sets optional inline SSML elements within this segment.
+    /// </summary>
+    public List<SsmlElement>? Elements { get; init; }
+}
+
+/// <summary>
+/// Represents an inline SSML element such as a break, emphasis, or say-as.
+/// </summary>
+public class SsmlElement
+{
+    /// <summary>
+    /// Gets or sets the element type (e.g., "break", "emphasis", "say-as", "phoneme").
+    /// </summary>
+    public required string Type { get; init; }
+
+    /// <summary>
+    /// Gets or sets the element attributes (e.g., "time" for break, "level" for emphasis).
+    /// </summary>
+    public Dictionary<string, string>? Attributes { get; init; }
+
+    /// <summary>
+    /// Gets or sets the text content for the element.
+    /// </summary>
+    public string? Content { get; init; }
+}

--- a/src/DiscordBot.Core/DTOs/SsmlBuildResponse.cs
+++ b/src/DiscordBot.Core/DTOs/SsmlBuildResponse.cs
@@ -1,0 +1,27 @@
+namespace DiscordBot.Core.DTOs;
+
+/// <summary>
+/// Response DTO for the SSML build operation.
+/// </summary>
+public class SsmlBuildResponse
+{
+    /// <summary>
+    /// Gets or sets the generated SSML markup.
+    /// </summary>
+    public required string Ssml { get; init; }
+
+    /// <summary>
+    /// Gets or sets whether the generated SSML is valid.
+    /// </summary>
+    public bool IsValid { get; init; }
+
+    /// <summary>
+    /// Gets or sets validation errors, if any.
+    /// </summary>
+    public List<string> Errors { get; init; } = new();
+
+    /// <summary>
+    /// Gets or sets validation warnings (non-critical issues).
+    /// </summary>
+    public List<string> Warnings { get; init; } = new();
+}

--- a/src/DiscordBot.Core/DTOs/SsmlSynthesisRequest.cs
+++ b/src/DiscordBot.Core/DTOs/SsmlSynthesisRequest.cs
@@ -1,0 +1,17 @@
+namespace DiscordBot.Core.DTOs;
+
+/// <summary>
+/// Request DTO for synthesizing speech from SSML markup.
+/// </summary>
+public class SsmlSynthesisRequest
+{
+    /// <summary>
+    /// Gets or sets the SSML markup to synthesize.
+    /// </summary>
+    public required string Ssml { get; init; }
+
+    /// <summary>
+    /// Gets or sets whether to play the synthesized audio in the user's voice channel.
+    /// </summary>
+    public bool PlayInVoiceChannel { get; init; } = false;
+}

--- a/src/DiscordBot.Core/DTOs/SsmlValidationRequest.cs
+++ b/src/DiscordBot.Core/DTOs/SsmlValidationRequest.cs
@@ -1,0 +1,12 @@
+namespace DiscordBot.Core.DTOs;
+
+/// <summary>
+/// Request DTO for validating SSML markup.
+/// </summary>
+public class SsmlValidationRequest
+{
+    /// <summary>
+    /// Gets or sets the SSML markup to validate.
+    /// </summary>
+    public required string Ssml { get; init; }
+}

--- a/src/DiscordBot.Core/DTOs/TtsSynthesisResponse.cs
+++ b/src/DiscordBot.Core/DTOs/TtsSynthesisResponse.cs
@@ -1,0 +1,22 @@
+namespace DiscordBot.Core.DTOs;
+
+/// <summary>
+/// Response DTO for TTS synthesis operations.
+/// </summary>
+public class TtsSynthesisResponse
+{
+    /// <summary>
+    /// Gets or sets the unique identifier for the synthesized audio.
+    /// </summary>
+    public required string AudioId { get; init; }
+
+    /// <summary>
+    /// Gets or sets the estimated duration of the audio in seconds.
+    /// </summary>
+    public double? DurationSeconds { get; init; }
+
+    /// <summary>
+    /// Gets or sets the list of voices used in the synthesis (for multi-voice SSML).
+    /// </summary>
+    public List<string>? VoicesUsed { get; init; }
+}


### PR DESCRIPTION
## Summary

- Add DTOs for SSML API endpoints in `src/DiscordBot.Core/DTOs/`
- `SsmlValidationRequest` - request DTO for validating SSML markup
- `SsmlSynthesisRequest` - request DTO for synthesizing speech from SSML
- `SsmlBuildRequest` with `SsmlSegment` and `SsmlElement` - structured SSML building
- `SsmlBuildResponse` - response DTO with built SSML and validation results
- `TtsSynthesisResponse` - synthesis response with `VoicesUsed` for multi-voice SSML

## Test plan

- [x] Build succeeds with no errors
- [ ] Verify DTOs are correctly used by API endpoints (follow-up implementation)

Closes #1336

🤖 Generated with [Claude Code](https://claude.com/claude-code)