### PR TITLE
feat(soundboard): add export all button to admin page (#1369)

### DIFF
--- a/src/DiscordBot.Bot/Pages/Guilds/Soundboard/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Soundboard/Index.cshtml
@@ -190,9 +190,20 @@
                             PartialUrl = $"/Guilds/Soundboard/{Model.ViewModel.GuildId}?handler=Partial"
                         }' />
                     </div>
-                    <span class="inline-flex items-center justify-center px-2.5 py-1 text-xs font-semibold text-accent-blue bg-accent-blue/20 rounded-full">
-                        @Model.ViewModel.Stats.TotalSounds @(Model.ViewModel.Stats.TotalSounds == 1 ? "sound" : "sounds")
-                    </span>
+                    <div class="flex items-center gap-3">
+                        <partial name="Shared/Components/_Button" model="@(new ButtonViewModel
+                        {
+                            Text = "Export All",
+                            Variant = ButtonVariant.Secondary,
+                            Size = ButtonSize.Small,
+                            IconLeft = "M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4",
+                            OnClick = "exportAllSounds()",
+                            IsDisabled = Model.ViewModel.Stats.TotalSounds == 0
+                        })" />
+                        <span class="inline-flex items-center justify-center px-2.5 py-1 text-xs font-semibold text-accent-blue bg-accent-blue/20 rounded-full">
+                            @Model.ViewModel.Stats.TotalSounds @(Model.ViewModel.Stats.TotalSounds == 1 ? "sound" : "sounds")
+                        </span>
+                    </div>
                 </div>
 
                 <!-- Sounds List Container (AJAX target) -->
@@ -516,6 +527,11 @@
         function downloadSound(soundId, fileName) {
             document.querySelectorAll('[id^="menu-"]').forEach(m => m.classList.add('hidden'));
             window.location.href = `/api/guilds/${window.guildId}/sounds/${soundId}/download`;
+        }
+
+        // Export all sounds as zip
+        function exportAllSounds() {
+            window.location.href = `/api/guilds/${window.guildId}/sounds/export`;
         }
 
         // File upload handling


### PR DESCRIPTION
## Summary

Added an "Export All" button to the Guilds/Soundboard admin page that allows users to download all sounds as a single zip file.

### Changes
- Added "Export All" button in the page header, positioned next to the sound count badge
- Button uses `ButtonVariant.Secondary` and `ButtonSize.Small` with a download arrow icon
- Button is automatically disabled when no sounds exist (`TotalSounds == 0`)
- Added `exportAllSounds()` JavaScript function that navigates to `/api/guilds/{guildId}/sounds/export` to trigger file download
- Guild ID is correctly treated as a string in JavaScript to preserve Discord snowflake ID precision

### Review Status
- Code Review: APPROVED
- UI Review: APPROVED  
- Review iterations: 1 (no fixes needed)
- Unresolved items: none

Closes #1369

🤖 Generated with [Claude Code](https://claude.com/claude-code)