### PR TITLE
feat: add PostgreSQL provider support foundation (#1541)

### DIFF
--- a/src/DiscordBot.Bot/Program.cs
+++ b/src/DiscordBot.Bot/Program.cs
@@ -16,6 +16,11 @@ using Serilog;
 using Serilog.Exceptions;
 using System.Reflection;
 
+// Npgsql 6+ defaults to timestamp with time zone for DateTime, which breaks existing
+// DateTime properties and HasDefaultValueSql("CURRENT_TIMESTAMP") calls in our entity configs.
+// This switch restores legacy behavior. See: https://www.npgsql.org/doc/types/datetime.htm
+AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
+
 // Get service version from assembly for consistent use across logging and APM
 var serviceVersion = Assembly.GetExecutingAssembly()
     .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion

--- a/src/DiscordBot.Bot/appsettings.json
+++ b/src/DiscordBot.Bot/appsettings.json
@@ -88,7 +88,8 @@
   },
   "Database": {
     "SlowQueryThresholdMs": 100,
-    "LogQueryParameters": true
+    "LogQueryParameters": true,
+    "Provider": null
   },
   "LogSanitization": {
     "Enabled": true,

--- a/src/DiscordBot.Infrastructure/Configuration/DatabaseSettings.cs
+++ b/src/DiscordBot.Infrastructure/Configuration/DatabaseSettings.cs
@@ -27,4 +27,10 @@ public class DatabaseSettings
     /// Default: true.
     /// </summary>
     public bool LogQueryParameters { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the database provider to use. Valid values: "Sqlite", "PostgreSql".
+    /// When null, the provider is auto-detected from the connection string.
+    /// </summary>
+    public string? Provider { get; set; }
 }

--- a/src/DiscordBot.Infrastructure/DiscordBot.Infrastructure.csproj
+++ b/src/DiscordBot.Infrastructure/DiscordBot.Infrastructure.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.*" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.*" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.14.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />

--- a/src/DiscordBot.Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/DiscordBot.Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using DiscordBot.Infrastructure.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Serilog;
 
 namespace DiscordBot.Infrastructure.Extensions;
 
@@ -28,15 +29,35 @@ public static class ServiceCollectionExtensions
         // Register query performance interceptor as singleton
         services.AddSingleton<QueryPerformanceInterceptor>();
 
-        // Register DbContext with SQLite and interceptor
+        // Register DbContext with provider detection
+        // Primary: explicit Database:Provider config key; Fallback: connection string heuristic
         var connectionString = configuration.GetConnectionString("DefaultConnection")
             ?? "Data Source=data/discordbot.db";
+
+        var dbSettings = configuration.GetSection(DatabaseSettings.SectionName).Get<DatabaseSettings>()
+            ?? new DatabaseSettings();
+        var isPostgreSql = dbSettings.Provider?.Equals("PostgreSql", StringComparison.OrdinalIgnoreCase) == true
+            || (string.IsNullOrEmpty(dbSettings.Provider) && IsPostgreSqlConnectionString(connectionString));
+
+        var providerName = isPostgreSql ? "PostgreSQL" : "SQLite";
+        Log.Information("Database provider: {Provider}", providerName);
 
         services.AddDbContext<BotDbContext>((serviceProvider, options) =>
         {
             var interceptor = serviceProvider.GetRequiredService<QueryPerformanceInterceptor>();
-            options.UseSqlite(connectionString)
-                   .AddInterceptors(interceptor);
+
+            if (isPostgreSql)
+            {
+                options.UseNpgsql(connectionString, npgsql =>
+                    npgsql.MigrationsAssembly("DiscordBot.Infrastructure"))
+                    .AddInterceptors(interceptor);
+            }
+            else
+            {
+                options.UseSqlite(connectionString, sqlite =>
+                    sqlite.MigrationsAssembly("DiscordBot.Infrastructure"))
+                    .AddInterceptors(interceptor);
+            }
         });
 
         // Register repositories
@@ -86,5 +107,17 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ICommandModuleConfigurationService, CommandModuleConfigurationService>();
 
         return services;
+    }
+
+    /// <summary>
+    /// Heuristic to detect PostgreSQL connection strings.
+    /// PostgreSQL strings typically contain Host= or Server=, while SQLite strings reference file paths.
+    /// Note: Npgsql accepts "Data Source=" as an alias for "Host=", making pure keyword matching
+    /// unreliable — this is why the explicit Database:Provider config is the primary mechanism.
+    /// </summary>
+    private static bool IsPostgreSqlConnectionString(string connectionString)
+    {
+        return connectionString.Contains("Host=", StringComparison.OrdinalIgnoreCase)
+            || connectionString.Contains("Server=", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/tests/DiscordBot.Tests/DiscordBot.Tests.csproj
+++ b/tests/DiscordBot.Tests/DiscordBot.Tests.csproj
@@ -12,8 +12,8 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="FluentAssertions" Version="8.8.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.23" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.23" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />


### PR DESCRIPTION
## Summary
- Replace unused `Microsoft.EntityFrameworkCore.SqlServer` with `Npgsql.EntityFrameworkCore.PostgreSQL` in Infrastructure project
- Implement two-tier database provider detection: explicit `Database:Provider` config key (primary) + connection string heuristic fallback (`Host=`/`Server=` → PostgreSQL, default → SQLite)
- Add `AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true)` for DateTime compatibility with Npgsql 6+
- Add `Provider` property to `DatabaseSettings` class and `appsettings.json`
- Align test project EF Core package versions (8.0.23) to match Npgsql's transitive dependencies

## Test plan
- [x] `dotnet build` succeeds with zero errors
- [x] `dotnet test` passes with same pre-existing failure count (39 vs 39 on main)
- [x] No new test failures introduced (diff confirmed identical test names)
- [ ] Verify SQLite still works as default with no config changes
- [ ] Verify `Database:Provider = "PostgreSql"` with PostgreSQL connection string connects successfully
- [ ] Verify startup log shows selected provider

Closes #1541
Closes #1546, closes #1547, closes #1548

🤖 Generated with [Claude Code](https://claude.com/claude-code)