### PR TITLE
fix: ConvertValue returns default for empty strings on nullable types

### DIFF
--- a/src/DiscordBot.Infrastructure/Services/SettingsService.cs
+++ b/src/DiscordBot.Infrastructure/Services/SettingsService.cs
@@ -480,6 +480,9 @@ public class SettingsService : ISettingsService
         // Handle nullable types
         var underlyingType = Nullable.GetUnderlyingType(targetType) ?? targetType;
 
+        if (string.IsNullOrWhiteSpace(value) && underlyingType != typeof(string))
+            return default;
+
         if (underlyingType == typeof(string))
         {
             return (T)(object)value;


### PR DESCRIPTION
## Summary

Added an early return check in `ConvertValue<T>()` that returns `default(T)` when the value is null, empty, or whitespace for non-string types. This prevents `FormatException` from being thrown when parsing empty setting values (e.g., `Appearance:DefaultThemeId` with value `''`) while preserving normal parsing behavior for non-empty values. Eliminates noisy warning logs on every page load.

## Changes
- src/DiscordBot.Infrastructure/Services/SettingsService.cs: Added null/empty/whitespace check before type conversion

Closes #1567