### PR TITLE
feat(vox): implement VoxClipLibrary singleton filesystem scanner (#1458)

### DIFF
--- a/src/DiscordBot.Bot/Extensions/VoiceServiceExtensions.cs
+++ b/src/DiscordBot.Bot/Extensions/VoiceServiceExtensions.cs
@@ -3,6 +3,8 @@ using DiscordBot.Bot.Services;
 using DiscordBot.Bot.Services.Tts;
 using DiscordBot.Core.Configuration;
 using DiscordBot.Core.Interfaces;
+using DiscordBot.Core.Interfaces.Vox;
+using DiscordBot.Infrastructure.Services.Vox;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -16,7 +18,7 @@ public static class VoiceServiceExtensions
 {
     /// <summary>
     /// Adds all voice-related services to the service collection.
-    /// This is a composite method that calls AddVoiceCore, AddSoundboard, and AddTts.
+    /// This is a composite method that calls AddVoiceCore, AddSoundboard, AddTts, and AddVox.
     /// </summary>
     /// <param name="services">The service collection to add services to.</param>
     /// <param name="configuration">The application configuration.</param>
@@ -26,6 +28,7 @@ public static class VoiceServiceExtensions
         services.AddVoiceCore(configuration);
         services.AddSoundboard(configuration);
         services.AddTts(configuration);
+        services.AddVox(configuration);
 
         return services;
     }
@@ -115,6 +118,24 @@ public static class VoiceServiceExtensions
 
         // Azure Speech TTS service (singleton for connection pooling)
         services.AddSingleton<ITtsService, AzureTtsService>();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Adds VOX clip library services for Half-Life style audio synthesis.
+    /// </summary>
+    /// <param name="services">The service collection to add services to.</param>
+    /// <param name="configuration">The application configuration.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddVox(this IServiceCollection services, IConfiguration configuration)
+    {
+        // Bind options
+        services.Configure<VoxOptions>(
+            configuration.GetSection(VoxOptions.SectionName));
+
+        // VOX clip library (singleton for shared state and performance)
+        services.AddSingleton<IVoxClipLibrary, VoxClipLibrary>();
 
         return services;
     }

--- a/src/DiscordBot.Infrastructure/Services/Vox/VoxClipLibrary.cs
+++ b/src/DiscordBot.Infrastructure/Services/Vox/VoxClipLibrary.cs
@@ -1,0 +1,277 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
+using DiscordBot.Core.Configuration;
+using DiscordBot.Core.DTOs.Vox;
+using DiscordBot.Core.Enums;
+using DiscordBot.Core.Interfaces.Vox;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace DiscordBot.Infrastructure.Services.Vox;
+
+/// <summary>
+/// Service implementation for the VOX clip library that manages and provides access to audio clips.
+/// Scans directories on initialization and provides fast lookup and search capabilities.
+/// </summary>
+public class VoxClipLibrary : IVoxClipLibrary
+{
+    private readonly ILogger<VoxClipLibrary> _logger;
+    private readonly VoxOptions _options;
+    private readonly Dictionary<VoxClipGroup, Dictionary<string, VoxClipInfo>> _clipInventory;
+    private readonly SemaphoreSlim _initLock;
+    private bool _initialized;
+
+    public VoxClipLibrary(
+        ILogger<VoxClipLibrary> logger,
+        IOptions<VoxOptions> options)
+    {
+        _logger = logger;
+        _options = options.Value;
+        _clipInventory = new Dictionary<VoxClipGroup, Dictionary<string, VoxClipInfo>>();
+        _initLock = new SemaphoreSlim(1, 1);
+    }
+
+    /// <inheritdoc/>
+    public async Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        await _initLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (_initialized)
+            {
+                _logger.LogWarning("VoxClipLibrary already initialized. Skipping re-initialization");
+                return;
+            }
+
+            _logger.LogInformation("Initializing VOX clip library from base path: {BasePath}", _options.BasePath);
+
+            var groups = new[] { VoxClipGroup.Vox, VoxClipGroup.Fvox, VoxClipGroup.Hgrunt };
+
+            foreach (var group in groups)
+            {
+                _clipInventory[group] = new Dictionary<string, VoxClipInfo>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            // Scan each group's directory in parallel
+            var scanTasks = groups.Select(group => ScanGroupDirectoryAsync(group, cancellationToken));
+            await Task.WhenAll(scanTasks);
+
+            // Log summary
+            foreach (var group in groups)
+            {
+                var count = _clipInventory[group].Count;
+                _logger.LogInformation("VOX clip library initialized: {Group} has {Count} clips", group, count);
+            }
+
+            _initialized = true;
+        }
+        finally
+        {
+            _initLock.Release();
+        }
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<VoxClipInfo> GetClips(VoxClipGroup group)
+    {
+        EnsureInitialized();
+        return _clipInventory[group].Values.ToList();
+    }
+
+    /// <inheritdoc/>
+    public VoxClipInfo? GetClip(VoxClipGroup group, string clipName)
+    {
+        EnsureInitialized();
+
+        if (string.IsNullOrWhiteSpace(clipName))
+            return null;
+
+        var normalizedName = clipName.ToLowerInvariant();
+        return _clipInventory[group].TryGetValue(normalizedName, out var clip) ? clip : null;
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<VoxClipInfo> SearchClips(VoxClipGroup group, string query, int maxResults = 25)
+    {
+        EnsureInitialized();
+
+        if (string.IsNullOrWhiteSpace(query))
+            return Array.Empty<VoxClipInfo>();
+
+        var normalizedQuery = query.ToLowerInvariant();
+        var clips = _clipInventory[group].Values;
+
+        // Separate prefix matches from substring matches
+        var prefixMatches = clips
+            .Where(c => c.Name.StartsWith(normalizedQuery, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(c => c.Name)
+            .ToList();
+
+        var substringMatches = clips
+            .Where(c => !c.Name.StartsWith(normalizedQuery, StringComparison.OrdinalIgnoreCase) &&
+                        c.Name.Contains(normalizedQuery, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(c => c.Name)
+            .ToList();
+
+        // Combine: prefix matches first, then substring matches
+        var results = new List<VoxClipInfo>(maxResults);
+        results.AddRange(prefixMatches.Take(maxResults));
+
+        var remaining = maxResults - results.Count;
+        if (remaining > 0)
+        {
+            results.AddRange(substringMatches.Take(remaining));
+        }
+
+        return results;
+    }
+
+    /// <inheritdoc/>
+    public string GetClipFilePath(VoxClipGroup group, string clipName)
+    {
+        EnsureInitialized();
+        var groupPath = GetGroupDirectoryPath(group);
+        var normalizedName = clipName.ToLowerInvariant();
+        return Path.Combine(groupPath, $"{normalizedName}.mp3");
+    }
+
+    /// <inheritdoc/>
+    public int GetClipCount(VoxClipGroup group)
+    {
+        EnsureInitialized();
+        return _clipInventory[group].Count;
+    }
+
+    private async Task ScanGroupDirectoryAsync(VoxClipGroup group, CancellationToken cancellationToken)
+    {
+        var groupPath = GetGroupDirectoryPath(group);
+
+        if (!Directory.Exists(groupPath))
+        {
+            _logger.LogWarning("VOX directory not found for group {Group}: {Path}", group, groupPath);
+            return;
+        }
+
+        var mp3Files = Directory.GetFiles(groupPath, "*.mp3", SearchOption.TopDirectoryOnly);
+
+        if (mp3Files.Length == 0)
+        {
+            _logger.LogInformation("No MP3 files found in {Group} directory: {Path}", group, groupPath);
+            return;
+        }
+
+        _logger.LogDebug("Scanning {Count} MP3 files in {Group} directory", mp3Files.Length, group);
+
+        // Process files in parallel for performance
+        var clips = new List<VoxClipInfo>(mp3Files.Length);
+        var lockObject = new object();
+
+        await Parallel.ForEachAsync(
+            mp3Files,
+            new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount, CancellationToken = cancellationToken },
+            async (filePath, ct) =>
+            {
+                var clipInfo = await ExtractClipInfoAsync(filePath, group, ct);
+                if (clipInfo != null)
+                {
+                    lock (lockObject)
+                    {
+                        clips.Add(clipInfo);
+                    }
+                }
+            });
+
+        // Add all clips to the inventory
+        foreach (var clip in clips)
+        {
+            _clipInventory[group][clip.Name] = clip;
+        }
+    }
+
+    private async Task<VoxClipInfo?> ExtractClipInfoAsync(string filePath, VoxClipGroup group, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var fileInfo = new FileInfo(filePath);
+            var fileName = Path.GetFileNameWithoutExtension(filePath).ToLowerInvariant();
+
+            // Extract duration using FFprobe
+            var duration = await GetAudioDurationAsync(filePath, cancellationToken);
+
+            return new VoxClipInfo
+            {
+                Name = fileName,
+                Group = group,
+                FileSizeBytes = fileInfo.Length,
+                DurationSeconds = duration
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to extract clip info from file: {FilePath}", filePath);
+            return null;
+        }
+    }
+
+    private async Task<double> GetAudioDurationAsync(string filePath, CancellationToken cancellationToken)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "ffprobe",
+            Arguments = $"-v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 \"{filePath}\"",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var process = new Process { StartInfo = startInfo };
+
+        try
+        {
+            process.Start();
+        }
+        catch (Win32Exception ex)
+        {
+            _logger.LogWarning(ex, "FFprobe not found. Duration will be set to 0. Install FFmpeg and ensure ffprobe is in PATH");
+            return 0.0;
+        }
+
+        var output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var error = await process.StandardError.ReadToEndAsync(cancellationToken);
+
+        await process.WaitForExitAsync(cancellationToken);
+
+        if (process.ExitCode != 0)
+        {
+            _logger.LogWarning("FFprobe exited with code {ExitCode} for file '{FilePath}': {Error}",
+                process.ExitCode, filePath, error);
+            return 0.0;
+        }
+
+        if (double.TryParse(output.Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out var duration))
+        {
+            return duration;
+        }
+
+        _logger.LogWarning("Failed to parse duration from FFprobe output for file '{FilePath}': {Output}",
+            filePath, output);
+        return 0.0;
+    }
+
+    private string GetGroupDirectoryPath(VoxClipGroup group)
+    {
+        var groupName = group.ToString().ToLowerInvariant();
+        return Path.Combine(_options.BasePath, groupName);
+    }
+
+    private void EnsureInitialized()
+    {
+        if (!_initialized)
+        {
+            throw new InvalidOperationException(
+                "VoxClipLibrary has not been initialized. Call InitializeAsync() before using the library.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements the VOX clip library singleton service as specified in issue #1458.

### Implementation Details

- Created `VoxClipLibrary` singleton service implementing `IVoxClipLibrary`
- Scans `sounds/vox/`, `sounds/fvox/`, `sounds/hgrunt/` directories for MP3 clips at startup
- Extracts clip metadata (name, file size, duration via FFprobe) in parallel for optimal performance
- Stores clips in `Dictionary<VoxClipGroup, Dictionary<string, VoxClipInfo>>` for fast lookup
- Provides search with prefix-match-first ordering (case-insensitive)
- Handles missing directories gracefully with warning logs
- Thread-safe initialization using SemaphoreSlim
- Registered as singleton via `AddVox()` extension method

### Files Changed

- `src/DiscordBot.Infrastructure/Services/Vox/VoxClipLibrary.cs` (created)
- `src/DiscordBot.Bot/Extensions/VoiceServiceExtensions.cs` (modified)

### Review Status

- Code Review: APPROVED after 1 fix iteration
- Review iterations: 1
- Fixed issues: Thread-safety in initialization, EnsureInitialized call in GetClipFilePath

Closes #1458

🤖 Generated with [Claude Code](https://claude.com/claude-code)