### PR TITLE
fix: replace broken confirm() with typed confirmation dialog on Privacy page (#1582)

### DIFF
--- a/src/DiscordBot.Bot/Pages/Account/Privacy.cshtml
+++ b/src/DiscordBot.Bot/Pages/Account/Privacy.cshtml
@@ -1,6 +1,6 @@
 @page
 @model PrivacyModel
-@using DiscordBot.Bot.ViewModels.Components
+@* ViewModels.Components removed — no longer using server-rendered confirmation modal *@
 @{
     ViewData["Title"] = "Privacy & Consent";
 }
@@ -229,7 +229,7 @@ else
                     <p class="text-sm text-text-secondary mb-3">
                         Permanently delete all your data from our system. This action cannot be undone.
                     </p>
-                    <button type="button" onclick="quickActions.showConfirmationModal('deleteDataModal')" class="inline-flex items-center justify-center gap-2 py-2 px-4 text-sm font-semibold text-white bg-error border border-error rounded-md transition-colors hover:bg-error-hover hover:border-error-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-error focus-visible:ring-offset-2 focus-visible:ring-offset-bg-secondary">
+                    <button type="button" onclick="deleteAllData()" class="inline-flex items-center justify-center gap-2 py-2 px-4 text-sm font-semibold text-white bg-error border border-error rounded-md transition-colors hover:bg-error-hover hover:border-error-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-error focus-visible:ring-offset-2 focus-visible:ring-offset-bg-secondary">
                         <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
                         </svg>
@@ -371,21 +371,50 @@ else
     </div>
 }
 
-@if (Model.IsDiscordLinked)
-{
-    <partial name="Shared/Components/_ConfirmationModal" model='new ConfirmationModalViewModel
-    {
-        Id = "deleteDataModal",
-        Title = "Delete All Data",
-        Message = "Are you sure you want to permanently delete ALL your data? This action cannot be undone.",
-        ConfirmText = "Delete My Data",
-        Variant = ConfirmationVariant.Danger,
-        FormAction = "/Account/Privacy",
-        FormHandler = "DeleteData"
-    }' />
-}
-
 <script>
+    async function deleteAllData() {
+        const confirmed = await quickActions.typedConfirm({
+            title: 'Permanently Delete All Data',
+            message: 'This will permanently delete ALL your personal data including message logs, preferences, and consent records. This action cannot be undone.',
+            requiredText: 'DELETE',
+            inputLabel: 'Type DELETE to confirm',
+            variant: 'danger',
+            confirmText: 'Delete All Data'
+        });
+        if (!confirmed) return;
+
+        const tokenInput = document.querySelector('input[name="__RequestVerificationToken"]');
+        if (!tokenInput) {
+            quickActions.showToast('Security token not found. Please refresh the page.', 'error');
+            return;
+        }
+        const token = tokenInput.value;
+        const btn = document.querySelector('[onclick="deleteAllData()"]');
+        if (btn) btn.disabled = true;
+
+        try {
+            const response = await fetch('?handler=DeleteData', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                    'RequestVerificationToken': token
+                },
+                body: '__RequestVerificationToken=' + encodeURIComponent(token)
+            });
+            const data = await response.json();
+            if (response.ok && data.success) {
+                quickActions.showToast(data.message || 'All data has been deleted.', 'success');
+                setTimeout(() => window.location.href = data.redirectUrl || '/', 2000);
+            } else {
+                quickActions.showToast(data.message || 'Failed to delete data. Please try again.', 'error');
+                if (btn) btn.disabled = false;
+            }
+        } catch (error) {
+            quickActions.showToast('An error occurred. Please try again.', 'error');
+            if (btn) btn.disabled = false;
+        }
+    }
+
     window.confirmConsentToggle = async function(checkbox) {
         const form = checkbox.closest('form');
         const consentName = form.dataset.consentName;

--- a/src/DiscordBot.Bot/Pages/Account/Privacy.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Account/Privacy.cshtml.cs
@@ -283,6 +283,7 @@ public class PrivacyModel : PageModel
 
     /// <summary>
     /// Handles POST requests to delete user data.
+    /// Returns JSON for AJAX consumption by the typed confirmation dialog flow.
     /// </summary>
     public async Task<IActionResult> OnPostDeleteDataAsync()
     {
@@ -292,15 +293,19 @@ public class PrivacyModel : PageModel
         if (user == null)
         {
             _logger.LogWarning("User not found during delete data");
-            return NotFound("User not found.");
+            return new JsonResult(new { success = false, message = "User not found." })
+            {
+                StatusCode = StatusCodes.Status404NotFound
+            };
         }
 
         if (!user.DiscordUserId.HasValue)
         {
             _logger.LogWarning("User {UserId} attempted to delete data without Discord account linked", user.Id);
-            StatusMessage = "You must link your Discord account before deleting data.";
-            IsSuccess = false;
-            return RedirectToPage();
+            return new JsonResult(new { success = false, message = "You must link your Discord account before deleting data." })
+            {
+                StatusCode = StatusCodes.Status400BadRequest
+            };
         }
 
         var discordUserId = user.DiscordUserId.Value;
@@ -315,9 +320,10 @@ public class PrivacyModel : PageModel
             if (!canPurge)
             {
                 _logger.LogWarning("Cannot purge user {UserId}: {BlockingReason}", user.Id, reason);
-                StatusMessage = reason ?? "Your data cannot be deleted at this time.";
-                IsSuccess = false;
-                return RedirectToPage();
+                return new JsonResult(new { success = false, message = reason ?? "Your data cannot be deleted at this time." })
+                {
+                    StatusCode = StatusCodes.Status400BadRequest
+                };
             }
 
             var result = await _purgeService.PurgeUserDataAsync(
@@ -332,18 +338,21 @@ public class PrivacyModel : PageModel
                 _logger.LogInformation("Successfully deleted data for user {UserId}. {RecordCount} records deleted",
                     user.Id, totalDeleted);
 
-                StatusMessage = $"Your data has been permanently deleted. {totalDeleted} records were removed from the system.";
-                IsSuccess = true;
-
-                // Sign out the user since their account has been deleted
-                return RedirectToPage("/Account/Logout", new { area = "" });
+                // Return JSON with a redirect URL so the client can navigate after showing the toast.
+                // The user's account has been purged, so redirect to logout.
+                return new JsonResult(new
+                {
+                    success = true,
+                    message = $"Your data has been permanently deleted. {totalDeleted} records were removed from the system.",
+                    redirectUrl = Url.Page("/Account/Logout") ?? "/"
+                });
             }
             else
             {
                 _logger.LogWarning("Failed to delete data for user {UserId}: {ErrorCode} - {ErrorMessage}",
                     user.Id, result.ErrorCode, result.ErrorMessage);
 
-                StatusMessage = result.ErrorCode switch
+                var errorMessage = result.ErrorCode switch
                 {
                     UserPurgeResultDto.UserNotFound => "User not found in the database.",
                     UserPurgeResultDto.UserHasAdminRole => "Cannot delete data for users with admin roles. Contact support.",
@@ -351,16 +360,20 @@ public class PrivacyModel : PageModel
                     UserPurgeResultDto.TransactionFailed => "Failed to delete data. Please try again.",
                     _ => result.ErrorMessage ?? "Failed to delete data. Please try again."
                 };
-                IsSuccess = false;
+
+                return new JsonResult(new { success = false, message = errorMessage })
+                {
+                    StatusCode = StatusCodes.Status422UnprocessableEntity
+                };
             }
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error deleting data for user {UserId}", user.Id);
-            StatusMessage = "An error occurred while deleting your data. Please try again.";
-            IsSuccess = false;
+            return new JsonResult(new { success = false, message = "An error occurred while deleting your data. Please try again." })
+            {
+                StatusCode = StatusCodes.Status500InternalServerError
+            };
         }
-
-        return RedirectToPage();
     }
 }


### PR DESCRIPTION
## Summary

- Replaced the broken `window.confirm()` on the Privacy page's "Delete All Data" button with `quickActions.typedConfirm()` — the old dialog told users to "type DELETE" but only offered OK/Cancel buttons with no text input
- Converted `OnPostDeleteDataAsync` handler from redirect responses to `JsonResult` for AJAX submission with toast feedback
- Added anti-forgery token null guard, double-submit protection (button disabling), and null-safe logout URL

Closes #1582

> **Note:** Issue #1581 (FlaggedEvents and performance alerts migration) was already completed in commit 2f27897. Those files already use `quickActions.confirm()` and `quickActions.showToast()` with no remaining native `alert()`/`confirm()` calls.

## Test plan

- [ ] Navigate to Account → Privacy & Consent
- [ ] Click "Delete My Data" button
- [ ] Verify the typed confirmation modal appears requiring "DELETE" to be typed
- [ ] Verify the confirm button is disabled until "DELETE" is typed exactly
- [ ] Type "DELETE" and click confirm — verify success toast appears and redirects to logout
- [ ] Test cancel/escape dismisses the modal without action
- [ ] Test with expired session (no anti-forgery token) — should show error toast, not crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)