### PR TITLE
feat(tts): Add /tts-styled slash command (#1337)

### DIFF
--- a/src/DiscordBot.Bot/Autocomplete/StylePresetAutocompleteHandler.cs
+++ b/src/DiscordBot.Bot/Autocomplete/StylePresetAutocompleteHandler.cs
@@ -1,0 +1,62 @@
+using Discord;
+using Discord.Interactions;
+using DiscordBot.Core.Interfaces;
+
+namespace DiscordBot.Bot.Autocomplete;
+
+/// <summary>
+/// Provides autocomplete suggestions for style presets in the /tts-styled command.
+/// Filters available presets based on user input and returns up to 25 matching results.
+/// </summary>
+public class StylePresetAutocompleteHandler : AutocompleteHandler
+{
+    /// <summary>
+    /// Generates autocomplete suggestions for style preset IDs.
+    /// Matches presets by preset ID, display name, or category in a case-insensitive manner.
+    /// Featured presets are prioritized in the results.
+    /// </summary>
+    /// <param name="context">The interaction context for the current command execution.</param>
+    /// <param name="autocompleteInteraction">The autocomplete interaction data.</param>
+    /// <param name="parameter">Information about the command parameter being completed.</param>
+    /// <param name="services">Service provider for resolving dependencies.</param>
+    /// <returns>An AutocompletionResult containing matching preset names, or empty if none available.</returns>
+    public override Task<AutocompletionResult> GenerateSuggestionsAsync(
+        IInteractionContext context,
+        IAutocompleteInteraction autocompleteInteraction,
+        IParameterInfo parameter,
+        IServiceProvider services)
+    {
+        // Guard against non-guild contexts (direct messages, etc.)
+        if (context.Guild == null)
+        {
+            return Task.FromResult(AutocompletionResult.FromSuccess());
+        }
+
+        var presetProvider = services.GetRequiredService<IStylePresetProvider>();
+        var userInput = autocompleteInteraction.Data.Current.Value?.ToString() ?? string.Empty;
+
+        // Get all presets
+        var allPresets = presetProvider.GetAllPresets();
+
+        // Filter and format results for autocomplete
+        var results = allPresets
+            .Where(p => string.IsNullOrEmpty(userInput) ||
+                       p.PresetId.Contains(userInput, StringComparison.OrdinalIgnoreCase) ||
+                       p.DisplayName.Contains(userInput, StringComparison.OrdinalIgnoreCase) ||
+                       (p.Category != null && p.Category.Contains(userInput, StringComparison.OrdinalIgnoreCase)))
+            .OrderByDescending(p => p.IsFeatured) // Featured presets first
+            .ThenBy(p => p.Category ?? string.Empty)
+            .ThenBy(p => p.DisplayName)
+            .Take(25) // Discord autocomplete result limit
+            .Select(p =>
+            {
+                var displayText = p.Category != null
+                    ? $"{p.Category}: {p.DisplayName}"
+                    : p.DisplayName;
+                return new AutocompleteResult(displayText, p.PresetId);
+            })
+            .ToList();
+
+        return Task.FromResult(AutocompletionResult.FromSuccess(results));
+    }
+}

--- a/src/DiscordBot.Bot/Commands/TtsModule.cs
+++ b/src/DiscordBot.Bot/Commands/TtsModule.cs
@@ -5,6 +5,7 @@ using DiscordBot.Bot.Autocomplete;
 using DiscordBot.Bot.Interfaces;
 using DiscordBot.Bot.Preconditions;
 using DiscordBot.Core.Entities;
+using DiscordBot.Core.Enums;
 using DiscordBot.Core.Interfaces;
 using DiscordBot.Core.Models;
 
@@ -23,6 +24,8 @@ public class TtsModule : InteractionModuleBase<SocketInteractionContext>
     private readonly ITtsService _ttsService;
     private readonly ITtsSettingsService _ttsSettingsService;
     private readonly ITtsHistoryService _ttsHistoryService;
+    private readonly ISsmlBuilder _ssmlBuilder;
+    private readonly IStylePresetProvider _stylePresetProvider;
     private readonly ILogger<TtsModule> _logger;
 
     /// <summary>
@@ -33,12 +36,16 @@ public class TtsModule : InteractionModuleBase<SocketInteractionContext>
         ITtsService ttsService,
         ITtsSettingsService ttsSettingsService,
         ITtsHistoryService ttsHistoryService,
+        ISsmlBuilder ssmlBuilder,
+        IStylePresetProvider stylePresetProvider,
         ILogger<TtsModule> logger)
     {
         _audioService = audioService;
         _ttsService = ttsService;
         _ttsSettingsService = ttsSettingsService;
         _ttsHistoryService = ttsHistoryService;
+        _ssmlBuilder = ssmlBuilder;
+        _stylePresetProvider = stylePresetProvider;
         _logger = logger;
     }
 
@@ -321,6 +328,357 @@ public class TtsModule : InteractionModuleBase<SocketInteractionContext>
             _logger.LogError(
                 ex,
                 "TTS command failed for user {UserId} in guild {GuildId}",
+                userId,
+                guildId);
+
+            var errorEmbed = new EmbedBuilder()
+                .WithTitle("TTS Error")
+                .WithDescription("An error occurred while processing your TTS request. Please try again later.")
+                .WithColor(Color.Red)
+                .WithCurrentTimestamp()
+                .Build();
+
+            if (Context.Interaction.HasResponded)
+            {
+                await FollowupAsync(embed: errorEmbed, ephemeral: true);
+            }
+            else
+            {
+                await RespondAsync(embed: errorEmbed, ephemeral: true);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Converts text to speech using a style preset and plays it in the user's voice channel.
+    /// Requires SSML to be enabled in guild settings.
+    /// </summary>
+    /// <param name="message">The text to speak.</param>
+    /// <param name="preset">The style preset ID to use.</param>
+    [SlashCommand("tts-styled", "Convert text to speech with style preset and play in voice channel")]
+    [RequireVoiceChannel]
+    public async Task TtsStyledAsync(
+        [Summary("message", "The text to speak (max 500 characters)")]
+        [MaxLength(500)]
+        string message,
+        [Summary("preset", "Style preset to use")]
+        [Autocomplete(typeof(StylePresetAutocompleteHandler))]
+        string preset)
+    {
+        var guildId = Context.Guild.Id;
+        var userId = Context.User.Id;
+        var username = Context.User.Username;
+
+        _logger.LogInformation(
+            "TTS-styled command executed by {Username} (ID: {UserId}) in guild {GuildName} (ID: {GuildId}), Message length: {MessageLength}, Preset: {Preset}",
+            username,
+            userId,
+            Context.Guild.Name,
+            guildId,
+            message.Length,
+            preset);
+
+        try
+        {
+            // Check if TTS service is configured
+            if (!_ttsService.IsConfigured)
+            {
+                _logger.LogWarning(
+                    "TTS-styled command used but service not configured in guild {GuildId}",
+                    guildId);
+
+                var notConfiguredEmbed = new EmbedBuilder()
+                    .WithTitle("TTS Not Available")
+                    .WithDescription("Text-to-speech is not configured on this server. Please contact an administrator.")
+                    .WithColor(Color.Red)
+                    .WithCurrentTimestamp()
+                    .Build();
+
+                await RespondAsync(embed: notConfiguredEmbed, ephemeral: true);
+                return;
+            }
+
+            // Get guild TTS settings
+            var settings = await _ttsSettingsService.GetOrCreateSettingsAsync(guildId);
+
+            // Check if SSML is enabled for guild
+            if (!settings.SsmlEnabled)
+            {
+                _logger.LogDebug(
+                    "TTS-styled command used but SSML not enabled in guild {GuildId}",
+                    guildId);
+
+                var ssmlNotEnabledEmbed = new EmbedBuilder()
+                    .WithTitle("SSML Not Enabled")
+                    .WithDescription("Styled TTS requires SSML to be enabled for this server. Please contact an administrator to enable it in TTS settings.")
+                    .WithColor(Color.Orange)
+                    .WithCurrentTimestamp()
+                    .Build();
+
+                await RespondAsync(embed: ssmlNotEnabledEmbed, ephemeral: true);
+                return;
+            }
+
+            // Get the style preset
+            var selectedPreset = _stylePresetProvider.GetPresetById(preset);
+            if (selectedPreset == null)
+            {
+                _logger.LogWarning(
+                    "Invalid preset ID {PresetId} requested in guild {GuildId}",
+                    preset,
+                    guildId);
+
+                var invalidPresetEmbed = new EmbedBuilder()
+                    .WithTitle("Invalid Preset")
+                    .WithDescription("The requested style preset was not found. Please select a valid preset.")
+                    .WithColor(Color.Red)
+                    .WithCurrentTimestamp()
+                    .Build();
+
+                await RespondAsync(embed: invalidPresetEmbed, ephemeral: true);
+                return;
+            }
+
+            // Check message length against guild settings
+            if (message.Length > settings.MaxMessageLength)
+            {
+                _logger.LogDebug(
+                    "TTS message too long: {Length} > {MaxLength} in guild {GuildId}",
+                    message.Length,
+                    settings.MaxMessageLength,
+                    guildId);
+
+                var tooLongEmbed = new EmbedBuilder()
+                    .WithTitle("Message Too Long")
+                    .WithDescription($"Message is too long. Maximum length is {settings.MaxMessageLength} characters.")
+                    .WithColor(Color.Red)
+                    .WithCurrentTimestamp()
+                    .Build();
+
+                await RespondAsync(embed: tooLongEmbed, ephemeral: true);
+                return;
+            }
+
+            // Check rate limit
+            var isRateLimited = await _ttsSettingsService.IsUserRateLimitedAsync(guildId, userId);
+            if (isRateLimited)
+            {
+                _logger.LogDebug(
+                    "User {UserId} rate limited for TTS in guild {GuildId}",
+                    userId,
+                    guildId);
+
+                var rateLimitEmbed = new EmbedBuilder()
+                    .WithTitle("Rate Limited")
+                    .WithDescription("You're sending TTS messages too quickly. Please wait a moment before trying again.")
+                    .WithColor(Color.Orange)
+                    .WithCurrentTimestamp()
+                    .Build();
+
+                await RespondAsync(embed: rateLimitEmbed, ephemeral: true);
+                return;
+            }
+
+            // Get user's voice channel
+            var guildUser = Context.User as SocketGuildUser;
+            var voiceChannel = guildUser?.VoiceChannel;
+
+            if (voiceChannel == null)
+            {
+                _logger.LogDebug(
+                    "User {UserId} not in voice channel for TTS-styled command in guild {GuildId}",
+                    userId,
+                    guildId);
+
+                var noVoiceEmbed = new EmbedBuilder()
+                    .WithTitle("Not in Voice Channel")
+                    .WithDescription("You need to be in a voice channel to use this command.")
+                    .WithColor(Color.Red)
+                    .WithCurrentTimestamp()
+                    .Build();
+
+                await RespondAsync(embed: noVoiceEmbed, ephemeral: true);
+                return;
+            }
+
+            // Defer the response since TTS synthesis may take a moment
+            await DeferAsync(ephemeral: true);
+
+            // Auto-join or switch to user's voice channel
+            var isConnected = _audioService.IsConnected(guildId);
+            if (!isConnected)
+            {
+                _logger.LogDebug(
+                    "Bot not connected to voice in guild {GuildId}, connecting to channel {ChannelId}",
+                    guildId,
+                    voiceChannel.Id);
+
+                await _audioService.JoinChannelAsync(guildId, voiceChannel.Id);
+            }
+            else
+            {
+                // Check if connected to a different channel
+                var currentChannelId = _audioService.GetConnectedChannelId(guildId);
+                if (currentChannelId.HasValue && currentChannelId.Value != voiceChannel.Id)
+                {
+                    _logger.LogDebug(
+                        "Bot connected to different channel in guild {GuildId}, switching from {CurrentChannelId} to {NewChannelId}",
+                        guildId,
+                        currentChannelId.Value,
+                        voiceChannel.Id);
+
+                    await _audioService.LeaveChannelAsync(guildId);
+                    await _audioService.JoinChannelAsync(guildId, voiceChannel.Id);
+                }
+            }
+
+            // Build SSML from preset
+            _ssmlBuilder.Reset();
+            _ssmlBuilder
+                .BeginDocument("en-US")
+                .WithVoice(selectedPreset.VoiceName)
+                .WithStyle(selectedPreset.Style, selectedPreset.StyleDegree);
+
+            if (selectedPreset.ProsodyOptions != null)
+            {
+                _ssmlBuilder.WithProsody(
+                    selectedPreset.ProsodyOptions.Speed,
+                    selectedPreset.ProsodyOptions.Pitch,
+                    selectedPreset.ProsodyOptions.Volume);
+            }
+
+            _ssmlBuilder
+                .AddText(message)
+                .EndStyle()
+                .EndVoice();
+
+            var ssmlText = _ssmlBuilder.Build();
+
+            // Synthesize speech with SSML mode
+            _logger.LogDebug(
+                "Synthesizing TTS with SSML for guild {GuildId} using preset {PresetId} (Voice: {Voice}, Style: {Style})",
+                guildId,
+                selectedPreset.PresetId,
+                selectedPreset.VoiceName,
+                selectedPreset.Style);
+
+            var startTime = DateTime.UtcNow;
+            Stream audioStream;
+            try
+            {
+                audioStream = await _ttsService.SynthesizeSpeechAsync(ssmlText, options: null, SynthesisMode.Ssml);
+            }
+            catch (InvalidOperationException ex)
+            {
+                _logger.LogError(ex, "TTS synthesis failed for guild {GuildId}", guildId);
+
+                var synthesisErrorEmbed = new EmbedBuilder()
+                    .WithTitle("Synthesis Failed")
+                    .WithDescription("Failed to generate speech. Please try again.")
+                    .WithColor(Color.Red)
+                    .WithCurrentTimestamp()
+                    .Build();
+
+                await FollowupAsync(embed: synthesisErrorEmbed, ephemeral: true);
+                return;
+            }
+
+            // Play the audio
+            var pcmStream = _audioService.GetOrCreatePcmStream(guildId);
+            if (pcmStream == null)
+            {
+                _logger.LogError("Failed to get PCM stream for guild {GuildId}", guildId);
+
+                var streamErrorEmbed = new EmbedBuilder()
+                    .WithTitle("Playback Error")
+                    .WithDescription("Failed to connect to voice channel. Please try again.")
+                    .WithColor(Color.Red)
+                    .WithCurrentTimestamp()
+                    .Build();
+
+                await FollowupAsync(embed: streamErrorEmbed, ephemeral: true);
+                return;
+            }
+
+            // Stream the audio to Discord
+            _logger.LogInformation(
+                "Playing styled TTS audio in guild {GuildId} for user {UserId}",
+                guildId,
+                userId);
+
+            _audioService.UpdateLastActivity(guildId);
+
+            await using (audioStream)
+            {
+                await audioStream.CopyToAsync(pcmStream);
+                await pcmStream.FlushAsync();
+            }
+
+            var endTime = DateTime.UtcNow;
+            var durationSeconds = (endTime - startTime).TotalSeconds;
+
+            // Log the TTS message to history
+            var ttsMessage = new TtsMessage
+            {
+                Id = Guid.NewGuid(),
+                GuildId = guildId,
+                UserId = userId,
+                Username = username,
+                Message = message,
+                Voice = selectedPreset.VoiceName,
+                DurationSeconds = durationSeconds,
+                CreatedAt = DateTime.UtcNow
+            };
+
+            await _ttsHistoryService.LogMessageAsync(ttsMessage);
+
+            _logger.LogInformation(
+                "TTS-styled playback completed for user {UserId} in guild {GuildId}, preset: {PresetId}, duration: {Duration:F2}s",
+                userId,
+                guildId,
+                selectedPreset.PresetId,
+                durationSeconds);
+
+            // Success response
+            var successEmbed = new EmbedBuilder()
+                .WithTitle("TTS Playing")
+                .WithDescription($"Now speaking: \"{TruncateMessage(message, 100)}\"")
+                .WithColor(Color.Green)
+                .AddField("Preset", selectedPreset.DisplayName, inline: true)
+                .AddField("Voice", selectedPreset.VoiceName, inline: true)
+                .AddField("Style", $"{selectedPreset.Style} ({selectedPreset.StyleDegree:F2})", inline: true)
+                .WithCurrentTimestamp()
+                .Build();
+
+            await FollowupAsync(embed: successEmbed, ephemeral: true);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            _logger.LogError(
+                "Bot lacks permissions to join voice channel in guild {GuildId}",
+                guildId);
+
+            var permissionEmbed = new EmbedBuilder()
+                .WithTitle("Permission Denied")
+                .WithDescription("I don't have permission to join that voice channel.")
+                .WithColor(Color.Red)
+                .WithCurrentTimestamp()
+                .Build();
+
+            if (Context.Interaction.HasResponded)
+            {
+                await FollowupAsync(embed: permissionEmbed, ephemeral: true);
+            }
+            else
+            {
+                await RespondAsync(embed: permissionEmbed, ephemeral: true);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "TTS-styled command failed for user {UserId} in guild {GuildId}",
                 userId,
                 guildId);
 

--- a/src/DiscordBot.Bot/Controllers/PortalTtsController.cs
+++ b/src/DiscordBot.Bot/Controllers/PortalTtsController.cs
@@ -613,7 +613,7 @@ public class PortalTtsController : ControllerBase
     [ProducesResponseType(typeof(SsmlValidationResult), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status400BadRequest)]
     [AllowAnonymous]
-    public IActionResult ValidateSsml([FromBody] SsmlValidationRequest request)
+    public IActionResult ValidateSsml([FromBody] Core.DTOs.Tts.SsmlValidationRequest request)
     {
         _logger.LogDebug("Validate SSML request, length: {Length}", request.Ssml.Length);
 
@@ -650,7 +650,7 @@ public class PortalTtsController : ControllerBase
     [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> SynthesizeSsml(
         ulong guildId,
-        [FromBody] SsmlSynthesisRequest request,
+        [FromBody] Core.DTOs.Tts.SsmlSynthesisRequest request,
         CancellationToken cancellationToken)
     {
         _logger.LogInformation("Synthesize SSML request for guild {GuildId}, PlayInVoiceChannel: {PlayInVoiceChannel}",
@@ -919,10 +919,10 @@ public class PortalTtsController : ControllerBase
     /// <param name="request">The build request containing segments and elements.</param>
     /// <returns>Built SSML with validation results.</returns>
     [HttpPost("/api/portal/tts/build-ssml")]
-    [ProducesResponseType(typeof(SsmlBuildResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(Core.DTOs.Tts.SsmlBuildResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status400BadRequest)]
     [AllowAnonymous]
-    public IActionResult BuildSsml([FromBody] SsmlBuildRequest request)
+    public IActionResult BuildSsml([FromBody] Core.DTOs.Tts.SsmlBuildRequest request)
     {
         _logger.LogDebug("Build SSML request, language: {Language}, segments: {SegmentCount}",
             request.Language, request.Segments.Count);
@@ -1036,7 +1036,7 @@ public class PortalTtsController : ControllerBase
             // Validate the built SSML
             var validationResult = _ssmlValidator.Validate(ssml);
 
-            var response = new SsmlBuildResponse
+            var response = new Core.DTOs.Tts.SsmlBuildResponse
             {
                 Ssml = ssml,
                 IsValid = validationResult.IsValid,


### PR DESCRIPTION
## Summary

- Add `/tts-styled` Discord slash command for text-to-speech with emotional style presets
- Create `StylePresetAutocompleteHandler` for preset parameter autocomplete
- Check guild SSML enablement before processing
- Fix pre-existing ambiguous type reference errors in `PortalTtsController`

The command allows users to convert text to speech using predefined style presets (e.g., "Cheerful Jenny", "Excited Guy", "Newscast"). It builds SSML markup using the `ISsmlBuilder` service and synthesizes audio via Azure TTS with `SynthesisMode.Ssml`.

## Test Plan

- [ ] Verify `/tts-styled` command appears in Discord
- [ ] Test autocomplete shows available presets filtered by user input
- [ ] Verify error shown if SSML not enabled for guild
- [ ] Test audio plays with styled voice in voice channel
- [ ] Confirm TTS history logging records voice/preset info

Closes #1337

🤖 Generated with [Claude Code](https://claude.com/claude-code)