### PR TITLE
feat: add Phase 2 Blazor component library (#1654)

### DIFF
--- a/src/DiscordBot.Bot/Components/Interop/ChartJsInterop.cs
+++ b/src/DiscordBot.Bot/Components/Interop/ChartJsInterop.cs
@@ -1,0 +1,40 @@
+using Microsoft.JSInterop;
+
+namespace DiscordBot.Bot.Components.Interop;
+
+public class ChartJsInterop(IJSRuntime jsRuntime) : IAsyncDisposable
+{
+    private readonly HashSet<string> _chartIds = [];
+
+    public async ValueTask CreateChartAsync(string canvasId, object config)
+    {
+        await jsRuntime.InvokeVoidAsync("BlazorChartInterop.createChart", canvasId, config);
+        _chartIds.Add(canvasId);
+    }
+
+    public ValueTask UpdateChartAsync(string canvasId, object data) =>
+        jsRuntime.InvokeVoidAsync("BlazorChartInterop.updateChart", canvasId, data);
+
+    public async ValueTask DestroyChartAsync(string canvasId)
+    {
+        await jsRuntime.InvokeVoidAsync("BlazorChartInterop.destroyChart", canvasId);
+        _chartIds.Remove(canvasId);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var canvasId in _chartIds)
+        {
+            try
+            {
+                await jsRuntime.InvokeVoidAsync("BlazorChartInterop.destroyChart", canvasId);
+            }
+            catch (JSDisconnectedException)
+            {
+                // Circuit disconnected, chart is already gone
+            }
+        }
+
+        _chartIds.Clear();
+    }
+}

--- a/src/DiscordBot.Bot/Components/Interop/ClipboardInterop.cs
+++ b/src/DiscordBot.Bot/Components/Interop/ClipboardInterop.cs
@@ -1,0 +1,9 @@
+using Microsoft.JSInterop;
+
+namespace DiscordBot.Bot.Components.Interop;
+
+public class ClipboardInterop(IJSRuntime jsRuntime)
+{
+    public ValueTask CopyTextAsync(string text) =>
+        jsRuntime.InvokeVoidAsync("navigator.clipboard.writeText", text);
+}

--- a/src/DiscordBot.Bot/Components/Interop/NavigationInterop.cs
+++ b/src/DiscordBot.Bot/Components/Interop/NavigationInterop.cs
@@ -1,0 +1,12 @@
+using Microsoft.JSInterop;
+
+namespace DiscordBot.Bot.Components.Interop;
+
+public class NavigationInterop(IJSRuntime jsRuntime)
+{
+    public ValueTask ScrollToTopAsync() =>
+        jsRuntime.InvokeVoidAsync("window.scrollTo", 0, 0);
+
+    public ValueTask ScrollToElementAsync(string elementId) =>
+        jsRuntime.InvokeVoidAsync("BlazorNavigationInterop.scrollToElement", elementId);
+}

--- a/src/DiscordBot.Bot/Components/Interop/ThemeInterop.cs
+++ b/src/DiscordBot.Bot/Components/Interop/ThemeInterop.cs
@@ -1,0 +1,12 @@
+using Microsoft.JSInterop;
+
+namespace DiscordBot.Bot.Components.Interop;
+
+public class ThemeInterop(IJSRuntime jsRuntime)
+{
+    public ValueTask ApplyThemeAsync(string theme) =>
+        jsRuntime.InvokeVoidAsync("ThemeManager.applyTheme", theme);
+
+    public ValueTask<string> GetCurrentThemeAsync() =>
+        jsRuntime.InvokeAsync<string>("ThemeManager.getCurrentTheme");
+}

--- a/src/DiscordBot.Bot/Components/Interop/TimezoneInterop.cs
+++ b/src/DiscordBot.Bot/Components/Interop/TimezoneInterop.cs
@@ -1,0 +1,12 @@
+using Microsoft.JSInterop;
+
+namespace DiscordBot.Bot.Components.Interop;
+
+public class TimezoneInterop(IJSRuntime jsRuntime)
+{
+    public ValueTask<string> GetTimezoneAsync() =>
+        jsRuntime.InvokeAsync<string>("timezoneUtils.getTimezone");
+
+    public ValueTask<string> FormatLocalTimeAsync(string utcIso) =>
+        jsRuntime.InvokeAsync<string>("timezoneUtils.formatLocalTime", utcIso);
+}

--- a/src/DiscordBot.Bot/Components/Interop/ToastInterop.cs
+++ b/src/DiscordBot.Bot/Components/Interop/ToastInterop.cs
@@ -1,0 +1,15 @@
+using Microsoft.JSInterop;
+
+namespace DiscordBot.Bot.Components.Interop;
+
+public class ToastInterop(IJSRuntime jsRuntime)
+{
+    public ValueTask ShowAsync(string type, string message) =>
+        jsRuntime.InvokeVoidAsync("ToastManager.show", type, message);
+
+    public ValueTask ShowAsync(string type, string message, string title) =>
+        jsRuntime.InvokeVoidAsync("ToastManager.show", type, message, new { title });
+
+    public ValueTask ClearAllAsync() =>
+        jsRuntime.InvokeVoidAsync("ToastManager.clearAll");
+}

--- a/src/DiscordBot.Bot/Components/Shared/ActivityFeed.razor
+++ b/src/DiscordBot.Bot/Components/Shared/ActivityFeed.razor
@@ -1,0 +1,98 @@
+<div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden" id="activity-feed-card">
+    <!-- Header -->
+    <div class="px-4 py-3 border-b border-border-primary bg-bg-primary flex items-center justify-between">
+        <div class="flex items-center gap-2">
+            <svg class="w-5 h-5 text-accent-blue" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
+            </svg>
+            <h2 class="text-lg font-semibold text-text-primary">Live Activity</h2>
+        </div>
+        <button type="button"
+                class="btn-toggle"
+                aria-label="@(_isPaused ? "Resume activity feed" : "Pause activity feed")"
+                aria-pressed="@_isPaused.ToString().ToLowerInvariant()"
+                @onclick="TogglePause">
+            <svg class="w-4 h-4 @(_isPaused ? "hidden" : "")" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 9v6m4-6v6" />
+            </svg>
+            <svg class="w-4 h-4 @(_isPaused ? "" : "hidden")" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
+            </svg>
+            <span>@(_isPaused ? "Resume" : "Pause")</span>
+        </button>
+    </div>
+
+    <!-- Paused Indicator -->
+    @if (_isPaused)
+    {
+        <div class="px-4 py-2 bg-warning/10 border-b border-warning/20 text-warning text-sm flex items-center gap-2"
+             role="alert">
+            <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+            </svg>
+            <span>Activity feed is paused. Updates will resume when you unpause.</span>
+        </div>
+    }
+
+    <!-- Activity Feed Container -->
+    <div class="px-4 py-3 max-h-80 overflow-y-auto" id="activity-feed-container">
+        <div id="activity-feed" class="space-y-2" role="log" aria-live="polite" aria-atomic="false">
+            @if (Items.Any())
+            {
+                @foreach (var item in Items.Take(MaxItems))
+                {
+                    <div class="activity-item flex items-start gap-3 p-3 bg-bg-primary border border-border-primary rounded-md transition-all duration-150">
+                        <div class="flex-shrink-0 w-8 h-8 flex items-center justify-center bg-bg-tertiary rounded-full text-lg">
+                            <span class="activity-icon" aria-hidden="true">@GetIcon(item.Type)</span>
+                        </div>
+                        <div class="flex-1 min-w-0">
+                            <p class="text-sm text-text-primary">@item.Message</p>
+                            <div class="mt-1 flex items-center gap-2 text-xs text-text-tertiary">
+                                <span>@item.Source</span>
+                                <span aria-hidden="true">&bull;</span>
+                                <time>@item.RelativeTime</time>
+                            </div>
+                        </div>
+                    </div>
+                }
+            }
+            else
+            {
+                <div class="text-center py-8 text-text-tertiary text-sm">
+                    @EmptyMessage
+                </div>
+            }
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter] public bool IsPaused { get; set; }
+    [Parameter] public int MaxItems { get; set; } = 15;
+    [Parameter] public string EmptyMessage { get; set; } = "No recent activity";
+    [Parameter] public List<ActivityFeedItemViewModel> Items { get; set; } = new();
+    [Parameter] public EventCallback<bool> OnPauseToggled { get; set; }
+
+    // TODO: Subscribe to IDashboardEventBus in Phase 5
+
+    private bool _isPaused;
+
+    protected override void OnParametersSet()
+    {
+        _isPaused = IsPaused;
+    }
+
+    private async Task TogglePause()
+    {
+        _isPaused = !_isPaused;
+        await OnPauseToggled.InvokeAsync(_isPaused);
+    }
+
+    private static string GetIcon(ActivityItemType type) => type switch
+    {
+        ActivityItemType.Success => "\U0001f527",
+        ActivityItemType.Warning => "\u26a0\ufe0f",
+        ActivityItemType.Error => "\u274c",
+        _ => "\U0001f4e2"
+    };
+}

--- a/src/DiscordBot.Bot/Components/Shared/ActivityFeedTimeline.razor
+++ b/src/DiscordBot.Bot/Components/Shared/ActivityFeedTimeline.razor
@@ -1,0 +1,114 @@
+@{
+    var maxHeightStyle = !string.IsNullOrEmpty(MaxHeight) ? $"max-height: {MaxHeight};" : "";
+}
+
+<div class="bg-bg-secondary border border-border-primary rounded-xl overflow-hidden h-full flex flex-col">
+    <!-- Header -->
+    <div class="flex items-center justify-between px-6 py-4 border-b border-border-primary">
+        <div class="flex items-center gap-3">
+            <h2 class="text-lg font-semibold text-text-primary">@Title</h2>
+            @if (_isPaused)
+            {
+                <span class="text-xs text-warning font-medium">Paused</span>
+            }
+        </div>
+        <div class="flex items-center gap-2">
+            @if (ShowRefreshButton)
+            {
+                <button
+                    type="button"
+                    class="flex items-center gap-1.5 px-3 py-1.5 text-sm text-text-secondary hover:text-text-primary hover:bg-bg-hover rounded-md transition-all duration-150"
+                    aria-pressed="@_isPaused.ToString().ToLowerInvariant()"
+                    aria-label="@(_isPaused ? "Resume activity feed" : "Pause activity feed")"
+                    @onclick="TogglePause"
+                >
+                    <svg class="w-4 h-4 @(_isPaused ? "hidden" : "")" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 9v6m4-6v6m7-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                    <svg class="w-4 h-4 @(_isPaused ? "" : "hidden")" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                    <span>@(_isPaused ? "Resume" : "Pause")</span>
+                </button>
+            }
+        </div>
+    </div>
+
+    <!-- Timeline Container -->
+    <div class="p-4 overflow-y-auto flex-grow" style="@maxHeightStyle">
+        <div class="activity-timeline">
+            @if (Items.Any())
+            {
+                @foreach (var item in Items)
+                {
+                    <div class="activity-item @item.TypeClassName">
+                        <div class="bg-bg-primary/50 rounded-lg p-3">
+                            <div class="flex items-center gap-2 mb-1">
+                                <span class="activity-icon text-sm">@(item.Type == ActivityItemType.Success ? "\U0001f527" : "\u26a0\ufe0f")</span>
+                                <span class="activity-timestamp text-xs text-text-tertiary font-mono">@item.Timestamp.ToLocalTime().ToString("HH:mm:ss")</span>
+                            </div>
+                            <p class="text-sm text-text-primary activity-description">
+                                @if (!string.IsNullOrEmpty(item.CommandText))
+                                {
+                                    @((MarkupString)item.Message.Replace(item.CommandText, $"<span class=\"font-mono text-accent-orange\">{item.CommandText}</span>"))
+                                }
+                                else
+                                {
+                                    @item.Message
+                                }
+                            </p>
+                            <p class="text-xs text-text-tertiary mt-1 activity-guild">@item.Source - @item.RelativeTime</p>
+                        </div>
+                    </div>
+                }
+            }
+            <!-- Empty state (hidden when items exist) -->
+            @if (!Items.Any())
+            {
+                <div class="flex flex-col items-center justify-center py-12 text-center">
+                    <svg class="w-12 h-12 text-text-tertiary mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+                    </svg>
+                    <p class="text-sm text-text-secondary">No recent activity</p>
+                    <p class="text-xs text-text-tertiary mt-1">Activity will appear here as it occurs</p>
+                </div>
+            }
+        </div>
+    </div>
+
+    <!-- Footer -->
+    @if (!string.IsNullOrEmpty(ViewAllUrl))
+    {
+        <div class="px-6 py-3 border-t border-border-primary bg-bg-primary/30">
+            <a
+                href="@ViewAllUrl"
+                class="text-sm text-accent-blue hover:text-accent-blue-hover font-medium transition-colors duration-150"
+            >
+                View all activity
+                <svg class="inline-block w-4 h-4 ml-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                </svg>
+            </a>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter] public string Title { get; set; } = "Recent Activity";
+    [Parameter] public List<ActivityFeedItemViewModel> Items { get; set; } = new();
+    [Parameter] public bool ShowRefreshButton { get; set; } = true;
+    [Parameter] public string? ViewAllUrl { get; set; }
+    [Parameter] public string MaxHeight { get; set; } = "400px";
+    [Parameter] public EventCallback<bool> OnPauseToggled { get; set; }
+
+    // TODO: Subscribe to IDashboardEventBus in Phase 5
+
+    private bool _isPaused;
+
+    private async Task TogglePause()
+    {
+        _isPaused = !_isPaused;
+        await OnPauseToggled.InvokeAsync(_isPaused);
+    }
+}

--- a/src/DiscordBot.Bot/Components/Shared/Alert.razor
+++ b/src/DiscordBot.Bot/Components/Shared/Alert.razor
@@ -1,0 +1,51 @@
+@{
+    var (bgClass, borderClass, textClass, iconPath) = Variant switch
+    {
+        AlertVariant.Success => ("bg-success/10", "border-success/30", "text-success", "M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"),
+        AlertVariant.Warning => ("bg-warning/10", "border-warning/30", "text-warning", "M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"),
+        AlertVariant.Error => ("bg-error/10", "border-error/30", "text-error", "M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"),
+        _ => ("bg-info/10", "border-info/30", "text-info", "M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z")
+    };
+}
+
+<div class="flex items-start gap-3 p-4 rounded-lg border @bgClass @borderClass @textClass" role="alert" aria-live="polite" @attributes="AdditionalAttributes">
+    @if (ShowIcon)
+    {
+        <svg class="w-5 h-5 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@iconPath" />
+        </svg>
+    }
+
+    <div class="flex-1">
+        @if (!string.IsNullOrEmpty(Title))
+        {
+            <h3 class="text-sm font-semibold">@Title</h3>
+        }
+        <p class="text-sm opacity-90 @(!string.IsNullOrEmpty(Title) ? "mt-1" : "")">@Message</p>
+    </div>
+
+    @if (IsDismissible)
+    {
+        <button
+            type="button"
+            class="p-1 hover:opacity-70 transition-opacity"
+            aria-label="Dismiss"
+            @onclick="HandleDismiss">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+        </button>
+    }
+</div>
+
+@code {
+    [Parameter] public AlertVariant Variant { get; set; } = AlertVariant.Info;
+    [Parameter] public string? Title { get; set; }
+    [Parameter] public string Message { get; set; } = string.Empty;
+    [Parameter] public bool IsDismissible { get; set; }
+    [Parameter] public bool ShowIcon { get; set; } = true;
+    [Parameter] public EventCallback OnDismiss { get; set; }
+    [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private async Task HandleDismiss() => await OnDismiss.InvokeAsync();
+}

--- a/src/DiscordBot.Bot/Components/Shared/AuditLogCard.razor
+++ b/src/DiscordBot.Bot/Components/Shared/AuditLogCard.razor
@@ -1,0 +1,97 @@
+<!-- Audit Log Card -->
+<div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden">
+    <!-- Card Header -->
+    <div class="flex items-center justify-between px-5 py-4 border-b border-border-primary">
+        <div class="flex items-center gap-3">
+            <div class="p-2 bg-accent-purple/10 rounded-lg">
+                <svg class="w-5 h-5 text-accent-purple" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                </svg>
+            </div>
+            <h2 class="text-lg font-semibold text-text-primary">Recent Audit Logs</h2>
+        </div>
+        <AuthorizeView Policy="RequireAdmin">
+            <a
+                href="/Admin/AuditLogs"
+                class="p-2 text-text-secondary hover:text-text-primary hover:bg-bg-primary rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-accent-purple focus:ring-offset-2 focus:ring-offset-bg-secondary"
+                aria-label="View all audit logs"
+                title="View all audit logs"
+            >
+                <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6" />
+                </svg>
+            </a>
+        </AuthorizeView>
+    </div>
+
+    @if (Logs.Any())
+    {
+        <!-- Audit Log List -->
+        <div class="max-h-[400px] overflow-y-auto">
+            <ul class="divide-y divide-border-primary">
+                @foreach (var log in Logs)
+                {
+                    <li class="px-5 py-3 hover:bg-bg-primary/30 transition-colors">
+                        <div class="flex items-start gap-3">
+                            <!-- Category Icon -->
+                            <div class="flex-shrink-0 mt-0.5">
+                                <div class="p-1.5 bg-accent-purple/10 rounded-lg" title="@log.CategoryName">
+                                    <svg class="w-4 h-4 text-accent-purple" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@log.CategoryIcon" />
+                                    </svg>
+                                </div>
+                            </div>
+
+                            <!-- Log Details -->
+                            <div class="flex-1 min-w-0">
+                                <div class="flex items-baseline gap-2 flex-wrap">
+                                    <span class="font-medium text-sm text-text-primary">@log.ActionName</span>
+                                    <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-accent-purple/10 text-accent-purple">
+                                        @log.CategoryName
+                                    </span>
+                                </div>
+                                <p class="mt-1 text-sm text-text-secondary truncate" title="@log.Description">
+                                    @log.Description
+                                </p>
+                                <div class="mt-1 flex items-center gap-2 text-xs text-text-tertiary">
+                                    @if (!string.IsNullOrEmpty(log.GuildName))
+                                    {
+                                        <span class="truncate">@log.GuildName</span>
+                                        <span aria-hidden="true">&bull;</span>
+                                    }
+                                    <span class="flex-shrink-0">@log.RelativeTime</span>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                }
+            </ul>
+        </div>
+
+        <!-- Card Footer -->
+        <AuthorizeView Policy="RequireAdmin">
+            <div class="px-5 py-3 border-t border-border-primary bg-bg-primary/30">
+                <a href="/Admin/AuditLogs" class="text-sm font-medium text-accent-purple hover:text-accent-purple/80 transition-colors focus:outline-none focus:ring-2 focus:ring-accent-purple focus:ring-offset-2 focus:ring-offset-bg-secondary rounded px-2 py-1">
+                    View all audit logs
+                </a>
+            </div>
+        </AuthorizeView>
+    }
+    else
+    {
+        <!-- Empty State -->
+        <div class="px-5 py-12">
+            <div class="text-center">
+                <svg class="w-12 h-12 mx-auto text-text-tertiary mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                </svg>
+                <p class="text-text-secondary font-medium">No audit logs yet</p>
+                <p class="text-sm text-text-tertiary mt-1">System and user actions will appear here</p>
+            </div>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter] public IReadOnlyList<AuditLogItem> Logs { get; set; } = Array.Empty<AuditLogItem>();
+}

--- a/src/DiscordBot.Bot/Components/Shared/AutocompleteInput.razor
+++ b/src/DiscordBot.Bot/Components/Shared/AutocompleteInput.razor
@@ -1,0 +1,84 @@
+@inject IJSRuntime JSRuntime
+
+@{
+    var searchInputId = $"{Id}-search";
+    var helpTextId = $"{Id}-help";
+}
+
+<div class="space-y-1.5">
+    @if (!string.IsNullOrEmpty(Label))
+    {
+        <label for="@searchInputId" class="block text-sm font-medium text-text-primary">
+            @Label
+            @if (IsRequired)
+            {
+                <span class="text-error">*</span>
+            }
+        </label>
+    }
+
+    <div class="autocomplete-wrapper">
+        <input
+            type="text"
+            id="@searchInputId"
+            class="form-input w-full"
+            placeholder="@(Placeholder ?? "Search...")"
+            value="@InitialDisplayText"
+            autocomplete="off"
+            aria-required="@(IsRequired ? "true" : null)"
+            aria-describedby="@(!string.IsNullOrEmpty(HelpText) ? helpTextId : null)"
+        />
+        <input
+            type="hidden"
+            id="@Id"
+            name="@Name"
+            value="@InitialValue"
+        />
+    </div>
+
+    @if (!string.IsNullOrEmpty(HelpText))
+    {
+        <p id="@helpTextId" class="text-xs text-text-secondary">@HelpText</p>
+    }
+</div>
+
+@code {
+    [Parameter] public string Id { get; set; } = string.Empty;
+    [Parameter] public string Name { get; set; } = string.Empty;
+    [Parameter] public string? Label { get; set; }
+    [Parameter] public string? Placeholder { get; set; }
+    [Parameter] public string Endpoint { get; set; } = string.Empty;
+    [Parameter] public string? InitialValue { get; set; }
+    [Parameter] public string? InitialDisplayText { get; set; }
+    [Parameter] public string? GuildIdSourceElement { get; set; }
+    [Parameter] public bool IsRequired { get; set; }
+    [Parameter] public int MinChars { get; set; } = 2;
+    [Parameter] public int DebounceMs { get; set; } = 300;
+    [Parameter] public int MaxResults { get; set; } = 25;
+    [Parameter] public string NoResultsMessage { get; set; } = "No results found";
+    [Parameter] public string? HelpText { get; set; }
+
+    private bool _initialized;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender && !_initialized)
+        {
+            _initialized = true;
+            var searchInputId = $"{Id}-search";
+            var options = new
+            {
+                inputId = searchInputId,
+                hiddenInputId = Id,
+                endpoint = Endpoint,
+                guildIdSource = GuildIdSourceElement,
+                minChars = MinChars,
+                debounceMs = DebounceMs,
+                maxResults = MaxResults,
+                placeholder = Placeholder ?? "Search...",
+                noResultsMessage = NoResultsMessage
+            };
+            await JSRuntime.InvokeVoidAsync("AutocompleteManager.init", options);
+        }
+    }
+}

--- a/src/DiscordBot.Bot/Components/Shared/Badge.razor
+++ b/src/DiscordBot.Bot/Components/Shared/Badge.razor
@@ -1,0 +1,93 @@
+@{
+    var sizeClasses = Size switch
+    {
+        BadgeSize.Small => "px-2 py-0.5 text-xs",
+        BadgeSize.Large => "px-4 py-1.5 text-sm",
+        _ => "px-3 py-1 text-xs"
+    };
+
+    var iconSize = Size switch
+    {
+        BadgeSize.Small => "w-2.5 h-2.5",
+        BadgeSize.Large => "w-4 h-4",
+        _ => "w-3 h-3"
+    };
+
+    string variantClasses;
+    if (Style == BadgeStyle.Outline)
+    {
+        variantClasses = Variant switch
+        {
+            BadgeVariant.Orange => "border border-accent-orange text-accent-orange bg-transparent",
+            BadgeVariant.Blue => "border border-accent-blue text-accent-blue bg-transparent",
+            BadgeVariant.Success => "border border-success text-success bg-transparent",
+            BadgeVariant.Warning => "border border-warning text-warning bg-transparent",
+            BadgeVariant.Error => "border border-error text-error bg-transparent",
+            BadgeVariant.Info => "border border-info text-info bg-transparent",
+            _ => "border border-bg-tertiary text-text-secondary bg-transparent"
+        };
+    }
+    else if (Style == BadgeStyle.Subtle)
+    {
+        variantClasses = Variant switch
+        {
+            BadgeVariant.Orange => "bg-accent-orange/10 text-accent-orange",
+            BadgeVariant.Blue => "bg-accent-blue/10 text-accent-blue",
+            BadgeVariant.Success => "bg-success/10 text-success",
+            BadgeVariant.Warning => "bg-warning/10 text-warning",
+            BadgeVariant.Error => "bg-error/10 text-error",
+            BadgeVariant.Info => "bg-info/10 text-info",
+            _ => "bg-bg-tertiary/50 text-text-secondary"
+        };
+    }
+    else
+    {
+        variantClasses = Variant switch
+        {
+            BadgeVariant.Orange => "bg-accent-orange text-white",
+            BadgeVariant.Blue => "bg-accent-blue text-white",
+            BadgeVariant.Success => "bg-success text-white",
+            BadgeVariant.Warning => "bg-warning text-bg-primary",
+            BadgeVariant.Error => "bg-error text-white",
+            BadgeVariant.Info => "bg-info text-white",
+            _ => "bg-bg-tertiary text-text-secondary"
+        };
+    }
+
+    var gapClass = string.IsNullOrEmpty(IconLeft) && !IsRemovable ? "" : "gap-1.5";
+}
+
+<span class="inline-flex items-center @gapClass @sizeClasses font-semibold rounded-full @variantClasses" @attributes="AdditionalAttributes">
+    @if (!string.IsNullOrEmpty(IconLeft))
+    {
+        <svg class="@iconSize" fill="currentColor" viewBox="0 0 20 20">
+            <path fill-rule="evenodd" d="@IconLeft" clip-rule="evenodd" />
+        </svg>
+    }
+    @Text
+    @if (IsRemovable)
+    {
+        <button
+            type="button"
+            class="hover:bg-white/20 rounded-full p-0.5 transition-colors"
+            aria-label="Remove"
+            @onclick="HandleRemove">
+            <svg class="@iconSize" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+        </button>
+    }
+</span>
+
+@code {
+    [Parameter] public string Text { get; set; } = string.Empty;
+    [Parameter] public BadgeVariant Variant { get; set; } = BadgeVariant.Default;
+    [Parameter] public BadgeSize Size { get; set; } = BadgeSize.Medium;
+    [Parameter] public BadgeStyle Style { get; set; } = BadgeStyle.Filled;
+    [Parameter] public string? IconLeft { get; set; }
+    [Parameter] public bool IsRemovable { get; set; }
+    [Parameter] public EventCallback OnRemove { get; set; }
+    [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private async Task HandleRemove() => await OnRemove.InvokeAsync();
+}

--- a/src/DiscordBot.Bot/Components/Shared/BotStatusBanner.razor
+++ b/src/DiscordBot.Bot/Components/Shared/BotStatusBanner.razor
@@ -1,0 +1,106 @@
+@implements IDisposable
+
+@{
+    var bannerClass = IsOnline ? "bot-status-banner" : "bot-status-banner offline";
+    var iconColor = IsOnline ? "text-success" : "text-error";
+    var iconBgColor = IsOnline ? "bg-success/20" : "bg-error/20";
+    var statusBadgeBg = IsOnline ? "bg-success/20" : "bg-error/20";
+    var statusBadgeText = IsOnline ? "text-success" : "text-error";
+    var statusDotColor = IsOnline ? "bg-success" : "bg-error";
+    var statusHeading = IsOnline ? "Bot is Online" : "Bot is Offline";
+}
+
+<div class="@bannerClass mb-8" data-bot-status-card data-is-online="@IsOnline.ToString().ToLower()">
+    <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+        <!-- Status Info Section -->
+        <div class="flex items-center gap-4">
+            <!-- Icon -->
+            <div class="w-12 h-12 rounded-xl @iconBgColor flex items-center justify-center">
+                @if (IsOnline)
+                {
+                    <!-- Shield Check Icon (Online) -->
+                    <svg class="w-6 h-6 @iconColor" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+                    </svg>
+                }
+                else
+                {
+                    <!-- Shield Exclamation Icon (Offline) -->
+                    <svg class="w-6 h-6 @iconColor" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.618 5.984A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016zM12 9v2m0 4h.01" />
+                    </svg>
+                }
+            </div>
+
+            <!-- Text Content -->
+            <div>
+                <div class="flex items-center gap-2">
+                    <h2 class="text-lg font-semibold text-text-primary" data-status-heading>@statusHeading</h2>
+                    <!-- Status Badge -->
+                    <span class="inline-flex items-center gap-1.5 px-2 py-0.5 text-xs font-semibold @statusBadgeText @statusBadgeBg rounded-full" data-status-badge>
+                        <span class="w-1.5 h-1.5 @statusDotColor rounded-full @(IsOnline ? "animate-pulse" : "")" data-status-dot></span>
+                        <span data-connection-state data-status-text>@StatusText</span>
+                    </span>
+                </div>
+                <p class="text-sm text-text-secondary mt-0.5" data-summary-text>
+                    @if (IsOnline)
+                    {
+                        <text>Connected to <span data-guild-count>@ServerCount.ToString("N0")</span> @(ServerCount == 1 ? "server" : "servers") with @TotalMembers.ToString("N0") total @(TotalMembers == 1 ? "member" : "members")</text>
+                    }
+                    else
+                    {
+                        <text>Not currently connected to Discord</text>
+                    }
+                </p>
+            </div>
+        </div>
+
+        <!-- Metrics Section -->
+        <div class="flex items-center gap-6 text-sm @(IsOnline ? "" : "hidden")" data-metrics-section>
+            <!-- Uptime -->
+            <div class="text-center">
+                <p class="font-semibold text-text-primary" data-uptime>@UptimeDisplay</p>
+                <p class="text-xs text-text-tertiary">Uptime</p>
+            </div>
+
+            <!-- Version -->
+            <div class="text-center">
+                <p class="font-semibold text-text-primary" data-version>@Version</p>
+                <p class="text-xs text-text-tertiary">Version</p>
+            </div>
+
+            <!-- Latency -->
+            <div class="text-center">
+                <p class="font-semibold text-text-primary"><span data-latency>@LatencyMs</span><span class="text-text-tertiary">ms</span></p>
+                <p class="text-xs text-text-tertiary">Latency</p>
+            </div>
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter] public bool IsOnline { get; set; }
+    [Parameter] public string StatusText { get; set; } = "Disconnected";
+    [Parameter] public int ServerCount { get; set; }
+    [Parameter] public int TotalMembers { get; set; }
+    [Parameter] public string UptimeDisplay { get; set; } = "0m";
+    [Parameter] public string Version { get; set; } = "v0.0.0";
+    [Parameter] public int LatencyMs { get; set; }
+
+    // TODO: Subscribe to IDashboardEventBus in Phase 5
+
+    private System.Threading.Timer? _refreshTimer;
+
+    protected override void OnInitialized()
+    {
+        _refreshTimer = new System.Threading.Timer(_ =>
+        {
+            InvokeAsync(StateHasChanged);
+        }, null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
+    }
+
+    public void Dispose()
+    {
+        _refreshTimer?.Dispose();
+    }
+}

--- a/src/DiscordBot.Bot/Components/Shared/BotStatusCard.razor
+++ b/src/DiscordBot.Bot/Components/Shared/BotStatusCard.razor
@@ -1,0 +1,85 @@
+@implements IDisposable
+
+@{
+    var statusIndicatorStatus = StatusType;
+    var isPulsing = StatusType == StatusType.Online;
+}
+
+<!-- Bot Status Card -->
+<div class="bg-bg-secondary border border-border-primary rounded-lg p-5" data-bot-status-card>
+    <!-- Card Header -->
+    <div class="flex items-center justify-between mb-4">
+        <h2 class="text-lg font-semibold text-text-primary">Bot Status</h2>
+        <StatusIndicator Status="@statusIndicatorStatus"
+                         DisplayStyle="StatusDisplayStyle.BadgeStyle"
+                         IsPulsing="@isPulsing" />
+    </div>
+
+    <!-- Metrics Grid -->
+    <div class="grid grid-cols-2 gap-4 mb-4">
+        <!-- Connection State -->
+        <div>
+            <p class="text-xs text-text-tertiary mb-1">Connection</p>
+            <div class="flex items-center gap-2">
+                <StatusIndicator Status="@statusIndicatorStatus"
+                                 DisplayStyle="StatusDisplayStyle.DotOnly"
+                                 Size="StatusSize.Small" />
+                <p class="text-sm font-medium text-text-primary" data-connection-state>@ConnectionState</p>
+            </div>
+        </div>
+
+        <!-- Latency -->
+        <div>
+            <p class="text-xs text-text-tertiary mb-1">Latency</p>
+            <p class="text-sm font-medium text-text-primary">
+                <span data-latency>@LatencyMs</span><span class="text-text-secondary"> ms</span>
+            </p>
+        </div>
+
+        <!-- Uptime -->
+        <div>
+            <p class="text-xs text-text-tertiary mb-1">Uptime</p>
+            <p class="text-sm font-medium text-text-primary" data-uptime>@UptimeFormatted</p>
+        </div>
+
+        <!-- Guild Count -->
+        <div>
+            <p class="text-xs text-text-tertiary mb-1">Servers</p>
+            <p class="text-sm font-medium text-text-primary" data-guild-count>@GuildCount</p>
+        </div>
+    </div>
+
+    <!-- Footer -->
+    <div class="pt-3 border-t border-border-primary">
+        <p class="text-xs text-text-tertiary">
+            Last updated: <span data-last-updated>@_lastUpdated</span>
+        </p>
+    </div>
+</div>
+
+@code {
+    [Parameter] public StatusType StatusType { get; set; } = StatusType.Offline;
+    [Parameter] public string ConnectionState { get; set; } = string.Empty;
+    [Parameter] public int LatencyMs { get; set; }
+    [Parameter] public string UptimeFormatted { get; set; } = string.Empty;
+    [Parameter] public int GuildCount { get; set; }
+
+    // TODO: Subscribe to IDashboardEventBus in Phase 5
+
+    private string _lastUpdated = "Just now";
+    private System.Threading.Timer? _timer;
+
+    protected override void OnInitialized()
+    {
+        _timer = new System.Threading.Timer(_ =>
+        {
+            _lastUpdated = "Just now";
+            InvokeAsync(StateHasChanged);
+        }, null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
+    }
+
+    public void Dispose()
+    {
+        _timer?.Dispose();
+    }
+}

--- a/src/DiscordBot.Bot/Components/Shared/Button.razor
+++ b/src/DiscordBot.Bot/Components/Shared/Button.razor
@@ -1,0 +1,83 @@
+@{
+    var sizeClasses = Size switch
+    {
+        ButtonSize.Small => "px-3 py-1.5 text-xs",
+        ButtonSize.Large => "px-6 py-3 text-base",
+        _ => "px-5 py-2.5 text-sm"
+    };
+
+    var variantClasses = Variant switch
+    {
+        ButtonVariant.Secondary => "text-text-primary bg-transparent border border-border-primary hover:bg-bg-hover",
+        ButtonVariant.Accent => "text-white bg-accent-blue hover:bg-accent-blue-hover active:bg-accent-blue-active",
+        ButtonVariant.Danger => "text-white bg-error hover:bg-error/80",
+        ButtonVariant.Ghost => "text-text-secondary hover:text-text-primary hover:bg-bg-hover",
+        _ => "text-white bg-accent-orange hover:bg-accent-orange-hover active:bg-accent-orange-active"
+    };
+
+    var baseClasses = IsIconOnly
+        ? "p-2.5 text-text-secondary hover:text-text-primary hover:bg-bg-hover rounded-md transition-colors"
+        : $"inline-flex items-center justify-center gap-2 {sizeClasses} font-semibold {variantClasses} rounded-md transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-blue disabled:opacity-50 disabled:cursor-not-allowed";
+
+    var additionalClass = AdditionalAttributes?.GetValueOrDefault("class")?.ToString();
+    var finalClasses = string.IsNullOrEmpty(additionalClass) ? baseClasses : $"{baseClasses} {additionalClass}";
+
+    var isDisabled = IsDisabled || IsLoading;
+    var ariaLabel = AriaLabel ?? (IsIconOnly ? Text : null);
+}
+
+<button
+    type="@Type"
+    class="@finalClasses"
+    disabled="@isDisabled"
+    aria-busy="@(IsLoading ? "true" : null)"
+    aria-label="@ariaLabel"
+    @onclick="OnClick"
+    @attributes="ExtraAttributes">
+    @if (IsLoading)
+    {
+        <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+        </svg>
+        <span class="sr-only">Loading</span>
+    }
+    else if (!string.IsNullOrEmpty(IconLeft))
+    {
+        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="@IconLeft" />
+        </svg>
+    }
+
+    @if (!IsIconOnly)
+    {
+        <span>@Text</span>
+    }
+
+    @if (!IsLoading && !string.IsNullOrEmpty(IconRight))
+    {
+        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="@IconRight" />
+        </svg>
+    }
+</button>
+
+@code {
+    [Parameter] public string Text { get; set; } = string.Empty;
+    [Parameter] public ButtonVariant Variant { get; set; } = ButtonVariant.Primary;
+    [Parameter] public ButtonSize Size { get; set; } = ButtonSize.Medium;
+    [Parameter] public string Type { get; set; } = "button";
+    [Parameter] public string? IconLeft { get; set; }
+    [Parameter] public string? IconRight { get; set; }
+    [Parameter] public bool IsDisabled { get; set; }
+    [Parameter] public bool IsLoading { get; set; }
+    [Parameter] public string? LoadingText { get; set; }
+    [Parameter] public bool IsIconOnly { get; set; }
+    [Parameter] public string? AriaLabel { get; set; }
+    [Parameter] public EventCallback OnClick { get; set; }
+    [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private Dictionary<string, object>? ExtraAttributes =>
+        AdditionalAttributes?.Where(a => a.Key != "class").ToDictionary(a => a.Key, a => a.Value)
+        is { Count: > 0 } dict ? dict : null;
+}

--- a/src/DiscordBot.Bot/Components/Shared/Card.razor
+++ b/src/DiscordBot.Bot/Components/Shared/Card.razor
@@ -1,0 +1,115 @@
+@{
+    var variantClasses = Variant switch
+    {
+        CardVariant.Flat => "bg-bg-secondary",
+        CardVariant.Elevated => "bg-bg-secondary border border-border-primary shadow-lg",
+        _ => "bg-bg-secondary border border-border-primary"
+    };
+
+    var interactiveClasses = IsInteractive
+        ? "cursor-pointer transition-all hover:border-accent-blue hover:-translate-y-0.5 hover:shadow-lg hover:shadow-accent-blue/15"
+        : "";
+
+    var cardClasses = $"{variantClasses} {interactiveClasses} rounded-lg overflow-hidden {CssClass ?? ""}".Trim();
+
+    var hasHeader = !string.IsNullOrEmpty(Title) || HeaderContent != null || HeaderActions != null;
+    var hasFooter = FooterContent != null;
+    var bodyOnly = !hasHeader && !hasFooter;
+}
+
+<div class="@cardClasses" @onclick="OnClick">
+    @if (hasHeader)
+    {
+        @if (IsCollapsible)
+        {
+            <button
+                type="button"
+                class="w-full flex items-center justify-between px-6 py-4 @(hasFooter || BodyContent != null ? "border-b border-border-primary" : "") hover:bg-bg-hover transition-colors"
+                @onclick="ToggleCollapse"
+                @onclick:stopPropagation="true"
+                aria-expanded="@(_isExpanded ? "true" : "false")"
+            >
+                <div>
+                    @if (HeaderContent != null)
+                    {
+                        @HeaderContent
+                    }
+                    else if (!string.IsNullOrEmpty(Title))
+                    {
+                        <h3 class="text-h5 text-text-primary">@Title</h3>
+                        @if (!string.IsNullOrEmpty(Subtitle))
+                        {
+                            <p class="text-sm text-text-secondary mt-1">@Subtitle</p>
+                        }
+                    }
+                </div>
+                <svg class="w-5 h-5 text-text-secondary transition-transform @(_isExpanded ? "" : "rotate-180")" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                </svg>
+            </button>
+        }
+        else
+        {
+            <div class="flex items-center justify-between px-6 py-4 @(hasFooter || BodyContent != null ? "border-b border-border-primary" : "")">
+                <div>
+                    @if (HeaderContent != null)
+                    {
+                        @HeaderContent
+                    }
+                    else if (!string.IsNullOrEmpty(Title))
+                    {
+                        <h3 class="text-h5 text-text-primary">@Title</h3>
+                        @if (!string.IsNullOrEmpty(Subtitle))
+                        {
+                            <p class="text-sm text-text-secondary mt-1">@Subtitle</p>
+                        }
+                    }
+                </div>
+                @if (HeaderActions != null)
+                {
+                    <div>
+                        @HeaderActions
+                    </div>
+                }
+            </div>
+        }
+    }
+
+    @if (BodyContent != null)
+    {
+        <div class="@(bodyOnly ? "p-6" : IsCollapsible && !_isExpanded ? "p-6 hidden" : "p-6")">
+            @BodyContent
+        </div>
+    }
+
+    @if (hasFooter)
+    {
+        <div class="flex items-center justify-between px-6 py-4 border-t border-border-primary bg-bg-primary/50">
+            @FooterContent
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter] public string? Title { get; set; }
+    [Parameter] public string? Subtitle { get; set; }
+    [Parameter] public RenderFragment? HeaderContent { get; set; }
+    [Parameter] public RenderFragment? HeaderActions { get; set; }
+    [Parameter] public RenderFragment? BodyContent { get; set; }
+    [Parameter] public RenderFragment? FooterContent { get; set; }
+    [Parameter] public CardVariant Variant { get; set; } = CardVariant.Default;
+    [Parameter] public bool IsInteractive { get; set; }
+    [Parameter] public bool IsCollapsible { get; set; }
+    [Parameter] public bool IsExpanded { get; set; } = true;
+    [Parameter] public EventCallback OnClick { get; set; }
+    [Parameter] public string? CssClass { get; set; }
+
+    private bool _isExpanded = true;
+
+    protected override void OnParametersSet()
+    {
+        _isExpanded = IsExpanded;
+    }
+
+    private void ToggleCollapse() => _isExpanded = !_isExpanded;
+}

--- a/src/DiscordBot.Bot/Components/Shared/CommandBreadcrumb.razor
+++ b/src/DiscordBot.Bot/Components/Shared/CommandBreadcrumb.razor
@@ -1,0 +1,33 @@
+@{
+    var tabDisplayName = ActiveTab switch
+    {
+        "command-list" => "Command List",
+        "execution-logs" => "Execution Logs",
+        "analytics" => "Analytics",
+        _ => "Command List"
+    };
+}
+
+<nav aria-label="Breadcrumb" class="mb-6">
+    <ol class="flex items-center gap-2 text-sm">
+        <li class="flex items-center gap-2">
+            <a href="/" class="text-text-secondary hover:text-accent-blue transition-colors">Home</a>
+            <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+        </li>
+        <li class="flex items-center gap-2">
+            <a href="/Commands" class="text-text-secondary hover:text-accent-blue transition-colors">Commands</a>
+            <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+        </li>
+        <li>
+            <span class="text-text-primary font-medium" aria-current="page" data-command-breadcrumb-active>@tabDisplayName</span>
+        </li>
+    </ol>
+</nav>
+
+@code {
+    [Parameter] public string ActiveTab { get; set; } = "command-list";
+}

--- a/src/DiscordBot.Bot/Components/Shared/CommandHeader.razor
+++ b/src/DiscordBot.Bot/Components/Shared/CommandHeader.razor
@@ -1,0 +1,13 @@
+<div class="mb-6">
+    <h1 class="text-2xl lg:text-3xl font-bold text-text-primary">@Title</h1>
+    @if (!string.IsNullOrEmpty(Subtitle))
+    {
+        <p class="text-sm text-text-secondary mt-1" data-command-subtitle>@Subtitle</p>
+    }
+</div>
+
+@code {
+    [Parameter] public string Title { get; set; } = "Commands";
+    [Parameter] public string? Subtitle { get; set; }
+    [Parameter] public string ActiveTab { get; set; } = "command-list";
+}

--- a/src/DiscordBot.Bot/Components/Shared/CommandLogDetailsModal.razor
+++ b/src/DiscordBot.Bot/Components/Shared/CommandLogDetailsModal.razor
@@ -1,0 +1,63 @@
+@if (IsVisible)
+{
+    <!-- Command Log Details Modal -->
+    <div class="fixed inset-0 z-[var(--z-modal)]" role="dialog" aria-modal="true" aria-labelledby="commandLogModalTitle">
+        <!-- Backdrop - click to close -->
+        <div class="fixed inset-0 bg-black/70 backdrop-blur-sm" @onclick="Close" aria-hidden="true"></div>
+
+        <!-- Modal Dialog -->
+        <div class="fixed inset-0 flex items-center justify-center p-8 pt-24 pb-8 overflow-y-auto">
+            <div class="bg-bg-secondary border border-border-primary rounded-lg shadow-xl w-full max-w-3xl max-h-[calc(100vh-12rem)] flex flex-col" role="document">
+                <!-- Modal Header -->
+                <div class="flex items-center justify-between px-6 py-4 border-b border-border-primary flex-shrink-0">
+                    <h2 id="commandLogModalTitle" class="text-lg font-semibold text-text-primary">
+                        Command Log Details
+                    </h2>
+                    <button type="button"
+                            @onclick="Close"
+                            class="text-text-tertiary hover:text-text-primary transition-colors"
+                            aria-label="Close modal">
+                        <svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                        </svg>
+                    </button>
+                </div>
+
+                <!-- Modal Body -->
+                <div class="px-6 py-6 overflow-y-auto flex-1">
+                    @if (Content is not null)
+                    {
+                        @Content
+                    }
+                    else
+                    {
+                        <!-- Loading spinner -->
+                        <div class="flex items-center justify-center py-12">
+                            <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-accent-blue"></div>
+                        </div>
+                    }
+                </div>
+
+                <!-- Modal Footer -->
+                <div class="flex justify-end px-6 py-4 border-t border-border-primary bg-bg-tertiary rounded-b-lg flex-shrink-0">
+                    <button type="button"
+                            @onclick="Close"
+                            class="btn btn-secondary">
+                        Close
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter] public bool IsVisible { get; set; }
+    [Parameter] public EventCallback<bool> IsVisibleChanged { get; set; }
+    [Parameter] public RenderFragment? Content { get; set; }
+
+    private async Task Close()
+    {
+        await IsVisibleChanged.InvokeAsync(false);
+    }
+}

--- a/src/DiscordBot.Bot/Components/Shared/CommandStatsCard.razor
+++ b/src/DiscordBot.Bot/Components/Shared/CommandStatsCard.razor
@@ -1,0 +1,119 @@
+@using System.Text.Json
+@using DiscordBot.Bot.ViewModels.Pages
+
+@{
+    var chartDataJson = JsonSerializer.Serialize(new
+    {
+        labels = TopCommands.Select(c => c.CommandName).ToArray(),
+        counts = TopCommands.Select(c => c.Count).ToArray(),
+        totalCommands = TotalCommands,
+        timeRangeHours = TimeRangeHours
+    });
+}
+
+<!-- Command Usage Statistics Card -->
+<div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden h-full flex flex-col" data-command-stats-card>
+    <!-- Card Header -->
+    <div class="flex items-center justify-between px-5 py-4 border-b border-border-primary">
+        <div class="flex items-center gap-3">
+            <div class="p-2 bg-accent-orange/10 rounded-lg">
+                <svg class="w-5 h-5 text-accent-orange" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                </svg>
+            </div>
+            <h2 class="text-lg font-semibold text-text-primary">Command Usage</h2>
+        </div>
+        <div class="flex items-center gap-3">
+            <label for="commandTimeRange" class="sr-only">Select time range</label>
+            <select
+                id="commandTimeRange"
+                class="px-3 py-1.5 text-sm bg-bg-primary border border-border-primary rounded-lg text-text-primary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors cursor-pointer appearance-none pr-8"
+                style="background-image: url('data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 fill=%27none%27 viewBox=%270 0 20 20%27%3e%3cpath stroke=%27%23a8a5a3%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27 stroke-width=%271.5%27 d=%27M6 8l4 4 4-4%27/%3e%3c/svg%3e'); background-position: right 0.5rem center; background-repeat: no-repeat; background-size: 1.25em 1.25em;"
+                aria-label="Select time range for statistics"
+                data-time-range-selector
+                value="@(TimeRangeHours?.ToString() ?? "")"
+                @onchange="OnTimeRangeChanged"
+            >
+                <option value="24" selected="@(TimeRangeHours == 24)">Last 24 hours</option>
+                <option value="168" selected="@(TimeRangeHours == 168)">Last 7 days</option>
+                <option value="720" selected="@(TimeRangeHours == 720)">Last 30 days</option>
+                <option value="" selected="@(!TimeRangeHours.HasValue)">All time</option>
+            </select>
+        </div>
+    </div>
+
+    <!-- Card Body -->
+    <div class="p-5 flex-grow">
+        <!-- Total Count Display -->
+        <div class="mb-6 p-4 bg-bg-primary/50 rounded-lg border border-border-secondary">
+            <div class="flex items-center justify-between">
+                <div>
+                    <p class="text-sm font-medium text-text-secondary">Total Commands Executed</p>
+                    <p class="mt-1 text-3xl font-bold text-text-primary" data-total-count>@TotalCommands.ToString("N0")</p>
+                </div>
+                <div class="text-text-secondary">
+                    <svg class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+                    </svg>
+                </div>
+            </div>
+        </div>
+
+        <!-- Chart Container -->
+        @if (TopCommands.Any())
+        {
+            <div style="position: relative; min-height: 300px; max-height: 400px;">
+                <canvas id="commandUsageChart" aria-label="Horizontal bar chart showing top 10 commands by usage count" role="img"></canvas>
+            </div>
+        }
+        else
+        {
+            <!-- Empty State -->
+            <div class="py-12 text-center" data-empty-state>
+                <svg class="w-12 h-12 mx-auto text-text-tertiary mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                </svg>
+                <p class="text-text-secondary font-medium">No command data available</p>
+                <p class="text-sm text-text-tertiary mt-1">Commands will appear here once they are executed</p>
+            </div>
+        }
+    </div>
+
+    <!-- Card Footer -->
+    <div class="flex items-center justify-between px-5 py-3 border-t border-border-primary bg-bg-primary/30">
+        <span class="text-sm text-text-tertiary" data-command-count-label>
+            @if (TopCommands.Any())
+            {
+                <text>Showing top @TopCommands.Count commands</text>
+            }
+            else
+            {
+                <text>No commands to display</text>
+            }
+        </span>
+        <AuthorizeView Policy="RequireModerator">
+            <a href="/Commands?tab=logs" class="text-sm font-medium text-accent-blue hover:text-accent-blue-hover transition-colors focus:outline-none focus:ring-2 focus:ring-accent-blue focus:ring-offset-2 focus:ring-offset-bg-secondary rounded px-2 py-1">
+                View All Logs
+            </a>
+        </AuthorizeView>
+    </div>
+</div>
+
+<!-- Embed initial chart data for JavaScript -->
+<script type="application/json" data-command-stats-initial>
+@((MarkupString)chartDataJson)
+</script>
+
+@code {
+    [Parameter] public int TotalCommands { get; set; }
+    [Parameter] public IReadOnlyList<CommandUsageStat> TopCommands { get; set; } = Array.Empty<CommandUsageStat>();
+    [Parameter] public int? TimeRangeHours { get; set; }
+    [Parameter] public EventCallback<int?> OnTimeRangeChange { get; set; }
+
+    private async Task OnTimeRangeChanged(ChangeEventArgs e)
+    {
+        var value = e.Value?.ToString();
+        var hours = string.IsNullOrEmpty(value) ? (int?)null : int.Parse(value);
+        await OnTimeRangeChange.InvokeAsync(hours);
+    }
+}

--- a/src/DiscordBot.Bot/Components/Shared/ConfirmationModal.razor
+++ b/src/DiscordBot.Bot/Components/Shared/ConfirmationModal.razor
@@ -1,0 +1,100 @@
+@if (IsVisible)
+{
+    <!-- Confirmation Modal -->
+    <div class="fixed inset-0 z-[var(--z-modal)]" role="alertdialog" aria-modal="true" aria-labelledby="@(Id)Title" aria-describedby="@(Id)Desc">
+        <!-- Backdrop -->
+        <div class="fixed inset-0 bg-black/70 backdrop-blur-sm" @onclick="Cancel" aria-hidden="true"></div>
+
+        <!-- Modal Dialog -->
+        <div class="fixed inset-0 flex items-center justify-center p-4">
+            <div class="bg-bg-tertiary border border-border-primary rounded-lg shadow-xl max-w-md w-full" role="document">
+                <!-- Modal Content -->
+                <div class="p-6">
+                    <div class="flex items-start gap-4">
+                        <!-- Icon -->
+                        <div class="flex-shrink-0 w-10 h-10 rounded-full bg-@GetVariantColorClass()/20 flex items-center justify-center">
+                            <svg class="w-5 h-5 text-@GetVariantColorClass()" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                @if (!string.IsNullOrEmpty(CustomIconPath))
+                                {
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@CustomIconPath" />
+                                }
+                                else
+                                {
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@GetDefaultIconPath()" />
+                                }
+                            </svg>
+                        </div>
+
+                        <!-- Text Content -->
+                        <div class="flex-1">
+                            <h3 id="@(Id)Title" class="text-lg font-semibold text-text-primary">@Title</h3>
+                            <p id="@(Id)Desc" class="mt-2 text-sm text-text-secondary">@Message</p>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Modal Footer -->
+                <div class="flex justify-end gap-3 px-6 py-4 bg-bg-secondary border-t border-border-primary rounded-b-lg">
+                    <button type="button"
+                            @onclick="Cancel"
+                            class="px-4 py-2 bg-bg-tertiary hover:bg-bg-hover border border-border-primary text-text-primary font-medium text-sm rounded-md transition-colors">
+                        @CancelText
+                    </button>
+
+                    <button type="button"
+                            @onclick="Confirm"
+                            class="px-4 py-2 @GetConfirmButtonClass() text-white font-medium text-sm rounded-md transition-colors min-w-[100px] flex items-center justify-center gap-2">
+                        <span>@ConfirmText</span>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter] public string Id { get; set; } = string.Empty;
+    [Parameter] public string Title { get; set; } = string.Empty;
+    [Parameter] public string Message { get; set; } = string.Empty;
+    [Parameter] public string ConfirmText { get; set; } = "Confirm";
+    [Parameter] public string CancelText { get; set; } = "Cancel";
+    [Parameter] public ConfirmationVariant Variant { get; set; } = ConfirmationVariant.Warning;
+    [Parameter] public string? CustomIconPath { get; set; }
+    [Parameter] public bool IsVisible { get; set; }
+    [Parameter] public EventCallback<bool> IsVisibleChanged { get; set; }
+    [Parameter] public EventCallback OnConfirm { get; set; }
+
+    private async Task Cancel()
+    {
+        await IsVisibleChanged.InvokeAsync(false);
+    }
+
+    private async Task Confirm()
+    {
+        await OnConfirm.InvokeAsync();
+        await IsVisibleChanged.InvokeAsync(false);
+    }
+
+    private string GetVariantColorClass() => Variant switch
+    {
+        ConfirmationVariant.Info => "accent-blue",
+        ConfirmationVariant.Warning => "warning",
+        ConfirmationVariant.Danger => "error",
+        _ => "warning"
+    };
+
+    private string GetConfirmButtonClass() => Variant switch
+    {
+        ConfirmationVariant.Info => "bg-accent-blue hover:bg-accent-blue-hover active:bg-accent-blue-active",
+        ConfirmationVariant.Warning => "bg-warning hover:bg-amber-600 active:bg-amber-700",
+        ConfirmationVariant.Danger => "bg-error hover:bg-red-600 active:bg-red-700",
+        _ => "bg-accent-orange hover:bg-accent-orange-hover active:bg-accent-orange-active"
+    };
+
+    private string GetDefaultIconPath() => Variant switch
+    {
+        ConfirmationVariant.Info => "M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z",
+        ConfirmationVariant.Danger => "M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z",
+        _ => "M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+    };
+}

--- a/src/DiscordBot.Bot/Components/Shared/ConnectedServersWidget.razor
+++ b/src/DiscordBot.Bot/Components/Shared/ConnectedServersWidget.razor
@@ -1,0 +1,136 @@
+<div class="bg-bg-secondary border border-border-primary rounded-xl overflow-hidden h-full flex flex-col">
+    <!-- Card Header -->
+    <div class="flex items-center justify-between px-6 py-4 border-b border-border-primary">
+        <h2 class="text-lg font-semibold text-text-primary">@Title</h2>
+        @if (ShowViewAll)
+        {
+            <a href="@ViewAllUrl" class="text-sm font-medium text-accent-blue hover:text-accent-blue-hover transition-colors">
+                View All
+            </a>
+        }
+    </div>
+
+    <!-- Table Container -->
+    <div class="overflow-x-auto flex-grow">
+        <table class="w-full">
+            <thead class="bg-bg-primary/50">
+                <tr>
+                    <th class="px-6 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Server</th>
+                    <th class="px-6 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Members</th>
+                    <th class="px-6 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Status</th>
+                    <th class="px-6 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Commands</th>
+                    <th class="px-6 py-3 text-right text-xs font-semibold text-text-secondary uppercase tracking-wider">Actions</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-border-primary">
+                @if (Servers.Any())
+                {
+                    @foreach (var server in Servers)
+                    {
+                        <tr class="hover:bg-bg-hover transition-colors cursor-pointer group focus:outline-none focus:ring-2 focus:ring-border-focus focus:ring-inset"
+                            tabindex="0"
+                            role="link"
+                            aria-label="View details for @server.Name"
+                            @onclick="() => OnServerClicked.InvokeAsync(server)"
+                            @onkeydown="(e) => HandleKeyDown(e, server)">
+                            <td class="px-6 py-4">
+                                <div class="flex items-center gap-3">
+                                    @if (!string.IsNullOrEmpty(server.IconUrl))
+                                    {
+                                        <img src="@server.IconUrl" alt="@server.Name icon" class="w-10 h-10 rounded-full" />
+                                    }
+                                    else
+                                    {
+                                        <div class="w-10 h-10 rounded-full bg-gradient-to-br @server.AvatarGradient flex items-center justify-center text-white font-bold text-sm">
+                                            @server.Initials
+                                        </div>
+                                    }
+                                    <div>
+                                        <p class="font-medium text-text-primary group-hover:text-accent-blue transition-colors">@server.Name</p>
+                                        <p class="text-xs text-text-tertiary font-mono">ID: @server.Id</p>
+                                    </div>
+                                </div>
+                            </td>
+                            <td class="px-6 py-4 text-text-secondary">@server.MemberCount.ToString("N0")</td>
+                            <td class="px-6 py-4">
+                                @{
+                                    var statusText = server.Status.ToString();
+                                    var statusColor = server.Status switch
+                                    {
+                                        ServerConnectionStatus.Online => "success",
+                                        ServerConnectionStatus.Idle => "warning",
+                                        ServerConnectionStatus.Offline => "text-tertiary",
+                                        _ => "text-tertiary"
+                                    };
+                                    var statusBgColor = server.Status switch
+                                    {
+                                        ServerConnectionStatus.Online => "success/10",
+                                        ServerConnectionStatus.Idle => "warning/10",
+                                        ServerConnectionStatus.Offline => "border-primary/50",
+                                        _ => "border-primary/50"
+                                    };
+                                    var statusDotColor = server.Status switch
+                                    {
+                                        ServerConnectionStatus.Online => "bg-success",
+                                        ServerConnectionStatus.Idle => "bg-warning",
+                                        ServerConnectionStatus.Offline => "bg-text-tertiary",
+                                        _ => "bg-text-tertiary"
+                                    };
+                                }
+                                <span class="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-semibold text-@statusColor bg-@statusBgColor rounded-full">
+                                    <span class="w-1.5 h-1.5 @statusDotColor rounded-full"></span>
+                                    @statusText
+                                </span>
+                            </td>
+                            <td class="px-6 py-4 text-text-secondary">@server.CommandsToday.ToString("N0")</td>
+                            <td class="px-6 py-4 text-right">
+                                <button
+                                    class="p-2 text-text-secondary hover:text-text-primary hover:bg-bg-hover rounded-lg transition-colors"
+                                    aria-label="Server actions for @server.Name"
+                                    @onclick="() => OnServerActionClicked.InvokeAsync(server)"
+                                    @onclick:stopPropagation="true">
+                                    <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" />
+                                    </svg>
+                                </button>
+                            </td>
+                        </tr>
+                    }
+                }
+                else
+                {
+                    <tr>
+                        <td colspan="5" class="px-6 py-12 text-center">
+                            <div class="flex flex-col items-center justify-center">
+                                <svg class="w-12 h-12 text-text-tertiary mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" />
+                                </svg>
+                                <p class="text-sm text-text-secondary">No connected servers</p>
+                                <p class="text-xs text-text-tertiary mt-1">Servers will appear here when the bot joins them</p>
+                            </div>
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+</div>
+
+@code {
+    [Parameter] public string Title { get; set; } = "Connected Servers";
+    [Parameter] public string ViewAllUrl { get; set; } = "/Servers";
+    [Parameter] public List<ConnectedServerItemViewModel> Servers { get; set; } = new();
+    [Parameter] public int TotalServerCount { get; set; }
+    [Parameter] public EventCallback<ConnectedServerItemViewModel> OnServerClicked { get; set; }
+    [Parameter] public EventCallback<ConnectedServerItemViewModel> OnServerActionClicked { get; set; }
+
+    private bool ShowViewAll => TotalServerCount > Servers.Count;
+
+    private async Task HandleKeyDown(KeyboardEventArgs e, ConnectedServerItemViewModel server)
+    {
+        if (e.Key == "Enter")
+        {
+            await OnServerClicked.InvokeAsync(server);
+        }
+    }
+}

--- a/src/DiscordBot.Bot/Components/Shared/ConnectionStatus.razor
+++ b/src/DiscordBot.Bot/Components/Shared/ConnectionStatus.razor
@@ -1,0 +1,28 @@
+@{
+    var stateStr = State.ToString().ToLowerInvariant();
+    var displayText = CustomText ?? State switch
+    {
+        ConnectionState.Connected => "Connected",
+        ConnectionState.Connecting => "Connecting...",
+        ConnectionState.Reconnecting => "Reconnecting...",
+        ConnectionState.Disconnected => "Disconnected",
+        _ => "Unknown"
+    };
+}
+
+<div class="connection-status inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-semibold bg-bg-tertiary border border-border-primary"
+     data-state="@stateStr"
+     role="status"
+     aria-live="polite"
+     @attributes="AdditionalAttributes">
+    <span class="connection-dot relative w-2 h-2 rounded-full"></span>
+    <span class="connection-text">@displayText</span>
+</div>
+
+@code {
+    [Parameter] public ConnectionState State { get; set; } = ConnectionState.Disconnected;
+    [Parameter] public string? CustomText { get; set; }
+    [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    // TODO: Subscribe to IDashboardEventBus in Phase 5
+}

--- a/src/DiscordBot.Bot/Components/Shared/DashboardWidget.razor
+++ b/src/DiscordBot.Bot/Components/Shared/DashboardWidget.razor
@@ -1,0 +1,94 @@
+@{
+    var colSpanClass = ColSpan == 2 ? "md:col-span-2" : "md:col-span-1";
+}
+
+<div class="@colSpanClass bg-bg-secondary border border-border-primary rounded-lg overflow-hidden">
+    <!-- Widget Header -->
+    <div class="px-4 sm:px-6 py-4">
+        <div class="flex items-center justify-between">
+            <div class="flex items-center gap-2">
+                @if (!string.IsNullOrEmpty(IconSvgPath))
+                {
+                    <svg class="w-5 h-5 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@IconSvgPath" />
+                    </svg>
+                }
+                <h3 class="text-lg font-semibold text-text-primary">@Title</h3>
+                @if (IsEnabled.HasValue)
+                {
+                    @if (IsEnabled.Value)
+                    {
+                        <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-success/20 text-success">
+                            <span class="w-1.5 h-1.5 rounded-full bg-success mr-1"></span>
+                            @EnabledLabel
+                        </span>
+                    }
+                    else
+                    {
+                        <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-error/20 text-error">
+                            <span class="w-1.5 h-1.5 rounded-full bg-error mr-1"></span>
+                            @DisabledLabel
+                        </span>
+                    }
+                }
+            </div>
+            <div class="flex items-center gap-3">
+                @if (HeaderActions?.Any() == true)
+                {
+                    foreach (var action in HeaderActions)
+                    {
+                        <a href="@action.Url" class="text-sm text-text-secondary hover:text-text-primary transition-colors">
+                            @action.Text
+                        </a>
+                    }
+                }
+                @if (!string.IsNullOrEmpty(DetailUrl))
+                {
+                    <a href="@DetailUrl" class="text-sm text-accent-blue hover:text-accent-blue/80 transition-colors">
+                        @DetailLinkText
+                    </a>
+                }
+            </div>
+        </div>
+        @if (!string.IsNullOrEmpty(Subtitle))
+        {
+            <p class="text-sm text-text-secondary mt-1">@Subtitle</p>
+        }
+    </div>
+
+    <!-- Widget Body -->
+    <div class="px-4 sm:px-6 pb-4 sm:pb-6">
+        @if (BodyContent != null)
+        {
+            @BodyContent
+        }
+        else if (EmptyStateModel != null)
+        {
+            <EmptyState
+                Type="@EmptyStateModel.Type"
+                Title="@EmptyStateModel.Title"
+                Description="@EmptyStateModel.Description"
+                IconSvgPath="@EmptyStateModel.IconSvgPath"
+                PrimaryActionText="@EmptyStateModel.PrimaryActionText"
+                PrimaryActionUrl="@EmptyStateModel.PrimaryActionUrl"
+                SecondaryActionText="@EmptyStateModel.SecondaryActionText"
+                SecondaryActionUrl="@EmptyStateModel.SecondaryActionUrl"
+                Size="@EmptyStateModel.Size" />
+        }
+    </div>
+</div>
+
+@code {
+    [Parameter] public string Title { get; set; } = string.Empty;
+    [Parameter] public string? Subtitle { get; set; }
+    [Parameter] public string? DetailUrl { get; set; }
+    [Parameter] public string DetailLinkText { get; set; } = "View All \u2192";
+    [Parameter] public string? IconSvgPath { get; set; }
+    [Parameter] public bool? IsEnabled { get; set; }
+    [Parameter] public string EnabledLabel { get; set; } = "Enabled";
+    [Parameter] public string DisabledLabel { get; set; } = "Disabled";
+    [Parameter] public RenderFragment? BodyContent { get; set; }
+    [Parameter] public EmptyStateViewModel? EmptyStateModel { get; set; }
+    [Parameter] public int ColSpan { get; set; } = 1;
+    [Parameter] public List<WidgetHeaderAction>? HeaderActions { get; set; }
+}

--- a/src/DiscordBot.Bot/Components/Shared/EmphasisToolbar.razor
+++ b/src/DiscordBot.Bot/Components/Shared/EmphasisToolbar.razor
@@ -1,0 +1,272 @@
+@inject IJSRuntime JS
+
+<div id="@ContainerId"
+     class="emphasis-toolbar hidden"
+     role="toolbar"
+     aria-label="Text formatting toolbar"
+     data-target="@TargetTextareaId">
+
+    <!-- Strong Emphasis -->
+    <button type="button"
+            class="emphasis-toolbar__button emphasis-toolbar__button--strong @(!EmphasisSupported ? "emphasis-toolbar__button--emphasis-disabled" : "")"
+            title="Strong Emphasis@(ShowKeyboardShortcuts ? " (Ctrl+B)" : "")"
+            data-action="emphasis"
+            data-level="strong"
+            aria-label="Apply strong emphasis to selected text"
+            @onclick="OnStrongEmphasis">
+        <strong>B</strong>
+    </button>
+
+    <!-- Moderate Emphasis -->
+    <button type="button"
+            class="emphasis-toolbar__button emphasis-toolbar__button--moderate @(!EmphasisSupported ? "emphasis-toolbar__button--emphasis-disabled" : "")"
+            title="Moderate Emphasis@(ShowKeyboardShortcuts ? " (Ctrl+E)" : "")"
+            data-action="emphasis"
+            data-level="moderate"
+            aria-label="Apply moderate emphasis to selected text"
+            @onclick="OnModerateEmphasis">
+        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
+        </svg>
+    </button>
+
+    <div class="emphasis-toolbar__separator"></div>
+
+    <!-- Insert Pause -->
+    <button type="button"
+            class="emphasis-toolbar__button"
+            title="Insert Pause"
+            data-action="pause"
+            aria-label="Insert pause at cursor position"
+            @onclick="OnPause">
+        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 4v16m12-16v16" />
+        </svg>
+    </button>
+
+    <div class="emphasis-toolbar__separator"></div>
+
+    <!-- Say-as Number -->
+    <button type="button"
+            class="emphasis-toolbar__button"
+            title="Say as Number"
+            data-action="say-as"
+            data-interpret-as="cardinal"
+            aria-label="Format selected text as number"
+            @onclick="OnSayAsCardinal">
+        <strong>#</strong>
+    </button>
+
+    <!-- Say-as Date -->
+    <button type="button"
+            class="emphasis-toolbar__button"
+            title="Say as Date"
+            data-action="say-as"
+            data-interpret-as="date"
+            aria-label="Format selected text as date"
+            @onclick="OnSayAsDate">
+        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5" />
+        </svg>
+    </button>
+
+    <div class="emphasis-toolbar__separator"></div>
+
+    <!-- Clear Formatting -->
+    <button type="button"
+            class="emphasis-toolbar__button"
+            title="Clear Formatting"
+            data-action="clear"
+            aria-label="Remove formatting from selected text"
+            @onclick="OnClearFormatting">
+        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+    </button>
+</div>
+
+@if (!EmphasisSupported)
+{
+    <div id="@(ContainerId)-emphasis-notice"
+         class="emphasis-toolbar__notice"
+         role="status"
+         aria-live="polite">
+        <em>Emphasis is not supported by this voice.</em>
+    </div>
+}
+
+<style>
+    .emphasis-toolbar {
+        position: fixed;
+        background: var(--color-bg-secondary);
+        border: 1px solid var(--color-border-primary);
+        border-radius: 0.5rem;
+        padding: 0.5rem;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.3);
+        z-index: var(--z-popover, 1000);
+        animation: emphasisToolbar_slideUp 0.2s ease-out;
+        pointer-events: auto;
+    }
+
+    .emphasis-toolbar.hidden {
+        display: none;
+        pointer-events: none;
+    }
+
+    @@keyframes emphasisToolbar_slideUp {
+        from {
+            opacity: 0;
+            transform: translateY(10px);
+        }
+        to {
+            opacity: 1;
+            transform: translateY(0);
+        }
+    }
+
+    .emphasis-toolbar__button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 40px;
+        height: 40px;
+        border-radius: 0.375rem;
+        background: var(--color-bg-tertiary);
+        border: 1px solid var(--color-border-primary);
+        color: var(--color-text-primary);
+        cursor: pointer;
+        transition: all 150ms ease-out;
+        font-weight: 600;
+        font-size: 0.75rem;
+    }
+
+    .emphasis-toolbar__button:hover {
+        background: var(--color-bg-hover);
+        border-color: var(--color-accent-orange);
+    }
+
+    .emphasis-toolbar__button:focus {
+        outline: none;
+        box-shadow: 0 0 0 3px var(--color-accent-orange-muted);
+    }
+
+    .emphasis-toolbar__button--strong {
+        color: var(--color-accent-orange);
+    }
+
+    .emphasis-toolbar__button--strong:hover {
+        background: var(--color-accent-orange-muted);
+        border-color: var(--color-accent-orange);
+    }
+
+    .emphasis-toolbar__button--moderate {
+        color: var(--color-accent-blue);
+    }
+
+    .emphasis-toolbar__button--moderate:hover {
+        background: var(--color-accent-blue-muted);
+        border-color: var(--color-accent-blue);
+    }
+
+    .emphasis-toolbar__button svg {
+        width: 1rem;
+        height: 1rem;
+        flex-shrink: 0;
+    }
+
+    .emphasis-toolbar__separator {
+        width: 1px;
+        height: 24px;
+        background: var(--color-border-secondary);
+        margin: 0 0.25rem;
+    }
+
+    .emphasis-toolbar__button--emphasis-disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+        pointer-events: none;
+    }
+
+    .emphasis-toolbar__notice {
+        position: fixed;
+        background: var(--color-bg-secondary);
+        border: 1px solid var(--color-border-primary);
+        border-radius: 0.375rem;
+        padding: 0.375rem 0.75rem;
+        font-size: 0.75rem;
+        color: var(--color-text-tertiary);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+        z-index: var(--z-popover, 1000);
+        white-space: nowrap;
+    }
+
+    .emphasis-toolbar__notice.hidden {
+        display: none;
+    }
+
+    @@media (max-width: 767px) {
+        .emphasis-toolbar {
+            position: fixed !important;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            width: 100%;
+            border-radius: 0.75rem 0.75rem 0 0;
+            padding: 1rem;
+            justify-content: center;
+            box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.5);
+            animation: emphasisToolbar_slideUpMobile 0.3s ease-out;
+        }
+
+        @@keyframes emphasisToolbar_slideUpMobile {
+            from {
+                opacity: 0;
+                transform: translateY(100%);
+            }
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+
+        .emphasis-toolbar__button {
+            min-width: 44px;
+            min-height: 44px;
+        }
+    }
+</style>
+
+@code {
+    [Parameter] public string TargetTextareaId { get; set; } = string.Empty;
+    [Parameter] public string ContainerId { get; set; } = "emphasisToolbar";
+    [Parameter] public EventCallback<EmphasisFormatAction> OnFormatChange { get; set; }
+    [Parameter] public bool ShowKeyboardShortcuts { get; set; } = true;
+    [Parameter] public bool EmphasisSupported { get; set; } = true;
+
+    private Task OnStrongEmphasis() => ApplyFormat("emphasis", "strong");
+    private Task OnModerateEmphasis() => ApplyFormat("emphasis", "moderate");
+    private Task OnPause() => ApplyFormat("pause", "");
+    private Task OnSayAsCardinal() => ApplyFormat("say-as", "cardinal");
+    private Task OnSayAsDate() => ApplyFormat("say-as", "date");
+    private Task OnClearFormatting() => ApplyFormat("clear", "");
+
+    private async Task ApplyFormat(string action, string option)
+    {
+        if (action == "emphasis" && !EmphasisSupported) return;
+
+        await OnFormatChange.InvokeAsync(new EmphasisFormatAction
+        {
+            Action = action,
+            Option = option
+        });
+    }
+
+    public class EmphasisFormatAction
+    {
+        public string Action { get; set; } = string.Empty;
+        public string Option { get; set; } = string.Empty;
+    }
+}

--- a/src/DiscordBot.Bot/Components/Shared/EmptyState.razor
+++ b/src/DiscordBot.Bot/Components/Shared/EmptyState.razor
@@ -1,0 +1,83 @@
+@{
+    var (containerClasses, iconContainer, iconSize, titleSize, descSize, buttonSize, iconGap) = Size switch
+    {
+        EmptyStateSize.Compact => ("max-w-[320px] space-y-3 py-5", "p-3", "w-10 h-10", "text-base", "text-xs", "px-4 py-2 text-xs", "gap-1.5"),
+        EmptyStateSize.Large => ("max-w-[500px] space-y-6 py-12", "p-5", "w-20 h-20", "text-2xl", "text-base", "px-6 py-3 text-base", "gap-2.5"),
+        _ => ("max-w-[400px] space-y-4 py-8", "p-4", "w-16 h-16", "text-lg", "text-sm", "px-5 py-2.5 text-sm", "gap-2")
+    };
+
+    var iconPath = IconSvgPath ?? Type switch
+    {
+        EmptyStateType.NoResults => "M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z",
+        EmptyStateType.FirstTime => "M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 00-2.456 2.456zM16.894 20.567L16.5 21.75l-.394-1.183a2.25 2.25 0 00-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 001.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 001.423 1.423l1.183.394-1.183.394a2.25 2.25 0 00-1.423 1.423z",
+        EmptyStateType.Error => "M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z",
+        EmptyStateType.NoPermission => "M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z",
+        EmptyStateType.Offline => "M8.288 15.038a5.25 5.25 0 017.424 0M5.106 11.856c3.807-3.808 9.98-3.808 13.788 0M1.924 8.674c5.565-5.565 14.587-5.565 20.152 0M12.53 18.22l-.53.53-.53-.53a.75.75 0 011.06 0z",
+        _ => "M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"
+    };
+
+    var iconStrokeWidth = Type == EmptyStateType.NoData ? "1.5" : "2";
+}
+
+<div class="flex flex-col items-center text-center @containerClasses mx-auto">
+    <div class="@iconContainer bg-bg-tertiary rounded-full">
+        <svg class="@iconSize text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="@iconStrokeWidth" d="@iconPath" />
+        </svg>
+    </div>
+
+    <div>
+        <h3 class="@titleSize font-semibold text-text-primary @(Size == EmptyStateSize.Compact ? "mb-1" : "mb-2")">@Title</h3>
+        <p class="@descSize text-text-secondary">@Description</p>
+    </div>
+
+    @if (!string.IsNullOrEmpty(PrimaryActionText) || !string.IsNullOrEmpty(SecondaryActionText))
+    {
+        <div class="flex flex-col sm:flex-row items-center gap-3">
+            @if (!string.IsNullOrEmpty(PrimaryActionText))
+            {
+                @if (!string.IsNullOrEmpty(PrimaryActionUrl))
+                {
+                    <a href="@PrimaryActionUrl" class="inline-flex items-center @iconGap @buttonSize bg-accent-orange hover:bg-accent-orange-hover text-white font-semibold rounded-md transition-colors">
+                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+                        </svg>
+                        @PrimaryActionText
+                    </a>
+                }
+                else
+                {
+                    <button
+                        type="button"
+                        class="inline-flex items-center @iconGap @buttonSize bg-accent-orange hover:bg-accent-orange-hover text-white font-semibold rounded-md transition-colors"
+                        @onclick="PrimaryActionClick">
+                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+                        </svg>
+                        @PrimaryActionText
+                    </button>
+                }
+            }
+
+            @if (!string.IsNullOrEmpty(SecondaryActionText) && !string.IsNullOrEmpty(SecondaryActionUrl))
+            {
+                <a href="@SecondaryActionUrl" class="@descSize text-accent-blue hover:text-accent-blue-hover transition-colors">
+                    @SecondaryActionText
+                </a>
+            }
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter] public EmptyStateType Type { get; set; } = EmptyStateType.NoData;
+    [Parameter] public string Title { get; set; } = "No Data";
+    [Parameter] public string Description { get; set; } = "There are no items to display.";
+    [Parameter] public string? IconSvgPath { get; set; }
+    [Parameter] public string? PrimaryActionText { get; set; }
+    [Parameter] public string? PrimaryActionUrl { get; set; }
+    [Parameter] public EventCallback PrimaryActionClick { get; set; }
+    [Parameter] public string? SecondaryActionText { get; set; }
+    [Parameter] public string? SecondaryActionUrl { get; set; }
+    [Parameter] public EmptyStateSize Size { get; set; } = EmptyStateSize.Default;
+}

--- a/src/DiscordBot.Bot/Components/Shared/EnhancedCard.razor
+++ b/src/DiscordBot.Bot/Components/Shared/EnhancedCard.razor
@@ -1,0 +1,127 @@
+@{
+    var accentClass = AccentColor switch
+    {
+        CardAccent.Blue => "accent-blue",
+        CardAccent.Orange => "accent-orange",
+        CardAccent.Success => "accent-success",
+        CardAccent.Info => "accent-info",
+        _ => ""
+    };
+
+    var hoverClass = HoverLift ? "hover:transform hover:-translate-y-0.5" : "";
+    var interactiveClass = IsInteractive ? "cursor-pointer" : "";
+    var cardClasses = $"card-enhanced {accentClass} {hoverClass} {interactiveClass} {CssClass ?? ""}".Trim();
+
+    var hasHeader = !string.IsNullOrEmpty(Title) || HeaderContent != null || HeaderActions != null;
+    var hasFooter = FooterContent != null;
+    var bodyOnly = !hasHeader && !hasFooter;
+    var bodyPaddingClass = CompactPadding ? "p-4" : "p-6";
+}
+
+<div class="@cardClasses"
+     @(Id != null ? $"id=\"{Id}\"" : "")
+     @onclick="OnClick">
+
+    @if (hasHeader)
+    {
+        @if (IsCollapsible)
+        {
+            <button
+                type="button"
+                class="w-full flex items-center justify-between px-6 py-4 @(hasFooter || BodyContent != null ? "border-b border-border-primary" : "") hover:bg-bg-hover transition-colors"
+                @onclick="ToggleCollapse"
+                @onclick:stopPropagation="true"
+                aria-expanded="@(_isExpanded ? "true" : "false")"
+            >
+                <div class="text-left">
+                    @if (HeaderContent != null)
+                    {
+                        @HeaderContent
+                    }
+                    else if (!string.IsNullOrEmpty(Title))
+                    {
+                        <h3 class="text-lg font-semibold text-text-primary">@Title</h3>
+                        @if (!string.IsNullOrEmpty(Subtitle))
+                        {
+                            <p class="text-sm text-text-secondary mt-1">@Subtitle</p>
+                        }
+                    }
+                </div>
+                <svg class="w-5 h-5 text-text-secondary transition-transform @(_isExpanded ? "" : "rotate-180")"
+                     fill="none"
+                     viewBox="0 0 24 24"
+                     stroke="currentColor"
+                     aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                </svg>
+            </button>
+        }
+        else
+        {
+            <div class="flex items-center justify-between px-6 py-4 @(hasFooter || BodyContent != null ? "border-b border-border-primary" : "")">
+                <div>
+                    @if (HeaderContent != null)
+                    {
+                        @HeaderContent
+                    }
+                    else if (!string.IsNullOrEmpty(Title))
+                    {
+                        <h3 class="text-lg font-semibold text-text-primary">@Title</h3>
+                        @if (!string.IsNullOrEmpty(Subtitle))
+                        {
+                            <p class="text-sm text-text-secondary mt-1">@Subtitle</p>
+                        }
+                    }
+                </div>
+                @if (HeaderActions != null)
+                {
+                    <div>
+                        @HeaderActions
+                    </div>
+                }
+            </div>
+        }
+    }
+
+    @if (BodyContent != null)
+    {
+        <div class="@(bodyOnly ? bodyPaddingClass : IsCollapsible && !_isExpanded ? $"{bodyPaddingClass} hidden" : bodyPaddingClass)">
+            @BodyContent
+        </div>
+    }
+
+    @if (hasFooter)
+    {
+        <div class="flex items-center justify-between px-6 py-4 border-t border-border-primary bg-bg-primary/50">
+            @FooterContent
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter] public string? Title { get; set; }
+    [Parameter] public string? Subtitle { get; set; }
+    [Parameter] public RenderFragment? HeaderContent { get; set; }
+    [Parameter] public RenderFragment? HeaderActions { get; set; }
+    [Parameter] public RenderFragment? BodyContent { get; set; }
+    [Parameter] public RenderFragment? FooterContent { get; set; }
+    [Parameter] public CardAccent AccentColor { get; set; } = CardAccent.None;
+    [Parameter] public bool ShowGradientTop { get; set; } = true;
+    [Parameter] public bool HoverLift { get; set; } = true;
+    [Parameter] public bool IsInteractive { get; set; }
+    [Parameter] public EventCallback OnClick { get; set; }
+    [Parameter] public bool IsCollapsible { get; set; }
+    [Parameter] public bool IsExpanded { get; set; } = true;
+    [Parameter] public string? CssClass { get; set; }
+    [Parameter] public bool CompactPadding { get; set; }
+    [Parameter] public string? Id { get; set; }
+
+    private bool _isExpanded = true;
+
+    protected override void OnParametersSet()
+    {
+        _isExpanded = IsExpanded;
+    }
+
+    private void ToggleCollapse() => _isExpanded = !_isExpanded;
+}

--- a/src/DiscordBot.Bot/Components/Shared/FormInput.razor
+++ b/src/DiscordBot.Bot/Components/Shared/FormInput.razor
@@ -1,0 +1,173 @@
+@{
+    var sizeClasses = Size switch
+    {
+        InputSize.Small => "py-1.5 px-3 text-xs",
+        InputSize.Large => "py-3 px-4 text-base",
+        _ => "py-2.5 px-3.5 text-sm"
+    };
+
+    var validationClasses = ValidationState switch
+    {
+        ValidationState.Error => "border-error focus:border-error focus:ring-error/15",
+        ValidationState.Success => "border-success focus:border-success focus:ring-success/15",
+        ValidationState.Warning => "border-warning focus:border-warning focus:ring-warning/15",
+        _ => "border-border-primary focus:border-accent-blue focus:ring-accent-blue/15"
+    };
+
+    var paddingLeft = !string.IsNullOrEmpty(IconLeft) ? "pl-10" : "";
+    var paddingRight = !string.IsNullOrEmpty(IconRight) ? "pr-10" : "";
+
+    var inputClasses = $"w-full {sizeClasses} {paddingLeft} {paddingRight} text-text-primary bg-bg-primary border {validationClasses} rounded-md placeholder-text-tertiary transition-colors focus:outline-none focus:ring-[3px]";
+
+    if (IsDisabled)
+    {
+        inputClasses += " bg-bg-secondary text-text-tertiary cursor-not-allowed opacity-60";
+    }
+
+    var helpTextId = $"{Id}-help";
+    var errorId = $"{Id}-error";
+    var successId = $"{Id}-success";
+    var warningId = $"{Id}-warning";
+
+    var describedByIds = new List<string>();
+    if (!string.IsNullOrEmpty(HelpText) && ValidationState == ValidationState.None)
+    {
+        describedByIds.Add(helpTextId);
+    }
+    if (ValidationState == ValidationState.Error && !string.IsNullOrEmpty(ValidationMessage))
+    {
+        describedByIds.Add(errorId);
+    }
+    if (ValidationState == ValidationState.Success && !string.IsNullOrEmpty(ValidationMessage))
+    {
+        describedByIds.Add(successId);
+    }
+    if (ValidationState == ValidationState.Warning && !string.IsNullOrEmpty(ValidationMessage))
+    {
+        describedByIds.Add(warningId);
+    }
+    var ariaDescribedBy = describedByIds.Count > 0 ? string.Join(" ", describedByIds) : null;
+    var ariaInvalid = ValidationState == ValidationState.Error;
+}
+
+<div class="space-y-1.5">
+    @if (!string.IsNullOrEmpty(Label))
+    {
+        <label for="@Id" class="block text-sm font-medium text-text-primary">
+            @Label
+            @if (IsRequired)
+            {
+                <span class="text-error">*</span>
+            }
+        </label>
+    }
+
+    <div class="relative">
+        @if (!string.IsNullOrEmpty(IconLeft))
+        {
+            <div class="absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none">
+                <svg class="w-5 h-5 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@IconLeft" />
+                </svg>
+            </div>
+        }
+
+        <input
+            type="@Type"
+            id="@Id"
+            name="@Name"
+            class="@inputClasses"
+            placeholder="@Placeholder"
+            value="@Value"
+            required="@IsRequired"
+            aria-required="@(IsRequired ? "true" : null)"
+            disabled="@IsDisabled"
+            readonly="@IsReadOnly"
+            maxlength="@MaxLength"
+            aria-describedby="@ariaDescribedBy"
+            aria-invalid="@(ariaInvalid ? "true" : null)"
+            @oninput="HandleInput"
+            @attributes="AdditionalAttributes" />
+
+        @if (!string.IsNullOrEmpty(IconRight))
+        {
+            <div class="absolute right-3 top-1/2 -translate-y-1/2">
+                <svg class="w-5 h-5 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@IconRight" />
+                </svg>
+            </div>
+        }
+    </div>
+
+    @if (!string.IsNullOrEmpty(HelpText) && ValidationState == ValidationState.None)
+    {
+        <p id="@helpTextId" class="text-xs text-text-secondary">@HelpText</p>
+    }
+
+    @if (ValidationState == ValidationState.Error && !string.IsNullOrEmpty(ValidationMessage))
+    {
+        <p id="@errorId" class="flex items-center gap-1.5 text-xs text-error" role="alert">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            @ValidationMessage
+        </p>
+    }
+
+    @if (ValidationState == ValidationState.Success && !string.IsNullOrEmpty(ValidationMessage))
+    {
+        <p id="@successId" class="flex items-center gap-1.5 text-xs text-success">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            @ValidationMessage
+        </p>
+    }
+
+    @if (ValidationState == ValidationState.Warning && !string.IsNullOrEmpty(ValidationMessage))
+    {
+        <p id="@warningId" class="flex items-center gap-1.5 text-xs text-warning" role="alert">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+            </svg>
+            @ValidationMessage
+        </p>
+    }
+
+    @if (ShowCharacterCount && MaxLength.HasValue)
+    {
+        <div class="flex justify-end">
+            <span class="text-xs text-text-tertiary">
+                @(Value?.Length ?? 0)/@MaxLength.Value
+            </span>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter] public string Id { get; set; } = string.Empty;
+    [Parameter] public string Name { get; set; } = string.Empty;
+    [Parameter] public string? Label { get; set; }
+    [Parameter] public string Type { get; set; } = "text";
+    [Parameter] public string? Placeholder { get; set; }
+    [Parameter] public string? Value { get; set; }
+    [Parameter] public EventCallback<string?> ValueChanged { get; set; }
+    [Parameter] public string? HelpText { get; set; }
+    [Parameter] public InputSize Size { get; set; } = InputSize.Medium;
+    [Parameter] public ValidationState ValidationState { get; set; } = ValidationState.None;
+    [Parameter] public string? ValidationMessage { get; set; }
+    [Parameter] public bool IsRequired { get; set; }
+    [Parameter] public bool IsDisabled { get; set; }
+    [Parameter] public bool IsReadOnly { get; set; }
+    [Parameter] public string? IconLeft { get; set; }
+    [Parameter] public string? IconRight { get; set; }
+    [Parameter] public int? MaxLength { get; set; }
+    [Parameter] public bool ShowCharacterCount { get; set; }
+    [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private async Task HandleInput(ChangeEventArgs e)
+    {
+        Value = e.Value?.ToString();
+        await ValueChanged.InvokeAsync(Value);
+    }
+}

--- a/src/DiscordBot.Bot/Components/Shared/FormSelect.razor
+++ b/src/DiscordBot.Bot/Components/Shared/FormSelect.razor
@@ -1,0 +1,140 @@
+@{
+    var sizeClasses = Size switch
+    {
+        InputSize.Small => "py-1.5 px-3 text-xs",
+        InputSize.Large => "py-3 px-4 text-base",
+        _ => "py-2.5 px-3.5 text-sm"
+    };
+
+    var validationClasses = ValidationState switch
+    {
+        ValidationState.Error => "border-error focus:border-error focus:ring-error/15",
+        ValidationState.Success => "border-success focus:border-success focus:ring-success/15",
+        ValidationState.Warning => "border-warning focus:border-warning focus:ring-warning/15",
+        _ => "border-border-primary focus:border-accent-blue focus:ring-accent-blue/15"
+    };
+
+    var selectClasses = $"w-full {sizeClasses} pr-10 text-text-primary bg-bg-primary border {validationClasses} rounded-md appearance-none transition-colors focus:outline-none focus:ring-[3px]";
+
+    if (IsDisabled)
+    {
+        selectClasses += " bg-bg-secondary text-text-tertiary cursor-not-allowed opacity-60";
+    }
+}
+
+<div class="space-y-1.5">
+    @if (!string.IsNullOrEmpty(Label))
+    {
+        <label for="@Id" class="block text-sm font-medium text-text-primary">
+            @Label
+            @if (IsRequired)
+            {
+                <span class="text-error">*</span>
+            }
+        </label>
+    }
+
+    <div class="relative">
+        <select
+            id="@Id"
+            name="@Name"
+            class="@selectClasses"
+            required="@IsRequired"
+            disabled="@IsDisabled"
+            multiple="@AllowMultiple"
+            @onchange="HandleChange"
+            @attributes="AdditionalAttributes">
+            @if (!string.IsNullOrEmpty(Placeholder) && !AllowMultiple)
+            {
+                var placeholderSelected = string.IsNullOrEmpty(SelectedValue);
+                <option value="" disabled selected="@placeholderSelected">@Placeholder</option>
+            }
+
+            @if (OptionGroups != null && OptionGroups.Any())
+            {
+                @foreach (var group in OptionGroups)
+                {
+                    <optgroup label="@group.Label">
+                        @foreach (var option in group.Options)
+                        {
+                            <option value="@option.Value" selected="@(option.Value == SelectedValue)" disabled="@option.IsDisabled">@option.Text</option>
+                        }
+                    </optgroup>
+                }
+            }
+            else
+            {
+                @foreach (var option in Options)
+                {
+                    <option value="@option.Value" selected="@(option.Value == SelectedValue)" disabled="@option.IsDisabled">@option.Text</option>
+                }
+            }
+        </select>
+
+        <div class="absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none">
+            <svg class="w-5 h-5 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            </svg>
+        </div>
+    </div>
+
+    @if (!string.IsNullOrEmpty(HelpText) && ValidationState == ValidationState.None)
+    {
+        <p class="text-xs text-text-secondary">@HelpText</p>
+    }
+
+    @if (ValidationState == ValidationState.Error && !string.IsNullOrEmpty(ValidationMessage))
+    {
+        <p class="flex items-center gap-1.5 text-xs text-error">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            @ValidationMessage
+        </p>
+    }
+
+    @if (ValidationState == ValidationState.Success && !string.IsNullOrEmpty(ValidationMessage))
+    {
+        <p class="flex items-center gap-1.5 text-xs text-success">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            @ValidationMessage
+        </p>
+    }
+
+    @if (ValidationState == ValidationState.Warning && !string.IsNullOrEmpty(ValidationMessage))
+    {
+        <p class="flex items-center gap-1.5 text-xs text-warning">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+            </svg>
+            @ValidationMessage
+        </p>
+    }
+</div>
+
+@code {
+    [Parameter] public string Id { get; set; } = string.Empty;
+    [Parameter] public string Name { get; set; } = string.Empty;
+    [Parameter] public string? Label { get; set; }
+    [Parameter] public string? Placeholder { get; set; } = "Select an option";
+    [Parameter] public string? SelectedValue { get; set; }
+    [Parameter] public EventCallback<string?> SelectedValueChanged { get; set; }
+    [Parameter] public List<SelectOption> Options { get; set; } = new();
+    [Parameter] public List<SelectOptionGroup>? OptionGroups { get; set; }
+    [Parameter] public string? HelpText { get; set; }
+    [Parameter] public InputSize Size { get; set; } = InputSize.Medium;
+    [Parameter] public ValidationState ValidationState { get; set; } = ValidationState.None;
+    [Parameter] public string? ValidationMessage { get; set; }
+    [Parameter] public bool IsRequired { get; set; }
+    [Parameter] public bool IsDisabled { get; set; }
+    [Parameter] public bool AllowMultiple { get; set; }
+    [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private async Task HandleChange(ChangeEventArgs e)
+    {
+        SelectedValue = e.Value?.ToString();
+        await SelectedValueChanged.InvokeAsync(SelectedValue);
+    }
+}

--- a/src/DiscordBot.Bot/Components/Shared/FormToggle.razor
+++ b/src/DiscordBot.Bot/Components/Shared/FormToggle.razor
@@ -1,0 +1,113 @@
+<div class="flex items-start gap-4">
+    <label class="form-toggle @(IsDisabled ? "opacity-60 cursor-not-allowed" : "cursor-pointer")">
+        <input type="checkbox"
+               id="@Id"
+               name="@Name"
+               class="form-toggle-input"
+               data-setting-toggle="true"
+               checked="@IsChecked"
+               disabled="@IsDisabled"
+               value="true"
+               @onchange="HandleChange" />
+        <span class="form-toggle-track">
+            <span class="form-toggle-thumb"></span>
+        </span>
+    </label>
+
+    @if (!string.IsNullOrEmpty(Label) || !string.IsNullOrEmpty(Description))
+    {
+        <div class="flex-1">
+            @if (!string.IsNullOrEmpty(Label))
+            {
+                <label for="@Id" class="block text-sm font-semibold text-text-primary @(IsDisabled ? "cursor-not-allowed" : "cursor-pointer")">
+                    @Label
+                </label>
+            }
+            @if (!string.IsNullOrEmpty(Description))
+            {
+                <p class="text-xs text-text-secondary mt-1">@Description</p>
+            }
+        </div>
+    }
+</div>
+
+<style>
+    /* Toggle Switch Component */
+    .form-toggle {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+    }
+
+    .form-toggle-input {
+        position: absolute;
+        opacity: 0;
+        width: 0;
+        height: 0;
+    }
+
+    .form-toggle-track {
+        position: relative;
+        display: inline-block;
+        width: 2.75rem;
+        height: 1.5rem;
+        background-color: #3f4447;
+        border-radius: 9999px;
+        flex-shrink: 0;
+        transition: background-color 0.2s ease-in-out;
+    }
+
+    .form-toggle-thumb {
+        position: absolute;
+        top: 0.125rem;
+        left: 0.125rem;
+        width: 1.25rem;
+        height: 1.25rem;
+        background-color: #d7d3d0;
+        border-radius: 50%;
+        transition: transform 0.2s ease-in-out, background-color 0.2s ease-in-out;
+    }
+
+    .form-toggle:hover .form-toggle-track {
+        background-color: #4a4f52;
+    }
+
+    .form-toggle:hover .form-toggle-input:checked + .form-toggle-track {
+        background-color: #e5591f;
+    }
+
+    .form-toggle-input:focus-visible + .form-toggle-track {
+        outline: 2px solid #098ecf;
+        outline-offset: 2px;
+    }
+
+    .form-toggle-input:checked + .form-toggle-track {
+        background-color: #cb4e1b;
+    }
+
+    .form-toggle-input:checked + .form-toggle-track .form-toggle-thumb {
+        transform: translateX(1.25rem);
+        background-color: white;
+    }
+
+    .form-toggle-input:disabled + .form-toggle-track {
+        opacity: 0.6;
+        cursor: not-allowed;
+    }
+</style>
+
+@code {
+    [Parameter] public string Id { get; set; } = string.Empty;
+    [Parameter] public string Name { get; set; } = string.Empty;
+    [Parameter] public string? Label { get; set; }
+    [Parameter] public string? Description { get; set; }
+    [Parameter] public bool IsChecked { get; set; }
+    [Parameter] public EventCallback<bool> IsCheckedChanged { get; set; }
+    [Parameter] public bool IsDisabled { get; set; }
+
+    private async Task HandleChange(ChangeEventArgs e)
+    {
+        IsChecked = (bool)(e.Value ?? false);
+        await IsCheckedChanged.InvokeAsync(IsChecked);
+    }
+}

--- a/src/DiscordBot.Bot/Components/Shared/GuildBreadcrumb.razor
+++ b/src/DiscordBot.Bot/Components/Shared/GuildBreadcrumb.razor
@@ -1,0 +1,33 @@
+@if (Items?.Any() == true)
+{
+    <nav aria-label="Breadcrumb" class="mb-6">
+        <ol class="flex items-center gap-2 text-sm">
+            @foreach (var item in Items)
+            {
+                <li class="flex items-center gap-2">
+                    @if (!item.IsCurrent && !string.IsNullOrEmpty(item.Url))
+                    {
+                        <a href="@item.Url" class="text-text-secondary hover:text-accent-blue transition-colors">
+                            @item.Label
+                        </a>
+                    }
+                    else
+                    {
+                        <span class="text-text-primary font-medium">@item.Label</span>
+                    }
+
+                    @if (!item.IsCurrent)
+                    {
+                        <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                        </svg>
+                    }
+                </li>
+            }
+        </ol>
+    </nav>
+}
+
+@code {
+    [Parameter] public List<BreadcrumbItem>? Items { get; set; }
+}

--- a/src/DiscordBot.Bot/Components/Shared/GuildHeader.razor
+++ b/src/DiscordBot.Bot/Components/Shared/GuildHeader.razor
@@ -1,0 +1,109 @@
+@{
+    var hasActions = Actions?.Any() == true;
+    var hasStatusBadge = StatusBadge != null;
+}
+
+<div class="mb-8">
+    <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+        <!-- Left: Icon + Title + Description -->
+        <div class="flex items-center gap-4">
+            <!-- Guild Icon -->
+            @if (!string.IsNullOrEmpty(GuildIconUrl))
+            {
+                <img src="@GuildIconUrl"
+                     alt="@GuildName"
+                     class="w-12 h-12 rounded-full flex-shrink-0" />
+            }
+            else
+            {
+                <div class="w-12 h-12 rounded-full bg-gradient-to-br from-accent-blue to-accent-orange flex items-center justify-center text-white font-bold text-lg flex-shrink-0">
+                    @(GuildName.Length >= 2 ? GuildName[..2].ToUpper() : GuildName.ToUpper())
+                </div>
+            }
+
+            <!-- Title + Description -->
+            <div>
+                <h1 class="text-2xl font-bold text-text-primary">@PageTitle</h1>
+                @if (!string.IsNullOrEmpty(PageDescription))
+                {
+                    <p class="mt-1 text-sm text-text-secondary">@PageDescription</p>
+                }
+            </div>
+        </div>
+
+        <!-- Right: Status Badge + Action Buttons -->
+        @if (hasActions || hasStatusBadge)
+        {
+            <div class="flex items-center gap-2">
+                @if (hasStatusBadge)
+                {
+                    <Badge Text="@StatusBadge!.Text"
+                           Variant="@StatusBadge.Variant"
+                           Size="@StatusBadge.Size"
+                           Style="@StatusBadge.Style" />
+                }
+                @if (hasActions)
+                {
+                    @foreach (var action in Actions!)
+                    {
+                        @if (action.Style == HeaderActionStyle.Primary)
+                        {
+                            <a href="@action.Url"
+                               target="@(action.OpenInNewTab ? "_blank" : null)"
+                               rel="@(action.OpenInNewTab ? "noopener noreferrer" : null)"
+                               class="px-4 py-2 bg-accent-orange text-white font-medium text-sm rounded-lg hover:bg-accent-orange-hover transition-colors inline-flex items-center gap-2">
+                                @if (!string.IsNullOrEmpty(action.Icon))
+                                {
+                                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@action.Icon" />
+                                    </svg>
+                                }
+                                <span>@action.Label</span>
+                            </a>
+                        }
+                        else if (action.Style == HeaderActionStyle.Secondary)
+                        {
+                            <a href="@action.Url"
+                               target="@(action.OpenInNewTab ? "_blank" : null)"
+                               rel="@(action.OpenInNewTab ? "noopener noreferrer" : null)"
+                               class="px-3 py-2 text-sm font-medium text-text-secondary hover:text-accent-blue bg-bg-secondary border border-border-primary rounded-lg hover:border-border-focus transition-colors inline-flex items-center gap-2">
+                                @if (!string.IsNullOrEmpty(action.Icon))
+                                {
+                                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@action.Icon" />
+                                    </svg>
+                                }
+                                <span>@action.Label</span>
+                            </a>
+                        }
+                        else if (action.Style == HeaderActionStyle.Link)
+                        {
+                            <a href="@action.Url"
+                               target="@(action.OpenInNewTab ? "_blank" : null)"
+                               rel="@(action.OpenInNewTab ? "noopener noreferrer" : null)"
+                               class="text-sm font-medium text-accent-blue hover:text-accent-blue-hover transition-colors inline-flex items-center gap-1">
+                                @if (!string.IsNullOrEmpty(action.Icon))
+                                {
+                                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@action.Icon" />
+                                    </svg>
+                                }
+                                <span>@action.Label</span>
+                            </a>
+                        }
+                    }
+                }
+            </div>
+        }
+    </div>
+</div>
+
+@code {
+    [Parameter] public ulong GuildId { get; set; }
+    [Parameter] public string GuildName { get; set; } = string.Empty;
+    [Parameter] public string? GuildIconUrl { get; set; }
+    [Parameter] public string PageTitle { get; set; } = string.Empty;
+    [Parameter] public string? PageDescription { get; set; }
+    [Parameter] public List<HeaderAction>? Actions { get; set; }
+    [Parameter] public BadgeViewModel? StatusBadge { get; set; }
+}

--- a/src/DiscordBot.Bot/Components/Shared/GuildPreviewPopup.razor
+++ b/src/DiscordBot.Bot/Components/Shared/GuildPreviewPopup.razor
@@ -1,0 +1,103 @@
+<div class="preview-popup preview-popup-guild" data-guild-id="@GuildId">
+    <!-- Header -->
+    <div class="preview-header">
+        <div class="preview-avatar">
+            @if (!string.IsNullOrEmpty(IconUrl))
+            {
+                <img src="@IconUrl" alt="@Name" class="w-14 h-14 rounded-lg object-cover" />
+            }
+            else
+            {
+                <div class="w-14 h-14 rounded-lg bg-accent-blue-muted flex items-center justify-center">
+                    <span class="text-xl font-semibold text-accent-blue">
+                        @(Name.FirstOrDefault().ToString().ToUpperInvariant())
+                    </span>
+                </div>
+            }
+        </div>
+        <div class="preview-identity flex-1 min-w-0">
+            <span class="preview-username block text-sm font-semibold text-text-primary truncate">
+                @Name
+            </span>
+            <span class="preview-displayname block text-xs text-text-secondary">
+                @MemberCount.ToString("N0") members
+                @if (OnlineMemberCount.HasValue)
+                {
+                    <span class="text-text-tertiary">(@OnlineMemberCount.Value.ToString("N0") online)</span>
+                }
+            </span>
+        </div>
+        @if (!IsActive)
+        {
+            <span class="preview-badge px-1.5 py-0.5 bg-warning-bg text-warning text-xs font-medium rounded" title="Inactive">
+                Inactive
+            </span>
+        }
+    </div>
+
+    <!-- Body -->
+    <div class="preview-body">
+        <div class="preview-meta space-y-2 text-xs">
+            <div class="preview-meta-item flex justify-between">
+                <span class="text-text-tertiary">Owner</span>
+                <span class="text-accent-blue">@OwnerUsername</span>
+            </div>
+            <div class="preview-meta-item flex justify-between">
+                <span class="text-text-tertiary">Bot joined</span>
+                <span class="text-text-secondary">@BotJoinedAt.ToString("MMM d, yyyy")</span>
+            </div>
+            @if (ActiveFeatures.Count > 0)
+            {
+                <div class="preview-meta-item flex justify-between items-start">
+                    <span class="text-text-tertiary">Features</span>
+                    <div class="flex flex-wrap gap-1 justify-end max-w-[180px]">
+                        @foreach (var feature in ActiveFeatures.Take(4))
+                        {
+                            var badgeClass = feature.ToLowerInvariant() switch
+                            {
+                                "moderation" or "automod" => "bg-accent-orange-muted text-accent-orange",
+                                "ratwatch" or "rat watch" => "bg-success-bg text-success",
+                                "welcome" => "bg-accent-blue-muted text-accent-blue",
+                                "logging" => "bg-info-bg text-info",
+                                _ => "bg-bg-hover text-text-secondary"
+                            };
+                            <span class="preview-feature-tag px-1.5 py-0.5 text-[10px] font-medium rounded @badgeClass">
+                                @feature
+                            </span>
+                        }
+                        @if (ActiveFeatures.Count > 4)
+                        {
+                            <span class="preview-feature-tag px-1.5 py-0.5 text-[10px] font-medium rounded bg-bg-hover text-text-tertiary">
+                                +@(ActiveFeatures.Count - 4)
+                            </span>
+                        }
+                    </div>
+                </div>
+            }
+        </div>
+    </div>
+
+    <!-- Footer -->
+    <div class="preview-footer">
+        <a href="@DetailsUrl" class="flex-1 px-3 py-1.5 text-xs font-medium text-white bg-accent-blue rounded hover:bg-accent-blue-hover transition-colors text-center">
+            View Guild
+        </a>
+        <a href="@SettingsUrl" class="flex-1 px-3 py-1.5 text-xs font-medium text-text-secondary bg-bg-tertiary border border-border-primary rounded hover:bg-bg-hover transition-colors text-center">
+            Settings
+        </a>
+    </div>
+</div>
+
+@code {
+    [Parameter] public ulong GuildId { get; set; }
+    [Parameter] public string Name { get; set; } = string.Empty;
+    [Parameter] public string? IconUrl { get; set; }
+    [Parameter] public int MemberCount { get; set; }
+    [Parameter] public int? OnlineMemberCount { get; set; }
+    [Parameter] public string OwnerUsername { get; set; } = string.Empty;
+    [Parameter] public DateTime BotJoinedAt { get; set; }
+    [Parameter] public IReadOnlyList<string> ActiveFeatures { get; set; } = [];
+    [Parameter] public bool IsActive { get; set; }
+    [Parameter] public string DetailsUrl { get; set; } = string.Empty;
+    [Parameter] public string SettingsUrl { get; set; } = string.Empty;
+}

--- a/src/DiscordBot.Bot/Components/Shared/GuildStatsCard.razor
+++ b/src/DiscordBot.Bot/Components/Shared/GuildStatsCard.razor
@@ -1,0 +1,33 @@
+<!-- Guild Stats Card -->
+<div class="block bg-bg-secondary border border-border-primary rounded-lg p-5 transition-colors">
+    <div class="flex items-center justify-between">
+        <div>
+            <p class="text-sm font-medium text-text-secondary">Total Servers</p>
+            <p class="mt-2 text-3xl font-bold text-text-primary">@TotalGuilds</p>
+            <p class="mt-1 text-xs text-text-tertiary flex items-center gap-1.5">
+                <span class="inline-flex items-center gap-1 text-success">
+                    <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                    @ActiveGuilds Active
+                </span>
+                @if (InactiveGuilds > 0)
+                {
+                    <span class="text-text-tertiary">&bull;</span>
+                    <span class="text-text-tertiary">@InactiveGuilds Inactive</span>
+                }
+            </p>
+        </div>
+        <div class="p-3 bg-accent-blue/10 rounded-lg transition-colors">
+            <svg class="w-6 h-6 text-accent-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" />
+            </svg>
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter] public int TotalGuilds { get; set; }
+    [Parameter] public int ActiveGuilds { get; set; }
+    [Parameter] public int InactiveGuilds { get; set; }
+}

--- a/src/DiscordBot.Bot/Components/Shared/HeroMetricCard.razor
+++ b/src/DiscordBot.Bot/Components/Shared/HeroMetricCard.razor
@@ -1,0 +1,121 @@
+@{
+    var accentClass = AccentColor switch
+    {
+        CardAccent.Blue => "accent-blue",
+        CardAccent.Orange => "accent-orange",
+        CardAccent.Success => "accent-success",
+        CardAccent.Info => "accent-info",
+        _ => "accent-blue"
+    };
+
+    var trendClass = TrendDirection switch
+    {
+        TrendDirection.Up => "trend-up",
+        TrendDirection.Down => "trend-down",
+        TrendDirection.Neutral => "trend-neutral",
+        _ => "trend-neutral"
+    };
+
+    var trendIconSvg = TrendDirection switch
+    {
+        TrendDirection.Up =>
+            "<path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M5 10l7-7m0 0l7 7m-7-7v18\" />",
+        TrendDirection.Down =>
+            "<path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M19 14l-7 7m0 0l-7-7m7 7V3\" />",
+        TrendDirection.Neutral =>
+            "<path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M20 12H4\" />",
+        _ => "<path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M20 12H4\" />"
+    };
+
+    var iconBgClass = AccentColor switch
+    {
+        CardAccent.Blue => "bg-accent-blue/10",
+        CardAccent.Orange => "bg-accent-orange/10",
+        CardAccent.Success => "bg-success/10",
+        CardAccent.Info => "bg-info/10",
+        _ => "bg-accent-blue/10"
+    };
+
+    var iconTextClass = AccentColor switch
+    {
+        CardAccent.Blue => "text-accent-blue",
+        CardAccent.Orange => "text-accent-orange",
+        CardAccent.Success => "text-success",
+        CardAccent.Info => "text-info",
+        _ => "text-accent-blue"
+    };
+
+    var sparklineColorVar = AccentColor switch
+    {
+        CardAccent.Blue => "var(--color-accent-blue)",
+        CardAccent.Orange => "var(--color-accent-orange)",
+        CardAccent.Success => "var(--color-success)",
+        CardAccent.Info => "var(--color-info)",
+        _ => "var(--color-accent-blue)"
+    };
+
+    var cardClasses = $"hero-metric-card {accentClass} {CssClass ?? ""}".Trim();
+}
+
+<div class="@cardClasses"
+     @(Id != null ? $"id=\"{Id}\"" : "")>
+    <div class="flex items-start justify-between">
+        <div>
+            <p class="text-sm font-medium text-text-secondary">@Title</p>
+            <p class="mt-2 text-3xl font-bold text-text-primary" @(DataAttribute != null ? DataAttribute : "")>@Value</p>
+
+            @if (!string.IsNullOrEmpty(TrendValue) || !string.IsNullOrEmpty(TrendLabel))
+            {
+                <div class="mt-2 flex items-center gap-1.5">
+                    @if (!string.IsNullOrEmpty(TrendValue))
+                    {
+                        <span class="@trendClass flex items-center gap-1 text-xs font-medium">
+                            <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                                @((MarkupString)trendIconSvg)
+                            </svg>
+                            @TrendValue
+                        </span>
+                    }
+                    @if (!string.IsNullOrEmpty(TrendLabel))
+                    {
+                        <span class="text-xs text-text-tertiary">@TrendLabel</span>
+                    }
+                </div>
+            }
+        </div>
+
+        @if (!string.IsNullOrEmpty(IconSvg))
+        {
+            <div class="p-3 @iconBgClass rounded-xl">
+                <svg class="w-6 h-6 @iconTextClass" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                    @((MarkupString)IconSvg)
+                </svg>
+            </div>
+        }
+    </div>
+
+    @if (ShowSparkline && SparklineData.Any())
+    {
+        <div class="sparkline mt-4" aria-hidden="true">
+            @foreach (var height in SparklineData)
+            {
+                <div class="sparkline-bar" style="height: @(height)%; background-color: @sparklineColorVar"></div>
+            }
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter] public string Title { get; set; } = string.Empty;
+    [Parameter] public string Value { get; set; } = string.Empty;
+    [Parameter] public string TrendValue { get; set; } = string.Empty;
+    [Parameter] public TrendDirection TrendDirection { get; set; } = TrendDirection.Neutral;
+    [Parameter] public string TrendLabel { get; set; } = string.Empty;
+    [Parameter] public CardAccent AccentColor { get; set; } = CardAccent.Blue;
+    [Parameter] public string IconSvg { get; set; } = string.Empty;
+    [Parameter] public bool ShowSparkline { get; set; }
+    [Parameter] public List<int> SparklineData { get; set; } = new();
+    [Parameter] public string? Id { get; set; }
+    [Parameter] public string? CssClass { get; set; }
+    [Parameter] public string? DataAttribute { get; set; }
+}

--- a/src/DiscordBot.Bot/Components/Shared/LoadingSpinner.razor
+++ b/src/DiscordBot.Bot/Components/Shared/LoadingSpinner.razor
@@ -1,0 +1,110 @@
+@{
+    var (outerSize, innerSize, borderWidth) = Size switch
+    {
+        SpinnerSize.Small => ("w-6 h-6", "w-3 h-3", "border-2"),
+        SpinnerSize.Large => ("w-16 h-16", "w-8 h-8", "border-4"),
+        _ => ("w-10 h-10", "w-5 h-5", "border-[3px]")
+    };
+
+    var colorClass = Color switch
+    {
+        SpinnerColor.Orange => "border-t-accent-orange",
+        SpinnerColor.White => "border-white/20 border-t-white",
+        _ => "border-t-accent-blue"
+    };
+
+    var bgColorClass = Color switch
+    {
+        SpinnerColor.Orange => "bg-accent-orange",
+        SpinnerColor.White => "bg-white",
+        _ => "bg-accent-blue"
+    };
+
+    var borderColorClass = Color switch
+    {
+        SpinnerColor.White => "border-white",
+        _ => $"border-{(Color == SpinnerColor.Orange ? "accent-orange" : "accent-blue")}"
+    };
+
+    var dotSize = Size switch
+    {
+        SpinnerSize.Small => "w-1.5 h-1.5",
+        SpinnerSize.Large => "w-4 h-4",
+        _ => "w-2.5 h-2.5"
+    };
+}
+
+@if (IsOverlay)
+{
+    <div class="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-bg-primary/80 rounded-lg" @attributes="AdditionalAttributes">
+        @if (Variant == SpinnerVariant.Dots)
+        {
+            <div class="flex items-center justify-center gap-1.5">
+                <div class="@dotSize @bgColorClass rounded-full animate-bounce" style="animation-delay: -0.32s"></div>
+                <div class="@dotSize @bgColorClass rounded-full animate-bounce" style="animation-delay: -0.16s"></div>
+                <div class="@dotSize @bgColorClass rounded-full animate-bounce"></div>
+            </div>
+        }
+        else if (Variant == SpinnerVariant.Pulse)
+        {
+            <div class="relative flex items-center justify-center">
+                <div class="absolute @outerSize @borderWidth @borderColorClass rounded-full animate-ping opacity-75"></div>
+                <div class="@innerSize @bgColorClass rounded-full animate-pulse"></div>
+            </div>
+        }
+        else
+        {
+            <div class="@outerSize @borderWidth border-white/20 @colorClass rounded-full animate-spin"></div>
+        }
+        @if (!string.IsNullOrEmpty(Message))
+        {
+            <p class="text-sm text-text-primary">@Message</p>
+        }
+        @if (!string.IsNullOrEmpty(SubMessage))
+        {
+            <p class="text-xs text-text-tertiary">@SubMessage</p>
+        }
+    </div>
+}
+else
+{
+    <div class="@(string.IsNullOrEmpty(Message) ? "inline-flex" : "flex flex-col items-center justify-center gap-3")" @attributes="AdditionalAttributes">
+        @if (Variant == SpinnerVariant.Dots)
+        {
+            <div class="flex items-center justify-center gap-1.5">
+                <div class="@dotSize @bgColorClass rounded-full animate-bounce" style="animation-delay: -0.32s"></div>
+                <div class="@dotSize @bgColorClass rounded-full animate-bounce" style="animation-delay: -0.16s"></div>
+                <div class="@dotSize @bgColorClass rounded-full animate-bounce"></div>
+            </div>
+        }
+        else if (Variant == SpinnerVariant.Pulse)
+        {
+            <div class="relative flex items-center justify-center">
+                <div class="absolute @outerSize @borderWidth @borderColorClass rounded-full animate-ping opacity-75"></div>
+                <div class="@innerSize @bgColorClass rounded-full animate-pulse"></div>
+            </div>
+        }
+        else
+        {
+            <div class="@outerSize @borderWidth border-white/20 @colorClass rounded-full animate-spin"></div>
+        }
+        @if (!string.IsNullOrEmpty(Message))
+        {
+            <p class="text-sm text-text-primary">@Message</p>
+        }
+        @if (!string.IsNullOrEmpty(SubMessage))
+        {
+            <p class="text-xs text-text-tertiary">@SubMessage</p>
+        }
+    </div>
+}
+
+@code {
+    [Parameter] public SpinnerVariant Variant { get; set; } = SpinnerVariant.Simple;
+    [Parameter] public SpinnerSize Size { get; set; } = SpinnerSize.Medium;
+    [Parameter] public string? Message { get; set; }
+    [Parameter] public string? SubMessage { get; set; }
+    [Parameter] public SpinnerColor Color { get; set; } = SpinnerColor.Blue;
+    [Parameter] public bool IsOverlay { get; set; }
+    [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+}

--- a/src/DiscordBot.Bot/Components/Shared/ModeSwitcher.razor
+++ b/src/DiscordBot.Bot/Components/Shared/ModeSwitcher.razor
@@ -1,0 +1,140 @@
+@inject IJSRuntime JS
+
+@{
+    string GetModeLabel(TtsMode mode) => mode switch
+    {
+        TtsMode.Simple => "Simple",
+        TtsMode.Standard => "Standard",
+        TtsMode.Pro => "Pro",
+        _ => mode.ToString()
+    };
+
+    string GetModeValue(TtsMode mode) => mode switch
+    {
+        TtsMode.Simple => "simple",
+        TtsMode.Standard => "standard",
+        TtsMode.Pro => "pro",
+        _ => mode.ToString().ToLowerInvariant()
+    };
+
+    string GetModeIconPath(TtsMode mode) => mode switch
+    {
+        TtsMode.Simple => "M12 18.75a6 6 0 0 0 6-6v-1.5m-6 7.5a6 6 0 0 1-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 0 1-3-3V4.5a3 3 0 1 1 6 0v8.25a3 3 0 0 1-3 3Z",
+        TtsMode.Standard => "M10.5 6h9.75M10.5 6a1.5 1.5 0 1 1-3 0m3 0a1.5 1.5 0 1 0-3 0M3.75 6H7.5m3 12h9.75m-9.75 0a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m-3.75 0H7.5m9-6h3.75m-3.75 0a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m-9.75 0h9.75",
+        TtsMode.Pro => "m3.75 13.5 10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75Z",
+        _ => ""
+    };
+}
+
+<div id="@ContainerId"
+     class="flex gap-2 bg-bg-tertiary p-1 rounded-lg"
+     role="tablist"
+     aria-label="TTS mode selection"
+     data-current-mode="@GetModeValue(Value)">
+
+    @foreach (var mode in Enum.GetValues<TtsMode>())
+    {
+        var isActive = mode == Value;
+        var buttonId = $"{ContainerId}-mode-{GetModeValue(mode)}";
+        var modeValue = mode;
+
+        <button type="button"
+                id="@buttonId"
+                class="flex-1 flex items-center justify-center gap-2 px-4 py-2 rounded-md font-semibold text-sm transition-all duration-200 @(isActive ? "bg-accent-orange text-white shadow-md" : "bg-bg-tertiary text-text-secondary hover:text-text-primary")"
+                role="tab"
+                aria-selected="@(isActive ? "true" : "false")"
+                tabindex="@(isActive ? "0" : "-1")"
+                data-mode="@GetModeValue(mode)"
+                @onclick="() => SelectMode(modeValue)">
+            <svg class="w-4 h-4 flex-shrink-0"
+                 fill="none"
+                 viewBox="0 0 24 24"
+                 stroke="currentColor"
+                 aria-hidden="true">
+                <path stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="@GetModeIconPath(mode)" />
+            </svg>
+            <span>@GetModeLabel(mode)</span>
+        </button>
+    }
+</div>
+
+<style>
+    @@media (max-width: 767px) {
+        #@ContainerId {
+            flex-direction: column;
+        }
+
+        #@ContainerId button[role="tab"] {
+            width: 100%;
+            min-height: 44px;
+            padding: 0.75rem 1rem;
+        }
+    }
+</style>
+
+@code {
+    [Parameter] public TtsMode Value { get; set; } = TtsMode.Standard;
+    [Parameter] public EventCallback<TtsMode> ValueChanged { get; set; }
+    [Parameter] public string ContainerId { get; set; } = "modeSwitcher";
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            try
+            {
+                var savedMode = await JS.InvokeAsync<string?>("localStorage.getItem", "tts_mode_preference");
+                if (!string.IsNullOrEmpty(savedMode) && TryParseMode(savedMode, out var mode) && mode != Value)
+                {
+                    Value = mode;
+                    await ValueChanged.InvokeAsync(mode);
+                    StateHasChanged();
+                }
+            }
+            catch
+            {
+                // localStorage may not be available during SSR
+            }
+        }
+    }
+
+    private async Task SelectMode(TtsMode mode)
+    {
+        if (mode == Value) return;
+
+        Value = mode;
+        await ValueChanged.InvokeAsync(mode);
+
+        var modeValue = mode switch
+        {
+            TtsMode.Simple => "simple",
+            TtsMode.Standard => "standard",
+            TtsMode.Pro => "pro",
+            _ => mode.ToString().ToLowerInvariant()
+        };
+
+        try
+        {
+            await JS.InvokeVoidAsync("localStorage.setItem", "tts_mode_preference", modeValue);
+        }
+        catch
+        {
+            // localStorage may not be available during SSR
+        }
+    }
+
+    private static bool TryParseMode(string value, out TtsMode mode)
+    {
+        mode = value switch
+        {
+            "simple" => TtsMode.Simple,
+            "standard" => TtsMode.Standard,
+            "pro" => TtsMode.Pro,
+            _ => default
+        };
+        return value is "simple" or "standard" or "pro";
+    }
+}

--- a/src/DiscordBot.Bot/Components/Shared/NavTabs.razor
+++ b/src/DiscordBot.Bot/Components/Shared/NavTabs.razor
@@ -1,0 +1,113 @@
+@{
+    var containerId = $"{ContainerId}-container";
+    var navId = $"{ContainerId}-nav";
+    var styleClass = StyleVariant switch
+    {
+        NavTabStyle.Pills => "nav-tabs-pills",
+        NavTabStyle.Bordered => "nav-tabs-bordered",
+        _ => "nav-tabs-underline"
+    };
+}
+
+<div class="nav-tabs-container @styleClass"
+     id="@containerId"
+     data-nav-tabs
+     data-navigation-mode="@NavigationMode.ToString().ToLowerInvariant()"
+     data-persistence-mode="@PersistenceMode.ToString().ToLowerInvariant()"
+     data-container-id="@ContainerId">
+    <nav class="nav-tabs-list"
+         id="@navId"
+         role="tablist"
+         aria-label="@AriaLabel">
+        @foreach (var tab in Tabs)
+        {
+            var isActive = tab.Id == ActiveTabId;
+            var tabElementId = $"{ContainerId}-tab-{tab.Id}";
+            var panelElementId = $"{ContainerId}-panel-{tab.Id}";
+            var tabClass = GetTabClass(tab);
+
+            if (NavigationMode == NavMode.PageNavigation)
+            {
+                <a href="@(tab.Href ?? "#")"
+                   class="@tabClass"
+                   id="@tabElementId"
+                   role="tab"
+                   aria-selected="@(isActive ? "true" : "false")"
+                   aria-disabled="@(tab.Disabled ? "true" : null)"
+                   tabindex="@(isActive ? "0" : "-1")"
+                   data-tab-id="@tab.Id">
+                    @RenderTabContent(tab, isActive)
+                </a>
+            }
+            else if (NavigationMode == NavMode.Ajax)
+            {
+                <button type="button"
+                        class="@tabClass"
+                        id="@tabElementId"
+                        role="tab"
+                        aria-selected="@(isActive ? "true" : "false")"
+                        aria-controls="@panelElementId"
+                        tabindex="@(isActive ? "0" : "-1")"
+                        disabled="@(tab.Disabled ? true : null)"
+                        aria-disabled="@(tab.Disabled ? "true" : null)"
+                        data-tab-id="@tab.Id"
+                        data-ajax-url="@tab.Href">
+                    @RenderTabContent(tab, isActive)
+                </button>
+            }
+            else
+            {
+                <button type="button"
+                        class="@tabClass"
+                        id="@tabElementId"
+                        role="tab"
+                        aria-selected="@(isActive ? "true" : "false")"
+                        aria-controls="@panelElementId"
+                        tabindex="@(isActive ? "0" : "-1")"
+                        disabled="@(tab.Disabled ? true : null)"
+                        aria-disabled="@(tab.Disabled ? "true" : null)"
+                        data-tab-id="@tab.Id">
+                    @RenderTabContent(tab, isActive)
+                </button>
+            }
+        }
+    </nav>
+</div>
+
+@code {
+    [Parameter] public IReadOnlyList<NavTabItem> Tabs { get; set; } = [];
+    [Parameter] public string ActiveTabId { get; set; } = string.Empty;
+    [Parameter] public NavTabStyle StyleVariant { get; set; } = NavTabStyle.Underline;
+    [Parameter] public NavMode NavigationMode { get; set; } = NavMode.InPage;
+    [Parameter] public NavPersistence PersistenceMode { get; set; } = NavPersistence.Hash;
+    [Parameter] public string AriaLabel { get; set; } = "Navigation";
+    [Parameter] public string ContainerId { get; set; } = "navTabs";
+
+    private string GetTabClass(NavTabItem tab)
+    {
+        var classes = "nav-tabs-item";
+        if (tab.Id == ActiveTabId) classes += " active";
+        if (tab.Disabled) classes += " disabled";
+        return classes;
+    }
+
+    private RenderFragment RenderTabContent(NavTabItem tab, bool isActive) => __builder =>
+    {
+        if (tab.HasIcon)
+        {
+            <svg class="nav-tabs-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@tab.IconPathOutline" />
+            </svg>
+        }
+
+        if (!string.IsNullOrEmpty(tab.ShortLabel))
+        {
+            <span class="tab-label-long">@tab.Label</span>
+            <span class="tab-label-short">@tab.ShortLabel</span>
+        }
+        else
+        {
+            <span>@tab.Label</span>
+        }
+    };
+}

--- a/src/DiscordBot.Bot/Components/Shared/PageLoadingOverlay.razor
+++ b/src/DiscordBot.Bot/Components/Shared/PageLoadingOverlay.razor
@@ -1,0 +1,38 @@
+<!-- Page Loading Overlay -->
+<div id="@Id"
+     class="loading-overlay hidden"
+     role="alert"
+     aria-live="polite"
+     aria-busy="true">
+
+    <!-- Spinner and Messages -->
+    <LoadingSpinner
+        Variant="@Variant"
+        Size="@Size"
+        Message="@Message"
+        SubMessage="@SubMessage"
+        Color="SpinnerColor.White" />
+
+    <!-- Optional Cancel Button -->
+    @if (ShowCancelButton)
+    {
+        <button type="button"
+                class="btn btn-secondary btn-sm mt-4"
+                id="@(Id)CancelBtn"
+                @onclick="OnCancel"
+                aria-label="@CancelText">
+            @CancelText
+        </button>
+    }
+</div>
+
+@code {
+    [Parameter] public string Id { get; set; } = "pageLoadingOverlay";
+    [Parameter] public SpinnerVariant Variant { get; set; } = SpinnerVariant.Simple;
+    [Parameter] public SpinnerSize Size { get; set; } = SpinnerSize.Large;
+    [Parameter] public string? Message { get; set; } = "Loading...";
+    [Parameter] public string? SubMessage { get; set; }
+    [Parameter] public bool ShowCancelButton { get; set; }
+    [Parameter] public string CancelText { get; set; } = "Cancel";
+    [Parameter] public EventCallback OnCancel { get; set; }
+}

--- a/src/DiscordBot.Bot/Components/Shared/Pagination.razor
+++ b/src/DiscordBot.Bot/Components/Shared/Pagination.razor
@@ -1,0 +1,328 @@
+@{
+    var startItem = (CurrentPage - 1) * PageSize + 1;
+    var endItem = Math.Min(CurrentPage * PageSize, TotalItems);
+    var isFirstPage = CurrentPage == 1;
+    var isLastPage = CurrentPage == TotalPages;
+
+    // Generate page numbers to show (max 7 buttons: 1 ... 4 5 6 ... 10)
+    var pagesToShow = new List<int?>();
+    if (TotalPages <= 7)
+    {
+        for (int i = 1; i <= TotalPages; i++)
+            pagesToShow.Add(i);
+    }
+    else
+    {
+        pagesToShow.Add(1);
+
+        if (CurrentPage <= 4)
+        {
+            for (int i = 2; i <= Math.Min(5, TotalPages - 1); i++)
+                pagesToShow.Add(i);
+            pagesToShow.Add(null); // ellipsis
+        }
+        else if (CurrentPage >= TotalPages - 3)
+        {
+            pagesToShow.Add(null);
+            for (int i = Math.Max(2, TotalPages - 4); i < TotalPages; i++)
+                pagesToShow.Add(i);
+        }
+        else
+        {
+            pagesToShow.Add(null);
+            for (int i = CurrentPage - 1; i <= CurrentPage + 1; i++)
+                pagesToShow.Add(i);
+            pagesToShow.Add(null);
+        }
+
+        pagesToShow.Add(TotalPages);
+    }
+}
+
+@if (Style == PaginationStyle.Simple)
+{
+    <nav aria-label="Pagination" class="flex items-center gap-3">
+        <a
+            href="@BuildUrl(CurrentPage - 1)"
+            class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-text-secondary bg-bg-secondary border border-border-primary rounded-md hover:bg-bg-hover transition-colors @(isFirstPage ? "pointer-events-none opacity-50" : "")"
+            aria-disabled="@(isFirstPage ? "true" : "false")">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+            </svg>
+            Previous
+        </a>
+        <a
+            href="@BuildUrl(CurrentPage + 1)"
+            class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-text-secondary bg-bg-secondary border border-border-primary rounded-md hover:bg-bg-hover transition-colors @(isLastPage ? "pointer-events-none opacity-50" : "")"
+            aria-disabled="@(isLastPage ? "true" : "false")">
+            Next
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+        </a>
+    </nav>
+}
+else if (Style == PaginationStyle.Compact)
+{
+    <nav aria-label="Pagination" class="flex items-center justify-between gap-4">
+        <a
+            href="@BuildUrl(CurrentPage - 1)"
+            class="px-3 py-2 text-sm text-text-secondary bg-bg-secondary border border-border-primary rounded-md hover:bg-bg-hover transition-colors @(isFirstPage ? "pointer-events-none opacity-50" : "")"
+            aria-label="Previous page"
+            aria-disabled="@(isFirstPage ? "true" : "false")">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+            </svg>
+        </a>
+        <span class="text-sm text-text-secondary">
+            Page <span class="font-medium text-text-primary">@CurrentPage</span> of <span class="font-medium text-text-primary">@TotalPages</span>
+        </span>
+        <a
+            href="@BuildUrl(CurrentPage + 1)"
+            class="px-3 py-2 text-sm text-text-secondary bg-bg-secondary border border-border-primary rounded-md hover:bg-bg-hover transition-colors @(isLastPage ? "pointer-events-none opacity-50" : "")"
+            aria-label="Next page"
+            aria-disabled="@(isLastPage ? "true" : "false")">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+        </a>
+    </nav>
+}
+else if (Style == PaginationStyle.Bordered)
+{
+    <nav aria-label="Pagination" class="inline-flex items-center bg-bg-secondary border border-border-primary rounded-lg overflow-hidden">
+        <a
+            href="@BuildUrl(CurrentPage - 1)"
+            class="px-3 py-2 text-sm text-text-secondary hover:bg-bg-hover border-r border-border-primary @(isFirstPage ? "pointer-events-none opacity-50" : "")"
+            aria-label="Previous page"
+            aria-disabled="@(isFirstPage ? "true" : "false")">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+            </svg>
+        </a>
+        @foreach (var page in pagesToShow)
+        {
+            if (page == null)
+            {
+                <span class="px-4 py-2 text-sm text-text-tertiary border-r border-border-primary">...</span>
+            }
+            else if (page == CurrentPage)
+            {
+                <span class="px-4 py-2 text-sm font-medium text-white bg-accent-orange border-r border-border-primary">@(page)</span>
+            }
+            else
+            {
+                <a href="@BuildUrl(page.Value)" class="px-4 py-2 text-sm text-text-secondary hover:bg-bg-hover border-r border-border-primary transition-colors">@(page)</a>
+            }
+        }
+        <a
+            href="@BuildUrl(CurrentPage + 1)"
+            class="px-3 py-2 text-sm text-text-secondary hover:bg-bg-hover @(isLastPage ? "pointer-events-none opacity-50" : "")"
+            aria-label="Next page"
+            aria-disabled="@(isLastPage ? "true" : "false")">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+        </a>
+    </nav>
+}
+else
+{
+    @* Full Pagination Style *@
+    if (ShowPageSizeSelector || ShowItemCount)
+    {
+        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            <div class="flex items-center gap-3">
+                @if (ShowPageSizeSelector)
+                {
+                    <label for="pageSize" class="text-sm text-text-secondary">Show:</label>
+                    <select
+                        id="pageSize"
+                        class="px-3 py-1.5 text-sm bg-bg-primary border border-border-primary rounded-md text-text-primary focus:border-accent-blue"
+                        onchange="@($"window.location.href='{BuildUrl(1)}&{PageSizeParameterName}=' + this.value")">
+                        @foreach (var size in PageSizeOptions)
+                        {
+                            <option value="@size" selected="@(size == PageSize)">@size</option>
+                        }
+                    </select>
+                }
+                @if (ShowItemCount)
+                {
+                    <span class="text-sm text-text-secondary">
+                        Showing <span class="font-medium text-text-primary">@startItem-@endItem</span> of <span class="font-medium text-text-primary">@TotalItems</span>
+                    </span>
+                }
+            </div>
+            <nav aria-label="Pagination" class="flex items-center gap-1">
+                @if (ShowFirstLast)
+                {
+                    <a
+                        href="@BuildUrl(1)"
+                        class="px-2 py-2 text-sm text-text-secondary hover:bg-bg-hover rounded-md transition-colors @(isFirstPage ? "pointer-events-none opacity-50 cursor-not-allowed" : "")"
+                        aria-label="First page"
+                        aria-disabled="@(isFirstPage ? "true" : "false")">
+                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 19l-7-7 7-7m8 14l-7-7 7-7" />
+                        </svg>
+                    </a>
+                }
+
+                <a
+                    href="@BuildUrl(CurrentPage - 1)"
+                    class="px-2 py-2 text-sm text-text-secondary hover:bg-bg-hover rounded-md transition-colors @(isFirstPage ? "pointer-events-none opacity-50 cursor-not-allowed" : "")"
+                    aria-label="Previous page"
+                    aria-disabled="@(isFirstPage ? "true" : "false")">
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+                    </svg>
+                </a>
+
+                @foreach (var pageNum in pagesToShow)
+                {
+                    if (pageNum == null)
+                    {
+                        <span class="px-2 py-2 text-text-tertiary">...</span>
+                    }
+                    else if (pageNum == CurrentPage)
+                    {
+                        <span class="px-3 py-2 text-sm font-medium text-white bg-accent-orange rounded-md" aria-current="page">@(pageNum)</span>
+                    }
+                    else
+                    {
+                        <a href="@BuildUrl(pageNum.Value)" class="px-3 py-2 text-sm text-text-secondary hover:bg-bg-hover rounded-md transition-colors">@(pageNum)</a>
+                    }
+                }
+
+                <a
+                    href="@BuildUrl(CurrentPage + 1)"
+                    class="px-2 py-2 text-sm text-text-secondary hover:bg-bg-hover rounded-md transition-colors @(isLastPage ? "pointer-events-none opacity-50 cursor-not-allowed" : "")"
+                    aria-label="Next page"
+                    aria-disabled="@(isLastPage ? "true" : "false")">
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                    </svg>
+                </a>
+
+                @if (ShowFirstLast)
+                {
+                    <a
+                        href="@BuildUrl(TotalPages)"
+                        class="px-2 py-2 text-sm text-text-secondary hover:bg-bg-hover rounded-md transition-colors @(isLastPage ? "pointer-events-none opacity-50 cursor-not-allowed" : "")"
+                        aria-label="Last page"
+                        aria-disabled="@(isLastPage ? "true" : "false")">
+                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 5l7 7-7 7M5 5l7 7-7 7" />
+                        </svg>
+                    </a>
+                }
+            </nav>
+        </div>
+    }
+    else
+    {
+        <nav aria-label="Pagination" class="flex items-center gap-1">
+            @if (ShowFirstLast)
+            {
+                <a
+                    href="@BuildUrl(1)"
+                    class="px-2 py-2 text-sm text-text-secondary hover:bg-bg-hover rounded-md transition-colors @(isFirstPage ? "pointer-events-none opacity-50 cursor-not-allowed" : "")"
+                    aria-label="First page"
+                    aria-disabled="@(isFirstPage ? "true" : "false")">
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 19l-7-7 7-7m8 14l-7-7 7-7" />
+                    </svg>
+                </a>
+            }
+
+            <a
+                href="@BuildUrl(CurrentPage - 1)"
+                class="px-2 py-2 text-sm text-text-secondary hover:bg-bg-hover rounded-md transition-colors @(isFirstPage ? "pointer-events-none opacity-50 cursor-not-allowed" : "")"
+                aria-label="Previous page"
+                aria-disabled="@(isFirstPage ? "true" : "false")">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+                </svg>
+            </a>
+
+            @foreach (var page in pagesToShow)
+            {
+                if (page == null)
+                {
+                    <span class="px-2 py-2 text-text-tertiary">...</span>
+                }
+                else if (page == CurrentPage)
+                {
+                    <span class="px-3 py-2 text-sm font-medium text-white bg-accent-orange rounded-md" aria-current="page">@(page)</span>
+                }
+                else
+                {
+                    <a href="@BuildUrl(page.Value)" class="px-3 py-2 text-sm text-text-secondary hover:bg-bg-hover rounded-md transition-colors">@(page)</a>
+                }
+            }
+
+            <a
+                href="@BuildUrl(CurrentPage + 1)"
+                class="px-2 py-2 text-sm text-text-secondary hover:bg-bg-hover rounded-md transition-colors @(isLastPage ? "pointer-events-none opacity-50 cursor-not-allowed" : "")"
+                aria-label="Next page"
+                aria-disabled="@(isLastPage ? "true" : "false")">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                </svg>
+            </a>
+
+            @if (ShowFirstLast)
+            {
+                <a
+                    href="@BuildUrl(TotalPages)"
+                    class="px-2 py-2 text-sm text-text-secondary hover:bg-bg-hover rounded-md transition-colors @(isLastPage ? "pointer-events-none opacity-50 cursor-not-allowed" : "")"
+                    aria-label="Last page"
+                    aria-disabled="@(isLastPage ? "true" : "false")">
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 5l7 7-7 7M5 5l7 7-7 7" />
+                    </svg>
+                </a>
+            }
+        </nav>
+    }
+}
+
+@code {
+    [Parameter] public int CurrentPage { get; set; } = 1;
+    [Parameter] public int TotalPages { get; set; } = 1;
+    [Parameter] public int TotalItems { get; set; }
+    [Parameter] public int PageSize { get; set; } = 10;
+    [Parameter] public int[] PageSizeOptions { get; set; } = new[] { 10, 25, 50, 100 };
+    [Parameter] public PaginationStyle Style { get; set; } = PaginationStyle.Full;
+    [Parameter] public bool ShowPageSizeSelector { get; set; }
+    [Parameter] public bool ShowItemCount { get; set; }
+    [Parameter] public bool ShowFirstLast { get; set; } = true;
+    [Parameter] public string BaseUrl { get; set; } = string.Empty;
+    [Parameter] public string PageParameterName { get; set; } = "page";
+    [Parameter] public string PageSizeParameterName { get; set; } = "pageSize";
+
+    private string StripQueryParam(string url, string paramName)
+    {
+        var queryIndex = url.IndexOf('?');
+        if (queryIndex < 0) return url;
+        var basePath = url[..queryIndex];
+        var queryString = url[(queryIndex + 1)..];
+        var pairs = queryString.Split('&')
+            .Where(p => !p.StartsWith(paramName + "=", StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        if (pairs.Length == 0) return basePath;
+        return basePath + "?" + string.Join("&", pairs);
+    }
+
+    private string BuildUrl(int page, int? pageSize = null)
+    {
+        if (string.IsNullOrEmpty(BaseUrl)) return "#";
+        var baseUrl = StripQueryParam(BaseUrl, PageParameterName);
+        if (pageSize.HasValue)
+            baseUrl = StripQueryParam(baseUrl, PageSizeParameterName);
+        var separator = baseUrl.Contains('?') ? "&" : "?";
+        var url = $"{baseUrl}{separator}{PageParameterName}={page}";
+        if (pageSize.HasValue)
+            url += $"&{PageSizeParameterName}={pageSize.Value}";
+        return url;
+    }
+}

--- a/src/DiscordBot.Bot/Components/Shared/PauseModal.razor
+++ b/src/DiscordBot.Bot/Components/Shared/PauseModal.razor
@@ -1,0 +1,154 @@
+@if (IsVisible)
+{
+    <!-- Pause Insertion Modal -->
+    <div class="fixed inset-0 z-[var(--z-modal)]" role="dialog" aria-modal="true" aria-labelledby="@(Id)Title">
+        <!-- Backdrop -->
+        <div class="fixed inset-0 bg-black/70 backdrop-blur-sm" @onclick="Cancel" aria-hidden="true"></div>
+
+        <!-- Modal Dialog -->
+        <div class="fixed inset-0 flex items-center justify-center p-4">
+            <div class="bg-bg-secondary border border-border-primary rounded-lg shadow-xl max-w-md w-full" role="document">
+                <!-- Modal Header -->
+                <div class="flex items-center justify-between px-6 py-4 border-b border-border-primary">
+                    <h2 id="@(Id)Title" class="text-lg font-semibold text-text-primary">@Title</h2>
+                    <button type="button"
+                            @onclick="Cancel"
+                            class="inline-flex items-center justify-center w-8 h-8 rounded-md bg-transparent hover:bg-bg-hover border-0 text-text-secondary hover:text-text-primary transition-colors text-2xl leading-none"
+                            aria-label="Close">
+                        &times;
+                    </button>
+                </div>
+
+                <!-- Modal Content -->
+                <div class="p-6">
+                    <!-- Duration Slider -->
+                    <div class="mb-6">
+                        <label class="block text-xs font-semibold uppercase tracking-wider text-text-secondary mb-3">
+                            Pause Duration
+                        </label>
+                        <div class="flex flex-col gap-4">
+                            <div class="flex items-baseline justify-between">
+                                <div class="text-4xl font-bold text-accent-blue">@_currentDuration</div>
+                                <div class="text-sm text-text-secondary ml-2">milliseconds</div>
+                            </div>
+                            <input type="range"
+                                   class="w-full h-2 rounded-full bg-border-primary outline-none cursor-pointer appearance-none"
+                                   style="@GetSliderBackground()"
+                                   min="@MinDuration"
+                                   max="@MaxDuration"
+                                   step="@Step"
+                                   value="@_currentDuration"
+                                   @oninput="OnSliderInput"
+                                   aria-label="Pause duration slider">
+                        </div>
+                    </div>
+
+                    <!-- Quick Duration Buttons -->
+                    <div class="mb-6">
+                        <label class="block text-xs font-semibold uppercase tracking-wider text-text-secondary mb-3">
+                            Quick Select
+                        </label>
+                        <div class="grid grid-cols-3 gap-3">
+                            @foreach (var preset in _presets)
+                            {
+                                var isActive = _currentDuration == preset.Value;
+                                <button type="button"
+                                        @onclick="() => SelectPreset(preset.Value)"
+                                        class="flex flex-col items-center justify-center gap-2 p-4 bg-bg-tertiary hover:bg-bg-hover border-2 @(isActive ? "border-accent-blue" : "border-border-primary") rounded-lg font-medium transition-all">
+                                    <span class="text-sm font-semibold @(isActive ? "text-accent-blue" : "text-text-primary")">@(preset.Value)ms</span>
+                                    <span class="text-xs @(isActive ? "text-accent-blue" : "text-text-secondary")">@preset.Label</span>
+                                </button>
+                            }
+                        </div>
+                    </div>
+
+                    <!-- Live Preview -->
+                    <div>
+                        <label class="block text-xs font-semibold uppercase tracking-wider text-text-secondary mb-3">
+                            Live Preview
+                        </label>
+                        <div class="bg-bg-tertiary border border-border-primary rounded-lg p-4">
+                            <div class="text-sm text-text-secondary mb-3">Example text with pause:</div>
+                            <div class="bg-bg-secondary border-l-4 border-accent-blue p-3 rounded-sm font-mono text-accent-blue break-all">
+                                Hello <span class="text-accent-blue">[<svg class="inline align-middle mr-0.5" fill="currentColor" viewBox="0 0 24 24" width="12" height="12"><path d="M6 4h4v16H6V4zm8 0h4v16h-4V4z"/></svg>@(_currentDuration)ms]</span> World
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Modal Footer -->
+                <div class="flex gap-3 px-6 py-4 bg-bg-secondary border-t border-border-primary rounded-b-lg">
+                    <button type="button"
+                            @onclick="Cancel"
+                            class="flex-1 px-4 py-2 bg-bg-tertiary hover:bg-bg-hover border border-border-primary text-text-primary font-medium text-sm rounded-md transition-colors">
+                        @CancelText
+                    </button>
+                    <button type="button"
+                            @onclick="Insert"
+                            class="flex-1 px-4 py-2 bg-accent-orange hover:bg-accent-orange-hover text-white font-medium text-sm rounded-md transition-colors">
+                        @InsertText
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter] public string Id { get; set; } = "pauseModal";
+    [Parameter] public string Title { get; set; } = "Insert Pause";
+    [Parameter] public int MinDuration { get; set; } = 100;
+    [Parameter] public int MaxDuration { get; set; } = 3000;
+    [Parameter] public int Step { get; set; } = 100;
+    [Parameter] public int DefaultDuration { get; set; } = 500;
+    [Parameter] public string InsertText { get; set; } = "Insert Pause";
+    [Parameter] public string CancelText { get; set; } = "Cancel";
+    [Parameter] public bool IsVisible { get; set; }
+    [Parameter] public EventCallback<bool> IsVisibleChanged { get; set; }
+    [Parameter] public EventCallback<int> OnInsert { get; set; }
+
+    private int _currentDuration;
+
+    private static readonly (int Value, string Label)[] _presets =
+    [
+        (250, "Short"),
+        (500, "Medium"),
+        (1000, "Long")
+    ];
+
+    protected override void OnInitialized()
+    {
+        _currentDuration = DefaultDuration;
+    }
+
+    private void OnSliderInput(ChangeEventArgs e)
+    {
+        if (int.TryParse(e.Value?.ToString(), out var value))
+        {
+            _currentDuration = value;
+        }
+    }
+
+    private void SelectPreset(int duration)
+    {
+        _currentDuration = duration;
+    }
+
+    private async Task Cancel()
+    {
+        _currentDuration = DefaultDuration;
+        await IsVisibleChanged.InvokeAsync(false);
+    }
+
+    private async Task Insert()
+    {
+        await OnInsert.InvokeAsync(_currentDuration);
+        await IsVisibleChanged.InvokeAsync(false);
+    }
+
+    private string GetSliderBackground()
+    {
+        var percentage = ((double)(_currentDuration - MinDuration) / (MaxDuration - MinDuration)) * 100;
+        return $"background-image: linear-gradient(to right, var(--color-accent-blue) 0%, var(--color-accent-blue) {percentage:F1}%, var(--color-border-primary) {percentage:F1}%, var(--color-border-primary) 100%);";
+    }
+}

--- a/src/DiscordBot.Bot/Components/Shared/PresetBar.razor
+++ b/src/DiscordBot.Bot/Components/Shared/PresetBar.razor
@@ -1,0 +1,226 @@
+@{
+    var anyActive = Presets.Any(p => p.IsActive);
+    var presetIndex = 0;
+}
+
+<div id="@ContainerId"
+     class="presets-bar"
+     role="group"
+     aria-label="Voice preset selection"
+     data-callback="@OnPresetApplyJsCallback">
+
+    @foreach (var preset in Presets)
+    {
+        var buttonId = $"{ContainerId}-preset-{preset.Id}";
+        var isActive = _activePresetId == preset.Id || (string.IsNullOrEmpty(_activePresetId) && preset.IsActive);
+        var isFirst = presetIndex == 0;
+        presetIndex++;
+
+        <button type="button"
+                id="@buttonId"
+                class="preset-button @(isActive ? "preset-button--active" : "")"
+                title="@preset.Description"
+                aria-pressed="@(isActive ? "true" : "false")"
+                tabindex="@(isActive || (!anyActive && isFirst) ? "0" : "-1")"
+                data-preset-id="@preset.Id"
+                data-preset-name="@preset.Name"
+                data-preset-voice="@preset.VoiceName"
+                data-preset-style="@(preset.Style ?? "")"
+                data-preset-speed="@preset.Speed"
+                data-preset-pitch="@preset.Pitch"
+                @onclick="() => ApplyPreset(preset)">
+            @RenderPresetIcon(preset.Icon)
+            <span class="preset-button__label">@preset.Name</span>
+            @if (isActive)
+            {
+                <span class="preset-button__active-badge" aria-label="Active preset">Active</span>
+            }
+        </button>
+    }
+</div>
+
+<style>
+    /* Preset Bar Container */
+    .presets-bar {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 0.75rem;
+    }
+
+    /* Preset Button */
+    .preset-button {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 1rem 0.75rem;
+        background: var(--color-bg-tertiary);
+        border: 2px solid var(--color-border-primary);
+        border-radius: 0.75rem;
+        color: var(--color-text-secondary);
+        font-size: 0.875rem;
+        font-weight: 500;
+        text-align: center;
+        cursor: pointer;
+        transition: all 200ms cubic-bezier(0.4, 0, 0.2, 1);
+        position: relative;
+    }
+
+    .preset-button:hover {
+        background: var(--color-bg-hover);
+        color: var(--color-text-primary);
+        border-color: var(--color-accent-orange-muted);
+        transform: translateY(-2px);
+    }
+
+    .preset-button:active {
+        transform: translateY(0);
+    }
+
+    /* Active State */
+    .preset-button--active {
+        border-color: var(--color-accent-orange);
+        background: var(--color-accent-orange-muted);
+        color: var(--color-accent-orange);
+        box-shadow: 0 0 0 3px rgba(203, 78, 27, 0.15),
+                    0 4px 12px rgba(203, 78, 27, 0.2);
+    }
+
+    .preset-button--active:hover {
+        border-color: var(--color-accent-orange-hover);
+        color: var(--color-accent-orange-hover);
+    }
+
+    /* Icon */
+    .preset-button svg {
+        width: 1.5rem;
+        height: 1.5rem;
+        flex-shrink: 0;
+    }
+
+    /* Label */
+    .preset-button__label {
+        display: block;
+        line-height: 1.25;
+    }
+
+    /* Active Badge */
+    .preset-button__active-badge {
+        position: absolute;
+        top: 0.375rem;
+        right: 0.375rem;
+        padding: 0.125rem 0.375rem;
+        background: var(--color-accent-orange);
+        color: white;
+        font-size: 0.625rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        border-radius: 0.25rem;
+    }
+
+    /* Pulse Animation (applied on click) */
+    @@keyframes preset-pulse {
+        0% {
+            box-shadow: 0 0 0 0 rgba(203, 78, 27, 0.7);
+        }
+        50% {
+            box-shadow: 0 0 0 10px rgba(203, 78, 27, 0);
+        }
+        100% {
+            box-shadow: 0 0 0 0 rgba(203, 78, 27, 0);
+        }
+    }
+
+    .preset-button--pulse {
+        animation: preset-pulse 200ms ease-out;
+    }
+
+    /* Mobile: Horizontal Scroll Carousel */
+    @@media (max-width: 767px) {
+        .presets-bar {
+            display: flex;
+            overflow-x: auto;
+            -webkit-overflow-scrolling: touch;
+            scroll-snap-type: x mandatory;
+            gap: 0.5rem;
+            padding-bottom: 0.5rem;
+        }
+
+        .preset-button {
+            min-width: 6rem;
+            min-height: 44px;
+            flex-shrink: 0;
+            scroll-snap-align: start;
+        }
+
+        /* Hide scrollbar but keep functionality */
+        .presets-bar::-webkit-scrollbar {
+            height: 4px;
+        }
+
+        .presets-bar::-webkit-scrollbar-track {
+            background: var(--color-bg-tertiary);
+            border-radius: 2px;
+        }
+
+        .presets-bar::-webkit-scrollbar-thumb {
+            background: var(--color-border-primary);
+            border-radius: 2px;
+        }
+
+        .presets-bar::-webkit-scrollbar-thumb:hover {
+            background: var(--color-accent-orange);
+        }
+    }
+</style>
+
+@code {
+    [Parameter] public IReadOnlyList<PresetButtonViewModel> Presets { get; set; } = Array.Empty<PresetButtonViewModel>();
+    [Parameter] public string ContainerId { get; set; } = "presetBar";
+    [Parameter] public string? OnPresetApplyJsCallback { get; set; }
+    [Parameter] public string? ActivePreset { get; set; }
+    [Parameter] public EventCallback<string?> ActivePresetChanged { get; set; }
+    [Parameter] public EventCallback<PresetButtonViewModel> OnPresetApply { get; set; }
+
+    private string? _activePresetId;
+
+    protected override void OnParametersSet()
+    {
+        _activePresetId = ActivePreset;
+    }
+
+    private async Task ApplyPreset(PresetButtonViewModel preset)
+    {
+        _activePresetId = preset.Id;
+        await ActivePresetChanged.InvokeAsync(preset.Id);
+        await OnPresetApply.InvokeAsync(preset);
+    }
+
+    private static RenderFragment RenderPresetIcon(string iconName) => __builder =>
+    {
+        string iconPath = iconName switch
+        {
+            "sparkles" => "M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z",
+            "megaphone" => "M10.34 15.84c-.688-.06-1.386-.09-2.09-.09H7.5a4.5 4.5 0 1 1 0-9h.75c.704 0 1.402-.03 2.09-.09m0 9.18c.253.962.584 1.892.985 2.783.247.55.06 1.21-.463 1.511l-.657.38a.75.75 0 0 1-1.024-.272 21.37 21.37 0 0 1-1.26-2.672.747.747 0 0 1-.015-.065c-.255-.906-.47-1.834-.617-2.784m2.95 1.13c.62.057 1.246.09 1.879.09h.75a4.5 4.5 0 0 0 0-9h-.75c-.633 0-1.26.03-1.88.09m-.97 7.5v1.875c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V15.84m4.5 0V15.84",
+            "computer-desktop" => "M9 17.25v1.007a3 3 0 0 1-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0 1 15 18.257V17.25m6-12V15a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 15V5.25m18 0A2.25 2.25 0 0 0 18.75 3H5.25A2.25 2.25 0 0 0 3 5.25m18 0V12a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 12V5.25",
+            "face-smile" => "M15.182 15.182a4.5 4.5 0 0 1-6.364 0M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0ZM9.75 9.75c0 .414-.168.75-.375.75S9 10.164 9 9.75 9.168 9 9.375 9s.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Zm5.625 0c0 .414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Z",
+            "fire" => "M15.362 5.214A8.252 8.252 0 0 1 12 21 8.25 8.25 0 0 1 6.038 7.047 8.287 8.287 0 0 0 9 9.601a8.983 8.983 0 0 1 3.361-6.867 8.21 8.21 0 0 0 3 2.48Z",
+            "microphone" => "M12 18.75a6 6 0 0 0 6-6v-1.5m-6 7.5a6 6 0 0 1-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 0 1-3-3V4.5a3 3 0 1 1 6 0v8.25a3 3 0 0 1-3 3Z",
+            "speaker-x-mark" => "M17.25 9.75 19.5 12m0 0 2.25 2.25M19.5 12l2.25-2.25M19.5 12l-2.25 2.25m-10.5-6 4.72-4.72a.75.75 0 0 1 1.28.53v15.88a.75.75 0 0 1-1.28.53l-4.72-4.72H4.51c-.88 0-1.704-.507-1.938-1.354A9.009 9.009 0 0 1 2.25 12c0-.83.112-1.633.322-2.396C2.806 8.756 3.63 8.25 4.51 8.25H6.75Z",
+            "speaker-wave" => "M19.114 5.636a9 9 0 0 1 0 12.728M16.463 8.288a5.25 5.25 0 0 1 0 7.424M6.75 8.25l4.72-4.72a.75.75 0 0 1 1.28.53v15.88a.75.75 0 0 1-1.28.53l-4.72-4.72H4.51c-.88 0-1.704-.507-1.938-1.354A9.009 9.009 0 0 1 2.25 12c0-.83.112-1.633.322-2.396C2.806 8.756 3.63 8.25 4.51 8.25H6.75Z",
+            _ => "M12 18.75a6 6 0 0 0 6-6v-1.5m-6 7.5a6 6 0 0 1-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 0 1-3-3V4.5a3 3 0 1 1 6 0v8.25a3 3 0 0 1-3 3Z"
+        };
+
+        <svg class="w-6 h-6"
+             fill="none"
+             viewBox="0 0 24 24"
+             stroke="currentColor"
+             aria-hidden="true">
+            <path stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="@iconPath" />
+        </svg>
+    };
+}

--- a/src/DiscordBot.Bot/Components/Shared/PreviewPopupError.razor
+++ b/src/DiscordBot.Bot/Components/Shared/PreviewPopupError.razor
@@ -1,0 +1,24 @@
+@* Error state for preview popups *@
+<div class="preview-popup preview-popup-error">
+    <div class="p-4">
+        <div class="text-center py-4">
+            <div class="w-12 h-12 mx-auto mb-3 rounded-full bg-error-bg flex items-center justify-center">
+                <svg class="w-6 h-6 text-error" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                </svg>
+            </div>
+            <p class="text-sm font-medium text-text-primary mb-1">@ErrorTitle</p>
+            <p class="text-xs text-text-tertiary">@ErrorDescription</p>
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter] public string Type { get; set; } = "user";
+
+    private string ErrorTitle => Type == "guild" ? "Guild Unavailable" : "User Not Found";
+
+    private string ErrorDescription => Type == "guild"
+        ? "The bot may have been removed from this server or the server was deleted."
+        : "This user may have been deleted or is unavailable.";
+}

--- a/src/DiscordBot.Bot/Components/Shared/PreviewPopupLoading.razor
+++ b/src/DiscordBot.Bot/Components/Shared/PreviewPopupLoading.razor
@@ -1,0 +1,19 @@
+@* Loading skeleton for preview popups *@
+<div class="preview-popup preview-popup-loading">
+    <div class="preview-header">
+        <div class="w-12 h-12 rounded-full bg-bg-hover animate-pulse"></div>
+        <div class="flex-1 space-y-2">
+            <div class="h-4 w-24 bg-bg-hover rounded animate-pulse"></div>
+            <div class="h-3 w-16 bg-bg-hover rounded animate-pulse"></div>
+        </div>
+    </div>
+    <div class="preview-body space-y-2">
+        <div class="h-3 w-full bg-bg-hover rounded animate-pulse"></div>
+        <div class="h-3 w-3/4 bg-bg-hover rounded animate-pulse"></div>
+        <div class="h-3 w-1/2 bg-bg-hover rounded animate-pulse"></div>
+    </div>
+    <div class="preview-footer">
+        <div class="flex-1 h-7 bg-bg-hover rounded animate-pulse"></div>
+        <div class="flex-1 h-7 bg-bg-hover rounded animate-pulse"></div>
+    </div>
+</div>

--- a/src/DiscordBot.Bot/Components/Shared/QuickActionsCard.razor
+++ b/src/DiscordBot.Bot/Components/Shared/QuickActionsCard.razor
@@ -1,0 +1,72 @@
+<!-- Quick Actions Panel -->
+<div class="bg-bg-secondary border border-border-primary rounded-xl p-6">
+    <h2 class="text-lg font-semibold text-text-primary mb-4">@Title</h2>
+    <div class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 gap-4">
+        @foreach (var action in VisibleActions)
+        {
+            @if (action.ActionType == QuickActionType.Link)
+            {
+                <a href="@action.Href" class="quick-action-card">
+                    <div class="quick-action-icon bg-@GetColorClass(action.Color)/10">
+                        <svg class="w-6 h-6 text-@GetColorClass(action.Color)" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@action.IconPath" />
+                        </svg>
+                    </div>
+                    <span class="text-sm font-medium text-text-primary">@action.Label</span>
+                </a>
+            }
+            else
+            {
+                @if (action.RequiresConfirmation)
+                {
+                    <button type="button"
+                            @onclick="@(() => OnActionClick.InvokeAsync(action.ConfirmationModalId ?? action.Id))"
+                            class="quick-action-card">
+                        <div class="quick-action-icon bg-@GetColorClass(action.Color)/10">
+                            <svg class="w-6 h-6 text-@GetColorClass(action.Color)" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@action.IconPath" />
+                            </svg>
+                        </div>
+                        <span class="text-sm font-medium text-text-primary">@action.Label</span>
+                    </button>
+                }
+                else
+                {
+                    <button type="button"
+                            data-handler="@action.Handler"
+                            @onclick="@(() => OnActionClick.InvokeAsync(action.Handler ?? action.Id))"
+                            class="quick-action-card">
+                        <div class="quick-action-icon bg-@GetColorClass(action.Color)/10">
+                            <svg class="w-6 h-6 text-@GetColorClass(action.Color)" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@action.IconPath" />
+                            </svg>
+                        </div>
+                        <span class="text-sm font-medium text-text-primary">@action.Label</span>
+                    </button>
+                }
+            }
+        }
+    </div>
+</div>
+
+@code {
+    [Parameter] public string Title { get; set; } = "Quick Actions";
+    [Parameter] public IReadOnlyList<QuickActionItemViewModel> Actions { get; set; } = Array.Empty<QuickActionItemViewModel>();
+    [Parameter] public bool UserIsAdmin { get; set; }
+    [Parameter] public EventCallback<string> OnActionClick { get; set; }
+
+    private IEnumerable<QuickActionItemViewModel> VisibleActions =>
+        Actions.Where(a => !a.IsAdminOnly || UserIsAdmin);
+
+    private static string GetColorClass(QuickActionColor color) => color switch
+    {
+        QuickActionColor.Orange => "accent-orange",
+        QuickActionColor.Blue => "accent-blue",
+        QuickActionColor.Success => "success",
+        QuickActionColor.Warning => "warning",
+        QuickActionColor.Info => "info",
+        QuickActionColor.Error => "error",
+        QuickActionColor.Gray => "text-tertiary",
+        _ => "accent-blue"
+    };
+}

--- a/src/DiscordBot.Bot/Components/Shared/RecentActivityCard.razor
+++ b/src/DiscordBot.Bot/Components/Shared/RecentActivityCard.razor
@@ -1,0 +1,111 @@
+@using DiscordBot.Bot.ViewModels.Pages
+
+<!-- Recent Activity Card -->
+<div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden">
+    <!-- Card Header -->
+    <div class="flex items-center justify-between px-5 py-4 border-b border-border-primary">
+        <div class="flex items-center gap-3">
+            <div class="p-2 bg-accent-blue/10 rounded-lg">
+                <svg class="w-5 h-5 text-accent-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+            </div>
+            <h2 class="text-lg font-semibold text-text-primary">Recent Activity</h2>
+        </div>
+        <button
+            type="button"
+            @onclick="OnRefresh"
+            class="p-2 text-text-secondary hover:text-text-primary hover:bg-bg-primary rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-accent-blue focus:ring-offset-2 focus:ring-offset-bg-secondary"
+            aria-label="Refresh activity feed"
+            title="Refresh"
+        >
+            <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+            </svg>
+        </button>
+    </div>
+
+    @if (Activities.Any())
+    {
+        <!-- Activity List -->
+        <div class="max-h-[400px] overflow-y-auto">
+            <ul class="divide-y divide-border-primary">
+                @foreach (var activity in Activities)
+                {
+                    <li class="px-5 py-3 hover:bg-bg-primary/30 transition-colors">
+                        <div class="flex items-start gap-3">
+                            <!-- Status Icon -->
+                            <div class="flex-shrink-0 mt-0.5">
+                                @if (activity.Success)
+                                {
+                                    <div class="p-1 bg-status-online/10 rounded-full" title="Success">
+                                        <svg class="w-4 h-4 text-status-online" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                                            <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
+                                        </svg>
+                                    </div>
+                                }
+                                else
+                                {
+                                    <div class="p-1 bg-status-offline/10 rounded-full" title="Error">
+                                        <svg class="w-4 h-4 text-status-offline" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                                            <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
+                                        </svg>
+                                    </div>
+                                }
+                            </div>
+
+                            <!-- Activity Details -->
+                            <div class="flex-1 min-w-0">
+                                <div class="flex items-baseline gap-2 flex-wrap">
+                                    <span class="font-mono text-sm font-medium text-accent-blue">@activity.CommandName</span>
+                                    @if (!activity.Success && !string.IsNullOrEmpty(activity.ErrorMessage))
+                                    {
+                                        <span class="text-xs text-status-offline" title="@activity.ErrorMessage">failed</span>
+                                    }
+                                </div>
+                                <div class="mt-1 flex items-center gap-2 text-sm text-text-secondary">
+                                    <span class="truncate">@activity.GuildName</span>
+                                    <span aria-hidden="true">&bull;</span>
+                                    <span class="flex-shrink-0">@activity.RelativeTime</span>
+                                </div>
+                                @if (!activity.Success && !string.IsNullOrEmpty(activity.ErrorMessage))
+                                {
+                                    <p class="mt-1 text-xs text-text-tertiary truncate" title="@activity.ErrorMessage">
+                                        @activity.ErrorMessage
+                                    </p>
+                                }
+                            </div>
+                        </div>
+                    </li>
+                }
+            </ul>
+        </div>
+
+        <!-- Card Footer -->
+        <AuthorizeView Policy="RequireModerator">
+            <div class="px-5 py-3 border-t border-border-primary bg-bg-primary/30">
+                <a href="/Commands?tab=logs" class="text-sm font-medium text-accent-blue hover:text-accent-blue-hover transition-colors focus:outline-none focus:ring-2 focus:ring-accent-blue focus:ring-offset-2 focus:ring-offset-bg-secondary rounded px-2 py-1">
+                    View all activity
+                </a>
+            </div>
+        </AuthorizeView>
+    }
+    else
+    {
+        <!-- Empty State -->
+        <div class="px-5 py-12">
+            <div class="text-center">
+                <svg class="w-12 h-12 mx-auto text-text-tertiary mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <p class="text-text-secondary font-medium">No recent activity</p>
+                <p class="text-sm text-text-tertiary mt-1">Command activity will appear here as they are executed</p>
+            </div>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter] public IReadOnlyList<ActivityItem> Activities { get; set; } = Array.Empty<ActivityItem>();
+    [Parameter] public EventCallback OnRefresh { get; set; }
+}

--- a/src/DiscordBot.Bot/Components/Shared/RestartBanner.razor
+++ b/src/DiscordBot.Bot/Components/Shared/RestartBanner.razor
@@ -1,0 +1,27 @@
+<AuthorizeView Policy="RequireAdmin">
+    <Authorized>
+        <div class="mb-6 bg-warning/10 border-2 border-warning rounded-lg p-4">
+            <div class="flex items-start gap-3">
+                <div class="flex-shrink-0">
+                    <svg class="w-6 h-6 text-warning" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                    </svg>
+                </div>
+                <div class="flex-1">
+                    <h3 class="text-base font-semibold text-warning mb-1">Restart Required</h3>
+                    <p class="text-sm text-text-primary mb-3">
+                        You have made changes to settings that require a bot restart to take effect.
+                        Please go to the Bot Control tab in Settings to restart the bot.
+                    </p>
+                    <a href="/Admin/Settings"
+                       class="inline-flex items-center gap-2 px-4 py-2 bg-warning hover:bg-amber-600 active:bg-amber-700 text-text-inverse font-semibold text-sm rounded-lg transition-colors">
+                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                        </svg>
+                        Go to Bot Control
+                    </a>
+                </div>
+            </div>
+        </div>
+    </Authorized>
+</AuthorizeView>

--- a/src/DiscordBot.Bot/Components/Shared/RuleTypeIcon.razor
+++ b/src/DiscordBot.Bot/Components/Shared/RuleTypeIcon.razor
@@ -1,0 +1,20 @@
+@using DiscordBot.Core.Enums
+
+@{
+    var (iconPath, colorClass, title) = RuleType switch
+    {
+        RuleType.Spam => ("M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z", "text-warning", "Spam Detection"),
+        RuleType.Content => ("M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z", "text-error", "Content Filter"),
+        RuleType.Raid => ("M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z", "text-accent-blue", "Raid Protection"),
+        _ => ("M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z", "text-text-tertiary", "Unknown Rule")
+    };
+}
+
+<svg class="w-5 h-5 @colorClass" fill="none" viewBox="0 0 24 24" stroke="currentColor" title="@title" @attributes="AdditionalAttributes">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@iconPath" />
+</svg>
+
+@code {
+    [Parameter] public RuleType RuleType { get; set; }
+    [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+}

--- a/src/DiscordBot.Bot/Components/Shared/SeverityBadge.razor
+++ b/src/DiscordBot.Bot/Components/Shared/SeverityBadge.razor
@@ -1,0 +1,26 @@
+@using DiscordBot.Core.Enums
+
+@{
+    var (severityClass, label) = Severity switch
+    {
+        Severity.Low => ("severity-low", "Low"),
+        Severity.Medium => ("severity-medium", "Medium"),
+        Severity.High => ("severity-high", "High"),
+        Severity.Critical => ("severity-critical", "Critical"),
+        _ => ("severity-low", "Unknown")
+    };
+    var showPulse = Severity == Severity.Critical;
+}
+
+<span class="severity-badge @severityClass" @attributes="AdditionalAttributes">
+    @if (showPulse)
+    {
+        <span class="pulse-dot"></span>
+    }
+    @label
+</span>
+
+@code {
+    [Parameter] public Severity Severity { get; set; }
+    [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+}

--- a/src/DiscordBot.Bot/Components/Shared/Skeleton.razor
+++ b/src/DiscordBot.Bot/Components/Shared/Skeleton.razor
@@ -1,0 +1,33 @@
+@{
+    var (defaultWidth, defaultHeight, defaultRounded) = Type switch
+    {
+        SkeletonType.Text => ("w-full", "h-4", "rounded"),
+        SkeletonType.Title => ("w-full", "h-6", "rounded"),
+        SkeletonType.Avatar => ("w-10", "h-10", "rounded-full"),
+        SkeletonType.AvatarSmall => ("w-8", "h-8", "rounded-full"),
+        SkeletonType.AvatarLarge => ("w-16", "h-16", "rounded-full"),
+        SkeletonType.Button => ("w-24", "h-10", "rounded-md"),
+        SkeletonType.Card => ("w-full", "h-32", "rounded-lg"),
+        SkeletonType.Rectangle => ("w-full", "h-20", "rounded-md"),
+        _ => ("w-full", "h-4", "rounded")
+    };
+
+    var width = Width ?? defaultWidth;
+    var height = Height ?? defaultHeight;
+    var rounded = Rounded ? defaultRounded : "";
+    var animateClass = Animate ? "skeleton" : "skeleton-static";
+    var additionalClass = CssClass ?? "";
+
+    var allClasses = $"{width} {height} {rounded} {animateClass} {additionalClass}".Trim();
+}
+
+<div class="@allClasses" aria-hidden="true"></div>
+
+@code {
+    [Parameter] public SkeletonType Type { get; set; } = SkeletonType.Text;
+    [Parameter] public string? Width { get; set; }
+    [Parameter] public string? Height { get; set; }
+    [Parameter] public bool Rounded { get; set; } = true;
+    [Parameter] public bool Animate { get; set; } = true;
+    [Parameter] public string? CssClass { get; set; }
+}

--- a/src/DiscordBot.Bot/Components/Shared/SkeletonCard.razor
+++ b/src/DiscordBot.Bot/Components/Shared/SkeletonCard.razor
@@ -1,0 +1,91 @@
+@{
+    var cardClass = $"card {CssClass ?? ""}".Trim();
+}
+
+<div class="@cardClass">
+    @if (ShowHeader)
+    {
+        <div class="card-header">
+            <div class="skeleton w-32 h-6 rounded"></div>
+        </div>
+    }
+
+    <div class="card-body">
+        @if (Type == SkeletonCardType.Stats)
+        {
+            <!-- Stats Card: Icon + Value + Label -->
+            <div class="flex items-start gap-4">
+                <!-- Icon placeholder -->
+                <div class="skeleton w-12 h-12 rounded-lg flex-shrink-0"></div>
+
+                <!-- Stats content -->
+                <div class="flex-1 space-y-3">
+                    <div class="skeleton w-20 h-8 rounded"></div>
+                    <div class="skeleton w-24 h-4 rounded"></div>
+                </div>
+            </div>
+        }
+        else if (Type == SkeletonCardType.Server)
+        {
+            <!-- Server Card: Avatar + Name + Stats Row -->
+            <div class="flex flex-col gap-4">
+                <!-- Server header -->
+                <div class="flex items-center gap-3">
+                    <div class="skeleton w-12 h-12 rounded-lg flex-shrink-0"></div>
+                    <div class="flex-1 space-y-2">
+                        <div class="skeleton w-32 h-5 rounded"></div>
+                        <div class="skeleton w-24 h-4 rounded"></div>
+                    </div>
+                </div>
+
+                <!-- Stats row -->
+                <div class="grid grid-cols-3 gap-4">
+                    @for (var i = 0; i < 3; i++)
+                    {
+                        <div class="space-y-2">
+                            <div class="skeleton w-16 h-6 rounded"></div>
+                            <div class="skeleton w-20 h-3 rounded"></div>
+                        </div>
+                    }
+                </div>
+            </div>
+        }
+        else if (Type == SkeletonCardType.Activity)
+        {
+            <!-- Activity Feed: Icon + 2 Lines -->
+            <div class="space-y-4">
+                @for (var i = 0; i < 3; i++)
+                {
+                    <div class="flex items-start gap-3">
+                        <div class="skeleton w-10 h-10 rounded-full flex-shrink-0"></div>
+                        <div class="flex-1 space-y-2">
+                            <div class="skeleton w-full h-4 rounded"></div>
+                            <div class="skeleton w-3/4 h-3 rounded"></div>
+                        </div>
+                    </div>
+                }
+            </div>
+        }
+        else if (Type == SkeletonCardType.Table)
+        {
+            <!-- Table Row: Avatar + Name + Columns -->
+            <div class="space-y-3">
+                @for (var i = 0; i < 5; i++)
+                {
+                    <div class="flex items-center gap-4">
+                        <div class="skeleton w-10 h-10 rounded-full flex-shrink-0"></div>
+                        <div class="skeleton w-32 h-4 rounded"></div>
+                        <div class="skeleton w-24 h-4 rounded"></div>
+                        <div class="skeleton w-20 h-4 rounded ml-auto"></div>
+                    </div>
+                }
+            </div>
+        }
+    </div>
+</div>
+
+@code {
+    [Parameter] public SkeletonCardType Type { get; set; } = SkeletonCardType.Stats;
+    [Parameter] public bool ShowHeader { get; set; }
+    [Parameter] public string? CssClass { get; set; }
+}

--- a/src/DiscordBot.Bot/Components/Shared/SortDropdown.razor
+++ b/src/DiscordBot.Bot/Components/Shared/SortDropdown.razor
@@ -1,0 +1,78 @@
+@inject IJSRuntime JSRuntime
+
+@{
+    var currentSortLabel = SortOptions.FirstOrDefault(o => o.Value == CurrentSort)?.Label ?? "Sort";
+    var toggleId = $"{Id}Toggle";
+    var dropdownId = $"{Id}Menu";
+    var wrapperId = $"{Id}Wrapper";
+}
+
+<div class="relative sort-dropdown-wrapper" id="@wrapperId">
+    <button type="button"
+            id="@toggleId"
+            @onclick="ToggleDropdown"
+            class="flex items-center gap-2 px-3 py-1.5 text-sm bg-bg-tertiary border border-border-primary rounded-lg text-text-primary hover:bg-bg-hover focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors"
+            aria-haspopup="listbox"
+            aria-expanded="@(_isOpen ? "true" : "false")">
+        <svg class="w-4 h-4 text-text-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4h13M3 8h9m-9 4h6m4 0l4-4m0 0l4 4m-4-4v12" />
+        </svg>
+        <span>@currentSortLabel</span>
+        <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+        </svg>
+    </button>
+    @if (_isOpen)
+    {
+        <div id="@dropdownId"
+             class="absolute left-0 mt-1 w-40 bg-bg-tertiary border border-border-primary rounded-lg shadow-lg z-20"
+             role="listbox"
+             aria-labelledby="@toggleId">
+            @for (int i = 0; i < SortOptions.Count; i++)
+            {
+                var option = SortOptions[i];
+                var isSelected = option.Value == CurrentSort;
+                var isLast = i == SortOptions.Count - 1;
+                var roundedClass = isLast ? "rounded-b-lg" : "";
+                var selectedClass = isSelected ? "bg-bg-hover font-medium" : "";
+
+                <button type="button"
+                        class="block w-full text-left px-4 py-2 text-sm text-text-primary hover:bg-bg-hover @roundedClass @selectedClass"
+                        role="option"
+                        aria-selected="@isSelected.ToString().ToLower()"
+                        @onclick="() => SelectOption(option.Value)">
+                    <div class="flex items-center justify-between">
+                        <span>@option.Label</span>
+                        @if (isSelected)
+                        {
+                            <svg class="w-4 h-4 text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+                            </svg>
+                        }
+                    </div>
+                </button>
+            }
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter] public string Id { get; set; } = "sortDropdown";
+    [Parameter] public List<SortOption> SortOptions { get; set; } = new();
+    [Parameter] public string CurrentSort { get; set; } = string.Empty;
+    [Parameter] public string ParameterName { get; set; } = "sort";
+    [Parameter] public EventCallback<string> OnSortChanged { get; set; }
+
+    private bool _isOpen;
+
+    private void ToggleDropdown()
+    {
+        _isOpen = !_isOpen;
+    }
+
+    private async Task SelectOption(string value)
+    {
+        _isOpen = false;
+        await OnSortChanged.InvokeAsync(value);
+    }
+}

--- a/src/DiscordBot.Bot/Components/Shared/SsmlPreview.razor
+++ b/src/DiscordBot.Bot/Components/Shared/SsmlPreview.razor
@@ -1,0 +1,377 @@
+@inject IJSRuntime JS
+
+<div id="@ContainerId"
+     class="ssml-preview"
+     data-collapsed="@_isCollapsed.ToString().ToLower()"
+     data-show-count="@ShowCharacterCount.ToString().ToLower()">
+
+    <!-- Header -->
+    <button type="button"
+            class="ssml-preview__header"
+            @onclick="ToggleCollapsed"
+            aria-expanded="@(!_isCollapsed).ToString().ToLower()"
+            aria-controls="@(ContainerId)-content">
+
+        <div class="ssml-preview__header-left">
+            <svg class="ssml-preview__chevron"
+                 fill="none"
+                 viewBox="0 0 24 24"
+                 stroke="currentColor"
+                 aria-hidden="true">
+                <path stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M19 9l-7 7-7-7" />
+            </svg>
+
+            <span class="ssml-preview__title">SSML Preview (Read-only)</span>
+        </div>
+
+        @if (ShowCharacterCount)
+        {
+            <span id="@(ContainerId)-charCount"
+                  class="ssml-preview__char-count"
+                  role="status"
+                  aria-live="polite">
+                @GetCharacterCountText()
+            </span>
+        }
+    </button>
+
+    <!-- Content -->
+    <div id="@(ContainerId)-content"
+         class="ssml-preview__content @(_isCollapsed ? "collapsed" : "")">
+
+        <!-- Code Block -->
+        <pre id="@(ContainerId)-code"
+             class="ssml-preview__code"
+             role="region"
+             aria-label="SSML markup preview"
+             tabindex="0">@((MarkupString)GetHighlightedSsml())</pre>
+
+        <!-- Copy Button -->
+        <div class="ssml-preview__footer">
+            <button type="button"
+                    id="@(ContainerId)-copyBtn"
+                    class="ssml-preview__copy-btn"
+                    @onclick="CopyToClipboard"
+                    aria-label="Copy SSML to clipboard">
+                <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7v8a2 2 0 0 0 2 2h6M8 7V5a2 2 0 0 1 2-2h4.586a1 1 0 0 1 .707.293l4.414 4.414a1 1 0 0 1 .293.707V15a2 2 0 0 1-2 2h-2M8 7H6a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2v-2" />
+                </svg>
+                <span>Copy SSML</span>
+            </button>
+        </div>
+    </div>
+</div>
+
+<style>
+    .ssml-preview {
+        background: var(--color-bg-secondary);
+        border: 1px solid var(--color-border-primary);
+        border-radius: 0.5rem;
+        overflow: hidden;
+    }
+
+    .ssml-preview__header {
+        width: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.75rem 1rem;
+        background: var(--color-bg-tertiary);
+        border: none;
+        cursor: pointer;
+        transition: background 150ms ease-out;
+        font-family: inherit;
+    }
+
+    .ssml-preview__header:hover {
+        background: var(--color-bg-hover);
+    }
+
+    .ssml-preview__header:focus {
+        outline: none;
+        box-shadow: inset 0 0 0 2px var(--color-accent-orange);
+    }
+
+    .ssml-preview__header-left {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+    }
+
+    .ssml-preview__chevron {
+        width: 1.25rem;
+        height: 1.25rem;
+        color: var(--color-text-secondary);
+        transition: transform 200ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    [data-collapsed="false"] .ssml-preview__chevron {
+        transform: rotate(180deg);
+    }
+
+    .ssml-preview__title {
+        font-size: 0.875rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+    }
+
+    .ssml-preview__char-count {
+        font-size: 0.75rem;
+        font-weight: 500;
+        color: var(--color-text-secondary);
+        background: var(--color-bg-primary);
+        padding: 0.25rem 0.625rem;
+        border-radius: 0.375rem;
+        border: 1px solid var(--color-border-secondary);
+    }
+
+    .ssml-preview__content {
+        max-height: 400px;
+        overflow: hidden;
+        transition: max-height 200ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    .ssml-preview__content.collapsed {
+        max-height: 0;
+    }
+
+    .ssml-preview__code {
+        margin: 0;
+        padding: 1rem;
+        background: var(--color-bg-primary);
+        color: var(--color-text-primary);
+        font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+        font-size: 0.8125rem;
+        line-height: 1.5;
+        white-space: pre;
+        overflow-x: auto;
+        overflow-y: auto;
+        max-height: 300px;
+        border-top: 1px solid var(--color-border-primary);
+    }
+
+    .ssml-preview__code:focus {
+        outline: 2px solid var(--color-accent-orange);
+        outline-offset: -2px;
+    }
+
+    .ssml-tag {
+        color: var(--color-accent-blue);
+        font-weight: 600;
+    }
+
+    .ssml-attribute {
+        color: var(--color-accent-orange);
+        font-weight: 500;
+    }
+
+    .ssml-value {
+        color: var(--color-success);
+    }
+
+    .ssml-text {
+        color: var(--color-text-primary);
+    }
+
+    .ssml-preview__footer {
+        padding: 0.75rem 1rem;
+        background: var(--color-bg-secondary);
+        border-top: 1px solid var(--color-border-primary);
+        display: flex;
+        justify-content: flex-end;
+    }
+
+    .ssml-preview__copy-btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.5rem 1rem;
+        background: var(--color-bg-tertiary);
+        border: 1px solid var(--color-border-primary);
+        border-radius: 0.375rem;
+        color: var(--color-text-primary);
+        font-size: 0.875rem;
+        font-weight: 500;
+        cursor: pointer;
+        transition: all 150ms ease-out;
+        font-family: inherit;
+    }
+
+    .ssml-preview__copy-btn:hover {
+        background: var(--color-bg-hover);
+        border-color: var(--color-accent-orange);
+    }
+
+    .ssml-preview__copy-btn:focus {
+        outline: none;
+        box-shadow: 0 0 0 3px var(--color-accent-orange-muted);
+    }
+
+    .ssml-preview__copy-btn svg {
+        width: 1rem;
+        height: 1rem;
+        flex-shrink: 0;
+    }
+
+    @@media (max-width: 768px) {
+        .ssml-preview__header {
+            padding: 0.625rem 0.75rem;
+        }
+
+        .ssml-preview__title {
+            font-size: 0.8125rem;
+        }
+
+        .ssml-preview__char-count {
+            font-size: 0.6875rem;
+            padding: 0.1875rem 0.5rem;
+        }
+
+        .ssml-preview__code {
+            padding: 0.75rem;
+            font-size: 0.75rem;
+            max-height: 200px;
+        }
+
+        .ssml-preview__footer {
+            padding: 0.625rem 0.75rem;
+        }
+
+        .ssml-preview__copy-btn {
+            padding: 0.375rem 0.75rem;
+            font-size: 0.8125rem;
+        }
+    }
+</style>
+
+@code {
+    [Parameter] public string ContainerId { get; set; } = "ssmlPreview";
+    [Parameter] public string? SsmlContent { get; set; }
+    [Parameter] public bool StartCollapsed { get; set; } = true;
+    [Parameter] public EventCallback OnCopy { get; set; }
+    [Parameter] public bool ShowCharacterCount { get; set; } = true;
+    [Parameter] public int PlainTextLength { get; set; }
+
+    private bool _isCollapsed;
+
+    protected override void OnInitialized()
+    {
+        _isCollapsed = StartCollapsed;
+    }
+
+    private void ToggleCollapsed()
+    {
+        _isCollapsed = !_isCollapsed;
+    }
+
+    private async Task CopyToClipboard()
+    {
+        if (string.IsNullOrEmpty(SsmlContent)) return;
+
+        try
+        {
+            await JS.InvokeVoidAsync("navigator.clipboard.writeText", SsmlContent);
+            await OnCopy.InvokeAsync();
+        }
+        catch
+        {
+            // Clipboard API may not be available
+        }
+    }
+
+    private string GetCharacterCountText()
+    {
+        var ssmlLength = SsmlContent?.Length ?? 0;
+        if (ssmlLength == 0) return "0 chars";
+
+        if (PlainTextLength > 0)
+        {
+            var overhead = (int)Math.Round(((double)(ssmlLength - PlainTextLength) / PlainTextLength) * 100);
+            return $"{ssmlLength} chars ({PlainTextLength} plain text, +{overhead}% markup)";
+        }
+
+        return $"{ssmlLength} chars";
+    }
+
+    private string GetHighlightedSsml()
+    {
+        if (string.IsNullOrEmpty(SsmlContent)) return string.Empty;
+
+        return HighlightSsmlSyntax(SsmlContent);
+    }
+
+    private static string HighlightSsmlSyntax(string ssml)
+    {
+        var result = new System.Text.StringBuilder();
+        var i = 0;
+
+        while (i < ssml.Length)
+        {
+            if (ssml[i] == '<')
+            {
+                var tagEnd = ssml.IndexOf('>', i);
+                if (tagEnd == -1)
+                {
+                    result.Append(System.Net.WebUtility.HtmlEncode(ssml[i..]));
+                    break;
+                }
+
+                var tag = ssml.Substring(i, tagEnd - i + 1);
+                result.Append(HighlightTag(tag));
+                i = tagEnd + 1;
+            }
+            else
+            {
+                var nextTag = ssml.IndexOf('<', i);
+                var text = nextTag == -1 ? ssml[i..] : ssml[i..nextTag];
+                if (!string.IsNullOrEmpty(text))
+                {
+                    result.Append($"<span class=\"ssml-text\">{System.Net.WebUtility.HtmlEncode(text)}</span>");
+                }
+                i = nextTag == -1 ? ssml.Length : nextTag;
+            }
+        }
+
+        return result.ToString();
+    }
+
+    private static string HighlightTag(string tag)
+    {
+        var match = System.Text.RegularExpressions.Regex.Match(tag, @"^<(/?)([\w:-]+)(.*?)(/?)>$");
+        if (!match.Success)
+        {
+            return $"<span class=\"ssml-tag\">{System.Net.WebUtility.HtmlEncode(tag)}</span>";
+        }
+
+        var closingSlash = match.Groups[1].Value;
+        var tagName = match.Groups[2].Value;
+        var attributes = match.Groups[3].Value;
+        var selfClosing = match.Groups[4].Value;
+
+        var result = new System.Text.StringBuilder();
+        result.Append($"<span class=\"ssml-tag\">&lt;{closingSlash}{tagName}</span>");
+
+        if (!string.IsNullOrEmpty(attributes))
+        {
+            var attrHighlighted = System.Text.RegularExpressions.Regex.Replace(
+                attributes,
+                @"(\s+)([\w:-]+)(=)([""'])(.*?)\4",
+                m =>
+                {
+                    var space = m.Groups[1].Value;
+                    var attrName = m.Groups[2].Value;
+                    var equals = m.Groups[3].Value;
+                    var quote = m.Groups[4].Value;
+                    var value = System.Net.WebUtility.HtmlEncode(m.Groups[5].Value);
+                    return $"{space}<span class=\"ssml-attribute\">{attrName}</span>{equals}{quote}<span class=\"ssml-value\">{value}</span>{quote}";
+                });
+            result.Append(attrHighlighted);
+        }
+
+        result.Append($"<span class=\"ssml-tag\">{selfClosing}&gt;</span>");
+        return result.ToString();
+    }
+}

--- a/src/DiscordBot.Bot/Components/Shared/StatusBadge.razor
+++ b/src/DiscordBot.Bot/Components/Shared/StatusBadge.razor
@@ -1,0 +1,21 @@
+@using DiscordBot.Core.Enums
+
+@{
+    var (statusClass, label) = Status switch
+    {
+        FlaggedEventStatus.Pending => ("status-pending", "Pending"),
+        FlaggedEventStatus.Dismissed => ("status-dismissed", "Dismissed"),
+        FlaggedEventStatus.Acknowledged => ("status-acknowledged", "Acknowledged"),
+        FlaggedEventStatus.Actioned => ("status-actioned", "Actioned"),
+        _ => ("status-dismissed", "Unknown")
+    };
+}
+
+<span class="status-badge @statusClass" @attributes="AdditionalAttributes">
+    @label
+</span>
+
+@code {
+    [Parameter] public FlaggedEventStatus Status { get; set; }
+    [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+}

--- a/src/DiscordBot.Bot/Components/Shared/StatusIndicator.razor
+++ b/src/DiscordBot.Bot/Components/Shared/StatusIndicator.razor
@@ -1,0 +1,91 @@
+@{
+    var sizeClasses = Size switch
+    {
+        StatusSize.Small => "w-1.5 h-1.5",
+        StatusSize.Large => "w-3 h-3",
+        _ => "w-2 h-2"
+    };
+
+    var (colorClass, textColorClass) = Status switch
+    {
+        StatusType.Online => ("bg-success", "text-success"),
+        StatusType.Idle => ("bg-warning", "text-warning"),
+        StatusType.Busy => ("bg-error", "text-error"),
+        _ => ("bg-text-tertiary", "text-text-tertiary")
+    };
+
+    var displayText = Text ?? Status switch
+    {
+        StatusType.Online => "Online",
+        StatusType.Idle => "Idle",
+        StatusType.Busy => "Do Not Disturb",
+        _ => "Offline"
+    };
+}
+
+@if (DisplayStyle == StatusDisplayStyle.DotOnly)
+{
+    @if (IsPulsing)
+    {
+        <span class="relative inline-flex">
+            <span class="@sizeClasses @colorClass rounded-full"></span>
+            <span class="absolute inset-0 @sizeClasses @colorClass rounded-full animate-ping opacity-75"></span>
+        </span>
+    }
+    else
+    {
+        <span class="@sizeClasses @colorClass rounded-full"></span>
+    }
+}
+else if (DisplayStyle == StatusDisplayStyle.BadgeStyle)
+{
+    var badgeBgClass = Status switch
+    {
+        StatusType.Online => "bg-success/20 text-success",
+        StatusType.Idle => "bg-warning/20 text-warning",
+        StatusType.Busy => "bg-error/20 text-error",
+        _ => "bg-border-primary text-text-tertiary"
+    };
+    var badgeDotSize = "w-1.5 h-1.5";
+
+    <span class="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-semibold rounded-full @badgeBgClass" @attributes="AdditionalAttributes">
+        @if (IsPulsing)
+        {
+            <span class="relative inline-flex">
+                <span class="@badgeDotSize @colorClass rounded-full"></span>
+                <span class="absolute inset-0 @badgeDotSize @colorClass rounded-full animate-ping opacity-75"></span>
+            </span>
+        }
+        else
+        {
+            <span class="@badgeDotSize @colorClass rounded-full"></span>
+        }
+        @displayText
+    </span>
+}
+else
+{
+    <span class="inline-flex items-center gap-2 text-sm font-medium @textColorClass" @attributes="AdditionalAttributes">
+        @if (IsPulsing)
+        {
+            <span class="relative inline-flex">
+                <span class="@sizeClasses @colorClass rounded-full"></span>
+                <span class="absolute inset-0 @sizeClasses @colorClass rounded-full animate-ping opacity-75"></span>
+            </span>
+        }
+        else
+        {
+            <span class="@sizeClasses @colorClass rounded-full"></span>
+        }
+        @displayText
+    </span>
+}
+
+@code {
+    [Parameter] public StatusType Status { get; set; } = StatusType.Offline;
+    [Parameter] public string? Text { get; set; }
+    [Parameter] public StatusDisplayStyle DisplayStyle { get; set; } = StatusDisplayStyle.DotWithText;
+    [Parameter] public bool IsPulsing { get; set; }
+    [Parameter] public StatusSize Size { get; set; } = StatusSize.Medium;
+    [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+}

--- a/src/DiscordBot.Bot/Components/Shared/StyleSelector.razor
+++ b/src/DiscordBot.Bot/Components/Shared/StyleSelector.razor
@@ -1,0 +1,365 @@
+@{
+    var selectedStyleOption = AvailableStyles.FirstOrDefault(s => s.Value == SelectedStyle);
+    var selectedIconPath = GetStyleIconPath(SelectedStyle);
+}
+
+<div id="@ContainerId"
+     class="style-selector"
+     data-voice="@SelectedVoice"
+     data-style="@SelectedStyle"
+     data-intensity="@StyleIntensity">
+
+    <!-- Style Dropdown -->
+    <div class="style-selector__group">
+        <label for="@(ContainerId)-select" class="style-selector__label">
+            Speaking Style
+        </label>
+        <div class="style-selector__select-wrapper">
+            <select id="@(ContainerId)-select"
+                    class="style-selector__select"
+                    aria-label="Select speaking style"
+                    value="@SelectedStyle"
+                    @onchange="OnStyleChanged">
+                @foreach (var style in AvailableStyles)
+                {
+                    <option value="@style.Value"
+                            title="@style.Example"
+                            disabled="@style.IsDisabled"
+                            selected="@(style.Value == SelectedStyle)">
+                        @style.Label@(!string.IsNullOrEmpty(style.Description) ? $" - {style.Description}" : "")
+                    </option>
+                }
+            </select>
+            <div class="style-selector__select-icon">
+                @if (!string.IsNullOrEmpty(selectedIconPath))
+                {
+                    <svg class="w-5 h-5"
+                         fill="none"
+                         viewBox="0 0 24 24"
+                         stroke="currentColor"
+                         aria-hidden="true">
+                        <path stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              d="@selectedIconPath" />
+                    </svg>
+                }
+            </div>
+        </div>
+        <p class="style-selector__help-text"
+           title="Example phrase"
+           role="status"
+           aria-live="polite"
+           style="@(string.IsNullOrEmpty(SelectedStyle) ? "display: none;" : "")">
+            @(selectedStyleOption?.Example ?? "")
+        </p>
+        <p class="style-selector__no-styles-message" style="display: none;">
+            <em>This voice does not support speaking styles.</em>
+        </p>
+    </div>
+
+    <!-- Intensity Slider -->
+    <div class="style-selector__group">
+        <label for="@(ContainerId)-slider" class="style-selector__label">
+            Style Intensity
+        </label>
+        <div class="style-selector__slider-wrapper">
+            <input type="range"
+                   id="@(ContainerId)-slider"
+                   class="style-selector__slider"
+                   min="0.5"
+                   max="2.0"
+                   step="0.1"
+                   value="@StyleIntensity"
+                   disabled="@(string.IsNullOrEmpty(SelectedStyle))"
+                   aria-label="Adjust style intensity"
+                   aria-valuemin="0.5"
+                   aria-valuemax="2.0"
+                   aria-valuenow="@StyleIntensity"
+                   @oninput="OnIntensityChanged" />
+            <div class="style-selector__slider-labels">
+                <span class="style-selector__slider-label">Subtle</span>
+                <span class="style-selector__slider-label">Moderate</span>
+                <span class="style-selector__slider-label">Intense</span>
+            </div>
+        </div>
+        <div class="style-selector__intensity-value">
+            <span id="@(ContainerId)-intensity-display">@StyleIntensity.ToString("0.0")</span>
+        </div>
+    </div>
+</div>
+
+<style>
+    .style-selector {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+    }
+
+    .style-selector__group {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+    }
+
+    .style-selector__label {
+        font-size: 0.875rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+    }
+
+    .style-selector__select-wrapper {
+        position: relative;
+        display: flex;
+        align-items: center;
+    }
+
+    .style-selector__select {
+        width: 100%;
+        padding: 0.625rem 2.5rem 0.625rem 0.75rem;
+        background: var(--color-bg-primary);
+        border: 1px solid var(--color-border-primary);
+        border-radius: 0.5rem;
+        color: var(--color-text-primary);
+        font-size: 0.875rem;
+        font-weight: 500;
+        cursor: pointer;
+        transition: all 200ms cubic-bezier(0.4, 0, 0.2, 1);
+        appearance: none;
+    }
+
+    .style-selector__select:hover {
+        border-color: var(--color-accent-orange-muted);
+        background: var(--color-bg-hover);
+    }
+
+    .style-selector__select:focus {
+        outline: none;
+        border-color: var(--color-accent-orange);
+        box-shadow: 0 0 0 3px var(--color-accent-orange-muted);
+    }
+
+    .style-selector__select option:disabled {
+        color: var(--color-text-tertiary);
+        opacity: 0.5;
+    }
+
+    .style-selector__select-icon {
+        position: absolute;
+        right: 0.75rem;
+        pointer-events: none;
+        color: var(--color-text-secondary);
+        display: flex;
+        align-items: center;
+    }
+
+    .style-selector__select-icon svg {
+        width: 1.25rem;
+        height: 1.25rem;
+    }
+
+    .style-selector__help-text {
+        font-size: 0.75rem;
+        color: var(--color-text-tertiary);
+        font-style: italic;
+        margin: 0;
+    }
+
+    .style-selector__no-styles-message {
+        font-size: 0.8125rem;
+        color: var(--color-text-tertiary);
+        margin: 0.25rem 0 0 0;
+    }
+
+    .style-selector__slider-wrapper {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+    }
+
+    .style-selector__slider {
+        width: 100%;
+        height: 0.5rem;
+        background: var(--color-bg-tertiary);
+        border-radius: 0.25rem;
+        outline: none;
+        cursor: pointer;
+        transition: all 200ms cubic-bezier(0.4, 0, 0.2, 1);
+        -webkit-appearance: none;
+        appearance: none;
+    }
+
+    .style-selector__slider::-webkit-slider-track {
+        width: 100%;
+        height: 0.5rem;
+        background: var(--color-bg-tertiary);
+        border-radius: 0.25rem;
+    }
+
+    .style-selector__slider::-moz-range-track {
+        width: 100%;
+        height: 0.5rem;
+        background: var(--color-bg-tertiary);
+        border-radius: 0.25rem;
+    }
+
+    .style-selector__slider::-webkit-slider-thumb {
+        -webkit-appearance: none;
+        appearance: none;
+        width: 1.25rem;
+        height: 1.25rem;
+        background: var(--color-accent-orange);
+        border: 2px solid white;
+        border-radius: 50%;
+        cursor: pointer;
+        transition: all 200ms cubic-bezier(0.4, 0, 0.2, 1);
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    }
+
+    .style-selector__slider::-moz-range-thumb {
+        width: 1.25rem;
+        height: 1.25rem;
+        background: var(--color-accent-orange);
+        border: 2px solid white;
+        border-radius: 50%;
+        cursor: pointer;
+        transition: all 200ms cubic-bezier(0.4, 0, 0.2, 1);
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    }
+
+    .style-selector__slider:hover::-webkit-slider-thumb {
+        background: var(--color-accent-orange-hover);
+        transform: scale(1.1);
+    }
+
+    .style-selector__slider:hover::-moz-range-thumb {
+        background: var(--color-accent-orange-hover);
+        transform: scale(1.1);
+    }
+
+    .style-selector__slider:focus::-webkit-slider-thumb {
+        box-shadow: 0 0 0 4px var(--color-accent-orange-muted),
+                    0 2px 4px rgba(0, 0, 0, 0.2);
+    }
+
+    .style-selector__slider:focus::-moz-range-thumb {
+        box-shadow: 0 0 0 4px var(--color-accent-orange-muted),
+                    0 2px 4px rgba(0, 0, 0, 0.2);
+    }
+
+    .style-selector__slider:disabled {
+        cursor: not-allowed;
+    }
+
+    .style-selector__slider:disabled::-webkit-slider-track {
+        opacity: 0.5;
+    }
+
+    .style-selector__slider:disabled::-moz-range-track {
+        opacity: 0.5;
+    }
+
+    .style-selector__slider:disabled::-webkit-slider-thumb {
+        background: var(--color-text-tertiary);
+        cursor: not-allowed;
+        opacity: 0.5;
+    }
+
+    .style-selector__slider:disabled::-moz-range-thumb {
+        background: var(--color-text-tertiary);
+        cursor: not-allowed;
+        opacity: 0.5;
+    }
+
+    .style-selector__slider-labels {
+        display: flex;
+        justify-content: space-between;
+        padding: 0 0.25rem;
+    }
+
+    .style-selector__slider-label {
+        font-size: 0.75rem;
+        color: var(--color-text-tertiary);
+        font-weight: 500;
+    }
+
+    .style-selector__intensity-value {
+        text-align: center;
+        font-size: 0.875rem;
+        font-weight: 600;
+        color: var(--color-accent-orange);
+    }
+
+    @@media (max-width: 767px) {
+        .style-selector {
+            gap: 1.25rem;
+        }
+
+        .style-selector__select {
+            min-height: 44px;
+        }
+
+        .style-selector__slider-label {
+            font-size: 0.625rem;
+        }
+
+        .style-selector__slider::-webkit-slider-thumb {
+            width: 1.5rem;
+            height: 1.5rem;
+        }
+
+        .style-selector__slider::-moz-range-thumb {
+            width: 1.5rem;
+            height: 1.5rem;
+        }
+
+        .style-selector__slider::-webkit-slider-thumb:active {
+            transform: scale(1.2);
+        }
+
+        .style-selector__slider::-moz-range-thumb:active {
+            transform: scale(1.2);
+        }
+    }
+</style>
+
+@code {
+    [Parameter] public string SelectedVoice { get; set; } = string.Empty;
+    [Parameter] public string SelectedStyle { get; set; } = string.Empty;
+    [Parameter] public EventCallback<string> SelectedStyleChanged { get; set; }
+    [Parameter] public decimal StyleIntensity { get; set; } = 1.0m;
+    [Parameter] public EventCallback<decimal> StyleIntensityChanged { get; set; }
+    [Parameter] public IReadOnlyList<StyleOption> AvailableStyles { get; set; } = [];
+    [Parameter] public string ContainerId { get; set; } = "styleSelector";
+
+    private async Task OnStyleChanged(ChangeEventArgs e)
+    {
+        SelectedStyle = e.Value?.ToString() ?? string.Empty;
+        await SelectedStyleChanged.InvokeAsync(SelectedStyle);
+    }
+
+    private async Task OnIntensityChanged(ChangeEventArgs e)
+    {
+        if (decimal.TryParse(e.Value?.ToString(), out var intensity))
+        {
+            StyleIntensity = intensity;
+            await StyleIntensityChanged.InvokeAsync(StyleIntensity);
+        }
+    }
+
+    private static string GetStyleIconPath(string styleValue)
+    {
+        return styleValue switch
+        {
+            "cheerful" => "M15.182 15.182a4.5 4.5 0 0 1-6.364 0M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0ZM9.75 9.75c0 .414-.168.75-.375.75S9 10.164 9 9.75 9.168 9 9.375 9s.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Zm5.625 0c0 .414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Z",
+            "excited" => "M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z",
+            "friendly" => "M10.05 4.575a1.575 1.575 0 1 0-3.15 0v3m3.15-3v-1.5a1.575 1.575 0 0 1 3.15 0v1.5m-3.15 0 .075 5.925m3.075.75V4.575m0 0a1.575 1.575 0 0 1 3.15 0V15M6.9 7.575a1.575 1.575 0 1 0-3.15 0v8.175a6.75 6.75 0 0 0 6.75 6.75h2.018a5.25 5.25 0 0 0 3.712-1.538l1.732-1.732a5.25 5.25 0 0 0 1.538-3.712l.003-2.024a.668.668 0 0 1 .198-.471 1.575 1.575 0 1 0-2.228-2.228 3.818 3.818 0 0 0-1.12 2.687M6.9 7.575V12m6.27 4.318A4.49 4.49 0 0 1 16.35 15",
+            "sad" => "M15.182 16.318A4.486 4.486 0 0 0 12.016 15a4.486 4.486 0 0 0-3.198 1.318M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9.75-3.75h.008v.008h-.008V8.25Zm6 0h.008v.008h-.008V8.25Z",
+            "angry" => "M15.362 5.214A8.252 8.252 0 0 1 12 21 8.25 8.25 0 0 1 6.038 7.047 8.287 8.287 0 0 0 9 9.601a8.983 8.983 0 0 1 3.361-6.867 8.21 8.21 0 0 0 3 2.48Z",
+            "whispering" => "M17.25 9.75 19.5 12m0 0 2.25 2.25M19.5 12l2.25-2.25M19.5 12l-2.25 2.25m-10.5-6 4.72-4.72a.75.75 0 0 1 1.28.53v15.88a.75.75 0 0 1-1.28.53l-4.72-4.72H4.51c-.88 0-1.704-.507-1.938-1.354A9.009 9.009 0 0 1 2.25 12c0-.83.112-1.633.322-2.396C2.806 8.756 3.63 8.25 4.51 8.25H6.75Z",
+            "shouting" => "M19.114 5.636a9 9 0 0 1 0 12.728M16.463 8.288a5.25 5.25 0 0 1 0 7.424M6.75 8.25l4.72-4.72a.75.75 0 0 1 1.28.53v15.88a.75.75 0 0 1-1.28.53l-4.72-4.72H4.51c-.88 0-1.704-.507-1.938-1.354A9.009 9.009 0 0 1 2.25 12c0-.83.112-1.633.322-2.396C2.806 8.756 3.63 8.25 4.51 8.25H6.75Z",
+            "newscast" => "M12 7.5h1.5m-1.5 3h1.5m-7.5 3h7.5m-7.5 3h7.5m3-9h3.375c.621 0 1.125.504 1.125 1.125V18a2.25 2.25 0 0 1-2.25 2.25M16.5 7.5V18a2.25 2.25 0 0 0 2.25 2.25M16.5 7.5V4.875c0-.621-.504-1.125-1.125-1.125H4.125C3.504 3.75 3 4.254 3 4.875V18a2.25 2.25 0 0 0 2.25 2.25h13.5M6 7.5h3v3H6v-3Z",
+            _ => ""
+        };
+    }
+}

--- a/src/DiscordBot.Bot/Components/Shared/TabPanel.razor
+++ b/src/DiscordBot.Bot/Components/Shared/TabPanel.razor
@@ -1,0 +1,121 @@
+@{
+    var containerClass = "tab-panel-container";
+    containerClass += $" tab-panel-{StyleVariant.ToString().ToLowerInvariant()}";
+    if (Compact)
+    {
+        containerClass += " tab-panel-compact";
+    }
+    if (!string.IsNullOrEmpty(ContainerClass))
+    {
+        containerClass += $" {ContainerClass}";
+    }
+}
+
+<div class="@containerClass"
+     id="@(Id)-container"
+     data-tab-panel
+     data-navigation-mode="@NavigationMode.ToString().ToLowerInvariant()"
+     data-persistence-mode="@PersistenceMode.ToString().ToLowerInvariant()"
+     data-panel-id="@Id"
+     data-no-auto-init="@(DisableAutoInit ? "true" : null)"
+     data-ajax-url-pattern="@(NavigationMode == TabNavigationMode.Ajax && !string.IsNullOrEmpty(AjaxUrlPattern) ? AjaxUrlPattern : null)"
+     data-ajax-content-target="@(NavigationMode == TabNavigationMode.Ajax && !string.IsNullOrEmpty(AjaxContentTarget) ? AjaxContentTarget : null)">
+    <nav class="tab-panel-tabs"
+         id="@(Id)-tablist"
+         role="tablist"
+         aria-label="@AriaLabel">
+        @foreach (var tab in Tabs)
+        {
+            var isActive = tab.Id == ActiveTabId;
+            var tabElementId = $"{Id}-tab-{tab.Id}";
+            var panelElementId = $"{Id}-panel-{tab.Id}";
+            var tabClass = GetTabClass(tab);
+
+            if (NavigationMode == TabNavigationMode.PageNavigation)
+            {
+                <a href="@(tab.Href ?? "#")"
+                   class="@tabClass"
+                   id="@tabElementId"
+                   role="tab"
+                   aria-selected="@(isActive ? "true" : "false")"
+                   aria-disabled="@(tab.Disabled ? "true" : null)"
+                   tabindex="@(tab.Disabled ? "-1" : null)"
+                   data-tab-id="@tab.Id">
+                    @RenderTabContent(tab, isActive)
+                </a>
+            }
+            else
+            {
+                <button type="button"
+                        class="@tabClass"
+                        id="@tabElementId"
+                        role="tab"
+                        aria-selected="@(isActive ? "true" : "false")"
+                        aria-controls="@panelElementId"
+                        tabindex="@(isActive ? "0" : "-1")"
+                        disabled="@(tab.Disabled ? true : null)"
+                        aria-disabled="@(tab.Disabled ? "true" : null)"
+                        data-tab-id="@tab.Id">
+                    @RenderTabContent(tab, isActive)
+                </button>
+            }
+        }
+    </nav>
+</div>
+
+@code {
+    [Parameter] public string Id { get; set; } = "tabPanel";
+    [Parameter] public IReadOnlyList<TabItemViewModel> Tabs { get; set; } = [];
+    [Parameter] public string ActiveTabId { get; set; } = string.Empty;
+    [Parameter] public TabNavigationMode NavigationMode { get; set; } = TabNavigationMode.InPage;
+    [Parameter] public TabPersistenceMode PersistenceMode { get; set; } = TabPersistenceMode.UrlHash;
+    [Parameter] public string AriaLabel { get; set; } = "Tab navigation";
+    [Parameter] public string? ContainerClass { get; set; }
+    [Parameter] public bool Compact { get; set; }
+    [Parameter] public TabStyleVariant StyleVariant { get; set; } = TabStyleVariant.Underline;
+    [Parameter] public string? AjaxUrlPattern { get; set; }
+    [Parameter] public string? AjaxContentTarget { get; set; }
+    [Parameter] public bool DisableAutoInit { get; set; }
+
+    private string GetTabClass(TabItemViewModel tab)
+    {
+        var classes = "tab-panel-tab";
+        if (tab.Id == ActiveTabId) classes += " active";
+        if (tab.Disabled) classes += " disabled";
+        return classes;
+    }
+
+    private RenderFragment RenderTabContent(TabItemViewModel tab, bool isActive) => __builder =>
+    {
+        if (tab.HasIcon)
+        {
+            var iconClass = isActive ? "tab-icon tab-icon-active" : "tab-icon";
+            <svg class="@iconClass" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@tab.IconPathOutline" />
+            </svg>
+        }
+
+        if (!string.IsNullOrEmpty(tab.ShortLabel))
+        {
+            <span class="tab-label-long">@tab.Label</span>
+            <span class="tab-label-short">@tab.ShortLabel</span>
+        }
+        else
+        {
+            <span>@tab.Label</span>
+        }
+
+        if (tab.HasBadge)
+        {
+            var badgeClass = tab.BadgeVariant switch
+            {
+                TabBadgeVariant.Success => "tab-badge tab-badge-success",
+                TabBadgeVariant.Warning => "tab-badge tab-badge-warning",
+                TabBadgeVariant.Error => "tab-badge tab-badge-error",
+                TabBadgeVariant.Info => "tab-badge tab-badge-info",
+                _ => "tab-badge"
+            };
+            <span class="@badgeClass">@tab.BadgeCount</span>
+        }
+    };
+}

--- a/src/DiscordBot.Bot/Components/Shared/ToastContainer.razor
+++ b/src/DiscordBot.Bot/Components/Shared/ToastContainer.razor
@@ -1,0 +1,12 @@
+@inject ToastInterop ToastInterop
+
+<div id="toastContainer"
+     class="fixed bottom-4 right-4 z-toast flex flex-col gap-2 pointer-events-none max-h-[calc(100vh-32px)] overflow-hidden"
+     role="region"
+     aria-live="polite"
+     aria-label="Notifications">
+    @* Toasts are dynamically added here via JavaScript *@
+</div>
+
+@code {
+}

--- a/src/DiscordBot.Bot/Components/Shared/TypedConfirmationModal.razor
+++ b/src/DiscordBot.Bot/Components/Shared/TypedConfirmationModal.razor
@@ -1,0 +1,119 @@
+@if (IsVisible)
+{
+    <!-- Typed Confirmation Modal -->
+    <div class="fixed inset-0 z-[var(--z-modal)]" role="alertdialog" aria-modal="true" aria-labelledby="@(Id)Title" aria-describedby="@(Id)Desc">
+        <!-- Backdrop -->
+        <div class="fixed inset-0 bg-black/70 backdrop-blur-sm" @onclick="Cancel"></div>
+
+        <!-- Modal Dialog -->
+        <div class="fixed inset-0 flex items-center justify-center p-4">
+            <div class="bg-bg-tertiary border border-border-primary rounded-lg shadow-xl max-w-md w-full" role="document">
+                <!-- Modal Content -->
+                <div class="p-6">
+                    <div class="flex items-start gap-4">
+                        <!-- Icon -->
+                        <div class="flex-shrink-0 w-10 h-10 rounded-full bg-@GetVariantColorClass()/20 flex items-center justify-center">
+                            <svg class="w-5 h-5 text-@GetVariantColorClass()" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="@GetDefaultIconPath()" />
+                            </svg>
+                        </div>
+
+                        <!-- Text Content -->
+                        <div class="flex-1">
+                            <h3 id="@(Id)Title" class="text-lg font-semibold text-text-primary">@Title</h3>
+                            <p id="@(Id)Desc" class="mt-2 text-sm text-text-secondary">@Message</p>
+
+                            <!-- Typed Input -->
+                            <div class="mt-4">
+                                <label for="@(Id)Input" class="block text-sm font-medium text-text-primary mb-2">
+                                    @InputLabel
+                                </label>
+                                <input
+                                    type="text"
+                                    id="@(Id)Input"
+                                    class="w-full px-3 py-2 text-sm bg-bg-primary border border-error rounded-md text-text-primary placeholder-text-tertiary focus:border-error focus:ring-1 focus:ring-error transition-colors"
+                                    placeholder="@RequiredText"
+                                    autocomplete="off"
+                                    @bind="_typedText"
+                                    @bind:event="oninput"
+                                />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Modal Footer -->
+                <div class="flex justify-end gap-3 px-6 py-4 bg-bg-secondary border-t border-border-primary rounded-b-lg">
+                    <button type="button"
+                            @onclick="Cancel"
+                            class="px-4 py-2 bg-bg-tertiary hover:bg-bg-hover border border-border-primary text-text-primary font-medium text-sm rounded-md transition-colors">
+                        @CancelText
+                    </button>
+
+                    <button type="button"
+                            @onclick="Confirm"
+                            disabled="@(!IsConfirmEnabled)"
+                            class="px-4 py-2 @GetConfirmButtonClass() text-white font-medium text-sm rounded-md transition-colors min-w-[100px] flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed">
+                        <span>@ConfirmText</span>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter] public string Id { get; set; } = string.Empty;
+    [Parameter] public string Title { get; set; } = string.Empty;
+    [Parameter] public string Message { get; set; } = string.Empty;
+    [Parameter] public string RequiredText { get; set; } = string.Empty;
+    [Parameter] public string InputLabel { get; set; } = string.Empty;
+    [Parameter] public string ConfirmText { get; set; } = "Confirm";
+    [Parameter] public string CancelText { get; set; } = "Cancel";
+    [Parameter] public ConfirmationVariant Variant { get; set; } = ConfirmationVariant.Danger;
+    [Parameter] public bool IsVisible { get; set; }
+    [Parameter] public EventCallback<bool> IsVisibleChanged { get; set; }
+    [Parameter] public EventCallback OnConfirm { get; set; }
+
+    private string _typedText = string.Empty;
+
+    private bool IsConfirmEnabled =>
+        string.Equals(_typedText, RequiredText, StringComparison.Ordinal);
+
+    private async Task Cancel()
+    {
+        _typedText = string.Empty;
+        await IsVisibleChanged.InvokeAsync(false);
+    }
+
+    private async Task Confirm()
+    {
+        if (!IsConfirmEnabled) return;
+        await OnConfirm.InvokeAsync();
+        _typedText = string.Empty;
+        await IsVisibleChanged.InvokeAsync(false);
+    }
+
+    private string GetVariantColorClass() => Variant switch
+    {
+        ConfirmationVariant.Info => "accent-blue",
+        ConfirmationVariant.Warning => "warning",
+        ConfirmationVariant.Danger => "error",
+        _ => "warning"
+    };
+
+    private string GetConfirmButtonClass() => Variant switch
+    {
+        ConfirmationVariant.Info => "bg-accent-blue hover:bg-accent-blue-hover active:bg-accent-blue-active disabled:hover:bg-accent-blue",
+        ConfirmationVariant.Warning => "bg-warning hover:bg-amber-600 active:bg-amber-700 disabled:hover:bg-warning",
+        ConfirmationVariant.Danger => "bg-error hover:bg-red-600 active:bg-red-700 disabled:hover:bg-error",
+        _ => "bg-accent-orange hover:bg-accent-orange-hover active:bg-accent-orange-active disabled:hover:bg-accent-orange"
+    };
+
+    private string GetDefaultIconPath() => Variant switch
+    {
+        ConfirmationVariant.Info => "M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z",
+        ConfirmationVariant.Danger => "M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z",
+        _ => "M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+    };
+}

--- a/src/DiscordBot.Bot/Components/Shared/UserPreviewPopup.razor
+++ b/src/DiscordBot.Bot/Components/Shared/UserPreviewPopup.razor
@@ -1,0 +1,100 @@
+<div class="preview-popup preview-popup-user" data-user-id="@UserId">
+    <!-- Header -->
+    <div class="preview-header">
+        <div class="preview-avatar">
+            @if (!string.IsNullOrEmpty(AvatarUrl))
+            {
+                <img src="@AvatarUrl" alt="@Username" class="w-12 h-12 rounded-full object-cover" />
+            }
+            else
+            {
+                <div class="w-12 h-12 rounded-full bg-accent-blue-muted flex items-center justify-center">
+                    <span class="text-lg font-semibold text-accent-blue">
+                        @(Username.FirstOrDefault().ToString().ToUpperInvariant())
+                    </span>
+                </div>
+            }
+        </div>
+        <div class="preview-identity flex-1 min-w-0">
+            <span class="preview-username block text-sm font-semibold text-text-primary truncate">
+                @Username
+            </span>
+            @if (!string.IsNullOrEmpty(DisplayName) && DisplayName != Username)
+            {
+                <span class="preview-displayname block text-xs text-text-secondary truncate">
+                    @DisplayName
+                </span>
+            }
+        </div>
+        @if (IsVerified)
+        {
+            <span class="preview-badge px-1.5 py-0.5 bg-success-bg text-success text-xs font-medium rounded" title="Verified">
+                <svg class="w-3.5 h-3.5 inline" fill="currentColor" viewBox="0 0 20 20">
+                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
+                </svg>
+            </span>
+        }
+    </div>
+
+    <!-- Body -->
+    <div class="preview-body">
+        <div class="preview-meta space-y-2 text-xs">
+            @if (MemberSince.HasValue)
+            {
+                <div class="preview-meta-item flex justify-between">
+                    <span class="text-text-tertiary">Member since</span>
+                    <span class="text-text-secondary">@MemberSince.Value.ToString("MMM yyyy")</span>
+                </div>
+            }
+            @if (Roles.Count > 0)
+            {
+                <div class="preview-meta-item flex justify-between items-start">
+                    <span class="text-text-tertiary">Roles</span>
+                    <span class="text-text-secondary text-right max-w-[140px] truncate">
+                        @string.Join(", ", Roles.Take(3))@(Roles.Count > 3 ? $" +{Roles.Count - 3}" : "")
+                    </span>
+                </div>
+            }
+            @if (LastActive.HasValue)
+            {
+                <div class="preview-meta-item flex justify-between">
+                    <span class="text-text-tertiary">Last active</span>
+                    <span class="text-text-secondary" data-utc="@LastActive.Value.ToString("o")">
+                        @LastActive.Value.ToString("g")
+                    </span>
+                </div>
+            }
+        </div>
+    </div>
+
+    <!-- Footer -->
+    <div class="preview-footer">
+        <a href="@ProfileUrl" class="flex-1 px-3 py-1.5 text-xs font-medium text-white bg-accent-blue rounded hover:bg-accent-blue-hover transition-colors text-center">
+            View Profile
+        </a>
+        @if (!string.IsNullOrEmpty(ModerationHistoryUrl))
+        {
+            <a href="@ModerationHistoryUrl" class="flex-1 px-3 py-1.5 text-xs font-medium text-text-secondary bg-bg-tertiary border border-border-primary rounded hover:bg-bg-hover transition-colors text-center inline-flex items-center justify-center gap-1">
+                Mod History
+                @if (HasActiveModeration)
+                {
+                    <span class="w-1.5 h-1.5 bg-warning rounded-full" title="Active case"></span>
+                }
+            </a>
+        }
+    </div>
+</div>
+
+@code {
+    [Parameter] public ulong UserId { get; set; }
+    [Parameter] public string Username { get; set; } = string.Empty;
+    [Parameter] public string? DisplayName { get; set; }
+    [Parameter] public string? AvatarUrl { get; set; }
+    [Parameter] public DateTime? MemberSince { get; set; }
+    [Parameter] public IReadOnlyList<string> Roles { get; set; } = [];
+    [Parameter] public DateTime? LastActive { get; set; }
+    [Parameter] public bool IsVerified { get; set; }
+    [Parameter] public bool HasActiveModeration { get; set; }
+    [Parameter] public string ProfileUrl { get; set; } = string.Empty;
+    [Parameter] public string? ModerationHistoryUrl { get; set; }
+}

--- a/src/DiscordBot.Bot/Components/Shared/VoiceChannelPanel.razor
+++ b/src/DiscordBot.Bot/Components/Shared/VoiceChannelPanel.razor
@@ -1,0 +1,319 @@
+@{
+    var statusClass = IsConnected ? "text-success" : "text-text-tertiary";
+    var statusText = IsConnected ? "Connected" : "Disconnected";
+    var statusBgClass = IsConnected ? "bg-success/20" : "bg-bg-tertiary";
+    var panelClasses = new List<string>();
+    if (IsCompact) panelClasses.Add("voice-panel-compact");
+    if (!ShowNowPlaying) panelClasses.Add("voice-panel-hide-now-playing");
+    var panelClass = string.Join(" ", panelClasses);
+}
+
+@if (IsCompact)
+{
+    <style>
+        .voice-panel-compact {
+            border: none !important;
+            background-color: transparent !important;
+        }
+
+        .voice-panel-compact > div {
+            padding: 0.75rem 0 !important;
+            border-left: none !important;
+            border-right: none !important;
+        }
+
+        .voice-panel-compact > div:first-child {
+            padding-top: 0 !important;
+        }
+
+        .voice-panel-compact h3 {
+            font-size: 0.8rem !important;
+        }
+
+        .voice-panel-compact #connection-status-badge {
+            font-size: 0.65rem !important;
+            padding: 0.125rem 0.375rem !important;
+        }
+
+        .voice-panel-compact #connection-status-dot {
+            width: 1px !important;
+            height: 1px !important;
+        }
+
+        .voice-panel-compact #connected-channel-info {
+            font-size: 0.8rem !important;
+        }
+
+        .voice-panel-compact #connected-channel-info svg {
+            width: 0.875rem !important;
+            height: 0.875rem !important;
+        }
+
+        .voice-panel-compact label {
+            font-size: 0.7rem !important;
+            margin-bottom: 0.25rem !important;
+        }
+
+        .voice-panel-compact .voice-channel-controls {
+            flex-direction: column !important;
+            gap: 0.5rem !important;
+        }
+
+        .voice-panel-compact #channel-selector {
+            width: 100% !important;
+            flex: none !important;
+            padding: 0.375rem 0.5rem !important;
+            font-size: 0.8rem !important;
+        }
+
+        .voice-panel-compact #leave-channel-btn {
+            width: 100% !important;
+            justify-content: center !important;
+            padding: 0.375rem 0.75rem !important;
+            font-size: 0.75rem !important;
+        }
+
+        .voice-panel-compact #leave-channel-btn svg {
+            width: 0.875rem !important;
+            height: 0.875rem !important;
+        }
+
+        .voice-panel-compact .voice-queue-section {
+            display: none !important;
+        }
+
+        .voice-panel-compact h4 {
+            font-size: 0.65rem !important;
+        }
+    </style>
+}
+
+@if (!ShowNowPlaying)
+{
+    <style>
+        .voice-panel-hide-now-playing #now-playing-section {
+            display: none !important;
+        }
+    </style>
+}
+
+<div id="voice-channel-panel"
+     class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden @panelClass"
+     data-guild-id="@GuildId"
+     data-connected="@IsConnected.ToString().ToLower()"
+     data-channel-id="@ConnectedChannelId">
+
+    <!-- Voice Channel Status Section -->
+    <div class="px-4 py-3 border-b border-border-primary">
+        <div class="flex items-center justify-between mb-2">
+            <h3 class="text-sm font-semibold text-text-primary">Voice Channel</h3>
+            <span id="connection-status-badge"
+                  class="inline-flex items-center gap-1.5 px-2 py-0.5 text-xs font-medium rounded-full @statusBgClass @statusClass">
+                <span id="connection-status-dot" class="w-1.5 h-1.5 rounded-full @(IsConnected ? "bg-success" : "bg-text-tertiary")"></span>
+                <span id="connection-status-text">@statusText</span>
+            </span>
+        </div>
+        @if (IsConnected && !string.IsNullOrEmpty(ConnectedChannelName))
+        {
+            <p id="connected-channel-info" class="text-sm text-text-secondary flex items-center gap-2">
+                <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z" />
+                </svg>
+                <span id="connected-channel-name">@ConnectedChannelName</span>
+                @if (ChannelMemberCount.HasValue)
+                {
+                    <span class="text-text-tertiary">(<span id="channel-member-count">@ChannelMemberCount</span> members)</span>
+                }
+            </p>
+        }
+        else
+        {
+            <p id="connected-channel-info" class="hidden text-sm text-text-secondary flex items-center gap-2">
+                <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z" />
+                </svg>
+                <span id="connected-channel-name"></span>
+                <span class="text-text-tertiary">(<span id="channel-member-count">0</span> members)</span>
+            </p>
+        }
+    </div>
+
+    <!-- Channel Control Section -->
+    <div class="px-4 py-3 border-b border-border-primary">
+        <label for="channel-selector" class="block text-xs font-medium text-text-secondary mb-1.5">
+            Select Channel
+        </label>
+        <div class="flex items-center gap-2 voice-channel-controls">
+            <select id="channel-selector"
+                    class="flex-1 bg-bg-tertiary border border-border-primary rounded-md px-3 py-1.5 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-accent-blue focus:border-transparent"
+                    @onchange="OnChannelSelected">
+                <option value="">-- Select a channel --</option>
+                @foreach (var channel in AvailableChannels)
+                {
+                    if (channel.Id == ConnectedChannelId)
+                    {
+                        <option value="@channel.Id" selected>
+                            @channel.Name (@channel.MemberCount)
+                        </option>
+                    }
+                    else
+                    {
+                        <option value="@channel.Id">
+                            @channel.Name (@channel.MemberCount)
+                        </option>
+                    }
+                }
+            </select>
+            @if (IsConnected)
+            {
+                <button id="leave-channel-btn"
+                        type="button"
+                        class="px-3 py-1.5 bg-error hover:bg-red-600 text-white text-sm font-medium rounded-md transition-colors flex items-center gap-1.5"
+                        title="Leave voice channel"
+                        @onclick="OnLeaveChannel">
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+                    </svg>
+                    Leave
+                </button>
+            }
+            else
+            {
+                <button id="leave-channel-btn"
+                        type="button"
+                        class="hidden px-3 py-1.5 bg-error hover:bg-red-600 text-white text-sm font-medium rounded-md transition-colors flex items-center gap-1.5"
+                        title="Leave voice channel">
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+                    </svg>
+                    Leave
+                </button>
+            }
+        </div>
+    </div>
+
+    <!-- Now Playing Section -->
+    <div id="now-playing-section" class="px-4 py-3 border-b border-border-primary @(NowPlaying == null ? "hidden" : "")">
+        <div class="flex items-center justify-between mb-2">
+            <h4 class="text-xs font-medium text-text-secondary uppercase tracking-wider">Now Playing</h4>
+            <button id="stop-playback-btn"
+                    type="button"
+                    class="p-1 text-error hover:bg-error/10 rounded transition-colors"
+                    title="Stop playback"
+                    @onclick="OnStopPlayback">
+                <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M6 6h12v12H6z"/>
+                </svg>
+            </button>
+        </div>
+        <div class="flex items-center gap-3">
+            <div class="w-10 h-10 bg-accent-blue/20 rounded-lg flex items-center justify-center text-accent-blue flex-shrink-0">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z"/>
+                </svg>
+            </div>
+            <div class="flex-1 min-w-0">
+                <p id="now-playing-name" class="text-sm font-medium text-text-primary truncate"
+                   title="@(NowPlaying?.Name ?? "Nothing playing")">
+                    @(NowPlaying?.Name ?? "Nothing playing")
+                </p>
+                @if (ShowProgress)
+                {
+                    <div class="mt-1.5">
+                        <div class="w-full bg-bg-tertiary rounded-full h-1.5"
+                             role="progressbar"
+                             aria-valuenow="@(NowPlaying?.ProgressPercent ?? 0)"
+                             aria-valuemin="0"
+                             aria-valuemax="100"
+                             aria-label="Playback progress">
+                            <div id="now-playing-progress"
+                                 class="bg-accent-blue h-1.5 rounded-full transition-all duration-300"
+                                 style="width: @(NowPlaying?.ProgressPercent ?? 0)%"></div>
+                        </div>
+                        <div class="flex justify-between mt-1 text-xs text-text-tertiary">
+                            <span id="now-playing-position">@FormatDuration(NowPlaying?.PositionSeconds ?? 0)</span>
+                            <span id="now-playing-duration">@FormatDuration(NowPlaying?.DurationSeconds ?? 0)</span>
+                        </div>
+                    </div>
+                }
+                else
+                {
+                    <p class="mt-1 text-xs text-text-tertiary">Playing...</p>
+                }
+            </div>
+        </div>
+    </div>
+
+    <!-- Queue Section -->
+    <div class="px-4 py-3 voice-queue-section">
+        <div class="flex items-center justify-between mb-3">
+            <h4 class="text-xs font-medium text-text-secondary uppercase tracking-wider">Queue</h4>
+            <span id="queue-count-badge" class="text-xs text-text-tertiary">
+                @(Queue.Count > 0 ? $"{Queue.Count} sound{(Queue.Count == 1 ? "" : "s")}" : "Empty")
+            </span>
+        </div>
+
+        @if (Queue.Any())
+        {
+            <ul id="queue-list" class="space-y-2">
+                @foreach (var item in Queue)
+                {
+                    <li class="flex items-center gap-3 p-2 bg-bg-tertiary rounded-lg group" data-queue-position="@item.Position">
+                        <span class="w-5 h-5 flex items-center justify-center text-xs text-text-tertiary font-medium">
+                            @item.Position
+                        </span>
+                        <div class="flex-1 min-w-0">
+                            <p class="text-sm text-text-primary truncate">@item.Name</p>
+                            <p class="text-xs text-text-tertiary">@item.DurationFormatted</p>
+                        </div>
+                        <button type="button"
+                                class="skip-queue-btn p-1 text-text-tertiary hover:text-accent-blue opacity-0 group-hover:opacity-100 transition-all"
+                                data-position="@item.Position"
+                                title="Skip to next">
+                            <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                                <path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z"/>
+                            </svg>
+                        </button>
+                    </li>
+                }
+            </ul>
+        }
+        else
+        {
+            <div id="queue-empty-state" class="text-center py-4">
+                <svg class="w-8 h-8 text-text-tertiary mx-auto mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
+                </svg>
+                <p class="text-sm text-text-tertiary">No sounds in queue</p>
+            </div>
+            <ul id="queue-list" class="hidden space-y-2"></ul>
+        }
+    </div>
+</div>
+
+@code {
+    // TODO: Subscribe to IDashboardEventBus in Phase 5
+
+    [Parameter] public ulong GuildId { get; set; }
+    [Parameter] public bool IsCompact { get; set; }
+    [Parameter] public bool ShowNowPlaying { get; set; } = true;
+    [Parameter] public bool ShowProgress { get; set; } = true;
+    [Parameter] public bool IsConnected { get; set; }
+    [Parameter] public string? ConnectedChannelName { get; set; }
+    [Parameter] public ulong? ConnectedChannelId { get; set; }
+    [Parameter] public int? ChannelMemberCount { get; set; }
+    [Parameter] public IReadOnlyList<VoiceChannelInfo> AvailableChannels { get; set; } = [];
+    [Parameter] public NowPlayingInfo? NowPlaying { get; set; }
+    [Parameter] public IReadOnlyList<QueueItemInfo> Queue { get; set; } = [];
+    [Parameter] public EventCallback<ChangeEventArgs> OnChannelSelected { get; set; }
+    [Parameter] public EventCallback OnLeaveChannel { get; set; }
+    [Parameter] public EventCallback OnStopPlayback { get; set; }
+
+    private static string FormatDuration(double seconds)
+    {
+        var ts = TimeSpan.FromSeconds(seconds);
+        return ts.TotalHours >= 1
+            ? $"{(int)ts.TotalHours}:{ts.Minutes:D2}:{ts.Seconds:D2}"
+            : $"{ts.Minutes}:{ts.Seconds:D2}";
+    }
+}

--- a/src/DiscordBot.Bot/Components/Shared/VoiceSelector.razor
+++ b/src/DiscordBot.Bot/Components/Shared/VoiceSelector.razor
@@ -1,0 +1,449 @@
+@{
+    var voicesByLocale = Voices
+        .GroupBy(v => new { v.Locale, v.LocaleDisplayName })
+        .OrderBy(g => g.Key.LocaleDisplayName)
+        .ToList();
+
+    var selectedVoiceOption = Voices.FirstOrDefault(v => v.Value == Value);
+    var triggerText = selectedVoiceOption != null
+        ? $"{selectedVoiceOption.DisplayName} ({selectedVoiceOption.Gender}) - {selectedVoiceOption.LocaleDisplayName}"
+        : Placeholder;
+}
+
+<div id="@ContainerId"
+     class="voice-selector"
+     data-selected-voice="@Value"
+     @ref="_containerRef">
+
+    <!-- Trigger Button -->
+    <button type="button"
+            class="voice-selector__trigger"
+            aria-haspopup="listbox"
+            aria-expanded="@_isOpen.ToString().ToLower()"
+            @onclick="ToggleDropdown">
+        <span class="voice-selector__trigger-text">@triggerText</span>
+        <svg class="voice-selector__trigger-icon"
+             fill="none"
+             viewBox="0 0 24 24"
+             stroke="currentColor"
+             aria-hidden="true">
+            <path stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+        </svg>
+    </button>
+
+    <!-- Dropdown Panel -->
+    <div class="voice-selector__dropdown" role="listbox" aria-label="Voice options" style="display: @(_isOpen ? "flex" : "none"); flex-direction: column;">
+        <!-- Search Input -->
+        <div class="voice-selector__search-wrapper">
+            <svg class="voice-selector__search-icon"
+                 fill="none"
+                 viewBox="0 0 24 24"
+                 stroke="currentColor"
+                 aria-hidden="true">
+                <path stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
+            </svg>
+            <input type="text"
+                   class="voice-selector__search"
+                   placeholder="@SearchPlaceholder"
+                   aria-label="Search voices"
+                   @oninput="OnSearchInput" />
+        </div>
+
+        <!-- Voice Groups -->
+        <div class="voice-selector__list">
+            @if (voicesByLocale.Any())
+            {
+                foreach (var group in voicesByLocale)
+                {
+                    var voiceCount = group.Count();
+                    var locale = group.Key.Locale;
+                    var isGroupVisible = !_filteredLocales.Any() || _filteredLocales.Contains(locale);
+                    var isGroupExpanded = !_collapsedGroups.Contains(locale);
+
+                    <div class="voice-selector__group @(!isGroupVisible ? "voice-selector__group--hidden" : "")" data-locale="@locale">
+                        <!-- Group Header (Tier 1) -->
+                        <button type="button"
+                                class="voice-selector__group-header"
+                                aria-expanded="@isGroupExpanded.ToString().ToLower()"
+                                @onclick="() => ToggleGroup(locale)">
+                            <span class="voice-selector__group-name">@group.Key.LocaleDisplayName</span>
+                            <span class="voice-selector__group-count">@voiceCount</span>
+                            <svg class="voice-selector__group-chevron"
+                                 fill="none"
+                                 viewBox="0 0 24 24"
+                                 stroke="currentColor"
+                                 aria-hidden="true">
+                                <path stroke-linecap="round"
+                                      stroke-linejoin="round"
+                                      stroke-width="2"
+                                      d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+                            </svg>
+                        </button>
+
+                        <!-- Voice Options (Tier 2) -->
+                        @if (isGroupExpanded)
+                        {
+                            <div class="voice-selector__options">
+                                @foreach (var voice in group.OrderBy(v => v.DisplayName))
+                                {
+                                    var isSelected = voice.Value == Value;
+                                    var searchText = $"{voice.DisplayName} {voice.Gender} {voice.LocaleDisplayName}".ToLower();
+                                    var isVoiceVisible = string.IsNullOrEmpty(_searchTerm) || searchText.Contains(_searchTerm, StringComparison.OrdinalIgnoreCase);
+
+                                    <button type="button"
+                                            class="voice-selector__option @(isSelected ? "voice-selector__option--selected" : "") @(!isVoiceVisible ? "voice-selector__option--hidden" : "")"
+                                            role="option"
+                                            aria-selected="@isSelected.ToString().ToLower()"
+                                            data-voice-value="@voice.Value"
+                                            @onclick="() => SelectVoice(voice.Value)">
+                                        <span class="voice-selector__option-name">@voice.DisplayName</span>
+                                        <span class="voice-selector__option-gender">(@voice.Gender)</span>
+                                        @if (isSelected)
+                                        {
+                                            <svg class="voice-selector__option-checkmark"
+                                                 fill="none"
+                                                 viewBox="0 0 24 24"
+                                                 stroke="currentColor"
+                                                 aria-hidden="true">
+                                                <path stroke-linecap="round"
+                                                      stroke-linejoin="round"
+                                                      stroke-width="2"
+                                                      d="M4.5 12.75l6 6 9-13.5" />
+                                            </svg>
+                                        }
+                                    </button>
+                                }
+                            </div>
+                        }
+                    </div>
+                }
+            }
+            else
+            {
+                <div class="voice-selector__empty">No voices available</div>
+            }
+        </div>
+    </div>
+</div>
+
+<style>
+    .voice-selector {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+    }
+
+    .voice-selector__trigger {
+        width: 100%;
+        padding: 0.625rem 2.5rem 0.625rem 0.75rem;
+        background: var(--color-bg-primary);
+        border: 1px solid var(--color-border-primary);
+        border-radius: 0.5rem;
+        color: var(--color-text-primary);
+        font-size: 0.875rem;
+        font-weight: 500;
+        cursor: pointer;
+        transition: all 200ms cubic-bezier(0.4, 0, 0.2, 1);
+        text-align: left;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        appearance: none;
+    }
+
+    .voice-selector__trigger:hover {
+        border-color: var(--color-accent-orange-hover);
+        background: var(--color-bg-hover);
+    }
+
+    .voice-selector__trigger:focus {
+        outline: none;
+        border-color: var(--color-accent-orange);
+        box-shadow: 0 0 0 3px var(--color-accent-orange-muted);
+    }
+
+    .voice-selector__trigger[aria-expanded="true"] .voice-selector__trigger-icon {
+        transform: rotate(180deg);
+    }
+
+    .voice-selector__trigger-text {
+        flex: 1;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .voice-selector__trigger-icon {
+        width: 1.25rem;
+        height: 1.25rem;
+        margin-left: 0.5rem;
+        color: var(--color-text-secondary);
+        transition: transform 150ms cubic-bezier(0.4, 0, 0.2, 1);
+        flex-shrink: 0;
+    }
+
+    .voice-selector__dropdown {
+        position: absolute;
+        top: calc(100% + 0.5rem);
+        left: 0;
+        right: 0;
+        background: var(--color-bg-tertiary);
+        border: 1px solid var(--color-border-primary);
+        border-radius: 0.5rem;
+        box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1),
+                    0 4px 6px -2px rgba(0, 0, 0, 0.05);
+        z-index: 50;
+        max-height: 20rem;
+    }
+
+    .voice-selector__search-wrapper {
+        position: relative;
+        padding: 0.75rem;
+        border-bottom: 1px solid var(--color-border-primary);
+    }
+
+    .voice-selector__search-icon {
+        position: absolute;
+        left: 1.25rem;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 1.125rem;
+        height: 1.125rem;
+        color: var(--color-text-secondary);
+        pointer-events: none;
+    }
+
+    .voice-selector__search {
+        width: 100%;
+        padding: 0.5rem 0.75rem 0.5rem 2.25rem;
+        background: var(--color-bg-primary);
+        border: 1px solid var(--color-border-primary);
+        border-radius: 0.375rem;
+        color: var(--color-text-primary);
+        font-size: 0.875rem;
+        transition: all 200ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    .voice-selector__search:focus {
+        outline: none;
+        border-color: var(--color-accent-orange);
+        box-shadow: 0 0 0 3px var(--color-accent-orange-muted);
+    }
+
+    .voice-selector__search::placeholder {
+        color: var(--color-text-tertiary);
+    }
+
+    .voice-selector__list {
+        overflow-y: auto;
+        max-height: calc(20rem - 3.5rem);
+    }
+
+    .voice-selector__group {
+        border-bottom: 1px solid var(--color-border-primary);
+    }
+
+    .voice-selector__group:last-child {
+        border-bottom: none;
+    }
+
+    .voice-selector__group.voice-selector__group--hidden {
+        display: none;
+    }
+
+    .voice-selector__group-header {
+        width: 100%;
+        padding: 0.625rem 0.75rem;
+        background: var(--color-bg-secondary);
+        border: none;
+        color: var(--color-text-secondary);
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        transition: background 200ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    .voice-selector__group-header:hover {
+        background: var(--color-bg-hover);
+    }
+
+    .voice-selector__group-name {
+        flex: 1;
+        text-align: left;
+    }
+
+    .voice-selector__group-count {
+        color: var(--color-text-tertiary);
+        font-size: 0.6875rem;
+    }
+
+    .voice-selector__group-chevron {
+        width: 1rem;
+        height: 1rem;
+        color: var(--color-text-secondary);
+        transition: transform 150ms cubic-bezier(0.4, 0, 0.2, 1);
+        flex-shrink: 0;
+    }
+
+    .voice-selector__group-header[aria-expanded="false"] .voice-selector__group-chevron {
+        transform: rotate(-90deg);
+    }
+
+    .voice-selector__options {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .voice-selector__option {
+        width: 100%;
+        padding: 0.625rem 0.75rem 0.625rem 2rem;
+        background: transparent;
+        border: none;
+        color: var(--color-text-primary);
+        font-size: 0.875rem;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        transition: background 200ms cubic-bezier(0.4, 0, 0.2, 1);
+        text-align: left;
+    }
+
+    .voice-selector__option:hover {
+        background: var(--color-bg-hover);
+    }
+
+    .voice-selector__option:focus {
+        outline: 2px solid var(--color-accent-orange);
+        outline-offset: -2px;
+        background: var(--color-bg-hover);
+    }
+
+    .voice-selector__option--selected {
+        background: var(--color-accent-orange-muted);
+    }
+
+    .voice-selector__option--selected:hover {
+        background: var(--color-accent-orange-muted);
+    }
+
+    .voice-selector__option.voice-selector__option--hidden {
+        display: none;
+    }
+
+    .voice-selector__option-name {
+        font-weight: 500;
+    }
+
+    .voice-selector__option-gender {
+        color: var(--color-text-secondary);
+        font-size: 0.8125rem;
+    }
+
+    .voice-selector__option-checkmark {
+        width: 1.125rem;
+        height: 1.125rem;
+        margin-left: auto;
+        color: var(--color-accent-orange);
+        flex-shrink: 0;
+    }
+
+    .voice-selector__empty {
+        padding: 2rem 1rem;
+        text-align: center;
+        color: var(--color-text-tertiary);
+        font-size: 0.875rem;
+    }
+
+    @@media (max-width: 767px) {
+        .voice-selector__trigger {
+            min-height: 44px;
+        }
+
+        .voice-selector__dropdown {
+            max-height: 16rem;
+        }
+
+        .voice-selector__list {
+            max-height: calc(16rem - 3.5rem);
+        }
+
+        .voice-selector__option {
+            min-height: 44px;
+            padding: 0.75rem 0.75rem 0.75rem 2rem;
+        }
+    }
+</style>
+
+@code {
+    [Parameter] public IReadOnlyList<VoiceSelectorVoiceOption> Voices { get; set; } = [];
+    [Parameter] public string Value { get; set; } = string.Empty;
+    [Parameter] public EventCallback<string> ValueChanged { get; set; }
+    [Parameter] public string ContainerId { get; set; } = "voiceSelector";
+    [Parameter] public string Placeholder { get; set; } = "Select a voice";
+    [Parameter] public string SearchPlaceholder { get; set; } = "Search voices...";
+
+    private bool _isOpen;
+    private string _searchTerm = string.Empty;
+    private HashSet<string> _collapsedGroups = new();
+    private HashSet<string> _filteredLocales = new();
+    private ElementReference _containerRef;
+
+    private void ToggleDropdown()
+    {
+        _isOpen = !_isOpen;
+        if (!_isOpen)
+        {
+            _searchTerm = string.Empty;
+            _filteredLocales.Clear();
+        }
+    }
+
+    private void ToggleGroup(string locale)
+    {
+        if (!_collapsedGroups.Remove(locale))
+        {
+            _collapsedGroups.Add(locale);
+        }
+    }
+
+    private async Task SelectVoice(string voiceValue)
+    {
+        Value = voiceValue;
+        _isOpen = false;
+        _searchTerm = string.Empty;
+        _filteredLocales.Clear();
+        await ValueChanged.InvokeAsync(voiceValue);
+    }
+
+    private void OnSearchInput(ChangeEventArgs e)
+    {
+        _searchTerm = e.Value?.ToString() ?? string.Empty;
+
+        if (string.IsNullOrEmpty(_searchTerm))
+        {
+            _filteredLocales.Clear();
+            return;
+        }
+
+        _filteredLocales = Voices
+            .Where(v =>
+            {
+                var searchText = $"{v.DisplayName} {v.Gender} {v.LocaleDisplayName}".ToLower();
+                return searchText.Contains(_searchTerm, StringComparison.OrdinalIgnoreCase);
+            })
+            .Select(v => v.Locale)
+            .ToHashSet();
+    }
+}

--- a/src/DiscordBot.Bot/Components/_Imports.razor
+++ b/src/DiscordBot.Bot/Components/_Imports.razor
@@ -8,3 +8,7 @@
 @using Microsoft.EntityFrameworkCore
 @using DiscordBot.Bot.Components
 @using DiscordBot.Bot.Components.Layout
+@using DiscordBot.Bot.Components.Shared
+@using DiscordBot.Bot.Components.Interop
+@using DiscordBot.Bot.ViewModels.Components
+@using DiscordBot.Bot.ViewModels.Components.Enums

--- a/src/DiscordBot.Bot/Extensions/BlazorInteropServiceExtensions.cs
+++ b/src/DiscordBot.Bot/Extensions/BlazorInteropServiceExtensions.cs
@@ -1,0 +1,25 @@
+using DiscordBot.Bot.Components.Interop;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DiscordBot.Bot.Extensions;
+
+/// <summary>
+/// Extension methods for registering Blazor JS interop services.
+/// </summary>
+public static class BlazorInteropServiceExtensions
+{
+    /// <summary>
+    /// Adds Blazor JS interop services to the service collection.
+    /// </summary>
+    public static IServiceCollection AddBlazorInteropServices(this IServiceCollection services)
+    {
+        services.AddScoped<ToastInterop>();
+        services.AddScoped<ThemeInterop>();
+        services.AddScoped<ChartJsInterop>();
+        services.AddScoped<TimezoneInterop>();
+        services.AddScoped<ClipboardInterop>();
+        services.AddScoped<NavigationInterop>();
+
+        return services;
+    }
+}

--- a/src/DiscordBot.Bot/Extensions/WebServiceExtensions.cs
+++ b/src/DiscordBot.Bot/Extensions/WebServiceExtensions.cs
@@ -46,6 +46,9 @@ public static class WebServiceExtensions
         // Revalidate auth state periodically in Blazor Server circuits
         services.AddScoped<AuthenticationStateProvider, RevalidatingAuthStateProvider>();
 
+        // Add Blazor JS interop services
+        services.AddBlazorInteropServices();
+
         // Capture client IP during circuit initialization for audit logging
         services.AddScoped<CircuitClientInfoService>();
         services.AddScoped<CircuitHandler, CircuitClientInfoService>(sp => sp.GetRequiredService<CircuitClientInfoService>());

--- a/src/DiscordBot.Bot/wwwroot/js/blazor-chart-interop.js
+++ b/src/DiscordBot.Bot/wwwroot/js/blazor-chart-interop.js
@@ -1,0 +1,46 @@
+/**
+ * Blazor Chart.js Interop
+ * Manages Chart.js instances for Blazor components.
+ */
+window.BlazorChartInterop = {
+    _charts: new Map(),
+
+    createChart: function (canvasId, config) {
+        const existing = this._charts.get(canvasId);
+        if (existing) existing.destroy();
+
+        const ctx = document.getElementById(canvasId)?.getContext('2d');
+        if (!ctx) return;
+
+        this._charts.set(canvasId, new Chart(ctx, config));
+    },
+
+    updateChart: function (canvasId, data) {
+        const chart = this._charts.get(canvasId);
+        if (!chart) return;
+
+        chart.data = data;
+        chart.update();
+    },
+
+    destroyChart: function (canvasId) {
+        const chart = this._charts.get(canvasId);
+        if (chart) {
+            chart.destroy();
+            this._charts.delete(canvasId);
+        }
+    }
+};
+
+/**
+ * Blazor Navigation Interop
+ * Provides DOM navigation helpers for Blazor components.
+ */
+window.BlazorNavigationInterop = {
+    scrollToElement: function (elementId) {
+        const el = document.getElementById(elementId);
+        if (el) {
+            el.scrollIntoView({ behavior: 'smooth' });
+        }
+    }
+};


### PR DESCRIPTION
## Summary

- Port all 55 shared Razor partial components (`.cshtml`) to 56 Blazor Server components (`.razor`) in `Components/Shared/`
- Create 6 JS interop services in `Components/Interop/` (Toast, Theme, ChartJs, Timezone, Clipboard, Navigation)
- Add `blazor-chart-interop.js` for Chart.js instance lifecycle management
- Register interop services via `AddBlazorInteropServices()` extension method
- Add `@using` directives to `_Imports.razor` for new namespaces

### Component Tiers

| Tier | Count | Description |
|------|-------|-------------|
| Tier 1 - Pure Render | 25 | Badge, Button, Alert, Card, Form inputs, Navigation, etc. |
| Tier 2 - Interactive | 9 | Modals, TabPanel, AutocompleteInput, SortDropdown, etc. |
| Tier 3 - Complex | 22 | Dashboard widgets, preview popups, voice/TTS controls |

### Porting Patterns Applied

- ViewModel `record` properties → `[Parameter]` properties
- `@Html.Raw()` → `@((MarkupString)content)` or `RenderFragment`
- Inline `<script>` blocks → `OnAfterRenderAsync` + `IJSRuntime`
- `onclick="jsFunc()"` strings → `EventCallback` parameters
- `<template>` elements → `@foreach` loops
- Form components follow `Value`/`ValueChanged` two-way binding convention
- Real-time components stub `// TODO: Subscribe to IDashboardEventBus in Phase 5`

## Test plan

- [x] `dotnet build` passes with 0 errors, 0 warnings
- [x] `dotnet test` — 3345 passed, 42 failed (pre-existing MetricsCollectionServiceTests failures, unrelated)
- [ ] Visual smoke test of components when wired into pages (Phase 3+)

Closes #1654, closes #1656, closes #1660, closes #1662, closes #1665

🤖 Generated with [Claude Code](https://claude.com/claude-code)