### PR TITLE
fix(ui): lighten config table hover background for text readability (#1318)

### DIFF
--- a/src/DiscordBot.Bot/wwwroot/css/performance-pages.css
+++ b/src/DiscordBot.Bot/wwwroot/css/performance-pages.css
@@ -699,7 +699,7 @@
 }
 
 .config-table tbody tr:hover {
-    background: rgba(47, 51, 54, 0.5);
+    background: rgba(9, 142, 207, 0.05);
 }
 
 .config-table input[type="number"] {


### PR DESCRIPTION
## Summary

Changed the `.config-table tbody tr:hover` background color from `rgba(47, 51, 54, 0.5)` to `rgba(9, 142, 207, 0.05)` to improve text readability of colored status indicators on the Performance Alerts configuration page. The new hover background matches the styling used in `.performance-table` and provides subtle hover feedback while maintaining proper contrast for green/yellow/red status text.

## Changes

- **File Modified**: `src/DiscordBot.Bot/wwwroot/css/performance-pages.css`
- **Change**: Updated hover background from dark gray (`rgba(47, 51, 54, 0.5)`) to light blue (`rgba(9, 142, 207, 0.05)`)

## Review Status

- Code Review: APPROVED
- UI Review: APPROVED
- Review iterations: 0
- Unresolved items: none

Closes #1318

🤖 Generated with [Claude Code](https://claude.com/claude-code)