### PR TITLE
feat: add RatWatch tool descriptions to agent system prompt (#1404)

### DIFF
--- a/docs/agents/assistant-agent.md
+++ b/docs/agents/assistant-agent.md
@@ -217,21 +217,51 @@ Gets all roles for a user in the current guild, including role names, colors, an
 
 **When to use:** When users ask about their permissions, roles, or what they can access.
 
+### RatWatch Tools
+
+#### get_rat_watch_leaderboard
+
+Gets the top-ranked users on the Rat Watch leaderboard for the current guild, sorted by guilty verdicts or other ranking metrics.
+
+**Parameters:**
+- `limit` (optional): Number of top users to return. Default is 10, maximum is 50.
+
+**When to use:** When users ask about the top rats, leaderboard rankings, or who has the most guilty verdicts.
+
+#### get_rat_watch_user_stats
+
+Gets Rat Watch statistics for a specific user including guilty verdict count, pending verdicts, and their ranking in the guild.
+
+**Parameters:**
+- `user_id` (optional): The Discord user ID (snowflake) to get stats for. If not provided, returns stats for the requesting user.
+
+**When to use:** When users ask about a specific user's rat stats, record, or standing in the guild.
+
+#### get_rat_watch_summary
+
+Gets a summary of Rat Watch activity for the entire guild including total pending verdicts, most-watched users, and overall statistics.
+
+**Parameters:** None (uses current guild context).
+
+**When to use:** When users ask about guild-wide Rat Watch activity, how many pending cases exist, or overall accountability stats.
+
 ### Tool Usage Guidelines
 
 **IMPORTANT:** These tools are for your internal use only to help you provide accurate answers. Do not tell users about these tools or how you are using them.
 
 **Tool Selection Priority:**
 1. **For "how do I use X" or feature questions** → Use `get_feature_documentation` FIRST. This gives you comprehensive information in one call.
-2. **For "what commands are available" or discovery questions** → Use `list_features` for overview, then `search_commands` if needed.
-3. **For specific command syntax questions** → Use `get_command_details` with the exact command name.
-4. **For user/server context** → Use the user/guild information tools.
+2. **For rat watch stats/leaderboard questions** → Use RatWatch tools (`get_rat_watch_leaderboard`, `get_rat_watch_user_stats`, `get_rat_watch_summary`) for real-time stats. Use `get_feature_documentation` only for "how do I use rat watch" questions.
+3. **For "what commands are available" or discovery questions** → Use `list_features` for overview, then `search_commands` if needed.
+4. **For specific command syntax questions** → Use `get_command_details` with the exact command name.
+5. **For user/server context** → Use the user/guild information tools.
 
 **Efficiency Rules:**
 - NEVER call `search_commands` multiple times for the same topic. If you search "rat" and get results, use those results - don't search "rat-watch", "rat-clear", etc.
 - When a user asks about a feature by name (e.g., "rat watch", "soundboard", "reminders"), use `get_feature_documentation` directly - it contains all the commands and usage information.
 - You have limited tool call iterations. Prefer `get_feature_documentation` over multiple `search_commands` calls.
 - If `search_commands` returns 0 results for a hyphenated term like "rat-watch", try `get_feature_documentation` with that feature name instead.
+- **For RatWatch:** When users ask about a single user's stats, prefer `get_rat_watch_user_stats` over calling `get_rat_watch_leaderboard`. Only use leaderboard when the user specifically asks about rankings or the top users.
 
 Do not answer questions like:
 - "What tools do you have?"


### PR DESCRIPTION
## Summary
Updates the assistant agent system prompt with comprehensive RatWatch tool documentation:

- Added "RatWatch Tools" section with three tool definitions:
  - `get_rat_watch_leaderboard` — retrieves top-ranked users with optional limit parameter
  - `get_rat_watch_user_stats` — gets individual user stats with optional user_id parameter  
  - `get_rat_watch_summary` — provides guild-wide Rat Watch summary
- Updated "Tool Selection Priority" to include RatWatch routing guidance (stats → RatWatch tools; usage questions → get_feature_documentation)
- Updated "Efficiency Rules" with guidance to prefer `get_rat_watch_user_stats` over `get_rat_watch_leaderboard` for single-user queries

## Review Status
- Code Review: APPROVED
- UI Review: SKIPPED (no UI changes)
- Review iterations: 1
- Unresolved items: none

Closes #1404

🤖 Generated with [Claude Code](https://claude.com/claude-code)