### PR TITLE
feat(vox): add DI registration and startup initialization (#1461)

### DIFF
--- a/src/DiscordBot.Bot/Extensions/VoiceServiceExtensions.cs
+++ b/src/DiscordBot.Bot/Extensions/VoiceServiceExtensions.cs
@@ -143,6 +143,9 @@ public static class VoiceServiceExtensions
         // VOX orchestration service (scoped for per-request pipeline coordination)
         services.AddScoped<IVoxService, VoxService>();
 
+        // VOX clip library initialization (hosted service for startup initialization)
+        services.AddHostedService<VoxClipLibraryInitializer>();
+
         return services;
     }
 }

--- a/src/DiscordBot.Bot/Services/VoxClipLibraryInitializer.cs
+++ b/src/DiscordBot.Bot/Services/VoxClipLibraryInitializer.cs
@@ -1,0 +1,67 @@
+using DiscordBot.Core.Enums;
+using DiscordBot.Core.Interfaces.Vox;
+using System.Diagnostics;
+
+namespace DiscordBot.Bot.Services;
+
+/// <summary>
+/// Hosted service that initializes the VOX clip library at application startup.
+/// Logs initialization timing and clip counts per group.
+/// </summary>
+public class VoxClipLibraryInitializer : IHostedService
+{
+    private readonly IVoxClipLibrary _clipLibrary;
+    private readonly ILogger<VoxClipLibraryInitializer> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VoxClipLibraryInitializer"/> class.
+    /// </summary>
+    /// <param name="clipLibrary">The VOX clip library to initialize.</param>
+    /// <param name="logger">The logger.</param>
+    public VoxClipLibraryInitializer(
+        IVoxClipLibrary clipLibrary,
+        ILogger<VoxClipLibraryInitializer> logger)
+    {
+        _clipLibrary = clipLibrary;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("VOX clip library initialization starting");
+
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            await _clipLibrary.InitializeAsync(cancellationToken);
+            stopwatch.Stop();
+
+            var voxCount = _clipLibrary.GetClipCount(VoxClipGroup.Vox);
+            var fvoxCount = _clipLibrary.GetClipCount(VoxClipGroup.Fvox);
+            var hgruntCount = _clipLibrary.GetClipCount(VoxClipGroup.Hgrunt);
+
+            _logger.LogInformation(
+                "VOX library initialized with {VoxCount} VOX, {FvoxCount} FVOX, {HgruntCount} HGrunt clips in {ElapsedMs}ms",
+                voxCount,
+                fvoxCount,
+                hgruntCount,
+                stopwatch.ElapsedMilliseconds);
+        }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+            _logger.LogError(ex, "Error initializing VOX clip library after {ElapsedMs}ms",
+                stopwatch.ElapsedMilliseconds);
+            throw;
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("VOX clip library initializer stopping");
+        return Task.CompletedTask;
+    }
+}

--- a/src/DiscordBot.Bot/appsettings.json
+++ b/src/DiscordBot.Bot/appsettings.json
@@ -211,6 +211,12 @@
     "DefaultAutoLeaveTimeoutMinutes": 0,
     "SupportedFormats": [ "mp3", "wav", "ogg" ]
   },
+  "Vox": {
+    "BasePath": "./sounds",
+    "DefaultWordGapMs": 50,
+    "MaxMessageWords": 50,
+    "MaxMessageLength": 500
+  },
   "SoundPlayLogRetention": {
     "Enabled": true,
     "RetentionDays": 90,


### PR DESCRIPTION
## Summary
- Created `VoxClipLibraryInitializer` hosted service that initializes the VOX clip library at startup
- Logs startup timing and clip counts per group (Vox, Fvox, Hgrunt) using Serilog structured logging
- Added VOX configuration section to appsettings.json with BasePath, DefaultWordGapMs, MaxMessageWords, MaxMessageLength
- Registered the hosted service in the existing AddVox() method in VoiceServiceExtensions.cs

## Files Changed
- src/DiscordBot.Bot/Services/VoxClipLibraryInitializer.cs (NEW)
- src/DiscordBot.Bot/Extensions/VoiceServiceExtensions.cs (modified)
- src/DiscordBot.Bot/appsettings.json (modified)

## Review Status
- Code Review: APPROVED
- Review iterations: 1 (passed first review)
- Unresolved items: none

Closes #1461

🤖 Generated with [Claude Code](https://claude.com/claude-code)