### PR TITLE
refactor: extract TTS playback pipeline into ITtsPlaybackService (#1408)

### DIFF
--- a/src/DiscordBot.Bot/Extensions/ApplicationServiceExtensions.cs
+++ b/src/DiscordBot.Bot/Extensions/ApplicationServiceExtensions.cs
@@ -1,6 +1,7 @@
 using DiscordBot.Bot.Interfaces;
 using DiscordBot.Bot.Services;
 using DiscordBot.Bot.Services.Commands;
+using DiscordBot.Bot.Services.Tts;
 using DiscordBot.Core.Interfaces;
 using DiscordBot.Infrastructure.Services;
 using Microsoft.Extensions.DependencyInjection;
@@ -44,6 +45,7 @@ public static class ApplicationServiceExtensions
         services.AddScoped<IUserDataExportService, UserDataExportService>();
         services.AddScoped<IBulkPurgeService, BulkPurgeService>();
         services.AddScoped<IThemeService, ThemeService>();
+        services.AddScoped<ITtsPlaybackService, TtsPlaybackService>();
 
         // Metrics update background services
         services.AddHostedService<MetricsUpdateService>();

--- a/src/DiscordBot.Bot/Interfaces/ITtsPlaybackService.cs
+++ b/src/DiscordBot.Bot/Interfaces/ITtsPlaybackService.cs
@@ -1,0 +1,31 @@
+using DiscordBot.Core.DTOs.Tts;
+
+namespace DiscordBot.Bot.Interfaces;
+
+/// <summary>
+/// Service interface for TTS playback orchestration.
+/// Consolidates PCM streaming, duration calculation, history logging, and activity tracking.
+/// </summary>
+public interface ITtsPlaybackService
+{
+    /// <summary>
+    /// Plays synthesized TTS audio to Discord voice channel.
+    /// Handles PCM streaming, duration calculation, history logging, and observability.
+    /// </summary>
+    /// <param name="guildId">The Discord guild snowflake ID.</param>
+    /// <param name="userId">The Discord user snowflake ID who triggered TTS.</param>
+    /// <param name="username">The username for history logging.</param>
+    /// <param name="message">The original text message (for history).</param>
+    /// <param name="voice">The voice name used for synthesis.</param>
+    /// <param name="audioStream">The synthesized audio stream (48kHz, 16-bit, stereo PCM).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Playback result containing success status, error message, duration, and logged message.</returns>
+    Task<TtsPlaybackResult> PlayAsync(
+        ulong guildId,
+        ulong userId,
+        string username,
+        string message,
+        string voice,
+        Stream audioStream,
+        CancellationToken cancellationToken = default);
+}

--- a/src/DiscordBot.Bot/Services/Tts/TtsPlaybackService.cs
+++ b/src/DiscordBot.Bot/Services/Tts/TtsPlaybackService.cs
@@ -1,0 +1,178 @@
+using DiscordBot.Bot.Interfaces;
+using DiscordBot.Bot.Tracing;
+using DiscordBot.Core.DTOs.Tts;
+using DiscordBot.Core.Entities;
+using DiscordBot.Core.Interfaces;
+
+namespace DiscordBot.Bot.Services.Tts;
+
+/// <summary>
+/// Service for TTS playback orchestration.
+/// Consolidates PCM streaming, duration calculation, history logging, and activity tracking.
+/// </summary>
+public class TtsPlaybackService : ITtsPlaybackService
+{
+    private readonly IAudioService _audioService;
+    private readonly ITtsHistoryService _ttsHistoryService;
+    private readonly ILogger<TtsPlaybackService> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TtsPlaybackService"/> class.
+    /// </summary>
+    /// <param name="audioService">The audio service for voice connections.</param>
+    /// <param name="ttsHistoryService">The TTS history service for logging messages.</param>
+    /// <param name="logger">The logger.</param>
+    public TtsPlaybackService(
+        IAudioService audioService,
+        ITtsHistoryService ttsHistoryService,
+        ILogger<TtsPlaybackService> logger)
+    {
+        _audioService = audioService;
+        _ttsHistoryService = ttsHistoryService;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task<TtsPlaybackResult> PlayAsync(
+        ulong guildId,
+        ulong userId,
+        string username,
+        string message,
+        string voice,
+        Stream audioStream,
+        CancellationToken cancellationToken = default)
+    {
+        // Validate parameters
+        ArgumentNullException.ThrowIfNull(audioStream);
+        ArgumentException.ThrowIfNullOrWhiteSpace(username);
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
+        ArgumentException.ThrowIfNullOrWhiteSpace(voice);
+
+        // Calculate duration from audio stream
+        var durationSeconds = CalculateAudioDuration(audioStream);
+
+        // Reset stream position to ensure we read from the beginning
+        audioStream.Position = 0;
+
+        // Get the PCM stream for playback
+        var pcmStream = _audioService.GetOrCreatePcmStream(guildId);
+        if (pcmStream == null)
+        {
+            _logger.LogError("Failed to get PCM stream for guild {GuildId}", guildId);
+            return new TtsPlaybackResult
+            {
+                Success = false,
+                ErrorMessage = "Failed to get audio stream. Please try reconnecting to the voice channel.",
+                DurationSeconds = durationSeconds
+            };
+        }
+
+        // Stream the audio to Discord
+        try
+        {
+            // Start activity for Discord audio streaming
+            using var streamActivity = BotActivitySource.StartDiscordAudioStreamActivity(
+                guildId: guildId,
+                durationSeconds: durationSeconds);
+
+            try
+            {
+                var bytesWritten = 0L;
+                var buffer = new byte[3840]; // 20ms at 48kHz stereo 16-bit
+                int bytesRead;
+
+                while ((bytesRead = await audioStream.ReadAsync(buffer, 0, buffer.Length, cancellationToken)) > 0)
+                {
+                    await pcmStream.WriteAsync(buffer, 0, bytesRead, cancellationToken);
+                    bytesWritten += bytesRead;
+                }
+
+                await pcmStream.FlushAsync(cancellationToken);
+
+                // Record streaming metrics
+                BotActivitySource.RecordAudioStreamMetrics(
+                    streamActivity,
+                    bytesWritten: bytesWritten,
+                    bufferCount: (int)(bytesWritten / 3840));
+
+                // Update activity to prevent auto-leave
+                _audioService.UpdateLastActivity(guildId);
+
+                _logger.LogInformation("Successfully played TTS message for guild {GuildId}. Bytes written: {BytesWritten}",
+                    guildId, bytesWritten);
+
+                BotActivitySource.SetSuccess(streamActivity);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to stream TTS audio for guild {GuildId}", guildId);
+                BotActivitySource.RecordException(streamActivity, ex);
+                throw;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to stream TTS audio for guild {GuildId}", guildId);
+            return new TtsPlaybackResult
+            {
+                Success = false,
+                ErrorMessage = "An error occurred while streaming audio to Discord.",
+                DurationSeconds = durationSeconds
+            };
+        }
+
+        // Record in history
+        var ttsMessage = new TtsMessage
+        {
+            Id = Guid.NewGuid(),
+            GuildId = guildId,
+            UserId = userId,
+            Username = username,
+            Message = message,
+            Voice = voice,
+            DurationSeconds = durationSeconds,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        try
+        {
+            await _ttsHistoryService.LogMessageAsync(ttsMessage, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to log TTS message to history for guild {GuildId}", guildId);
+            // Don't fail the playback if history logging fails
+        }
+
+        return new TtsPlaybackResult
+        {
+            Success = true,
+            DurationSeconds = durationSeconds,
+            LoggedMessage = ttsMessage
+        };
+    }
+
+    /// <summary>
+    /// Calculates the duration of PCM audio stream in seconds.
+    /// </summary>
+    /// <param name="audioStream">The audio stream (48kHz, 16-bit, stereo PCM).</param>
+    /// <returns>Duration in seconds.</returns>
+    /// <remarks>
+    /// PCM format: 48kHz sample rate, 16-bit (2 bytes per sample), stereo (2 channels).
+    /// Bytes per second = 48000 samples/sec * 2 bytes/sample * 2 channels = 192000 bytes/sec.
+    /// </remarks>
+    private static double CalculateAudioDuration(Stream audioStream)
+    {
+        if (!audioStream.CanSeek)
+        {
+            throw new ArgumentException("Audio stream must support seeking", nameof(audioStream));
+        }
+
+        const int sampleRate = 48000;
+        const int bytesPerSample = 2; // 16-bit
+        const int channels = 2; // stereo
+        const int bytesPerSecond = sampleRate * bytesPerSample * channels; // 192000
+
+        return audioStream.Length / (double)bytesPerSecond;
+    }
+}

--- a/src/DiscordBot.Core/DTOs/Tts/TtsPlaybackResult.cs
+++ b/src/DiscordBot.Core/DTOs/Tts/TtsPlaybackResult.cs
@@ -1,0 +1,30 @@
+using DiscordBot.Core.Entities;
+
+namespace DiscordBot.Core.DTOs.Tts;
+
+/// <summary>
+/// Result of a TTS playback operation.
+/// </summary>
+public class TtsPlaybackResult
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the playback was successful.
+    /// </summary>
+    public bool Success { get; set; }
+
+    /// <summary>
+    /// Gets or sets the error message if playback failed.
+    /// </summary>
+    public string? ErrorMessage { get; set; }
+
+    /// <summary>
+    /// Gets or sets the duration of the audio in seconds.
+    /// </summary>
+    public double DurationSeconds { get; set; }
+
+    /// <summary>
+    /// Gets or sets the logged TTS message entity.
+    /// Null if playback failed before logging.
+    /// </summary>
+    public TtsMessage? LoggedMessage { get; set; }
+}


### PR DESCRIPTION
## Summary

This PR refactors the TTS playback logic from three separate locations (Razor Page, API Controller, Slash Command) into a dedicated `ITtsPlaybackService` to improve maintainability and eliminate code duplication.

### New Components

- **`ITtsPlaybackService`** interface in `src/DiscordBot.Bot/Interfaces/` with `PlayAsync` method
- **`TtsPlaybackResult`** DTO in `src/DiscordBot.Core/DTOs/Tts/` for structured return values (success, error message, duration, logged TtsMessage)
- **`TtsPlaybackService`** implementation in `src/DiscordBot.Bot/Services/Tts/` that handles:
  - PCM stream retrieval via `IAudioService.GetOrCreatePcmStream`
  - Buffered audio streaming (3840-byte frames, 20ms at 48kHz stereo 16-bit)
  - Audio duration calculation (consolidated from duplicated implementations)
  - History logging via `ITtsHistoryService.LogMessageAsync`
  - Activity tracking via `IAudioService.UpdateLastActivity`
  - Observability spans via `BotActivitySource`
  - Parameter validation (null checks, string validation, stream capability checks)

### Refactored Components

- **`Index.cshtml.cs`** (Razor Page) - Delegates playback to `ITtsPlaybackService`, removed `CalculateAudioDuration`
- **`PortalTtsController.cs`** - Delegates playback to `ITtsPlaybackService`, removed `CalculateAudioDuration`, fixed duplicate duration calculation
- **`TtsModule.cs`** (Slash Command) - Delegates playback to `ITtsPlaybackService`
- **`ApplicationServiceExtensions.cs`** - Registered `ITtsPlaybackService` as scoped service

### Benefits

- Single source of truth for TTS playback logic
- Eliminated 3 instances of duplicated `CalculateAudioDuration` method
- Consistent error handling and logging across all TTS entry points
- Improved testability through dependency injection
- Better observability with consolidated activity tracking

## Review Status

- Code Review: APPROVED (after 1 fix iteration — 6 issues resolved)
- UI Review: SKIPPED (no UI changes)
- Review iterations: 2 (initial review + re-review)
- Unresolved items: None

Closes #1408

🤖 Generated with [Claude Code](https://claude.com/claude-code)