### PR TITLE
fix(ui): restyle Active status indicator as badge on Guild Details page (#1317)

### DIFF
--- a/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml.cs
@@ -395,14 +395,15 @@ public class DetailsModel : PageModel
             GuildIconUrl = guild.IconUrl,
             PageTitle = guild.Name,
             PageDescription = $"ID: {guild.Id}",
+            StatusBadge = new BadgeViewModel
+            {
+                Text = guild.IsActive ? "Active" : "Inactive",
+                Variant = guild.IsActive ? BadgeVariant.Success : BadgeVariant.Error,
+                Style = BadgeStyle.Subtle,
+                IconLeft = "M10 18a8 8 0 100-16 8 8 0 000 16z"
+            },
             Actions = ViewModel.CanEdit ? new List<HeaderAction>
             {
-                new()
-                {
-                    Label = "Active",
-                    Url = "#",
-                    Style = HeaderActionStyle.Secondary
-                },
                 new()
                 {
                     Label = "Sync",

--- a/src/DiscordBot.Bot/Pages/Shared/Components/_GuildHeader.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/Components/_GuildHeader.cshtml
@@ -1,6 +1,7 @@
 @model DiscordBot.Bot.ViewModels.Components.GuildHeaderViewModel
 @{
     var hasActions = Model.Actions?.Any() == true;
+    var hasStatusBadge = Model.StatusBadge != null;
 }
 
 <div class="mb-8">
@@ -31,53 +32,60 @@
             </div>
         </div>
 
-        <!-- Right: Action Buttons -->
-        @if (hasActions)
+        <!-- Right: Status Badge + Action Buttons -->
+        @if (hasActions || hasStatusBadge)
         {
             <div class="flex items-center gap-2">
-                @foreach (var action in Model.Actions!)
+                @if (hasStatusBadge)
                 {
-                    @if (action.Style == DiscordBot.Bot.ViewModels.Components.HeaderActionStyle.Primary)
+                    <partial name="Shared/Components/_Badge" model="Model.StatusBadge" />
+                }
+                @if (hasActions)
+                {
+                    @foreach (var action in Model.Actions!)
                     {
-                        <a href="@action.Url"
-                           @(action.OpenInNewTab ? "target=\"_blank\" rel=\"noopener noreferrer\"" : "")
-                           class="px-4 py-2 bg-accent-orange text-white font-medium text-sm rounded-lg hover:bg-accent-orange-hover transition-colors inline-flex items-center gap-2">
-                            @if (!string.IsNullOrEmpty(action.Icon))
-                            {
-                                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@action.Icon" />
-                                </svg>
-                            }
-                            <span>@action.Label</span>
-                        </a>
-                    }
-                    else if (action.Style == DiscordBot.Bot.ViewModels.Components.HeaderActionStyle.Secondary)
-                    {
-                        <a href="@action.Url"
-                           @(action.OpenInNewTab ? "target=\"_blank\" rel=\"noopener noreferrer\"" : "")
-                           class="px-3 py-2 text-sm font-medium text-text-secondary hover:text-accent-blue bg-bg-secondary border border-border-primary rounded-lg hover:border-border-focus transition-colors inline-flex items-center gap-2">
-                            @if (!string.IsNullOrEmpty(action.Icon))
-                            {
-                                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@action.Icon" />
-                                </svg>
-                            }
-                            <span>@action.Label</span>
-                        </a>
-                    }
-                    else if (action.Style == DiscordBot.Bot.ViewModels.Components.HeaderActionStyle.Link)
-                    {
-                        <a href="@action.Url"
-                           @(action.OpenInNewTab ? "target=\"_blank\" rel=\"noopener noreferrer\"" : "")
-                           class="text-sm font-medium text-accent-blue hover:text-accent-blue-hover transition-colors inline-flex items-center gap-1">
-                            @if (!string.IsNullOrEmpty(action.Icon))
-                            {
-                                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@action.Icon" />
-                                </svg>
-                            }
-                            <span>@action.Label</span>
-                        </a>
+                        @if (action.Style == DiscordBot.Bot.ViewModels.Components.HeaderActionStyle.Primary)
+                        {
+                            <a href="@action.Url"
+                               @(action.OpenInNewTab ? "target=\"_blank\" rel=\"noopener noreferrer\"" : "")
+                               class="px-4 py-2 bg-accent-orange text-white font-medium text-sm rounded-lg hover:bg-accent-orange-hover transition-colors inline-flex items-center gap-2">
+                                @if (!string.IsNullOrEmpty(action.Icon))
+                                {
+                                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@action.Icon" />
+                                    </svg>
+                                }
+                                <span>@action.Label</span>
+                            </a>
+                        }
+                        else if (action.Style == DiscordBot.Bot.ViewModels.Components.HeaderActionStyle.Secondary)
+                        {
+                            <a href="@action.Url"
+                               @(action.OpenInNewTab ? "target=\"_blank\" rel=\"noopener noreferrer\"" : "")
+                               class="px-3 py-2 text-sm font-medium text-text-secondary hover:text-accent-blue bg-bg-secondary border border-border-primary rounded-lg hover:border-border-focus transition-colors inline-flex items-center gap-2">
+                                @if (!string.IsNullOrEmpty(action.Icon))
+                                {
+                                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@action.Icon" />
+                                    </svg>
+                                }
+                                <span>@action.Label</span>
+                            </a>
+                        }
+                        else if (action.Style == DiscordBot.Bot.ViewModels.Components.HeaderActionStyle.Link)
+                        {
+                            <a href="@action.Url"
+                               @(action.OpenInNewTab ? "target=\"_blank\" rel=\"noopener noreferrer\"" : "")
+                               class="text-sm font-medium text-accent-blue hover:text-accent-blue-hover transition-colors inline-flex items-center gap-1">
+                                @if (!string.IsNullOrEmpty(action.Icon))
+                                {
+                                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@action.Icon" />
+                                    </svg>
+                                }
+                                <span>@action.Label</span>
+                            </a>
+                        }
                     }
                 }
             </div>

--- a/src/DiscordBot.Bot/ViewModels/Components/GuildHeaderViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Components/GuildHeaderViewModel.cs
@@ -35,6 +35,11 @@ public record GuildHeaderViewModel
     /// Optional list of action buttons to display in the header.
     /// </summary>
     public List<HeaderAction>? Actions { get; init; }
+
+    /// <summary>
+    /// Optional status badge displayed in the header (separate from action buttons).
+    /// </summary>
+    public BadgeViewModel? StatusBadge { get; init; }
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary
Replaced the non-interactive "Active" status button on the Guild Details page with a proper status badge component that better communicates the current state of the guild.

### Changes Made
- Added `StatusBadge` property to `GuildHeaderViewModel` to support rendering status indicators separately from action buttons
- Modified `_GuildHeader.cshtml` to render the StatusBadge before action buttons with proper null handling
- Updated `Details.cshtml.cs` to create a StatusBadge instead of a non-interactive HeaderAction button
- Active guilds display a green subtle badge with status dot icon; inactive guilds display a red subtle badge
- StatusBadge is visible to all users; action buttons remain conditional on edit permissions

### UI Improvements
- Better visual hierarchy by using badge variant instead of button
- Status indicator now clearly distinguished from interactive action buttons
- Consistent with design system badge component patterns

Closes #1317

## Review Status
- Code Review: APPROVED
- UI Review: APPROVED
- Review iterations: 2
- Unresolved items: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)