### PR TITLE
fix: copy AI assistant runtime docs into Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,8 +59,9 @@ WORKDIR /app
 # Copy published output
 COPY --from=build /app/publish ./
 
-# Copy AI assistant prompt templates (referenced at runtime by PromptTemplate service)
+# Copy AI assistant runtime docs (prompt templates + documentation tool articles)
 COPY docs/agents/ ./docs/agents/
+COPY docs/articles/ ./docs/articles/
 
 # Create data directory for SQLite database volume mount (not used when running PostgreSQL)
 RUN mkdir -p /app/data && chown -R appuser:appuser /app


### PR DESCRIPTION
## Summary
- Copy `docs/agents/` into Docker image for `PromptTemplate` service (agent prompt templates)
- Copy `docs/articles/` into Docker image for `DocumentationToolProvider` (assistant knowledge base)

Both paths are configured via `AssistantOptions` (`AgentPromptPath` and `DocumentationBasePath`) and are loaded at runtime, but were missing from the Docker image since they aren't part of `dotnet publish` output.

Closes #1598

## Test plan
- [ ] Build Docker image: `docker build -t discordbot .`
- [ ] Verify files exist: `docker run --rm discordbot ls docs/agents/ docs/articles/`
- [ ] Confirm AI assistant no longer logs "Template file not found" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)