### PR TITLE
fix: Audit Logs tab defaults to 30-day date range (#1572)

### DIFF
--- a/src/DiscordBot.Bot/Pages/Admin/Logs/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Admin/Logs/Index.cshtml.cs
@@ -210,14 +210,11 @@ public class IndexModel : PageModel
 
     private async Task LoadAuditLogsAsync(CancellationToken cancellationToken)
     {
-        // Set default date range to last 24 hours if no filters specified
-        if (!AuditStartDate.HasValue && !AuditEndDate.HasValue && !Category.HasValue &&
-            !Action.HasValue && string.IsNullOrEmpty(ActorId) &&
-            string.IsNullOrEmpty(TargetType) && !AuditGuildId.HasValue &&
-            string.IsNullOrEmpty(AuditSearchTerm))
+        // Default to last 30 days when no date filters specified
+        if (!AuditStartDate.HasValue && !AuditEndDate.HasValue)
         {
-            AuditStartDate = DateTime.UtcNow.AddDays(-1);
-            AuditEndDate = DateTime.UtcNow;
+            AuditStartDate = DateTime.UtcNow.Date.AddDays(-30);
+            AuditEndDate = DateTime.UtcNow.Date.AddDays(1);
         }
 
         _logger.LogDebug("Loading audit logs with filters: Category={Category}, Action={Action}, ActorId={ActorId}, TargetType={TargetType}, GuildId={GuildId}, StartDate={StartDate}, EndDate={EndDate}, SearchTerm={SearchTerm}, Page={Page}, PageSize={PageSize}",


### PR DESCRIPTION
## Summary
- Changed the Audit Logs tab default date range from 24 hours to **30 days**
- Date defaults now apply whenever `AuditStartDate` and `AuditEndDate` are both null, regardless of other filter values (Category, Action, Actor, etc.)
- Uses `.Date` for clean day boundaries (`today - 30` to `tomorrow`)

Closes #1572

## Test plan
- [ ] Load `/Admin/Logs?tab=audit` with no filters — verify 30-day range is shown in date inputs
- [ ] Set a Category filter without dates — verify 30-day default still applies
- [ ] Manually set custom dates — verify they are respected (not overwritten)
- [ ] Clear Filters — verify it resets to 30-day default
- [ ] Export CSV — verify it respects the default date range
- [ ] Check Message Logs tab — verify its 7-day default is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)