### PR TITLE
fix(ui): resolve Bot Control tab not displaying due to section ID mismatch (#1319)

### DIFF
--- a/src/DiscordBot.Bot/wwwroot/js/settings.js
+++ b/src/DiscordBot.Bot/wwwroot/js/settings.js
@@ -508,7 +508,7 @@
         // Update section visibility
         const sections = document.querySelectorAll('.settings-section');
         sections.forEach(section => {
-            if (section.id === `${category.toLowerCase()}-settings`) {
+            if (section.id === `${category.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase()}-settings`) {
                 section.classList.add('active');
             } else {
                 section.classList.remove('active');


### PR DESCRIPTION
## Summary
Fixed the Bot Control tab appearing empty on the Guild Settings page due to a section ID mismatch in the tab switching logic.

The tab switching code was converting the category name "BotControl" to "botcontrol-settings" using simple `toLowerCase()`, but the HTML section element has ID "bot-control-settings" (kebab-case). This caused the visibility toggle to fail, leaving the tab appearing empty.

## Changes
- Updated `settings.js` line 511 to properly convert camelCase category names to kebab-case section IDs
- Changed from `category.toLowerCase()` to `category.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase()`
- This now correctly matches HTML section IDs like `bot-control-settings`

## Testing
- Verified Bot Control tab now displays its settings content correctly
- Confirmed all other tabs (General, Logging, Moderation, etc.) continue to work properly

Closes #1319

🤖 Generated with [Claude Code](https://claude.com/claude-code)