### PR TITLE
fix(assistant): Wire AssistantOptions.Model to API calls

### DIFF
--- a/src/DiscordBot.Core/Configuration/AssistantOptions.cs
+++ b/src/DiscordBot.Core/Configuration/AssistantOptions.cs
@@ -79,15 +79,16 @@ public class AssistantOptions
 
     /// <summary>
     /// Gets or sets the Claude model identifier to use.
-    /// Default is "claude-3-5-sonnet-20241022".
+    /// Default is "claude-sonnet-4-20250514".
     /// </summary>
     /// <remarks>
     /// Available models:
-    /// - claude-3-5-sonnet-20241022 (recommended for balance of speed/quality)
-    /// - claude-3-opus-20240229 (highest quality, slower, more expensive)
-    /// - claude-3-haiku-20240307 (fastest, cheapest, lower quality)
+    /// - claude-sonnet-4-20250514 (recommended for balance of speed/quality)
+    /// - claude-opus-4-20250514 (highest quality, slower, more expensive)
+    /// - claude-haiku-4-20250514 (fastest, cheapest, lower quality)
+    /// If null or empty, falls back to Anthropic:DefaultModel.
     /// </remarks>
-    public string Model { get; set; } = "claude-3-5-sonnet-20241022";
+    public string Model { get; set; } = "claude-sonnet-4-20250514";
 
     /// <summary>
     /// Gets or sets the timeout for Claude API calls in milliseconds.

--- a/src/DiscordBot.Core/DTOs/LLM/AgentContext.cs
+++ b/src/DiscordBot.Core/DTOs/LLM/AgentContext.cs
@@ -23,6 +23,12 @@ public class AgentContext
     public ToolContext ExecutionContext { get; set; } = new();
 
     /// <summary>
+    /// The model identifier to use for this agent run.
+    /// If null, falls back to provider default.
+    /// </summary>
+    public string? Model { get; set; }
+
+    /// <summary>
     /// Maximum tokens to generate.
     /// </summary>
     public int MaxTokens { get; set; } = 2048;

--- a/src/DiscordBot.Infrastructure/Services/AssistantService.cs
+++ b/src/DiscordBot.Infrastructure/Services/AssistantService.cs
@@ -148,6 +148,7 @@ public class AssistantService : IAssistantService
                     ChannelId = channelId,
                     MessageId = messageId
                 },
+                Model = _options.Model,
                 MaxTokens = _options.MaxTokens,
                 Temperature = _options.Temperature,
                 MaxToolCallIterations = _options.MaxToolCallsPerQuestion

--- a/src/DiscordBot.Infrastructure/Services/LLM/AgentRunner.cs
+++ b/src/DiscordBot.Infrastructure/Services/LLM/AgentRunner.cs
@@ -62,6 +62,7 @@ public class AgentRunner : IAgentRunner
             SystemPrompt = context.SystemPrompt,
             Messages = conversationHistory,
             Tools = context.ToolRegistry?.GetEnabledTools().ToList(),
+            Model = context.Model,
             MaxTokens = context.MaxTokens,
             Temperature = context.Temperature,
             EnablePromptCaching = true


### PR DESCRIPTION
## Summary

- Fix `AssistantOptions.Model` not being used in API calls (was dead code)
- Add `Model` property to `AgentContext` DTO to pass model through pipeline
- Wire model from `AssistantService` → `AgentRunner` → `LlmRequest` → `AnthropicLlmClient`
- Update default model to `claude-sonnet-4-20250514`

## Problem

The `AssistantOptions.Model` property was defined but never passed through the pipeline. Model selection always fell back to `AnthropicOptions.DefaultModel`.

**Before:**
```
AssistantOptions.Model → (not used)
AgentContext (no Model) → AgentRunner → LlmRequest.Model = null
                                              ↓
AnthropicLlmClient → falls back to AnthropicOptions.DefaultModel
```

**After:**
```
AssistantOptions.Model → AssistantService → AgentContext.Model
                                                  ↓
                             AgentRunner → LlmRequest.Model
                                                  ↓
                        AnthropicLlmClient → uses request.Model (or falls back)
```

## Test plan

- [x] Core and Infrastructure projects build successfully
- [ ] Verify model is used by checking Anthropic API logs with different `Assistant:Model` values
- [ ] Existing AgentRunner tests pass (backward compatible - null Model falls back to default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)