### PR TITLE
feat: update Docker and env config for PostgreSQL support (#1543)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,9 +37,16 @@ Discord__OAuth__ClientSecret=YOUR_CLIENT_SECRET_HERE
 # DATABASE SETTINGS
 # =============================================================================
 
-# Default: SQLite at /app/data/discordbot.db (persisted via bot-data volume)
-# Override for PostgreSQL (when using --profile postgres):
-# ConnectionStrings__DefaultConnection=Host=postgres;Database=discordbot;Username=discordbot;Password=changeme
+# Database provider selection
+# Valid values: Sqlite (default, leave blank or omit), PostgreSql
+# DATABASE_PROVIDER=PostgreSql
+
+# Connection string for the database
+# SQLite (default — persisted via bot-data Docker volume):
+# CONNECTION_STRING=Data Source=data/discordbot.db
+#
+# PostgreSQL (when using --profile postgres; 'postgres' is the Docker service name):
+# CONNECTION_STRING=Host=postgres;Database=discordbot;Username=discordbot;Password=changeme
 
 # PostgreSQL container settings (when using --profile postgres):
 # POSTGRES_DB=discordbot

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ WORKDIR /app
 # Copy published output
 COPY --from=build /app/publish ./
 
-# Create data directory for SQLite volume mount and set ownership
+# Create data directory for SQLite database volume mount (not used when running PostgreSQL)
 RUN mkdir -p /app/data && chown -R appuser:appuser /app
 
 USER appuser

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,12 @@
 #   docker compose --profile postgres up -d                 # Bot + PostgreSQL
 #   docker compose --profile seq up -d                      # Bot + Seq logging
 #   docker compose --profile postgres --profile seq up -d   # Everything
+#
+# PostgreSQL workflow:
+#   1. Copy .env.example to .env and set DATABASE_PROVIDER=PostgreSql
+#   2. Set CONNECTION_STRING to the PostgreSQL connection string (use 'postgres' as hostname)
+#   3. Set POSTGRES_USER and POSTGRES_PASSWORD to match the connection string
+#   4. Run: docker compose --profile postgres up -d
 
 services:
   # ===========================================================================
@@ -15,6 +21,8 @@ services:
     env_file: .env
     environment:
       Observability__SeqUrl: ${SEQ_URL:-}
+      Database__Provider: ${DATABASE_PROVIDER:-}
+      ConnectionStrings__DefaultConnection: ${CONNECTION_STRING:-Data Source=data/discordbot.db}
     volumes:
       - bot-data:/app/data            # SQLite database persistence
       - ./sounds:/app/sounds:ro       # Optional: custom sound clips


### PR DESCRIPTION
## Summary
- Add `Database__Provider` and `ConnectionStrings__DefaultConnection` env vars to bot service in `docker-compose.yml` with shell-default syntax (SQLite remains default)
- Rewrite DATABASE SETTINGS section in `.env.example` with `DATABASE_PROVIDER` and `CONNECTION_STRING` documentation for both providers
- Update Dockerfile data directory comment to note it's unused for PostgreSQL

## Test plan
- [ ] `docker compose up -d` still works with SQLite (zero change)
- [ ] `docker compose --profile postgres up -d` with correct .env starts bot with PostgreSQL
- [x] YAML syntax validated

Closes #1543
Closes #1553, closes #1554, closes #1555

🤖 Generated with [Claude Code](https://claude.com/claude-code)