### PR TITLE
fix: resolve Discord OAuth redirect loop (#1536)

### DIFF
--- a/src/DiscordBot.Bot/Extensions/IdentityServiceExtensions.cs
+++ b/src/DiscordBot.Bot/Extensions/IdentityServiceExtensions.cs
@@ -76,7 +76,7 @@ public static class IdentityServiceExtensions
         {
             options.Cookie.HttpOnly = true;
             options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
-            options.Cookie.SameSite = SameSiteMode.Strict;
+            options.Cookie.SameSite = SameSiteMode.Lax;
             options.ExpireTimeSpan = TimeSpan.FromDays(identityConfig.CookieExpireDays);
             options.SlidingExpiration = identityConfig.CookieSlidingExpiration;
             options.LoginPath = identityConfig.LoginPath;

--- a/src/DiscordBot.Bot/Pages/Account/ExternalLogin.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Account/ExternalLogin.cshtml.cs
@@ -71,6 +71,13 @@ public class ExternalLoginModel : PageModel
     public async Task<IActionResult> OnGetCallbackAsync(string? returnUrl = null, string? remoteError = null)
     {
         returnUrl ??= Url.Content("~/");
+
+        // Sanitize ReturnUrl - if it points to the login page, redirect to home instead
+        if (!string.IsNullOrEmpty(returnUrl) && returnUrl.Contains("/Account/Login", StringComparison.OrdinalIgnoreCase))
+        {
+            returnUrl = Url.Content("~/");
+        }
+
         ReturnUrl = returnUrl;
 
         if (!string.IsNullOrEmpty(remoteError))

--- a/src/DiscordBot.Bot/Pages/Account/Login.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Account/Login.cshtml.cs
@@ -95,6 +95,13 @@ public class LoginModel : PageModel
         }
 
         returnUrl ??= Url.Content("~/");
+
+        // Sanitize ReturnUrl - if it points to the login page, redirect to home instead
+        if (!string.IsNullOrEmpty(returnUrl) && returnUrl.Contains("/Account/Login", StringComparison.OrdinalIgnoreCase))
+        {
+            returnUrl = Url.Content("~/");
+        }
+
         ReturnUrl = returnUrl;
 
         _logger.LogDebug("Login page accessed, return URL: {ReturnUrl}", returnUrl);
@@ -216,6 +223,12 @@ public class LoginModel : PageModel
         }
 
         returnUrl ??= Url.Content("~/");
+
+        // Sanitize ReturnUrl - if it points to the login page, redirect to home instead
+        if (!string.IsNullOrEmpty(returnUrl) && returnUrl.Contains("/Account/Login", StringComparison.OrdinalIgnoreCase))
+        {
+            returnUrl = Url.Content("~/");
+        }
 
         _logger.LogInformation("Discord OAuth login initiated");
 


### PR DESCRIPTION
## Summary

- Changed auth cookie `SameSite` from `Strict` to `Lax` in `IdentityServiceExtensions.cs` to allow cookies on top-level navigations (OAuth callback) while still protecting against CSRF on POST requests
- Added ReturnUrl sanitization in `Login.cshtml.cs` (OnGet and OnPostDiscordLogin) to redirect to `/` if ReturnUrl points back to the login page
- Added ReturnUrl sanitization in `ExternalLogin.cshtml.cs` (OnGetCallbackAsync) to apply the same sanitization after OAuth callback

## Root Cause

`SameSite=Strict` on the auth cookie prevented browsers from sending cookies on cross-site redirects (discord.com -> our app). After the OAuth flow completed, the app could not read the auth cookie, causing it to treat the user as unauthenticated and redirect back to login. Additionally, ReturnUrl was not sanitized when it pointed back to the login page, creating a redirect loop.

## Files Changed

- `src/DiscordBot.Bot/Extensions/IdentityServiceExtensions.cs`
- `src/DiscordBot.Bot/Pages/Account/Login.cshtml.cs`
- `src/DiscordBot.Bot/Pages/Account/ExternalLogin.cshtml.cs`

## Test Plan

- [ ] Log in via Discord OAuth and verify redirect lands on dashboard, not login page
- [ ] Verify CSRF protection still functions on POST requests with `SameSite=Lax`
- [ ] Confirm no redirect loop occurs when ReturnUrl is set to the login page URL

Closes #1536

🤖 Generated with [Claude Code](https://claude.com/claude-code)