### PR TITLE
feat: upgrade from .NET 8 to .NET 9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # =============================================================================
 # Build Stage
 # =============================================================================
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 
 WORKDIR /src
 
@@ -39,7 +39,7 @@ RUN dotnet publish src/DiscordBot.Bot/DiscordBot.Bot.csproj \
 # =============================================================================
 # Runtime Stage
 # =============================================================================
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS runtime
 
 # Install runtime dependencies (audio libs + curl for health checks)
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "9.0.311",
+    "rollForward": "latestMinor"
+  }
+}

--- a/src/DiscordBot.Bot/DiscordBot.Bot.csproj
+++ b/src/DiscordBot.Bot/DiscordBot.Bot.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>7b84433c-c2a8-46db-a8bf-58786ea4f28e</UserSecretsId>
@@ -15,13 +15,13 @@
 
   <ItemGroup>
     <PackageReference Include="Anthropic.SDK" Version="5.8.0" />
-    <PackageReference Include="AspNet.Security.OAuth.Discord" Version="8.0.0" />
+    <PackageReference Include="AspNet.Security.OAuth.Discord" Version="9.0.0" />
     <PackageReference Include="Cronos" Version="0.11.1" />
     <PackageReference Include="Discord.Net" Version="3.19.0-beta.1" />
     <PackageReference Include="libsodium" Version="1.0.20.1" />
     <PackageReference Include="OpusDotNet.opus.win-x64" Version="1.3.1" />
-    <PackageReference Include="Microsoft.CognitiveServices.Speech" Version="1.41.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.*">
+    <PackageReference Include="Microsoft.CognitiveServices.Speech" Version="1.41.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -30,12 +30,12 @@
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.14.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.15" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.10.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.14.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="8.0.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Bcl.TimeProvider" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="9.0.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Bcl.TimeProvider" Version="9.0.0" />
     <PackageReference Include="Elastic.Serilog.Sinks" Version="8.11.0" />
     <PackageReference Include="Elastic.Apm.SerilogEnricher" Version="8.6.0" />
     <PackageReference Include="Elastic.Apm.NetCoreAll" Version="1.29.0" />

--- a/src/DiscordBot.Core/DiscordBot.Core.csproj
+++ b/src/DiscordBot.Core/DiscordBot.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
   </ItemGroup>
 

--- a/src/DiscordBot.Infrastructure/DiscordBot.Infrastructure.csproj
+++ b/src/DiscordBot.Infrastructure/DiscordBot.Infrastructure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -10,11 +10,11 @@
 
   <ItemGroup>
     <PackageReference Include="Anthropic" Version="12.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.*" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.*" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.14.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />

--- a/tests/DiscordBot.Tests/DiscordBot.Tests.csproj
+++ b/tests/DiscordBot.Tests/DiscordBot.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -12,11 +12,11 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="FluentAssertions" Version="8.8.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.23" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.23" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />


### PR DESCRIPTION
## Summary
- All four `.csproj` files (Core, Infrastructure, Bot, Tests) upgraded from `net8.0` to `net9.0`
- Created `global.json` pinning SDK to 9.0.311 with `latestMinor` roll-forward
- Upgraded Microsoft/EF Core/Identity/ASP.NET packages from 8.x to 9.x
- Updated Dockerfile base images from `sdk:8.0`/`aspnet:8.0` to `sdk:9.0`/`aspnet:9.0`
- Fixed version warnings for `Microsoft.CognitiveServices.Speech` (1.41.0 → 1.41.1) and `OpenTelemetry.Instrumentation.EntityFrameworkCore` (beta.15 → 1.10.0-beta.1)

## Verification
- `dotnet build` passes with 0 errors (79 warnings, all pre-existing)
- `dotnet test`: 3348 passed, 39 failed, 19 skipped — **all 39 failures are pre-existing** on the `blazor-migration` branch (verified by running tests on the base branch without changes)
- No new warnings or errors introduced by the upgrade

## Package Changes
| Package | Old | New |
|---------|-----|-----|
| Microsoft.Extensions.Identity.Stores | 8.0.0 | 9.0.0 |
| Microsoft.AspNetCore.Identity.EntityFrameworkCore | 8.0.0 | 9.0.0 |
| Microsoft.EntityFrameworkCore (+ Sqlite, InMemory, Design) | 8.x | 9.0.0 |
| Npgsql.EntityFrameworkCore.PostgreSQL | 8.x | 9.0.0 |
| Microsoft.Extensions.Options.ConfigurationExtensions | 8.0.0 | 9.0.0 |
| AspNet.Security.OAuth.Discord | 8.0.0 | 9.0.0 |
| Microsoft.Extensions.Hosting.Systemd | 8.0.0 | 9.0.0 |
| Serilog.AspNetCore | 8.0.0 | 9.0.0 |
| Microsoft.Bcl.TimeProvider | 8.0.0 | 9.0.0 |
| Microsoft.EntityFrameworkCore.Design | 8.x | 9.0.0 |
| Microsoft.Extensions.Diagnostics.Testing | 8.0.0 | 9.0.0 |
| Microsoft.Extensions.TimeProvider.Testing | 8.0.0 | 9.0.0 |
| Microsoft.NET.Test.Sdk | 17.8.0 | 17.12.0 |
| Microsoft.CognitiveServices.Speech | 1.41.0 | 1.41.1 |
| OpenTelemetry.Instrumentation.EntityFrameworkCore | 1.0.0-beta.15 | 1.10.0-beta.1 |

## Test plan
- [x] `dotnet build` succeeds with no errors
- [x] `dotnet test` — no new failures (39 pre-existing failures unchanged)
- [ ] Manual: login flow, dashboard, major guild pages
- [ ] Docker build: `docker build .` succeeds
- [ ] EF Core migrations run for both SQLite and PostgreSQL contexts

Closes #1624, closes #1625, closes #1628

🤖 Generated with [Claude Code](https://claude.com/claude-code)