### PR TITLE
feat(soundboard): add export all sounds endpoint (#1368)

### DIFF
--- a/src/DiscordBot.Bot/Controllers/SoundsController.cs
+++ b/src/DiscordBot.Bot/Controllers/SoundsController.cs
@@ -1,3 +1,5 @@
+using System.IO.Compression;
+using System.Text.Json;
 using DiscordBot.Bot.Extensions;
 using DiscordBot.Core.DTOs;
 using DiscordBot.Core.Interfaces;
@@ -99,5 +101,194 @@ public class SoundsController : ControllerBase
 
         // Return file with range request support for audio playback
         return PhysicalFile(filePath, contentType, downloadFileName, enableRangeProcessing: true);
+    }
+
+    /// <summary>
+    /// Exports all sounds from a guild as a ZIP archive with manifest.
+    /// </summary>
+    /// <param name="guildId">The guild's Discord snowflake ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>ZIP file containing all sound files and manifest.json.</returns>
+    [HttpGet("export")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> ExportAllSounds(
+        ulong guildId,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Export all sounds request for guild {GuildId}", guildId);
+
+        // Get all sounds for the guild
+        var sounds = await _soundService.GetAllByGuildAsync(guildId, cancellationToken);
+
+        if (sounds.Count == 0)
+        {
+            _logger.LogWarning("No sounds found for guild {GuildId}", guildId);
+            return NotFound(new ApiErrorDto
+            {
+                Message = "No sounds to export",
+                Detail = "This guild has no sounds configured.",
+                StatusCode = StatusCodes.Status404NotFound,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
+
+        var exportId = Guid.NewGuid().ToString("N");
+        string? zipFilePath = null;
+
+        try
+        {
+            // Track used filenames for duplicate handling
+            var usedFileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var soundManifestEntries = new List<object>();
+            long totalSizeBytes = 0;
+
+            // Create ZIP archive directly
+            zipFilePath = Path.Combine(Path.GetTempPath(), $"sounds_export_{exportId}.zip");
+            using (var zipArchive = ZipFile.Open(zipFilePath, ZipArchiveMode.Create))
+            {
+                // Stream files directly into ZIP
+                foreach (var sound in sounds)
+                {
+                    var sourcePath = _soundFileService.GetSoundFilePath(guildId, sound.FileName);
+
+                    // Verify file exists
+                    if (!_soundFileService.SoundFileExists(guildId, sound.FileName))
+                    {
+                        _logger.LogWarning(
+                            "Sound file missing during export: {FilePath} for sound {SoundId}",
+                            sourcePath,
+                            sound.Id);
+                        continue;
+                    }
+
+                    // Sanitize sound name to prevent path traversal
+                    var sanitizedName = Path.GetInvalidFileNameChars()
+                        .Aggregate(sound.Name, (current, c) => current.Replace(c.ToString(), "_"));
+
+                    // Trim and handle empty names
+                    sanitizedName = sanitizedName.Trim();
+                    if (string.IsNullOrWhiteSpace(sanitizedName))
+                    {
+                        sanitizedName = $"sound_{sound.Id:N}";
+                    }
+
+                    // Handle reserved Windows filenames
+                    string[] reservedNames = ["CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"];
+                    if (reservedNames.Contains(sanitizedName, StringComparer.OrdinalIgnoreCase))
+                    {
+                        sanitizedName = $"_{sanitizedName}";
+                    }
+
+                    // Build human-readable filename
+                    var extension = Path.GetExtension(sound.FileName);
+                    var baseFileName = sanitizedName;
+                    var exportFileName = $"{baseFileName}{extension}";
+
+                    // Handle duplicate names with collision-safe counter
+                    var counter = 1;
+                    while (usedFileNames.Contains(exportFileName))
+                    {
+                        exportFileName = $"{baseFileName}-{counter}{extension}";
+                        counter++;
+                    }
+                    usedFileNames.Add(exportFileName);
+
+                    // Stream file directly into ZIP
+                    var entry = zipArchive.CreateEntry(exportFileName, CompressionLevel.Optimal);
+                    using var entryStream = entry.Open();
+                    using var sourceFileStream = new FileStream(sourcePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                    await sourceFileStream.CopyToAsync(entryStream, cancellationToken);
+
+                    totalSizeBytes += sound.FileSizeBytes;
+
+                    // Add to manifest
+                    soundManifestEntries.Add(new
+                    {
+                        id = sound.Id.ToString(),
+                        name = sound.Name,
+                        fileName = exportFileName,
+                        originalFileName = sound.FileName,
+                        durationSeconds = sound.DurationSeconds,
+                        fileSizeBytes = sound.FileSizeBytes,
+                        playCount = sound.PlayCount,
+                        uploadedById = sound.UploadedById?.ToString(),
+                        uploadedAt = sound.UploadedAt.ToString("O")
+                    });
+                }
+
+                // Check if any sounds were actually exported
+                if (soundManifestEntries.Count == 0)
+                {
+                    _logger.LogWarning("All sound files missing for guild {GuildId}", guildId);
+                    return NotFound(new ApiErrorDto
+                    {
+                        Message = "No sounds to export",
+                        Detail = "All sound files are missing from storage.",
+                        StatusCode = StatusCodes.Status404NotFound,
+                        TraceId = HttpContext.GetCorrelationId()
+                    });
+                }
+
+                // Create manifest.json
+                var manifest = new
+                {
+                    exportedAt = DateTime.UtcNow.ToString("O"),
+                    guildId = guildId.ToString(),
+                    guildName = sounds.FirstOrDefault()?.Guild?.Name ?? guildId.ToString(),
+                    totalSounds = soundManifestEntries.Count,
+                    totalSizeBytes,
+                    sounds = soundManifestEntries
+                };
+
+                var jsonOptions = new JsonSerializerOptions { WriteIndented = true };
+                var manifestJson = JsonSerializer.Serialize(manifest, jsonOptions);
+                var manifestEntry = zipArchive.CreateEntry("manifest.json", CompressionLevel.Optimal);
+                using var manifestStream = manifestEntry.Open();
+                using var manifestWriter = new StreamWriter(manifestStream);
+                await manifestWriter.WriteAsync(manifestJson.AsMemory(), cancellationToken);
+            }
+
+            _logger.LogInformation(
+                "Successfully exported {SoundCount} sounds for guild {GuildId}. Export ID: {ExportId}",
+                soundManifestEntries.Count,
+                guildId,
+                exportId);
+
+            // Stream the ZIP file
+            var fileStream = new FileStream(zipFilePath, FileMode.Open, FileAccess.Read, FileShare.None, 4096, FileOptions.DeleteOnClose);
+            var downloadFileName = $"{sounds.FirstOrDefault()?.Guild?.Name ?? guildId.ToString()}_sounds_export.zip";
+
+            return File(fileStream, "application/zip", downloadFileName);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Failed to export sounds for guild {GuildId}. Export ID: {ExportId}",
+                guildId,
+                exportId);
+
+            // Clean up ZIP file if it was created
+            if (zipFilePath != null && System.IO.File.Exists(zipFilePath))
+            {
+                try
+                {
+                    System.IO.File.Delete(zipFilePath);
+                }
+                catch (Exception cleanupEx)
+                {
+                    _logger.LogWarning(cleanupEx, "Failed to delete incomplete ZIP file: {ZipPath}", zipFilePath);
+                }
+            }
+
+            return StatusCode(StatusCodes.Status500InternalServerError, new ApiErrorDto
+            {
+                Message = "Export failed",
+                Detail = "An error occurred while creating the export archive.",
+                StatusCode = StatusCodes.Status500InternalServerError,
+                TraceId = HttpContext.GetCorrelationId()
+            });
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds a new GET endpoint to export all soundboard sounds for a guild as a ZIP archive with metadata manifest.

### Implementation Details

- **New Endpoint**: `GET /api/guilds/{guildId}/sounds/export`
- **ZIP Archive Creation**: Streams all sound files directly into a ZIP archive for memory efficiency
- **Human-Readable Filenames**: Renames files from UUID-based storage names to sound name + original extension
- **Duplicate Handling**: Adds suffix (-1, -2, etc.) for sounds with identical names
- **Manifest Metadata**: Includes `manifest.json` with guild info, sound details, and export timestamp
- **JavaScript-Safe IDs**: Discord snowflake IDs serialized as strings in JSON
- **Security**: Path traversal protection via filename sanitization (invalid chars, empty names, reserved Windows names)
- **Performance**: No temp staging directory; files streamed directly with `FileOptions.DeleteOnClose`
- **Error Handling**: Returns 404 if guild has no sounds or all files are missing
- **Concurrent Access**: Uses `FileShare.Read` for safe parallel access
- **Cancellation Support**: Full cancellation token propagation

### Files Changed

- `src/DiscordBot.Bot/Controllers/SoundsController.cs` - Added ExportAllSounds endpoint

### Review Status

- **Code Review**: APPROVED after 2 iterations
- **UI Review**: SKIPPED (no UI changes)
- **Unresolved Items**: None

All critical and major issues from code review have been resolved.

Closes #1368

🤖 Generated with [Claude Code](https://claude.com/claude-code)