### PR TITLE
feat: migrate VOX Portal to unified Now Playing (#1512)

### DIFF
--- a/src/DiscordBot.Bot/Pages/Portal/VOX/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Portal/VOX/Index.cshtml
@@ -334,36 +334,17 @@
         }
 
         /* Sidebar panels */
-        .vox-now-playing {
-            background-color: var(--color-bg-primary);
-            border-radius: 0.5rem;
-            padding: 1rem;
-        }
-
         .vox-stats {
             background-color: var(--color-bg-secondary);
             border-radius: 0.5rem;
             padding: 1rem;
         }
 
-        .vox-now-playing h3,
         .vox-stats h3 {
             font-size: 0.875rem;
             font-weight: 600;
             color: var(--color-text-primary);
             margin: 0 0 0.75rem 0;
-        }
-
-        .now-playing-message {
-            color: var(--color-text-secondary);
-            font-size: 0.875rem;
-            margin-bottom: 0.75rem;
-        }
-
-        .now-playing-empty {
-            color: var(--color-text-secondary);
-            font-size: 0.875rem;
-            font-style: italic;
         }
 
         .stat-item {
@@ -386,30 +367,6 @@
             color: var(--color-text-primary);
             font-size: 0.875rem;
             font-weight: 600;
-        }
-
-        .stop-btn {
-            width: 100%;
-            padding: 0.5rem;
-            background-color: var(--color-error);
-            color: white;
-            border: none;
-            border-radius: 0.375rem;
-            font-size: 0.875rem;
-            font-weight: 500;
-            cursor: pointer;
-            transition: background-color 0.2s;
-        }
-
-        .stop-btn:hover {
-            background-color: var(--color-error);
-            filter: brightness(0.9);
-            transform: scale(1.02);
-        }
-
-        .stop-btn:disabled {
-            opacity: 0.5;
-            cursor: not-allowed;
         }
 
         /* Group tabs container */
@@ -1961,26 +1918,6 @@ else
             {
                 @await Html.PartialAsync("../../Shared/Components/_VoiceChannelPanel", Model.VoicePanel)
             }
-
-            <!-- Now Playing -->
-            <div class="vox-now-playing">
-                <h3>Now Playing</h3>
-                @if (!string.IsNullOrEmpty(Model.NowPlayingMessage))
-                {
-                    <div class="now-playing-message">
-                        @Model.NowPlayingMessage
-                    </div>
-                    <button type="button" class="stop-btn" id="stop-playback-btn" aria-label="Stop VOX playback">
-                        Stop
-                    </button>
-                }
-                else
-                {
-                    <div class="now-playing-empty">
-                        No audio playing
-                    </div>
-                }
-            </div>
 
             <!-- Clip Stats -->
             <div class="vox-stats">

--- a/src/DiscordBot.Bot/Pages/Portal/VOX/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Portal/VOX/Index.cshtml.cs
@@ -139,6 +139,8 @@ public class IndexModel : PortalPageModelBase
             {
                 GuildId = guildId,
                 IsCompact = true,
+                ShowNowPlaying = true,
+                ShowProgress = false,
                 IsConnected = isConnected,
                 ConnectedChannelId = connectedChannelId,
                 ConnectedChannelName = connectedChannelName,
@@ -150,7 +152,9 @@ public class IndexModel : PortalPageModelBase
                         Name = c.Name,
                         MemberCount = c.MemberCount
                     }).ToList(),
-                NowPlaying = null,
+                NowPlaying = string.IsNullOrEmpty(NowPlayingMessage)
+                    ? null
+                    : new NowPlayingInfo { Name = NowPlayingMessage },
                 Queue = []
             };
 


### PR DESCRIPTION
## Summary

Migrated VOX Portal from its custom Now Playing section to the unified VoiceChannelPanel component with Now Playing support added in PR #1509.

### Changes Made
- Removed custom Now Playing HTML section from VOX Portal sidebar (`.vox-now-playing` div with message display and stop button)
- Deleted all custom Now Playing CSS classes: `.vox-now-playing`, `.now-playing-message`, `.now-playing-empty`, `.stop-btn` (including hover/disabled states)
- Updated VoicePanel construction to include `ShowNowPlaying = true` and `ShowProgress = false` (VOX concatenation has no known duration)
- Set `NowPlaying` property based on existing `NowPlayingMessage` to pass now-playing info to the unified component
- Preserved `.vox-stats h3` CSS selector that was previously shared with `.vox-now-playing h3`

### Files Changed
- `src/DiscordBot.Bot/Pages/Portal/VOX/Index.cshtml` - Removed custom Now Playing HTML and CSS (64 lines removed)
- `src/DiscordBot.Bot/Pages/Portal/VOX/Index.cshtml.cs` - Updated VoicePanel with ShowNowPlaying, ShowProgress, NowPlaying properties (5 lines added)

### Review Status
- Code Review: APPROVED
- UI Review: SKIPPED (no new UI elements added, only removal of custom section in favor of existing unified component)
- Review iterations: 1
- Unresolved items: none

Closes #1512

🤖 Generated with [Claude Code](https://claude.com/claude-code)