### PR TITLE
fix: host Blazor pages inside _Layout.cshtml with proper navigation

### DIFF
--- a/src/DiscordBot.Bot/Components/Layout/GuildLayout.razor
+++ b/src/DiscordBot.Bot/Components/Layout/GuildLayout.razor
@@ -3,3 +3,6 @@
 <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
     @Body
 </div>
+
+<script suppress-error="BL9992" src="/js/tab-panel.js"></script>
+<script suppress-error="BL9992" src="/js/guild-nav.js"></script>

--- a/src/DiscordBot.Bot/Components/Layout/MainLayout.razor
+++ b/src/DiscordBot.Bot/Components/Layout/MainLayout.razor
@@ -1,7 +1,3 @@
 @inherits LayoutComponentBase
 
-<div class="min-h-screen">
-    <main class="p-6 lg:p-8">
-        @Body
-    </main>
-</div>
+@Body

--- a/src/DiscordBot.Bot/Components/Pages/Account/AccessDenied.razor
+++ b/src/DiscordBot.Bot/Components/Pages/Account/AccessDenied.razor
@@ -44,9 +44,11 @@
                 <a href="/" class="flex-1 text-center py-2.5 px-4 text-sm font-semibold text-white bg-accent-orange border border-accent-orange rounded-md transition-colors hover:bg-accent-orange-hover hover:border-accent-orange-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-blue focus-visible:ring-offset-2 focus-visible:ring-offset-bg-secondary">
                     Go to Dashboard
                 </a>
-                <a href="/Account/Logout" class="flex-1 text-center py-2.5 px-4 text-sm font-semibold text-text-primary bg-transparent border border-border-primary rounded-md transition-colors hover:bg-bg-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-blue focus-visible:ring-offset-2 focus-visible:ring-offset-bg-secondary">
-                    Sign Out
-                </a>
+                <form method="post" action="/Account/Logout" class="flex-1">
+                    <button type="submit" class="w-full text-center py-2.5 px-4 text-sm font-semibold text-text-primary bg-transparent border border-border-primary rounded-md transition-colors hover:bg-bg-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-blue focus-visible:ring-offset-2 focus-visible:ring-offset-bg-secondary">
+                        Sign Out
+                    </button>
+                </form>
             </div>
         </div>
     </div>

--- a/src/DiscordBot.Bot/Components/Pages/Guilds/GuildDetails.razor
+++ b/src/DiscordBot.Bot/Components/Pages/Guilds/GuildDetails.razor
@@ -45,22 +45,8 @@ else
                  StatusBadge="@(new BadgeViewModel { Text = _guild.IsActive ? "Active" : "Inactive", Variant = _guild.IsActive ? BadgeVariant.Success : BadgeVariant.Error, Style = BadgeStyle.Subtle, IconLeft = "M10 18a8 8 0 100-16 8 8 0 000 16z" })"
                  Actions="@_headerActions" />
 
-    <!-- Guild Navigation - Desktop tabs -->
-    <div class="mb-6">
-        <div class="border-b border-border-primary">
-            <nav class="flex gap-6 -mb-px" aria-label="Guild navigation">
-                @foreach (var tab in GuildNavigationConfig.GetTabs().OrderBy(t => t.Order))
-                {
-                    var isActive = tab.Id == "overview";
-                    var tabUrl = tab.GetUrl((ulong)GuildId);
-                    <a href="@tabUrl"
-                       class="@(isActive ? "border-accent-blue text-accent-blue" : "border-transparent text-text-secondary hover:text-text-primary hover:border-border-primary") whitespace-nowrap py-3 px-1 border-b-2 font-medium text-sm transition-colors">
-                        @tab.Label
-                    </a>
-                }
-            </nav>
-        </div>
-    </div>
+    <!-- Guild Navigation Tabs -->
+    <GuildTabNavigation GuildId="(ulong)GuildId" ActiveTab="overview" />
 
     <!-- Guild Information Card -->
     <div class="bg-bg-secondary border border-border-primary rounded-lg p-4 sm:p-6 mb-6">

--- a/src/DiscordBot.Bot/Components/Shared/GuildTabNavigation.razor
+++ b/src/DiscordBot.Bot/Components/Shared/GuildTabNavigation.razor
@@ -1,0 +1,59 @@
+@using DiscordBot.Bot.Configuration
+@using DiscordBot.Bot.ViewModels.Components
+
+<!-- Guild Navigation Bar -->
+<div class="guild-nav-container mb-6" id="guildNavContainer">
+    <!-- Desktop: Horizontal tabs using TabPanel -->
+    <div class="hidden sm:block">
+        <TabPanel Id="guildNav"
+                  Tabs="@_tabs"
+                  ActiveTabId="@ActiveTab"
+                  StyleVariant="TabStyleVariant.Pills"
+                  NavigationMode="TabNavigationMode.PageNavigation"
+                  PersistenceMode="TabPersistenceMode.None"
+                  AriaLabel="Guild sections" />
+    </div>
+
+    <!-- Mobile: Dropdown -->
+    <div class="guild-nav-dropdown sm:hidden">
+        <button type="button"
+                id="guildNavDropdownToggle"
+                class="guild-nav-dropdown-button"
+                aria-haspopup="true"
+                aria-expanded="false">
+            <span id="guildNavSelectedText">@(_activeLabel ?? "Navigation")</span>
+            <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            </svg>
+        </button>
+        <div id="guildNavDropdownMenu"
+             class="hidden guild-nav-dropdown-menu"
+             role="region"
+             aria-label="Guild navigation menu">
+            @foreach (var tab in _tabs)
+            {
+                var isActive = tab.Id == ActiveTab;
+                <a href="@tab.Href"
+                   class="guild-nav-dropdown-item @(isActive ? "active" : "")">
+                    @tab.Label
+                </a>
+            }
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter, EditorRequired] public ulong GuildId { get; set; }
+    [Parameter, EditorRequired] public string ActiveTab { get; set; } = "overview";
+
+    private IReadOnlyList<TabItemViewModel> _tabs = [];
+    private string? _activeLabel;
+
+    protected override void OnParametersSet()
+    {
+        var navItems = GuildNavigationConfig.GetTabs();
+        var tabPanel = GuildNavBarHelper.CreateGuildNavBar(GuildId, ActiveTab, navItems);
+        _tabs = tabPanel.Tabs;
+        _activeLabel = _tabs.FirstOrDefault(t => t.Id == ActiveTab)?.Label;
+    }
+}

--- a/src/DiscordBot.Bot/Pages/Admin/Logs/Tabs/_AuditTab.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Logs/Tabs/_AuditTab.cshtml
@@ -450,7 +450,7 @@
                                     }
                                     <!-- View Details Link -->
                                     <div class="flex justify-end mt-3 pt-3 border-t border-border-secondary">
-                                        <a asp-page="/Admin/AuditLogs/Details" asp-route-id="@log.Id" class="text-sm text-accent-blue hover:text-accent-blue/80 transition-colors flex items-center gap-1">
+                                        <a href="/Admin/AuditLogs/Details/@log.Id" class="text-sm text-accent-blue hover:text-accent-blue/80 transition-colors flex items-center gap-1">
                                             View full details
                                             <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
@@ -640,7 +640,7 @@
 
                     <!-- View Details Link -->
                     <div class="mt-3 pt-3 border-t border-border-secondary">
-                        <a asp-page="/Admin/AuditLogs/Details" asp-route-id="@log.Id"
+                        <a href="/Admin/AuditLogs/Details/@log.Id"
                            class="text-accent-blue hover:text-accent-blue-hover text-sm font-medium transition-colors inline-flex items-center gap-1 min-h-[44px]">
                             View Details
                             <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">

--- a/src/DiscordBot.Bot/Pages/Admin/Logs/Tabs/_MessagesTab.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Logs/Tabs/_MessagesTab.cshtml
@@ -247,7 +247,7 @@
                                     @message.Content
                                 </td>
                                 <td class="px-6 py-4 whitespace-nowrap text-right">
-                                    <a asp-page="/Admin/MessageLogs/Details" asp-route-id="@message.Id" class="text-accent-blue hover:text-accent-blue/80 transition-colors" title="View Details">
+                                    <a href="/Admin/MessageLogs/Details/@message.Id" class="text-accent-blue hover:text-accent-blue/80 transition-colors" title="View Details">
                                         <svg class="w-5 h-5 inline-block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />

--- a/src/DiscordBot.Bot/Pages/Guilds/FlaggedEvents/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/FlaggedEvents/Index.cshtml
@@ -184,7 +184,7 @@
                                             </svg>
                                         </button>
                                     }
-                                    <a asp-page="/Guilds/FlaggedEvents/Details" asp-route-guildId="@Model.GuildId" asp-route-id="@evt.Id" class="text-accent-blue hover:text-accent-blue/80 transition-colors" title="View Details">
+                                    <a href="/Guilds/FlaggedEvents/Details/@Model.GuildId/@evt.Id" class="text-accent-blue hover:text-accent-blue/80 transition-colors" title="View Details">
                                         <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
@@ -232,7 +232,7 @@
                                 Dismiss
                             </button>
                         }
-                        <a asp-page="/Guilds/FlaggedEvents/Details" asp-route-guildId="@Model.GuildId" asp-route-id="@evt.Id" class="px-3 py-1.5 bg-accent-blue text-white text-sm font-medium rounded-md hover:bg-accent-blue/90 transition-colors">
+                        <a href="/Guilds/FlaggedEvents/Details/@Model.GuildId/@evt.Id" class="px-3 py-1.5 bg-accent-blue text-white text-sm font-medium rounded-md hover:bg-accent-blue/90 transition-colors">
                             View Details
                         </a>
                     </div>

--- a/src/DiscordBot.Bot/Pages/Guilds/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Index.cshtml
@@ -152,7 +152,7 @@
                     {
                         @foreach (var guild in Model.ViewModel.Guilds)
                         {
-                            var detailsUrl = Url.Page("Details", new { guildId = guild.Id });
+                            var detailsUrl = $"/Guilds/Details/{guild.Id}";
                             <tr class="hover:bg-bg-hover transition-colors cursor-pointer group focus:outline-none focus:ring-2 focus:ring-border-focus focus:ring-inset"
                                 onclick="if (!event.target.closest('button, a')) window.location.href='@detailsUrl'"
                                 tabindex="0"
@@ -215,7 +215,7 @@
                                             </svg>
                                             <span class="sync-text sr-only">Sync</span>
                                         </button>
-                                        <a asp-page="Details" asp-route-guildId="@guild.Id" class="p-2 text-text-secondary hover:text-accent-blue hover:bg-bg-hover rounded transition-colors" title="View Details">
+                                        <a href="/Guilds/Details/@guild.Id" class="p-2 text-text-secondary hover:text-accent-blue hover:bg-bg-hover rounded transition-colors" title="View Details">
                                             <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
@@ -262,7 +262,7 @@
         {
             @foreach (var guild in Model.ViewModel.Guilds)
             {
-                var mobileDetailsUrl = Url.Page("Details", new { id = guild.Id });
+                var mobileDetailsUrl = $"/Guilds/Details/{guild.Id}";
                 <div class="bg-bg-secondary border border-border-primary rounded-lg p-4 cursor-pointer group hover:bg-bg-hover transition-colors focus:outline-none focus:ring-2 focus:ring-border-focus focus:ring-inset"
                      onclick="if (!event.target.closest('button, a')) window.location.href='@mobileDetailsUrl'"
                      tabindex="0"
@@ -323,7 +323,7 @@
                             </svg>
                             <span class="sync-text">Sync</span>
                         </button>
-                        <a asp-page="Details" asp-route-guildId="@guild.Id" class="flex-1 inline-flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-text-secondary hover:text-text-primary border border-border-primary hover:bg-bg-hover rounded-lg transition-colors">
+                        <a href="/Guilds/Details/@guild.Id" class="flex-1 inline-flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-text-secondary hover:text-text-primary border border-border-primary hover:bg-bg-hover rounded-lg transition-colors">
                             <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />

--- a/src/DiscordBot.Bot/Pages/Search.cshtml
+++ b/src/DiscordBot.Bot/Pages/Search.cshtml
@@ -151,7 +151,7 @@
                         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                             @foreach (var guild in Model.ViewModel.GuildResults)
                             {
-                                <a asp-page="/Guilds/Details" asp-route-id="@guild.Id" class="block bg-bg-primary border border-border-primary rounded-lg p-4 hover:border-accent-blue hover:bg-bg-hover transition-all">
+                                <a href="/Guilds/Details/@guild.Id" class="block bg-bg-primary border border-border-primary rounded-lg p-4 hover:border-accent-blue hover:bg-bg-hover transition-all">
                                     <div class="flex items-start gap-3">
                                         @if (!string.IsNullOrEmpty(guild.IconUrl))
                                         {
@@ -230,7 +230,7 @@
                     <div class="divide-y divide-border-primary">
                         @foreach (var log in Model.ViewModel.CommandLogResults)
                         {
-                            <a asp-page="/CommandLogs/Details" asp-route-id="@log.Id" class="block px-6 py-4 hover:bg-bg-hover transition-colors">
+                            <a href="/CommandLogs/Details/@log.Id" class="block px-6 py-4 hover:bg-bg-hover transition-colors">
                                 <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
                                     <div class="flex-1 min-w-0">
                                         <div class="flex items-center gap-3 flex-wrap">
@@ -328,7 +328,7 @@
                         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                             @foreach (var user in Model.ViewModel.UserResults)
                             {
-                                <a asp-page="/Admin/Users/Details" asp-route-id="@user.Id" class="block bg-bg-primary border border-border-primary rounded-lg p-4 hover:border-accent-blue hover:bg-bg-hover transition-all">
+                                <a href="/Admin/Users/Details/@user.Id" class="block bg-bg-primary border border-border-primary rounded-lg p-4 hover:border-accent-blue hover:bg-bg-hover transition-all">
                                     <div class="flex items-start gap-3">
                                         @if (!string.IsNullOrEmpty(user.AvatarUrl))
                                         {

--- a/src/DiscordBot.Bot/Pages/Shared/_Navbar.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/_Navbar.cshtml
@@ -173,13 +173,13 @@
             <p class="text-xs text-text-secondary">@user?.Email</p>
           </div>
           <div class="pt-1">
-            <a asp-page="/Account/Profile" role="menuitem" class="flex items-center gap-2 px-4 py-2 text-sm text-text-primary hover:bg-bg-hover transition-colors">
+            <a href="/Account/Profile" role="menuitem" class="flex items-center gap-2 px-4 py-2 text-sm text-text-primary hover:bg-bg-hover transition-colors">
               <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
               </svg>
               Profile
             </a>
-            <a asp-page="/Account/Privacy" role="menuitem" class="flex items-center gap-2 px-4 py-2 text-sm text-text-primary hover:bg-bg-hover transition-colors">
+            <a href="/Account/Privacy" role="menuitem" class="flex items-center gap-2 px-4 py-2 text-sm text-text-primary hover:bg-bg-hover transition-colors">
               <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
               </svg>

--- a/src/DiscordBot.Bot/Pages/_BlazorHost.cshtml
+++ b/src/DiscordBot.Bot/Pages/_BlazorHost.cshtml
@@ -1,0 +1,14 @@
+@page
+@namespace DiscordBot.Bot.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@using Microsoft.AspNetCore.Components.Web
+@{
+    Layout = "_Layout";
+    ViewData["Title"] = "App";
+}
+
+<component type="typeof(DiscordBot.Bot.Components.Routes)" render-mode="ServerPrerendered" />
+
+@section Scripts {
+    <script src="_framework/blazor.server.js"></script>
+}

--- a/src/DiscordBot.Bot/Pages/_BlazorHost.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/_BlazorHost.cshtml.cs
@@ -1,0 +1,10 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace DiscordBot.Bot.Pages;
+
+public class BlazorHostModel : PageModel
+{
+    public void OnGet()
+    {
+    }
+}

--- a/src/DiscordBot.Bot/Program.cs
+++ b/src/DiscordBot.Bot/Program.cs
@@ -1,5 +1,4 @@
 using DiscordBot.Bot.Commands;
-using DiscordBot.Bot.Components;
 using DiscordBot.Bot.Extensions;
 using DiscordBot.Bot.Hubs;
 using DiscordBot.Bot.Middleware;
@@ -289,8 +288,9 @@ try
     // Map SignalR hub for real-time dashboard
     app.MapHub<DashboardHub>("/hubs/dashboard");
 
-    // Map Blazor Server components
-    app.MapRazorComponents<App>().AddInteractiveServerRenderMode();
+    // Map Blazor Server components hosted within _Layout.cshtml
+    app.MapBlazorHub();
+    app.MapFallbackToPage("/_BlazorHost");
 
     // Map Prometheus metrics endpoint
     app.UseOpenTelemetryPrometheusScrapingEndpoint();


### PR DESCRIPTION
## Summary

- **Layout shell**: Blazor pages rendered as standalone HTML without navbar/sidebar/JS. Created `_BlazorHost.cshtml` Razor Page host that renders Blazor components inside `_Layout.cshtml`, switched from `MapRazorComponents<App>()` to `MapBlazorHub()` + `MapFallbackToPage`
- **Guild tab navigation**: Created reusable `GuildTabNavigation.razor` component using `TabPanel` with Pills style, replacing inline tabs in GuildDetails
- **Broken links**: Fixed `asp-page` tag helpers that silently generated empty hrefs for migrated pages (Search, Navbar, Guilds/Index, AuditTab, MessagesTab, FlaggedEvents/Index)
- **AccessDenied logout**: Changed from `<a href>` (GET — broken) to `<form method="post">` (POST — works with LogoutModel)
- **MainLayout**: Simplified to just `@Body` to avoid double-wrapping with `_Layout.cshtml`

## Test plan

- [ ] `dotnet build` — 0 errors (verified)
- [ ] Navigate to a Blazor page (e.g. `/Guilds/Details/{id}`) — should have full app shell (navbar, sidebar, JS)
- [ ] Guild page tab navigation works (desktop pills + mobile dropdown)
- [ ] Profile/Privacy links in navbar user menu work
- [ ] Search results link to guild/command/user detail pages
- [ ] Audit/Message log "View Details" links work
- [ ] Flagged Events "View Details" links work
- [ ] AccessDenied "Sign Out" button works (POST logout)
- [ ] Existing Razor Pages have no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)