### PR TITLE
feat: migrate simple CRUD form pages to Blazor (#1629)

### DIFF
--- a/src/DiscordBot.Bot/Components/Pages/Admin/Users/UserCreate.razor
+++ b/src/DiscordBot.Bot/Components/Pages/Admin/Users/UserCreate.razor
@@ -1,0 +1,272 @@
+@page "/Admin/Users/Create"
+@attribute [Authorize(Policy = "RequireAdmin")]
+@using DiscordBot.Core.Interfaces
+@using DiscordBot.Core.DTOs
+@using System.Security.Claims
+@inject IUserManagementService UserManagementService
+@inject ILogger<UserCreate> Logger
+@inject AuthenticationStateProvider AuthenticationStateProvider
+@inject NavigationManager NavigationManager
+@inject ToastInterop Toast
+@inject IHttpContextAccessor HttpContextAccessor
+
+<PageTitle>Create User - Discord Bot Admin</PageTitle>
+
+<div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <!-- Header -->
+    <div class="mb-6">
+        <div class="flex items-center gap-2 text-sm text-text-secondary mb-2">
+            <a href="/Admin/Users" class="hover:text-text-primary">Users</a>
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+            <span class="text-text-primary">Create</span>
+        </div>
+        <h1 class="text-2xl font-bold text-text-primary">Create User</h1>
+        <p class="mt-1 text-sm text-text-secondary">Add a new user account to the system</p>
+    </div>
+
+    <!-- Error Alert -->
+    @if (!string.IsNullOrEmpty(_errorMessage))
+    {
+        <div class="mb-6">
+            <Alert Variant="AlertVariant.Error" Title="Error" Message="@_errorMessage" IsDismissible="true" />
+        </div>
+    }
+
+    <!-- Form Card -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg">
+        <div class="px-6 py-4 border-b border-border-primary">
+            <h2 class="text-sm font-semibold text-text-secondary uppercase tracking-wider">Account Information</h2>
+        </div>
+        <div class="p-6 space-y-6">
+            <FormInput Id="email"
+                       Name="email"
+                       Label="Email"
+                       Type="email"
+                       Placeholder="user@example.com"
+                       Value="@_email"
+                       ValueChanged="@(v => _email = v)"
+                       IsRequired="true"
+                       ValidationState="@_emailValidation"
+                       ValidationMessage="@_emailValidationMessage" />
+
+            <FormInput Id="displayName"
+                       Name="displayName"
+                       Label="Display Name"
+                       Type="text"
+                       Placeholder="Optional display name"
+                       Value="@_displayName"
+                       ValueChanged="@(v => _displayName = v)"
+                       MaxLength="100" />
+
+            <FormInput Id="password"
+                       Name="password"
+                       Label="Password"
+                       Type="password"
+                       Placeholder="Minimum 8 characters"
+                       Value="@_password"
+                       ValueChanged="@(v => _password = v)"
+                       IsRequired="true"
+                       ValidationState="@_passwordValidation"
+                       ValidationMessage="@_passwordValidationMessage" />
+
+            <FormInput Id="confirmPassword"
+                       Name="confirmPassword"
+                       Label="Confirm Password"
+                       Type="password"
+                       Placeholder="Re-enter password"
+                       Value="@_confirmPassword"
+                       ValueChanged="@(v => _confirmPassword = v)"
+                       IsRequired="true"
+                       ValidationState="@_confirmPasswordValidation"
+                       ValidationMessage="@_confirmPasswordValidationMessage" />
+
+            <FormSelect Id="role"
+                        Name="role"
+                        Label="Role"
+                        Placeholder="Select a role"
+                        SelectedValue="@_selectedRole"
+                        SelectedValueChanged="@(v => _selectedRole = v)"
+                        Options="@_roleOptions"
+                        IsRequired="true"
+                        ValidationState="@_roleValidation"
+                        ValidationMessage="@_roleValidationMessage" />
+
+            <FormToggle Id="sendWelcomeEmail"
+                        Name="sendWelcomeEmail"
+                        Label="Send Welcome Email"
+                        Description="Send an email to the user with their login credentials"
+                        IsChecked="@_sendWelcomeEmail"
+                        IsCheckedChanged="@(v => _sendWelcomeEmail = v)" />
+        </div>
+
+        <!-- Footer -->
+        <div class="flex justify-end gap-3 px-6 py-4 border-t border-border-primary">
+            <a href="/Admin/Users" class="inline-flex items-center gap-2 px-4 py-2 bg-bg-tertiary hover:bg-bg-hover border border-border-primary text-text-primary font-medium text-sm rounded-md transition-colors">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                </svg>
+                Cancel
+            </a>
+            <Button Text="Create User"
+                    Variant="ButtonVariant.Primary"
+                    OnClick="HandleSubmitAsync"
+                    IsLoading="_isSaving"
+                    LoadingText="Creating..."
+                    IsDisabled="_isSaving" />
+        </div>
+    </div>
+</div>
+
+@code {
+    private string? _email;
+    private string? _displayName;
+    private string? _password;
+    private string? _confirmPassword;
+    private string? _selectedRole = "Viewer";
+    private bool _sendWelcomeEmail = true;
+    private bool _isSaving;
+    private string? _errorMessage;
+    private string? _currentUserId;
+
+    private List<SelectOption> _roleOptions = new();
+
+    // Validation state
+    private ValidationState _emailValidation = ValidationState.None;
+    private string? _emailValidationMessage;
+    private ValidationState _passwordValidation = ValidationState.None;
+    private string? _passwordValidationMessage;
+    private ValidationState _confirmPasswordValidation = ValidationState.None;
+    private string? _confirmPasswordValidationMessage;
+    private ValidationState _roleValidation = ValidationState.None;
+    private string? _roleValidationMessage;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        _currentUserId = authState.User.FindFirstValue(ClaimTypes.NameIdentifier);
+
+        if (string.IsNullOrEmpty(_currentUserId))
+            return;
+
+        var roles = await UserManagementService.GetAvailableRolesAsync(_currentUserId);
+        _roleOptions = roles.Select(r => new SelectOption { Value = r, Text = r }).ToList();
+    }
+
+    private void ClearValidation()
+    {
+        _emailValidation = ValidationState.None;
+        _emailValidationMessage = null;
+        _passwordValidation = ValidationState.None;
+        _passwordValidationMessage = null;
+        _confirmPasswordValidation = ValidationState.None;
+        _confirmPasswordValidationMessage = null;
+        _roleValidation = ValidationState.None;
+        _roleValidationMessage = null;
+        _errorMessage = null;
+    }
+
+    private bool Validate()
+    {
+        ClearValidation();
+        var isValid = true;
+
+        if (string.IsNullOrWhiteSpace(_email))
+        {
+            _emailValidation = ValidationState.Error;
+            _emailValidationMessage = "Email is required.";
+            isValid = false;
+        }
+        else if (!_email.Contains('@') || !_email.Contains('.'))
+        {
+            _emailValidation = ValidationState.Error;
+            _emailValidationMessage = "Please enter a valid email address.";
+            isValid = false;
+        }
+
+        if (string.IsNullOrWhiteSpace(_password))
+        {
+            _passwordValidation = ValidationState.Error;
+            _passwordValidationMessage = "Password is required.";
+            isValid = false;
+        }
+        else if (_password.Length < 8)
+        {
+            _passwordValidation = ValidationState.Error;
+            _passwordValidationMessage = "Password must be at least 8 characters.";
+            isValid = false;
+        }
+
+        if (string.IsNullOrWhiteSpace(_confirmPassword))
+        {
+            _confirmPasswordValidation = ValidationState.Error;
+            _confirmPasswordValidationMessage = "Please confirm the password.";
+            isValid = false;
+        }
+        else if (_password != _confirmPassword)
+        {
+            _confirmPasswordValidation = ValidationState.Error;
+            _confirmPasswordValidationMessage = "Passwords do not match.";
+            isValid = false;
+        }
+
+        if (string.IsNullOrWhiteSpace(_selectedRole))
+        {
+            _roleValidation = ValidationState.Error;
+            _roleValidationMessage = "Please select a role.";
+            isValid = false;
+        }
+
+        return isValid;
+    }
+
+    private async Task HandleSubmitAsync()
+    {
+        if (_isSaving || string.IsNullOrEmpty(_currentUserId))
+            return;
+
+        if (!Validate())
+            return;
+
+        _isSaving = true;
+        _errorMessage = null;
+
+        try
+        {
+            var dto = new UserCreateDto
+            {
+                Email = _email!.Trim(),
+                DisplayName = string.IsNullOrWhiteSpace(_displayName) ? null : _displayName.Trim(),
+                Password = _password!,
+                ConfirmPassword = _confirmPassword!,
+                Role = _selectedRole!,
+                SendWelcomeEmail = _sendWelcomeEmail
+            };
+
+            var ipAddress = HttpContextAccessor.HttpContext?.Connection.RemoteIpAddress?.ToString();
+            var result = await UserManagementService.CreateUserAsync(dto, _currentUserId, ipAddress);
+
+            if (result.Succeeded)
+            {
+                await Toast.ShowAsync("success", "User created successfully.");
+                NavigationManager.NavigateTo("/Admin/Users");
+            }
+            else
+            {
+                _errorMessage = result.ErrorMessage ?? "An unexpected error occurred while creating the user.";
+                Logger.LogWarning("Failed to create user: {ErrorCode} - {ErrorMessage}",
+                    result.ErrorCode, result.ErrorMessage);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error creating user");
+            _errorMessage = "An unexpected error occurred. Please try again.";
+        }
+        finally
+        {
+            _isSaving = false;
+        }
+    }
+}

--- a/src/DiscordBot.Bot/Components/Pages/Admin/Users/UserDetails.razor
+++ b/src/DiscordBot.Bot/Components/Pages/Admin/Users/UserDetails.razor
@@ -37,7 +37,7 @@ else
                 </div>
                 @if (_viewModel.CanEdit)
                 {
-                    <a href="/Admin/Users/Edit?id=@user.Id" class="btn btn-primary">
+                    <a href="/Admin/Users/@user.Id/Edit" class="btn btn-primary">
                         <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
                         </svg>

--- a/src/DiscordBot.Bot/Components/Pages/Admin/Users/UserEdit.razor
+++ b/src/DiscordBot.Bot/Components/Pages/Admin/Users/UserEdit.razor
@@ -1,0 +1,426 @@
+@page "/Admin/Users/{UserId}/Edit"
+@attribute [Authorize(Policy = "RequireAdmin")]
+@using DiscordBot.Core.Interfaces
+@using DiscordBot.Core.DTOs
+@using System.Security.Claims
+@inject IUserManagementService UserManagementService
+@inject ILogger<UserEdit> Logger
+@inject AuthenticationStateProvider AuthenticationStateProvider
+@inject NavigationManager NavigationManager
+@inject ToastInterop Toast
+@inject IHttpContextAccessor HttpContextAccessor
+
+<PageTitle>Edit User - Discord Bot Admin</PageTitle>
+
+@if (_user is null)
+{
+    <div class="flex items-center justify-center py-12">
+        <div class="text-text-secondary">Loading...</div>
+    </div>
+}
+else
+{
+    <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <!-- Header -->
+        <div class="mb-6">
+            <div class="flex items-center gap-2 text-sm text-text-secondary mb-2">
+                <a href="/Admin/Users" class="hover:text-text-primary">Users</a>
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                </svg>
+                <a href="/Admin/Users/Details/@UserId" class="hover:text-text-primary">Details</a>
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                </svg>
+                <span class="text-text-primary">Edit</span>
+            </div>
+            <h1 class="text-2xl font-bold text-text-primary">Edit User</h1>
+            <p class="mt-1 text-sm text-text-secondary">Update user account settings for @(_user.DisplayName ?? _user.Email)</p>
+        </div>
+
+        <!-- Error Alert -->
+        @if (!string.IsNullOrEmpty(_errorMessage))
+        {
+            <div class="mb-6">
+                <Alert Variant="AlertVariant.Error" Title="Error" Message="@_errorMessage" IsDismissible="true" />
+            </div>
+        }
+
+        <!-- Account Information Card -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg mb-6">
+            <div class="px-6 py-4 border-b border-border-primary">
+                <h2 class="text-sm font-semibold text-text-secondary uppercase tracking-wider">Account Information</h2>
+            </div>
+            <div class="p-6 space-y-6">
+                <FormInput Id="email"
+                           Name="email"
+                           Label="Email"
+                           Type="email"
+                           Placeholder="user@example.com"
+                           Value="@_email"
+                           ValueChanged="@(v => _email = v)"
+                           IsRequired="true"
+                           ValidationState="@_emailValidation"
+                           ValidationMessage="@_emailValidationMessage" />
+
+                <FormInput Id="displayName"
+                           Name="displayName"
+                           Label="Display Name"
+                           Type="text"
+                           Placeholder="Optional display name"
+                           Value="@_displayName"
+                           ValueChanged="@(v => _displayName = v)"
+                           MaxLength="100" />
+
+                <FormSelect Id="role"
+                            Name="role"
+                            Label="Role"
+                            Placeholder="Select a role"
+                            SelectedValue="@_selectedRole"
+                            SelectedValueChanged="@(v => _selectedRole = v)"
+                            Options="@_roleOptions"
+                            IsRequired="true"
+                            IsDisabled="_isSelf"
+                            ValidationState="@_roleValidation"
+                            ValidationMessage="@_roleValidationMessage" />
+
+                <FormToggle Id="isActive"
+                            Name="isActive"
+                            Label="Active"
+                            Description="Inactive users cannot sign in to the application"
+                            IsChecked="@_isActive"
+                            IsCheckedChanged="@(v => _isActive = v)"
+                            IsDisabled="_isSelf" />
+            </div>
+
+            <!-- Footer -->
+            <div class="flex justify-end gap-3 px-6 py-4 border-t border-border-primary">
+                <a href="/Admin/Users/Details/@UserId" class="inline-flex items-center gap-2 px-4 py-2 bg-bg-tertiary hover:bg-bg-hover border border-border-primary text-text-primary font-medium text-sm rounded-md transition-colors">
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                    </svg>
+                    Cancel
+                </a>
+                <Button Text="Save Changes"
+                        Variant="ButtonVariant.Primary"
+                        OnClick="HandleSubmitAsync"
+                        IsLoading="_isSaving"
+                        LoadingText="Saving..."
+                        IsDisabled="_isSaving" />
+            </div>
+        </div>
+
+        <!-- Discord Account Card -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg mb-6">
+            <div class="px-6 py-4 border-b border-border-primary">
+                <h2 class="text-sm font-semibold text-text-secondary uppercase tracking-wider">Discord Account</h2>
+            </div>
+            <div class="p-6">
+                @if (_user.IsDiscordLinked)
+                {
+                    <div class="flex items-center justify-between">
+                        <div class="flex items-center gap-4">
+                            @if (!string.IsNullOrEmpty(_user.DiscordAvatarUrl))
+                            {
+                                <img class="h-12 w-12 rounded-full" src="@_user.DiscordAvatarUrl" alt="@_user.DiscordUsername" />
+                            }
+                            else
+                            {
+                                <div class="h-12 w-12 rounded-full bg-accent-blue flex items-center justify-center">
+                                    <span class="text-white font-bold text-lg">@(_user.DiscordUsername?.Substring(0, 1).ToUpper() ?? "?")</span>
+                                </div>
+                            }
+                            <div>
+                                <div class="flex items-center gap-2">
+                                    <svg class="w-5 h-5 text-accent-blue" fill="currentColor" viewBox="0 0 24 24">
+                                        <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515.074.074 0 00-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0 12.64 12.64 0 00-.617-1.25.077.077 0 00-.079-.037A19.736 19.736 0 003.677 4.37a.07.07 0 00-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 00.031.057 19.9 19.9 0 005.993 3.03.078.078 0 00.084-.028c.462-.63.874-1.295 1.226-1.994.021-.041.001-.09-.041-.106a13.107 13.107 0 01-1.872-.892.077.077 0 01-.008-.128 10.2 10.2 0 00.372-.292.074.074 0 01.077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 01.078.01c.12.098.246.198.373.292a.077.077 0 01-.006.127 12.299 12.299 0 01-1.873.892.077.077 0 00-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 00.084.028 19.839 19.839 0 006.002-3.03.077.077 0 00.032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 00-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/>
+                                    </svg>
+                                    <span class="text-sm font-medium text-text-primary">@_user.DiscordUsername</span>
+                                </div>
+                                <p class="text-xs text-text-tertiary mt-1">ID: @_user.DiscordUserId</p>
+                            </div>
+                        </div>
+                        <Button Text="Unlink Discord"
+                                Variant="ButtonVariant.Danger"
+                                OnClick="@(() => _showUnlinkModal = true)"
+                                IsDisabled="_isUnlinking" />
+                    </div>
+                }
+                else
+                {
+                    <div class="text-center py-4">
+                        <svg class="w-12 h-12 mx-auto text-text-tertiary mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+                        </svg>
+                        <p class="text-sm text-text-secondary">No Discord account linked</p>
+                    </div>
+                }
+            </div>
+        </div>
+
+        <!-- Password Management Card -->
+        <div class="bg-bg-secondary border border-border-primary rounded-lg">
+            <div class="px-6 py-4 border-b border-border-primary">
+                <h2 class="text-sm font-semibold text-text-secondary uppercase tracking-wider">Password Management</h2>
+            </div>
+            <div class="p-6">
+                <div class="flex items-center justify-between">
+                    <div>
+                        <p class="text-sm text-text-primary font-medium">Reset Password</p>
+                        <p class="text-xs text-text-secondary mt-1">Generate a new random password for this user. The current password will be invalidated.</p>
+                    </div>
+                    <Button Text="Reset Password"
+                            Variant="ButtonVariant.Danger"
+                            OnClick="@(() => _showResetPasswordModal = true)"
+                            IsDisabled="_isResettingPassword" />
+                </div>
+
+                @if (!string.IsNullOrEmpty(_generatedPassword))
+                {
+                    <div class="mt-4">
+                        <Alert Variant="AlertVariant.Warning"
+                               Title="New Password Generated"
+                               Message="@($"The new password is: {_generatedPassword} — Please copy this password now. It will not be shown again.")" />
+                    </div>
+                }
+            </div>
+        </div>
+    </div>
+
+    <!-- Confirmation Modals -->
+    <ConfirmationModal Id="resetPasswordModal"
+                       Title="Reset Password"
+                       Message="Are you sure you want to reset the password for this user? Their current password will be invalidated and a new one will be generated."
+                       ConfirmText="Reset Password"
+                       Variant="ConfirmationVariant.Danger"
+                       IsVisible="_showResetPasswordModal"
+                       IsVisibleChanged="@(v => _showResetPasswordModal = v)"
+                       OnConfirm="HandleResetPasswordAsync" />
+
+    <ConfirmationModal Id="unlinkDiscordModal"
+                       Title="Unlink Discord Account"
+                       Message="@($"Are you sure you want to unlink the Discord account ({_user.DiscordUsername}) from this user? They will need to re-link their account to use Discord features.")"
+                       ConfirmText="Unlink"
+                       Variant="ConfirmationVariant.Danger"
+                       IsVisible="_showUnlinkModal"
+                       IsVisibleChanged="@(v => _showUnlinkModal = v)"
+                       OnConfirm="HandleUnlinkDiscordAsync" />
+}
+
+@code {
+    [Parameter] public string UserId { get; set; } = string.Empty;
+
+    private UserDto? _user;
+    private string? _currentUserId;
+    private bool _isSelf;
+    private bool _isSaving;
+    private bool _isResettingPassword;
+    private bool _isUnlinking;
+    private string? _errorMessage;
+    private string? _generatedPassword;
+    private bool _showResetPasswordModal;
+    private bool _showUnlinkModal;
+
+    // Form fields
+    private string? _email;
+    private string? _displayName;
+    private string? _selectedRole;
+    private bool _isActive;
+
+    private List<SelectOption> _roleOptions = new();
+
+    // Validation state
+    private ValidationState _emailValidation = ValidationState.None;
+    private string? _emailValidationMessage;
+    private ValidationState _roleValidation = ValidationState.None;
+    private string? _roleValidationMessage;
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (string.IsNullOrEmpty(UserId))
+            return;
+
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        _currentUserId = authState.User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (string.IsNullOrEmpty(_currentUserId))
+            return;
+
+        _user = await UserManagementService.GetUserByIdAsync(UserId);
+        if (_user is null)
+        {
+            Logger.LogWarning("User {UserId} not found for editing", UserId);
+            return;
+        }
+
+        _isSelf = _currentUserId == UserId;
+
+        // Populate form fields from user data
+        _email = _user.Email;
+        _displayName = _user.DisplayName;
+        _selectedRole = _user.HighestRole;
+        _isActive = _user.IsActive;
+
+        // Load available roles
+        var roles = await UserManagementService.GetAvailableRolesAsync(_currentUserId);
+        _roleOptions = roles.Select(r => new SelectOption { Value = r, Text = r }).ToList();
+
+        Logger.LogInformation("User {CurrentUserId} editing user {TargetUserId}",
+            _currentUserId, UserId);
+    }
+
+    private void ClearValidation()
+    {
+        _emailValidation = ValidationState.None;
+        _emailValidationMessage = null;
+        _roleValidation = ValidationState.None;
+        _roleValidationMessage = null;
+        _errorMessage = null;
+    }
+
+    private bool Validate()
+    {
+        ClearValidation();
+        var isValid = true;
+
+        if (string.IsNullOrWhiteSpace(_email))
+        {
+            _emailValidation = ValidationState.Error;
+            _emailValidationMessage = "Email is required.";
+            isValid = false;
+        }
+        else if (!_email.Contains('@') || !_email.Contains('.'))
+        {
+            _emailValidation = ValidationState.Error;
+            _emailValidationMessage = "Please enter a valid email address.";
+            isValid = false;
+        }
+
+        if (string.IsNullOrWhiteSpace(_selectedRole))
+        {
+            _roleValidation = ValidationState.Error;
+            _roleValidationMessage = "Please select a role.";
+            isValid = false;
+        }
+
+        return isValid;
+    }
+
+    private async Task HandleSubmitAsync()
+    {
+        if (_isSaving || string.IsNullOrEmpty(_currentUserId))
+            return;
+
+        if (!Validate())
+            return;
+
+        _isSaving = true;
+        _errorMessage = null;
+
+        try
+        {
+            var dto = new UserUpdateDto
+            {
+                Email = _email?.Trim(),
+                DisplayName = string.IsNullOrWhiteSpace(_displayName) ? null : _displayName.Trim(),
+                Role = _isSelf ? null : _selectedRole,
+                IsActive = _isSelf ? null : _isActive
+            };
+
+            var ipAddress = HttpContextAccessor.HttpContext?.Connection.RemoteIpAddress?.ToString();
+            var result = await UserManagementService.UpdateUserAsync(UserId, dto, _currentUserId, ipAddress);
+
+            if (result.Succeeded)
+            {
+                await Toast.ShowAsync("success", "User updated successfully.");
+                NavigationManager.NavigateTo($"/Admin/Users/Details/{UserId}");
+            }
+            else
+            {
+                _errorMessage = result.ErrorMessage ?? "An unexpected error occurred while updating the user.";
+                Logger.LogWarning("Failed to update user {UserId}: {ErrorCode} - {ErrorMessage}",
+                    UserId, result.ErrorCode, result.ErrorMessage);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error updating user {UserId}", UserId);
+            _errorMessage = "An unexpected error occurred. Please try again.";
+        }
+        finally
+        {
+            _isSaving = false;
+        }
+    }
+
+    private async Task HandleResetPasswordAsync()
+    {
+        if (_isResettingPassword || string.IsNullOrEmpty(_currentUserId))
+            return;
+
+        _isResettingPassword = true;
+        _generatedPassword = null;
+
+        try
+        {
+            var ipAddress = HttpContextAccessor.HttpContext?.Connection.RemoteIpAddress?.ToString();
+            var result = await UserManagementService.ResetPasswordAsync(UserId, _currentUserId, ipAddress);
+
+            if (result.Succeeded)
+            {
+                _generatedPassword = result.GeneratedPassword;
+                await Toast.ShowAsync("success", "Password has been reset.");
+            }
+            else
+            {
+                _errorMessage = result.ErrorMessage ?? "Failed to reset password.";
+                Logger.LogWarning("Failed to reset password for user {UserId}: {ErrorCode} - {ErrorMessage}",
+                    UserId, result.ErrorCode, result.ErrorMessage);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error resetting password for user {UserId}", UserId);
+            _errorMessage = "An unexpected error occurred while resetting the password.";
+        }
+        finally
+        {
+            _isResettingPassword = false;
+        }
+    }
+
+    private async Task HandleUnlinkDiscordAsync()
+    {
+        if (_isUnlinking || string.IsNullOrEmpty(_currentUserId))
+            return;
+
+        _isUnlinking = true;
+
+        try
+        {
+            var ipAddress = HttpContextAccessor.HttpContext?.Connection.RemoteIpAddress?.ToString();
+            var result = await UserManagementService.UnlinkDiscordAccountAsync(UserId, _currentUserId, ipAddress);
+
+            if (result.Succeeded)
+            {
+                await Toast.ShowAsync("success", "Discord account unlinked.");
+                // Reload the user data to reflect the change
+                _user = await UserManagementService.GetUserByIdAsync(UserId);
+            }
+            else
+            {
+                _errorMessage = result.ErrorMessage ?? "Failed to unlink Discord account.";
+                Logger.LogWarning("Failed to unlink Discord for user {UserId}: {ErrorCode} - {ErrorMessage}",
+                    UserId, result.ErrorCode, result.ErrorMessage);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error unlinking Discord for user {UserId}", UserId);
+            _errorMessage = "An unexpected error occurred while unlinking the Discord account.";
+        }
+        finally
+        {
+            _isUnlinking = false;
+        }
+    }
+}

--- a/src/DiscordBot.Bot/Components/Pages/Guilds/GuildDetails.razor
+++ b/src/DiscordBot.Bot/Components/Pages/Guilds/GuildDetails.razor
@@ -654,7 +654,7 @@ else
             new()
             {
                 Label = "Edit Settings",
-                Url = $"/Guilds/Edit?id={guildDto.Id}",
+                Url = $"/Guilds/Edit/{guildDto.Id}",
                 Icon = "M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z",
                 Style = HeaderActionStyle.Primary
             }

--- a/src/DiscordBot.Bot/Components/Pages/Guilds/GuildEdit.razor
+++ b/src/DiscordBot.Bot/Components/Pages/Guilds/GuildEdit.razor
@@ -1,0 +1,223 @@
+@page "/Guilds/Edit/{GuildId:long}"
+@attribute [Authorize(Policy = "RequireAdmin")]
+@attribute [Authorize(Policy = "GuildAccess")]
+@layout GuildLayout
+@using DiscordBot.Core.DTOs
+@using DiscordBot.Core.Entities
+@using DiscordBot.Core.Interfaces
+@inject IGuildService GuildService
+@inject IGuildAudioSettingsService GuildAudioSettingsService
+@inject NavigationManager NavigationManager
+@inject ToastInterop Toast
+@inject ILogger<GuildEdit> Logger
+
+<PageTitle>Edit Guild Settings - Discord Bot Admin</PageTitle>
+
+@if (_guild is null && !_notFound)
+{
+    <div class="flex items-center justify-center py-12">
+        <div class="text-text-secondary">Loading...</div>
+    </div>
+}
+else if (_notFound)
+{
+    <div class="flex flex-col items-center justify-center py-12">
+        <svg class="w-16 h-16 text-text-tertiary mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        <h2 class="text-xl font-semibold text-text-primary mb-2">Guild Not Found</h2>
+        <p class="text-text-secondary mb-4">The guild you are looking for does not exist or you do not have access.</p>
+        <a href="/Guilds" class="text-accent-blue hover:text-accent-blue-hover transition-colors">Back to Guilds</a>
+    </div>
+}
+else
+{
+    <!-- Breadcrumb -->
+    <GuildBreadcrumb Items="@_breadcrumbItems" />
+
+    <!-- Guild Header -->
+    <GuildHeader GuildId="(ulong)GuildId"
+                 GuildName="@_guild!.Name"
+                 GuildIconUrl="@_guild.IconUrl"
+                 PageTitle="Edit Guild Settings"
+                 PageDescription="@($"Configure settings for {_guild.Name}")" />
+
+    <!-- Error Alert -->
+    @if (!string.IsNullOrEmpty(_errorMessage))
+    {
+        <div class="mb-6">
+            <Alert Variant="AlertVariant.Error"
+                   Title="Error"
+                   Message="@_errorMessage"
+                   IsDismissible="true"
+                   OnDismiss="@(() => _errorMessage = null)" />
+        </div>
+    }
+
+    <!-- General Settings Card -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden mb-6">
+        <div class="px-6 py-4 border-b border-border-primary">
+            <h2 class="text-sm font-semibold text-text-secondary uppercase tracking-wider">General Settings</h2>
+        </div>
+        <div class="p-6 space-y-6">
+            <FormToggle Id="botActive"
+                        Name="botActive"
+                        Label="Bot Active"
+                        Description="When disabled, the bot will not respond to commands in this guild."
+                        IsChecked="_isActive"
+                        IsCheckedChanged="@((bool val) => _isActive = val)"
+                        IsDisabled="_isSaving" />
+        </div>
+    </div>
+
+    <!-- Audio Settings Card -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden mb-6">
+        <div class="px-6 py-4 border-b border-border-primary">
+            <h2 class="text-sm font-semibold text-text-secondary uppercase tracking-wider">Audio Settings</h2>
+        </div>
+        <div class="p-6 space-y-6">
+            <FormToggle Id="audioEnabled"
+                        Name="audioEnabled"
+                        Label="Audio Enabled"
+                        Description="Enable or disable audio features such as soundboard, TTS, and VOX for this guild."
+                        IsChecked="_audioEnabled"
+                        IsCheckedChanged="@((bool val) => _audioEnabled = val)"
+                        IsDisabled="_isSaving" />
+
+            <FormInput Id="autoLeaveTimeout"
+                       Name="autoLeaveTimeout"
+                       Label="Auto-Leave Timeout (minutes)"
+                       Type="number"
+                       Value="@_autoLeaveTimeoutMinutes"
+                       ValueChanged="@((string? val) => _autoLeaveTimeoutMinutes = val)"
+                       HelpText="Minutes of inactivity before auto-leave. Set to 0 for indefinite."
+                       IsDisabled="_isSaving" />
+
+            <FormToggle Id="queueEnabled"
+                        Name="queueEnabled"
+                        Label="Queue Enabled"
+                        Description="When enabled, sounds are queued instead of replacing the currently playing sound."
+                        IsChecked="_queueEnabled"
+                        IsCheckedChanged="@((bool val) => _queueEnabled = val)"
+                        IsDisabled="_isSaving" />
+        </div>
+    </div>
+
+    <!-- Footer Actions -->
+    <div class="flex items-center justify-end gap-3">
+        <a href="/Guilds/Details/@GuildId"
+           class="px-5 py-2.5 text-sm font-medium text-text-secondary hover:text-text-primary bg-bg-secondary border border-border-primary rounded-lg hover:border-border-focus transition-colors">
+            Cancel
+        </a>
+        <Button Text="Save Settings"
+                Variant="ButtonVariant.Primary"
+                OnClick="HandleSaveAsync"
+                IsLoading="_isSaving"
+                LoadingText="Saving..."
+                IsDisabled="_isSaving" />
+    </div>
+}
+
+@code {
+    [Parameter] public long GuildId { get; set; }
+
+    private GuildDto? _guild;
+    private List<BreadcrumbItem>? _breadcrumbItems;
+    private bool _notFound;
+    private string? _errorMessage;
+    private bool _isSaving;
+
+    // General settings
+    private bool _isActive;
+
+    // Audio settings
+    private bool _audioEnabled;
+    private string? _autoLeaveTimeoutMinutes;
+    private bool _queueEnabled;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var guildId = (ulong)GuildId;
+
+        Logger.LogInformation("User accessing guild edit page for guild {GuildId}", guildId);
+
+        var guild = await GuildService.GetGuildByIdAsync(guildId);
+        if (guild is null)
+        {
+            Logger.LogWarning("Guild {GuildId} not found for editing", guildId);
+            _notFound = true;
+            return;
+        }
+
+        _guild = guild;
+        _isActive = guild.IsActive;
+
+        var audioSettings = await GuildAudioSettingsService.GetSettingsAsync(guildId);
+        _audioEnabled = audioSettings.AudioEnabled;
+        _autoLeaveTimeoutMinutes = audioSettings.AutoLeaveTimeoutMinutes.ToString();
+        _queueEnabled = audioSettings.QueueEnabled;
+
+        _breadcrumbItems = new List<BreadcrumbItem>
+        {
+            new() { Label = "Home", Url = "/" },
+            new() { Label = "Servers", Url = "/Guilds" },
+            new() { Label = guild.Name, Url = $"/Guilds/Details/{GuildId}" },
+            new() { Label = "Edit", IsCurrent = true }
+        };
+    }
+
+    private async Task HandleSaveAsync()
+    {
+        if (_isSaving) return;
+
+        _isSaving = true;
+        _errorMessage = null;
+
+        try
+        {
+            var guildId = (ulong)GuildId;
+
+            // Validate auto-leave timeout
+            if (!int.TryParse(_autoLeaveTimeoutMinutes, out var timeoutMinutes) || timeoutMinutes < 0 || timeoutMinutes > 1440)
+            {
+                _errorMessage = "Auto-leave timeout must be a number between 0 and 1440.";
+                return;
+            }
+
+            // Update general guild settings
+            var updateRequest = new GuildUpdateRequestDto
+            {
+                IsActive = _isActive
+            };
+
+            var updatedGuild = await GuildService.UpdateGuildAsync(guildId, updateRequest);
+            if (updatedGuild is null)
+            {
+                _errorMessage = "Failed to update guild settings. The guild may have been deleted.";
+                return;
+            }
+
+            // Update audio settings
+            await GuildAudioSettingsService.UpdateSettingsAsync(guildId, settings =>
+            {
+                settings.AudioEnabled = _audioEnabled;
+                settings.AutoLeaveTimeoutMinutes = timeoutMinutes;
+                settings.QueueEnabled = _queueEnabled;
+            });
+
+            Logger.LogInformation("Guild settings updated for guild {GuildId}", guildId);
+
+            await Toast.ShowAsync("success", "Guild settings saved successfully.");
+            NavigationManager.NavigateTo($"/Guilds/Details/{GuildId}");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error saving guild settings for guild {GuildId}", (ulong)GuildId);
+            _errorMessage = "An unexpected error occurred while saving settings. Please try again.";
+        }
+        finally
+        {
+            _isSaving = false;
+        }
+    }
+}

--- a/src/DiscordBot.Bot/Components/Pages/Guilds/GuildWelcome.razor
+++ b/src/DiscordBot.Bot/Components/Pages/Guilds/GuildWelcome.razor
@@ -1,0 +1,411 @@
+@page "/Guilds/Welcome/{GuildId:long}"
+@attribute [Authorize(Policy = "RequireAdmin")]
+@attribute [Authorize(Policy = "GuildAccess")]
+@layout GuildLayout
+@using DiscordBot.Bot.Components.Interop
+@using DiscordBot.Bot.ViewModels.Components
+@using DiscordBot.Core.DTOs
+@using DiscordBot.Core.Interfaces
+@using Discord.WebSocket
+@inject IGuildService GuildService
+@inject IWelcomeService WelcomeService
+@inject DiscordSocketClient DiscordClient
+@inject ToastInterop Toast
+@inject ILogger<GuildWelcome> Logger
+
+<PageTitle>Welcome Configuration - Discord Bot Admin</PageTitle>
+
+@if (_guild is null && !_notFound)
+{
+    <div class="flex items-center justify-center py-12">
+        <div class="text-text-secondary">Loading...</div>
+    </div>
+}
+else if (_notFound)
+{
+    <div class="flex flex-col items-center justify-center py-12 space-y-4">
+        <div class="text-text-secondary text-lg">Guild not found</div>
+        <a href="/Guilds" class="text-accent-blue hover:text-accent-blue-hover transition-colors text-sm">Back to Guilds</a>
+    </div>
+}
+else
+{
+    <!-- Breadcrumb -->
+    <GuildBreadcrumb Items="@_breadcrumbItems" />
+
+    <!-- Guild Header -->
+    <GuildHeader GuildId="(ulong)GuildId"
+                 GuildName="@_guild.Name"
+                 GuildIconUrl="@_guild.IconUrl"
+                 PageTitle="Welcome Configuration"
+                 PageDescription="Configure the welcome message sent when new members join" />
+
+    <!-- Error Alert -->
+    @if (!string.IsNullOrEmpty(_errorMessage))
+    {
+        <div class="mb-6">
+            <Alert Variant="AlertVariant.Error" Title="Error" Message="@_errorMessage" IsDismissible="true" />
+        </div>
+    }
+
+    <!-- Enable Toggle Card -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg p-6 mb-6">
+        <FormToggle Id="welcome-enabled"
+                    Name="IsEnabled"
+                    Label="Enable Welcome Messages"
+                    Description="Send a welcome message when a new member joins"
+                    IsChecked="_isEnabled"
+                    IsCheckedChanged="OnEnabledChanged" />
+    </div>
+
+    <!-- Configuration Card -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg mb-6">
+        <div class="relative">
+            @if (!_isEnabled)
+            {
+                <div class="absolute inset-0 bg-bg-secondary/60 z-10 rounded-lg"></div>
+            }
+
+            <div class="p-6 space-y-6">
+                <!-- Welcome Channel -->
+                <FormSelect Id="welcome-channel"
+                            Name="WelcomeChannelId"
+                            Label="Welcome Channel"
+                            Placeholder="Select a channel..."
+                            SelectedValue="@_selectedChannelId"
+                            SelectedValueChanged="OnChannelChanged"
+                            Options="@_channelOptions"
+                            IsRequired="true"
+                            IsDisabled="!_isEnabled"
+                            ValidationState="@_channelValidationState"
+                            ValidationMessage="@_channelValidationMessage" />
+
+                <!-- Welcome Message -->
+                <div class="space-y-1.5">
+                    <label for="welcome-message" class="block text-sm font-medium text-text-primary">
+                        Welcome Message
+                        <span class="text-error">*</span>
+                    </label>
+                    <textarea id="welcome-message"
+                              name="WelcomeMessage"
+                              class="w-full py-2.5 px-3.5 text-sm text-text-primary bg-bg-primary border border-border-primary rounded-md placeholder-text-tertiary transition-colors focus:outline-none focus:ring-[3px] focus:border-accent-blue focus:ring-accent-blue/15 min-h-[120px] resize-y"
+                              maxlength="2000"
+                              disabled="@(!_isEnabled)"
+                              placeholder="Welcome to {server}, {user}!"
+                              @bind="_welcomeMessage"
+                              @bind:event="oninput"></textarea>
+                    <div class="flex items-center justify-between">
+                        <span class="text-xs text-text-tertiary">Supports message tokens (see below)</span>
+                        <span class="text-xs text-text-tertiary">@((_welcomeMessage ?? "").Length) / 2,000</span>
+                    </div>
+                </div>
+
+                <!-- Token Help (Collapsible) -->
+                <details class="group">
+                    <summary class="flex items-center gap-2 cursor-pointer text-sm font-medium text-text-secondary hover:text-text-primary transition-colors select-none">
+                        <svg class="w-4 h-4 transition-transform group-open:rotate-90" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                        </svg>
+                        Available Tokens
+                    </summary>
+                    <div class="mt-3 bg-bg-primary border border-border-primary rounded-lg p-4 space-y-3">
+                        <div class="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
+                            <div class="flex items-center justify-between gap-2 px-3 py-2 bg-bg-secondary rounded">
+                                <div>
+                                    <code class="text-accent-blue font-mono text-xs">{user}</code>
+                                    <span class="text-text-secondary ml-2">@@NewMember (mention)</span>
+                                </div>
+                                <Button Text="Insert" Variant="ButtonVariant.Ghost" Size="ButtonSize.Small" OnClick="@(() => InsertToken("{user}"))" IsDisabled="!_isEnabled" />
+                            </div>
+                            <div class="flex items-center justify-between gap-2 px-3 py-2 bg-bg-secondary rounded">
+                                <div>
+                                    <code class="text-accent-blue font-mono text-xs">{username}</code>
+                                    <span class="text-text-secondary ml-2">NewMember</span>
+                                </div>
+                                <Button Text="Insert" Variant="ButtonVariant.Ghost" Size="ButtonSize.Small" OnClick="@(() => InsertToken("{username}"))" IsDisabled="!_isEnabled" />
+                            </div>
+                            <div class="flex items-center justify-between gap-2 px-3 py-2 bg-bg-secondary rounded">
+                                <div>
+                                    <code class="text-accent-blue font-mono text-xs">{server}</code>
+                                    <span class="text-text-secondary ml-2">Server name</span>
+                                </div>
+                                <Button Text="Insert" Variant="ButtonVariant.Ghost" Size="ButtonSize.Small" OnClick="@(() => InsertToken("{server}"))" IsDisabled="!_isEnabled" />
+                            </div>
+                            <div class="flex items-center justify-between gap-2 px-3 py-2 bg-bg-secondary rounded">
+                                <div>
+                                    <code class="text-accent-blue font-mono text-xs">{memberCount}</code>
+                                    <span class="text-text-secondary ml-2">1,234</span>
+                                </div>
+                                <Button Text="Insert" Variant="ButtonVariant.Ghost" Size="ButtonSize.Small" OnClick="@(() => InsertToken("{memberCount}"))" IsDisabled="!_isEnabled" />
+                            </div>
+                        </div>
+                    </div>
+                </details>
+
+                <!-- Include Avatar Toggle -->
+                <FormToggle Id="include-avatar"
+                            Name="IncludeAvatar"
+                            Label="Include Avatar"
+                            Description="Show the new member's avatar in the welcome message"
+                            IsChecked="_includeAvatar"
+                            IsCheckedChanged="OnIncludeAvatarChanged"
+                            IsDisabled="!_isEnabled" />
+
+                <!-- Use Embed Toggle -->
+                <FormToggle Id="use-embed"
+                            Name="UseEmbed"
+                            Label="Use Embed"
+                            Description="Send the welcome message as a rich embed instead of plain text"
+                            IsChecked="_useEmbed"
+                            IsCheckedChanged="OnUseEmbedChanged"
+                            IsDisabled="!_isEnabled" />
+
+                <!-- Embed Color (shown when UseEmbed is true) -->
+                @if (_useEmbed)
+                {
+                    <div class="space-y-1.5">
+                        <label for="embed-color" class="block text-sm font-medium text-text-primary">
+                            Embed Color
+                        </label>
+                        <div class="flex items-center gap-3">
+                            <input type="color"
+                                   id="embed-color-picker"
+                                   class="w-10 h-10 rounded cursor-pointer border border-border-primary"
+                                   value="@_embedColor"
+                                   disabled="@(!_isEnabled)"
+                                   @onchange="OnColorPickerChanged" />
+                            <input type="text"
+                                   id="embed-color"
+                                   class="w-32 py-2.5 px-3.5 text-sm text-text-primary bg-bg-primary border border-border-primary rounded-md font-mono placeholder-text-tertiary transition-colors focus:outline-none focus:ring-[3px] focus:border-accent-blue focus:ring-accent-blue/15"
+                                   maxlength="7"
+                                   placeholder="#5865F2"
+                                   value="@_embedColor"
+                                   disabled="@(!_isEnabled)"
+                                   @onchange="OnColorTextChanged" />
+                        </div>
+                        @if (!string.IsNullOrEmpty(_colorValidationMessage))
+                        {
+                            <p class="text-xs text-error">@_colorValidationMessage</p>
+                        }
+                    </div>
+                }
+            </div>
+        </div>
+    </div>
+
+    <!-- Footer: Save Button -->
+    <div class="flex justify-end">
+        <Button Text="Save Configuration"
+                Variant="ButtonVariant.Primary"
+                IsLoading="_isSaving"
+                LoadingText="Saving..."
+                OnClick="SaveAsync"
+                IconLeft="M5 13l4 4L19 7" />
+    </div>
+}
+
+@code {
+    [Parameter] public long GuildId { get; set; }
+
+    private GuildDto? _guild;
+    private List<BreadcrumbItem>? _breadcrumbItems;
+
+    // Form state
+    private bool _isEnabled;
+    private string? _selectedChannelId;
+    private string? _welcomeMessage;
+    private bool _includeAvatar;
+    private bool _useEmbed;
+    private string _embedColor = "#5865F2";
+
+    // Channel options
+    private List<SelectOption> _channelOptions = new();
+
+    // Validation
+    private ValidationState _channelValidationState = ValidationState.None;
+    private string? _channelValidationMessage;
+    private string? _colorValidationMessage;
+    private string? _errorMessage;
+
+    // UI state
+    private bool _isSaving;
+    private bool _notFound;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var guildId = (ulong)GuildId;
+
+        Logger.LogInformation("User accessing welcome configuration for guild {GuildId}", guildId);
+
+        var guildDto = await GuildService.GetGuildByIdAsync(guildId);
+        if (guildDto is null)
+        {
+            Logger.LogWarning("Guild {GuildId} not found", guildId);
+            _notFound = true;
+            return;
+        }
+
+        _guild = guildDto;
+
+        // Load welcome configuration (or use defaults)
+        var config = await WelcomeService.GetConfigurationAsync(guildId);
+        if (config is not null)
+        {
+            _isEnabled = config.IsEnabled;
+            _selectedChannelId = config.WelcomeChannelId?.ToString();
+            _welcomeMessage = config.WelcomeMessage;
+            _includeAvatar = config.IncludeAvatar;
+            _useEmbed = config.UseEmbed;
+            _embedColor = config.EmbedColor ?? "#5865F2";
+        }
+        else
+        {
+            // Defaults when no configuration exists
+            _isEnabled = false;
+            _welcomeMessage = "Welcome to {server}, {user}! You are member #{memberCount}.";
+            _includeAvatar = true;
+            _useEmbed = true;
+            _embedColor = "#5865F2";
+        }
+
+        // Load text channels from Discord
+        var socketGuild = DiscordClient.GetGuild(guildId);
+        if (socketGuild is not null)
+        {
+            _channelOptions = socketGuild.TextChannels
+                .OrderBy(c => c.Position)
+                .Select(c => new SelectOption
+                {
+                    Value = c.Id.ToString(),
+                    Text = $"# {c.Name}"
+                })
+                .ToList();
+        }
+
+        _breadcrumbItems = new List<BreadcrumbItem>
+        {
+            new() { Label = "Home", Url = "/" },
+            new() { Label = "Servers", Url = "/Guilds" },
+            new() { Label = guildDto.Name, Url = $"/Guilds/Details/{GuildId}" },
+            new() { Label = "Welcome", IsCurrent = true }
+        };
+    }
+
+    private void OnEnabledChanged(bool value)
+    {
+        _isEnabled = value;
+        ClearValidation();
+    }
+
+    private void OnChannelChanged(string? value)
+    {
+        _selectedChannelId = value;
+        ClearValidation();
+    }
+
+    private void OnIncludeAvatarChanged(bool value)
+    {
+        _includeAvatar = value;
+    }
+
+    private void OnUseEmbedChanged(bool value)
+    {
+        _useEmbed = value;
+    }
+
+    private void OnColorPickerChanged(ChangeEventArgs e)
+    {
+        _embedColor = e.Value?.ToString() ?? "#5865F2";
+        _colorValidationMessage = null;
+    }
+
+    private void OnColorTextChanged(ChangeEventArgs e)
+    {
+        _embedColor = e.Value?.ToString() ?? "#5865F2";
+        _colorValidationMessage = null;
+    }
+
+    private void InsertToken(string token)
+    {
+        _welcomeMessage = (_welcomeMessage ?? "") + token;
+    }
+
+    private void ClearValidation()
+    {
+        _channelValidationState = ValidationState.None;
+        _channelValidationMessage = null;
+        _colorValidationMessage = null;
+        _errorMessage = null;
+    }
+
+    private bool Validate()
+    {
+        ClearValidation();
+        var isValid = true;
+
+        if (_isEnabled && string.IsNullOrEmpty(_selectedChannelId))
+        {
+            _channelValidationState = ValidationState.Error;
+            _channelValidationMessage = "A welcome channel is required when welcome messages are enabled.";
+            isValid = false;
+        }
+
+        if (_useEmbed && !string.IsNullOrEmpty(_embedColor))
+        {
+            if (!System.Text.RegularExpressions.Regex.IsMatch(_embedColor, @"^#[0-9A-Fa-f]{6}$"))
+            {
+                _colorValidationMessage = "Embed color must be a valid hex color (e.g., #5865F2).";
+                isValid = false;
+            }
+        }
+
+        return isValid;
+    }
+
+    private async Task SaveAsync()
+    {
+        if (_isSaving) return;
+        if (!Validate())
+            return;
+
+        _isSaving = true;
+        _errorMessage = null;
+
+        try
+        {
+            var guildId = (ulong)GuildId;
+
+            var updateDto = new WelcomeConfigurationUpdateDto
+            {
+                IsEnabled = _isEnabled,
+                WelcomeChannelId = !string.IsNullOrEmpty(_selectedChannelId) ? ulong.Parse(_selectedChannelId) : null,
+                WelcomeMessage = _welcomeMessage,
+                IncludeAvatar = _includeAvatar,
+                UseEmbed = _useEmbed,
+                EmbedColor = _useEmbed ? _embedColor : null
+            };
+
+            var result = await WelcomeService.UpdateConfigurationAsync(guildId, updateDto);
+
+            if (result is not null)
+            {
+                Logger.LogInformation("Welcome configuration updated for guild {GuildId}", guildId);
+                await Toast.ShowAsync("success", "Welcome configuration saved successfully.");
+            }
+            else
+            {
+                Logger.LogWarning("Failed to update welcome configuration for guild {GuildId}", guildId);
+                _errorMessage = "Failed to save welcome configuration. Please try again.";
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error saving welcome configuration for guild {GuildId}", (ulong)GuildId);
+            _errorMessage = "An unexpected error occurred while saving. Please try again.";
+        }
+        finally
+        {
+            _isSaving = false;
+        }
+    }
+}

--- a/src/DiscordBot.Bot/Components/Pages/Guilds/ScheduledMessages/ScheduledMessageCreate.razor
+++ b/src/DiscordBot.Bot/Components/Pages/Guilds/ScheduledMessages/ScheduledMessageCreate.razor
@@ -1,0 +1,434 @@
+@page "/Guilds/ScheduledMessages/Create/{GuildId:long}"
+@rendermode InteractiveServer
+@attribute [Authorize(Policy = "RequireAdmin")]
+@attribute [Authorize(Policy = "GuildAccess")]
+@layout GuildLayout
+@using Discord.WebSocket
+@using DiscordBot.Core.DTOs
+@using DiscordBot.Core.Enums
+@using DiscordBot.Core.Interfaces
+@using DiscordBot.Bot.ViewModels.Pages
+@using System.Security.Claims
+@inject IScheduledMessageService ScheduledMessageService
+@inject IGuildService GuildService
+@inject DiscordSocketClient DiscordClient
+@inject ILogger<ScheduledMessageCreate> Logger
+@inject AuthenticationStateProvider AuthenticationStateProvider
+@inject NavigationManager NavigationManager
+@inject ToastInterop Toast
+
+<PageTitle>Create Scheduled Message - Discord Bot Admin</PageTitle>
+
+@if (_guildName is null)
+{
+    <div class="flex items-center justify-center py-12">
+        <div class="text-text-secondary">Loading...</div>
+    </div>
+}
+else
+{
+    <!-- Breadcrumb -->
+    <GuildBreadcrumb Items="@_breadcrumbItems" />
+
+    <!-- Back Link -->
+    <div class="mb-6">
+        <a href="/Guilds/ScheduledMessages/@GuildId" class="inline-flex items-center gap-2 text-sm text-text-secondary hover:text-accent-blue transition-colors">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+            </svg>
+            Back to Scheduled Messages
+        </a>
+    </div>
+
+    <!-- Page Header -->
+    <div class="mb-8">
+        <h1 class="text-2xl font-bold text-text-primary">Create Scheduled Message</h1>
+        <p class="mt-1 text-sm text-text-secondary">Schedule a new automated message for @_guildName</p>
+    </div>
+
+    <!-- Error Alert -->
+    @if (!string.IsNullOrEmpty(_errorMessage))
+    {
+        <div class="mb-6">
+            <Alert Variant="AlertVariant.Error" Message="@_errorMessage" IsDismissible="true" />
+        </div>
+    }
+
+    <!-- Message Content Card -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg mb-6">
+        <div class="px-6 py-4 border-b border-border-primary">
+            <h2 class="text-lg font-semibold text-text-primary">Message Content</h2>
+        </div>
+        <div class="p-6 space-y-6">
+            <!-- Title -->
+            <FormInput Id="title"
+                       Name="title"
+                       Label="Title"
+                       Placeholder="Enter a title for this scheduled message"
+                       Value="@_title"
+                       ValueChanged="@((v) => _title = v)"
+                       IsRequired="true"
+                       MaxLength="200"
+                       ShowCharacterCount="true"
+                       ValidationState="@GetValidationState(nameof(_title))"
+                       ValidationMessage="@GetValidationMessage(nameof(_title))" />
+
+            <!-- Content (textarea) -->
+            <div class="space-y-1.5">
+                <label for="content" class="block text-sm font-medium text-text-primary">
+                    Message Content
+                    <span class="text-error">*</span>
+                </label>
+                <textarea id="content"
+                          name="content"
+                          rows="6"
+                          maxlength="2000"
+                          placeholder="Enter the message content to send (supports Discord markdown)"
+                          class="w-full py-2.5 px-3.5 text-sm text-text-primary bg-bg-primary border @(_validationErrors.ContainsKey(nameof(_content)) ? "border-error focus:border-error focus:ring-error/15" : "border-border-primary focus:border-accent-blue focus:ring-accent-blue/15") rounded-md placeholder-text-tertiary transition-colors focus:outline-none focus:ring-[3px]"
+                          @bind="_content"
+                          @bind:event="oninput"></textarea>
+                @if (_validationErrors.ContainsKey(nameof(_content)))
+                {
+                    <p class="flex items-center gap-1.5 text-xs text-error" role="alert">
+                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        </svg>
+                        @_validationErrors[nameof(_content)]
+                    </p>
+                }
+                <div class="flex justify-end">
+                    <span class="text-xs text-text-tertiary">
+                        @(_content?.Length ?? 0)/2000
+                    </span>
+                </div>
+            </div>
+
+            <!-- Target Channel -->
+            <FormSelect Id="channelId"
+                        Name="channelId"
+                        Label="Target Channel"
+                        Placeholder="Select a channel..."
+                        SelectedValue="@_selectedChannelId"
+                        SelectedValueChanged="@((v) => _selectedChannelId = v)"
+                        Options="@_channelOptions"
+                        IsRequired="true"
+                        ValidationState="@GetValidationState(nameof(_selectedChannelId))"
+                        ValidationMessage="@GetValidationMessage(nameof(_selectedChannelId))" />
+        </div>
+    </div>
+
+    <!-- Schedule Card -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg mb-6">
+        <div class="px-6 py-4 border-b border-border-primary">
+            <h2 class="text-lg font-semibold text-text-primary">Schedule</h2>
+        </div>
+        <div class="p-6 space-y-6">
+            <!-- Frequency -->
+            <FormSelect Id="frequency"
+                        Name="frequency"
+                        Label="Frequency"
+                        SelectedValue="@(((int)_frequency).ToString())"
+                        SelectedValueChanged="@OnFrequencyChanged"
+                        Options="@_frequencyOptions"
+                        IsRequired="true" />
+
+            <!-- Next Execution -->
+            <FormInput Id="nextExecution"
+                       Name="nextExecution"
+                       Label="Next Execution (UTC)"
+                       Type="datetime-local"
+                       Value="@_nextExecutionLocal"
+                       ValueChanged="@((v) => _nextExecutionLocal = v)"
+                       IsRequired="true"
+                       HelpText="Date and time in UTC when the message should first be sent"
+                       ValidationState="@GetValidationState(nameof(_nextExecutionLocal))"
+                       ValidationMessage="@GetValidationMessage(nameof(_nextExecutionLocal))" />
+
+            <!-- Cron Expression (Custom frequency only) -->
+            @if (_frequency == ScheduleFrequency.Custom)
+            {
+                <FormInput Id="cronExpression"
+                           Name="cronExpression"
+                           Label="Cron Expression"
+                           Placeholder="e.g., 0 9 * * 1 (every Monday at 9 AM)"
+                           Value="@_cronExpression"
+                           ValueChanged="@((v) => _cronExpression = v)"
+                           IsRequired="true"
+                           MaxLength="100"
+                           HelpText="Standard cron expression (minute hour day-of-month month day-of-week)"
+                           ValidationState="@GetValidationState(nameof(_cronExpression))"
+                           ValidationMessage="@GetValidationMessage(nameof(_cronExpression))" />
+            }
+        </div>
+    </div>
+
+    <!-- Status Card -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg mb-6">
+        <div class="px-6 py-4 border-b border-border-primary">
+            <h2 class="text-lg font-semibold text-text-primary">Status</h2>
+        </div>
+        <div class="p-6">
+            <FormToggle Id="isEnabled"
+                        Name="isEnabled"
+                        Label="Enabled"
+                        Description="When enabled, the message will be sent on schedule. Disable to pause execution."
+                        IsChecked="@_isEnabled"
+                        IsCheckedChanged="@((v) => _isEnabled = v)" />
+        </div>
+    </div>
+
+    <!-- Actions -->
+    <div class="flex items-center justify-end gap-3">
+        <a href="/Guilds/ScheduledMessages/@GuildId"
+           class="px-4 py-2 bg-bg-tertiary hover:bg-bg-hover border border-border-primary text-text-primary font-medium text-sm rounded-md transition-colors">
+            Cancel
+        </a>
+        <Button Text="Create Message"
+                Variant="ButtonVariant.Primary"
+                OnClick="@HandleCreate"
+                IsLoading="@_isSaving"
+                LoadingText="Creating..." />
+    </div>
+}
+
+@code {
+    [Parameter] public long GuildId { get; set; }
+
+    private string? _guildName;
+    private List<BreadcrumbItem>? _breadcrumbItems;
+    private List<SelectOption> _channelOptions = new();
+    private List<SelectOption> _frequencyOptions = new();
+
+    // Form fields
+    private string? _title;
+    private string? _content;
+    private string? _selectedChannelId;
+    private ScheduleFrequency _frequency = ScheduleFrequency.Daily;
+    private string? _nextExecutionLocal;
+    private string? _cronExpression;
+    private bool _isEnabled = true;
+
+    // State
+    private bool _isSaving;
+    private string? _errorMessage;
+    private Dictionary<string, string> _validationErrors = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        var guildId = (ulong)GuildId;
+        Logger.LogInformation("User accessing scheduled message create page for guild {GuildId}", guildId);
+
+        var guild = await GuildService.GetGuildByIdAsync(guildId);
+        if (guild == null)
+        {
+            Logger.LogWarning("Guild {GuildId} not found", guildId);
+            return;
+        }
+
+        _guildName = guild.Name;
+
+        // Load channels from Discord
+        LoadChannelOptions(guildId);
+
+        // Build frequency options
+        _frequencyOptions = new List<SelectOption>
+        {
+            new() { Value = ((int)ScheduleFrequency.Once).ToString(), Text = "Once" },
+            new() { Value = ((int)ScheduleFrequency.Hourly).ToString(), Text = "Hourly" },
+            new() { Value = ((int)ScheduleFrequency.Daily).ToString(), Text = "Daily" },
+            new() { Value = ((int)ScheduleFrequency.Weekly).ToString(), Text = "Weekly" },
+            new() { Value = ((int)ScheduleFrequency.Monthly).ToString(), Text = "Monthly" },
+            new() { Value = ((int)ScheduleFrequency.Custom).ToString(), Text = "Custom (Cron)" }
+        };
+
+        _breadcrumbItems = new List<BreadcrumbItem>
+        {
+            new() { Label = "Home", Url = "/" },
+            new() { Label = "Servers", Url = "/Guilds" },
+            new() { Label = guild.Name, Url = $"/Guilds/Details/{GuildId}" },
+            new() { Label = "Messages", Url = $"/Guilds/ScheduledMessages/{GuildId}" },
+            new() { Label = "Create", IsCurrent = true }
+        };
+    }
+
+    private void LoadChannelOptions(ulong guildId)
+    {
+        var discordGuild = DiscordClient.GetGuild(guildId);
+        if (discordGuild == null)
+        {
+            Logger.LogWarning("Could not fetch Discord guild {GuildId} from client", guildId);
+            return;
+        }
+
+        var channels = new List<(ulong Id, string Name, int Position, string Prefix)>();
+
+        foreach (var channel in discordGuild.TextChannels.Where(c => c != null))
+        {
+            var prefix = channel is SocketNewsChannel ? "\ud83d\udce2 " : "# ";
+            channels.Add((channel.Id, channel.Name, channel.Position, prefix));
+        }
+
+        foreach (var channel in discordGuild.VoiceChannels.Where(c => c != null))
+        {
+            channels.Add((channel.Id, channel.Name, channel.Position, "\ud83d\udd0a "));
+        }
+
+        foreach (var channel in discordGuild.StageChannels.Where(c => c != null))
+        {
+            channels.Add((channel.Id, channel.Name, channel.Position, "\ud83c\udfa4 "));
+        }
+
+        _channelOptions = channels
+            .OrderBy(c => c.Position)
+            .Select(c => new SelectOption
+            {
+                Value = c.Id.ToString(),
+                Text = $"{c.Prefix}{c.Name}"
+            })
+            .ToList();
+
+        Logger.LogDebug("Retrieved {ChannelCount} text-capable channels for guild {GuildId}",
+            _channelOptions.Count, guildId);
+    }
+
+    private void OnFrequencyChanged(string? value)
+    {
+        if (int.TryParse(value, out var intVal) && Enum.IsDefined(typeof(ScheduleFrequency), intVal))
+        {
+            _frequency = (ScheduleFrequency)intVal;
+        }
+
+        // Clear cron validation if not custom
+        if (_frequency != ScheduleFrequency.Custom)
+        {
+            _cronExpression = null;
+            _validationErrors.Remove(nameof(_cronExpression));
+        }
+    }
+
+    private bool Validate()
+    {
+        _validationErrors.Clear();
+
+        if (string.IsNullOrWhiteSpace(_title))
+        {
+            _validationErrors[nameof(_title)] = "Title is required.";
+        }
+        else if (_title.Length > 200)
+        {
+            _validationErrors[nameof(_title)] = "Title cannot exceed 200 characters.";
+        }
+
+        if (string.IsNullOrWhiteSpace(_content))
+        {
+            _validationErrors[nameof(_content)] = "Message content is required.";
+        }
+        else if (_content.Length > 2000)
+        {
+            _validationErrors[nameof(_content)] = "Message content cannot exceed 2000 characters (Discord limit).";
+        }
+
+        if (string.IsNullOrWhiteSpace(_selectedChannelId))
+        {
+            _validationErrors[nameof(_selectedChannelId)] = "A channel must be selected.";
+        }
+
+        if (string.IsNullOrWhiteSpace(_nextExecutionLocal))
+        {
+            _validationErrors[nameof(_nextExecutionLocal)] = "Next execution time is required.";
+        }
+
+        if (_frequency == ScheduleFrequency.Custom && string.IsNullOrWhiteSpace(_cronExpression))
+        {
+            _validationErrors[nameof(_cronExpression)] = "Cron expression is required for custom schedules.";
+        }
+
+        return _validationErrors.Count == 0;
+    }
+
+    private async Task HandleCreate()
+    {
+        _errorMessage = null;
+
+        if (!Validate())
+        {
+            return;
+        }
+
+        _isSaving = true;
+
+        try
+        {
+            // Validate cron expression for custom frequency
+            if (_frequency == ScheduleFrequency.Custom && !string.IsNullOrWhiteSpace(_cronExpression))
+            {
+                var (isValid, errorMessage) = await ScheduledMessageService.ValidateCronExpressionAsync(_cronExpression);
+                if (!isValid)
+                {
+                    _validationErrors[nameof(_cronExpression)] = errorMessage ?? "Invalid cron expression.";
+                    return;
+                }
+            }
+
+            // Parse the datetime-local value (treat as UTC)
+            if (!DateTime.TryParse(_nextExecutionLocal, out var nextExecution))
+            {
+                _validationErrors[nameof(_nextExecutionLocal)] = "Invalid date/time format.";
+                return;
+            }
+
+            var nextExecutionUtc = DateTime.SpecifyKind(nextExecution, DateTimeKind.Utc);
+
+            // Parse channel ID
+            if (!ulong.TryParse(_selectedChannelId, out var channelId))
+            {
+                _validationErrors[nameof(_selectedChannelId)] = "Invalid channel selection.";
+                return;
+            }
+
+            // Get current user identifier
+            var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+            var userId = authState.User.FindFirstValue(ClaimTypes.NameIdentifier) ?? "Unknown";
+
+            var createDto = new ScheduledMessageCreateDto
+            {
+                GuildId = (ulong)GuildId,
+                ChannelId = channelId,
+                Title = _title!.Trim(),
+                Content = _content!.Trim(),
+                Frequency = _frequency,
+                CronExpression = _frequency == ScheduleFrequency.Custom ? _cronExpression : null,
+                IsEnabled = _isEnabled,
+                NextExecutionAt = nextExecutionUtc,
+                CreatedBy = userId
+            };
+
+            var result = await ScheduledMessageService.CreateAsync(createDto);
+
+            Logger.LogInformation("Successfully created scheduled message {MessageId} for guild {GuildId}",
+                result.Id, GuildId);
+
+            await Toast.ShowAsync("success", "Scheduled message created successfully.");
+            NavigationManager.NavigateTo($"/Guilds/ScheduledMessages/{GuildId}");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to create scheduled message for guild {GuildId}", GuildId);
+            _errorMessage = "An error occurred while creating the scheduled message. Please try again.";
+        }
+        finally
+        {
+            _isSaving = false;
+        }
+    }
+
+    private ValidationState GetValidationState(string fieldName)
+    {
+        return _validationErrors.ContainsKey(fieldName) ? ValidationState.Error : ValidationState.None;
+    }
+
+    private string? GetValidationMessage(string fieldName)
+    {
+        return _validationErrors.TryGetValue(fieldName, out var message) ? message : null;
+    }
+}

--- a/src/DiscordBot.Bot/Components/Pages/Guilds/ScheduledMessages/ScheduledMessageEdit.razor
+++ b/src/DiscordBot.Bot/Components/Pages/Guilds/ScheduledMessages/ScheduledMessageEdit.razor
@@ -1,0 +1,612 @@
+@page "/Guilds/ScheduledMessages/Edit/{GuildId:long}/{MessageId:guid}"
+@rendermode InteractiveServer
+@attribute [Authorize(Policy = "RequireAdmin")]
+@attribute [Authorize(Policy = "GuildAccess")]
+@layout GuildLayout
+@using Discord.WebSocket
+@using DiscordBot.Core.DTOs
+@using DiscordBot.Core.Enums
+@using DiscordBot.Core.Interfaces
+@using DiscordBot.Bot.ViewModels.Pages
+@using System.Security.Claims
+@inject IScheduledMessageService ScheduledMessageService
+@inject IGuildService GuildService
+@inject DiscordSocketClient DiscordClient
+@inject ILogger<ScheduledMessageEdit> Logger
+@inject AuthenticationStateProvider AuthenticationStateProvider
+@inject NavigationManager NavigationManager
+@inject ToastInterop Toast
+
+<PageTitle>Edit Scheduled Message - Discord Bot Admin</PageTitle>
+
+@if (_message is null)
+{
+    <div class="flex items-center justify-center py-12">
+        <div class="text-text-secondary">Loading...</div>
+    </div>
+}
+else
+{
+    <!-- Breadcrumb -->
+    <GuildBreadcrumb Items="@_breadcrumbItems" />
+
+    <!-- Back Link -->
+    <div class="mb-6">
+        <a href="/Guilds/ScheduledMessages/@GuildId" class="inline-flex items-center gap-2 text-sm text-text-secondary hover:text-accent-blue transition-colors">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+            </svg>
+            Back to Scheduled Messages
+        </a>
+    </div>
+
+    <!-- Page Header -->
+    <div class="mb-8 flex items-start justify-between">
+        <div>
+            <h1 class="text-2xl font-bold text-text-primary">Edit Scheduled Message</h1>
+            <p class="mt-1 text-sm text-text-secondary">Edit scheduled message for @_guildName</p>
+        </div>
+        <div class="flex items-center gap-2">
+            <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-semibold @GetStatusBadgeClass()">
+                <span class="w-1.5 h-1.5 rounded-full @GetStatusDotClass()"></span>
+                @GetStatusDisplay()
+            </span>
+        </div>
+    </div>
+
+    <!-- Error Alert -->
+    @if (!string.IsNullOrEmpty(_errorMessage))
+    {
+        <div class="mb-6">
+            <Alert Variant="AlertVariant.Error" Message="@_errorMessage" IsDismissible="true" />
+        </div>
+    }
+
+    <!-- Message Content Card -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg mb-6">
+        <div class="px-6 py-4 border-b border-border-primary">
+            <h2 class="text-lg font-semibold text-text-primary">Message Content</h2>
+        </div>
+        <div class="p-6 space-y-6">
+            <!-- Title -->
+            <FormInput Id="title"
+                       Name="title"
+                       Label="Title"
+                       Placeholder="Enter a title for this scheduled message"
+                       Value="@_title"
+                       ValueChanged="@((v) => _title = v)"
+                       IsRequired="true"
+                       MaxLength="200"
+                       ShowCharacterCount="true"
+                       ValidationState="@GetValidationState(nameof(_title))"
+                       ValidationMessage="@GetValidationMessage(nameof(_title))" />
+
+            <!-- Content (textarea) -->
+            <div class="space-y-1.5">
+                <label for="content" class="block text-sm font-medium text-text-primary">
+                    Message Content
+                    <span class="text-error">*</span>
+                </label>
+                <textarea id="content"
+                          name="content"
+                          rows="6"
+                          maxlength="2000"
+                          placeholder="Enter the message content to send (supports Discord markdown)"
+                          class="w-full py-2.5 px-3.5 text-sm text-text-primary bg-bg-primary border @(_validationErrors.ContainsKey(nameof(_content)) ? "border-error focus:border-error focus:ring-error/15" : "border-border-primary focus:border-accent-blue focus:ring-accent-blue/15") rounded-md placeholder-text-tertiary transition-colors focus:outline-none focus:ring-[3px]"
+                          @bind="_content"
+                          @bind:event="oninput"></textarea>
+                @if (_validationErrors.ContainsKey(nameof(_content)))
+                {
+                    <p class="flex items-center gap-1.5 text-xs text-error" role="alert">
+                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        </svg>
+                        @_validationErrors[nameof(_content)]
+                    </p>
+                }
+                <div class="flex justify-end">
+                    <span class="text-xs text-text-tertiary">
+                        @(_content?.Length ?? 0)/2000
+                    </span>
+                </div>
+            </div>
+
+            <!-- Target Channel -->
+            <FormSelect Id="channelId"
+                        Name="channelId"
+                        Label="Target Channel"
+                        Placeholder="Select a channel..."
+                        SelectedValue="@_selectedChannelId"
+                        SelectedValueChanged="@((v) => _selectedChannelId = v)"
+                        Options="@_channelOptions"
+                        IsRequired="true"
+                        ValidationState="@GetValidationState(nameof(_selectedChannelId))"
+                        ValidationMessage="@GetValidationMessage(nameof(_selectedChannelId))" />
+        </div>
+    </div>
+
+    <!-- Schedule Card -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg mb-6">
+        <div class="px-6 py-4 border-b border-border-primary">
+            <h2 class="text-lg font-semibold text-text-primary">Schedule</h2>
+        </div>
+        <div class="p-6 space-y-6">
+            <!-- Frequency -->
+            <FormSelect Id="frequency"
+                        Name="frequency"
+                        Label="Frequency"
+                        SelectedValue="@(((int)_frequency).ToString())"
+                        SelectedValueChanged="@OnFrequencyChanged"
+                        Options="@_frequencyOptions"
+                        IsRequired="true" />
+
+            <!-- Next Execution -->
+            <FormInput Id="nextExecution"
+                       Name="nextExecution"
+                       Label="Next Execution (UTC)"
+                       Type="datetime-local"
+                       Value="@_nextExecutionLocal"
+                       ValueChanged="@((v) => _nextExecutionLocal = v)"
+                       IsRequired="true"
+                       HelpText="Date and time in UTC when the message should next be sent"
+                       ValidationState="@GetValidationState(nameof(_nextExecutionLocal))"
+                       ValidationMessage="@GetValidationMessage(nameof(_nextExecutionLocal))" />
+
+            <!-- Cron Expression (Custom frequency only) -->
+            @if (_frequency == ScheduleFrequency.Custom)
+            {
+                <FormInput Id="cronExpression"
+                           Name="cronExpression"
+                           Label="Cron Expression"
+                           Placeholder="e.g., 0 9 * * 1 (every Monday at 9 AM)"
+                           Value="@_cronExpression"
+                           ValueChanged="@((v) => _cronExpression = v)"
+                           IsRequired="true"
+                           MaxLength="100"
+                           HelpText="Standard cron expression (minute hour day-of-month month day-of-week)"
+                           ValidationState="@GetValidationState(nameof(_cronExpression))"
+                           ValidationMessage="@GetValidationMessage(nameof(_cronExpression))" />
+            }
+        </div>
+    </div>
+
+    <!-- Status Card -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg mb-6">
+        <div class="px-6 py-4 border-b border-border-primary">
+            <h2 class="text-lg font-semibold text-text-primary">Status</h2>
+        </div>
+        <div class="p-6">
+            <FormToggle Id="isEnabled"
+                        Name="isEnabled"
+                        Label="Enabled"
+                        Description="When enabled, the message will be sent on schedule. Disable to pause execution."
+                        IsChecked="@_isEnabled"
+                        IsCheckedChanged="@((v) => _isEnabled = v)" />
+        </div>
+    </div>
+
+    <!-- Metadata Card -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg mb-6">
+        <div class="px-6 py-4 border-b border-border-primary">
+            <h2 class="text-lg font-semibold text-text-primary">Details</h2>
+        </div>
+        <div class="p-6">
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+                <div>
+                    <span class="text-xs font-medium text-text-tertiary uppercase tracking-wider">Created</span>
+                    <p class="mt-1 text-sm text-text-primary" data-utc="@_createdAtUtcIso" data-format="datetime-seconds"></p>
+                </div>
+                <div>
+                    <span class="text-xs font-medium text-text-tertiary uppercase tracking-wider">Last Updated</span>
+                    <p class="mt-1 text-sm text-text-primary" data-utc="@_updatedAtUtcIso" data-format="datetime-seconds"></p>
+                </div>
+                <div>
+                    <span class="text-xs font-medium text-text-tertiary uppercase tracking-wider">Last Executed</span>
+                    @if (_lastExecutedAtUtcIso is not null)
+                    {
+                        <p class="mt-1 text-sm text-text-primary" data-utc="@_lastExecutedAtUtcIso" data-format="datetime-seconds"></p>
+                    }
+                    else
+                    {
+                        <p class="mt-1 text-sm text-text-tertiary">Never</p>
+                    }
+                </div>
+                <div>
+                    <span class="text-xs font-medium text-text-tertiary uppercase tracking-wider">Created By</span>
+                    <p class="mt-1 text-sm text-text-primary">@_message.CreatedBy</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Actions -->
+    <div class="flex items-center justify-between">
+        <Button Text="Delete Message"
+                Variant="ButtonVariant.Danger"
+                OnClick="@ShowDeleteConfirmation"
+                IsLoading="@_isDeleting"
+                LoadingText="Deleting..."
+                IconLeft="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+
+        <div class="flex items-center gap-3">
+            <a href="/Guilds/ScheduledMessages/@GuildId"
+               class="px-4 py-2 bg-bg-tertiary hover:bg-bg-hover border border-border-primary text-text-primary font-medium text-sm rounded-md transition-colors">
+                Cancel
+            </a>
+            <Button Text="Save Changes"
+                    Variant="ButtonVariant.Primary"
+                    OnClick="@HandleSave"
+                    IsLoading="@_isSaving"
+                    LoadingText="Saving..." />
+        </div>
+    </div>
+
+    <!-- Delete Confirmation Modal -->
+    <ConfirmationModal Id="deleteMessageModal"
+                       Title="Delete Scheduled Message"
+                       Message="@($"Are you sure you want to delete \"{_message.Title}\"? This action cannot be undone.")"
+                       ConfirmText="Delete"
+                       CancelText="Cancel"
+                       Variant="ConfirmationVariant.Danger"
+                       IsVisible="@_showDeleteConfirmation"
+                       IsVisibleChanged="@((v) => _showDeleteConfirmation = v)"
+                       OnConfirm="@HandleDelete" />
+}
+
+@code {
+    [Parameter] public long GuildId { get; set; }
+    [Parameter] public Guid MessageId { get; set; }
+
+    private ScheduledMessageDto? _message;
+    private string? _guildName;
+    private List<BreadcrumbItem>? _breadcrumbItems;
+    private List<SelectOption> _channelOptions = new();
+    private List<SelectOption> _frequencyOptions = new();
+
+    // Form fields
+    private string? _title;
+    private string? _content;
+    private string? _selectedChannelId;
+    private ScheduleFrequency _frequency = ScheduleFrequency.Daily;
+    private string? _nextExecutionLocal;
+    private string? _cronExpression;
+    private bool _isEnabled = true;
+
+    // Metadata
+    private string? _createdAtUtcIso;
+    private string? _updatedAtUtcIso;
+    private string? _lastExecutedAtUtcIso;
+
+    // State
+    private bool _isSaving;
+    private bool _isDeleting;
+    private bool _showDeleteConfirmation;
+    private string? _errorMessage;
+    private Dictionary<string, string> _validationErrors = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        var guildId = (ulong)GuildId;
+        Logger.LogInformation("User accessing scheduled message edit page for message {MessageId} in guild {GuildId}", MessageId, guildId);
+
+        // Load the message
+        var message = await ScheduledMessageService.GetByIdAsync(MessageId);
+        if (message == null)
+        {
+            Logger.LogWarning("Scheduled message {MessageId} not found", MessageId);
+            return;
+        }
+
+        // Verify message belongs to this guild
+        if (message.GuildId != guildId)
+        {
+            Logger.LogWarning("Scheduled message {MessageId} does not belong to guild {GuildId}", MessageId, guildId);
+            return;
+        }
+
+        _message = message;
+
+        // Load guild info
+        var guild = await GuildService.GetGuildByIdAsync(guildId);
+        if (guild == null)
+        {
+            Logger.LogWarning("Guild {GuildId} not found", guildId);
+            return;
+        }
+
+        _guildName = guild.Name;
+
+        // Load channels from Discord
+        LoadChannelOptions(guildId);
+
+        // Build frequency options
+        _frequencyOptions = new List<SelectOption>
+        {
+            new() { Value = ((int)ScheduleFrequency.Once).ToString(), Text = "Once" },
+            new() { Value = ((int)ScheduleFrequency.Hourly).ToString(), Text = "Hourly" },
+            new() { Value = ((int)ScheduleFrequency.Daily).ToString(), Text = "Daily" },
+            new() { Value = ((int)ScheduleFrequency.Weekly).ToString(), Text = "Weekly" },
+            new() { Value = ((int)ScheduleFrequency.Monthly).ToString(), Text = "Monthly" },
+            new() { Value = ((int)ScheduleFrequency.Custom).ToString(), Text = "Custom (Cron)" }
+        };
+
+        // Populate form fields from existing message
+        _title = message.Title;
+        _content = message.Content;
+        _selectedChannelId = message.ChannelId.ToString();
+        _frequency = message.Frequency;
+        _cronExpression = message.CronExpression;
+        _isEnabled = message.IsEnabled;
+
+        // Format next execution for datetime-local input (yyyy-MM-ddTHH:mm)
+        if (message.NextExecutionAt.HasValue)
+        {
+            var utcTime = DateTime.SpecifyKind(message.NextExecutionAt.Value, DateTimeKind.Utc);
+            _nextExecutionLocal = utcTime.ToString("yyyy-MM-ddTHH:mm");
+        }
+
+        // Metadata for display
+        _createdAtUtcIso = DateTime.SpecifyKind(message.CreatedAt, DateTimeKind.Utc).ToString("o");
+        _updatedAtUtcIso = DateTime.SpecifyKind(message.UpdatedAt, DateTimeKind.Utc).ToString("o");
+        _lastExecutedAtUtcIso = message.LastExecutedAt.HasValue
+            ? DateTime.SpecifyKind(message.LastExecutedAt.Value, DateTimeKind.Utc).ToString("o")
+            : null;
+
+        _breadcrumbItems = new List<BreadcrumbItem>
+        {
+            new() { Label = "Home", Url = "/" },
+            new() { Label = "Servers", Url = "/Guilds" },
+            new() { Label = guild.Name, Url = $"/Guilds/Details/{GuildId}" },
+            new() { Label = "Messages", Url = $"/Guilds/ScheduledMessages/{GuildId}" },
+            new() { Label = "Edit", IsCurrent = true }
+        };
+    }
+
+    private void LoadChannelOptions(ulong guildId)
+    {
+        var discordGuild = DiscordClient.GetGuild(guildId);
+        if (discordGuild == null)
+        {
+            Logger.LogWarning("Could not fetch Discord guild {GuildId} from client", guildId);
+            return;
+        }
+
+        var channels = new List<(ulong Id, string Name, int Position, string Prefix)>();
+
+        foreach (var channel in discordGuild.TextChannels.Where(c => c != null))
+        {
+            var prefix = channel is SocketNewsChannel ? "\ud83d\udce2 " : "# ";
+            channels.Add((channel.Id, channel.Name, channel.Position, prefix));
+        }
+
+        foreach (var channel in discordGuild.VoiceChannels.Where(c => c != null))
+        {
+            channels.Add((channel.Id, channel.Name, channel.Position, "\ud83d\udd0a "));
+        }
+
+        foreach (var channel in discordGuild.StageChannels.Where(c => c != null))
+        {
+            channels.Add((channel.Id, channel.Name, channel.Position, "\ud83c\udfa4 "));
+        }
+
+        _channelOptions = channels
+            .OrderBy(c => c.Position)
+            .Select(c => new SelectOption
+            {
+                Value = c.Id.ToString(),
+                Text = $"{c.Prefix}{c.Name}"
+            })
+            .ToList();
+
+        Logger.LogDebug("Retrieved {ChannelCount} text-capable channels for guild {GuildId}",
+            _channelOptions.Count, guildId);
+    }
+
+    private void OnFrequencyChanged(string? value)
+    {
+        if (int.TryParse(value, out var intVal) && Enum.IsDefined(typeof(ScheduleFrequency), intVal))
+        {
+            _frequency = (ScheduleFrequency)intVal;
+        }
+
+        if (_frequency != ScheduleFrequency.Custom)
+        {
+            _cronExpression = null;
+            _validationErrors.Remove(nameof(_cronExpression));
+        }
+    }
+
+    private bool Validate()
+    {
+        _validationErrors.Clear();
+
+        if (string.IsNullOrWhiteSpace(_title))
+        {
+            _validationErrors[nameof(_title)] = "Title is required.";
+        }
+        else if (_title.Length > 200)
+        {
+            _validationErrors[nameof(_title)] = "Title cannot exceed 200 characters.";
+        }
+
+        if (string.IsNullOrWhiteSpace(_content))
+        {
+            _validationErrors[nameof(_content)] = "Message content is required.";
+        }
+        else if (_content.Length > 2000)
+        {
+            _validationErrors[nameof(_content)] = "Message content cannot exceed 2000 characters (Discord limit).";
+        }
+
+        if (string.IsNullOrWhiteSpace(_selectedChannelId))
+        {
+            _validationErrors[nameof(_selectedChannelId)] = "A channel must be selected.";
+        }
+
+        if (string.IsNullOrWhiteSpace(_nextExecutionLocal))
+        {
+            _validationErrors[nameof(_nextExecutionLocal)] = "Next execution time is required.";
+        }
+
+        if (_frequency == ScheduleFrequency.Custom && string.IsNullOrWhiteSpace(_cronExpression))
+        {
+            _validationErrors[nameof(_cronExpression)] = "Cron expression is required for custom schedules.";
+        }
+
+        return _validationErrors.Count == 0;
+    }
+
+    private async Task HandleSave()
+    {
+        _errorMessage = null;
+
+        if (!Validate())
+        {
+            return;
+        }
+
+        _isSaving = true;
+
+        try
+        {
+            // Validate cron expression for custom frequency
+            if (_frequency == ScheduleFrequency.Custom && !string.IsNullOrWhiteSpace(_cronExpression))
+            {
+                var (isValid, errorMessage) = await ScheduledMessageService.ValidateCronExpressionAsync(_cronExpression);
+                if (!isValid)
+                {
+                    _validationErrors[nameof(_cronExpression)] = errorMessage ?? "Invalid cron expression.";
+                    return;
+                }
+            }
+
+            // Parse the datetime-local value (treat as UTC)
+            if (!DateTime.TryParse(_nextExecutionLocal, out var nextExecution))
+            {
+                _validationErrors[nameof(_nextExecutionLocal)] = "Invalid date/time format.";
+                return;
+            }
+
+            var nextExecutionUtc = DateTime.SpecifyKind(nextExecution, DateTimeKind.Utc);
+
+            // Parse channel ID
+            if (!ulong.TryParse(_selectedChannelId, out var channelId))
+            {
+                _validationErrors[nameof(_selectedChannelId)] = "Invalid channel selection.";
+                return;
+            }
+
+            var updateDto = new ScheduledMessageUpdateDto
+            {
+                ChannelId = channelId,
+                Title = _title!.Trim(),
+                Content = _content!.Trim(),
+                Frequency = _frequency,
+                CronExpression = _frequency == ScheduleFrequency.Custom ? _cronExpression : null,
+                IsEnabled = _isEnabled,
+                NextExecutionAt = nextExecutionUtc
+            };
+
+            var result = await ScheduledMessageService.UpdateAsync(MessageId, updateDto);
+
+            if (result == null)
+            {
+                Logger.LogWarning("Scheduled message {MessageId} not found during update", MessageId);
+                _errorMessage = "Scheduled message not found. It may have been deleted.";
+                return;
+            }
+
+            Logger.LogInformation("Successfully updated scheduled message {MessageId} for guild {GuildId}",
+                MessageId, GuildId);
+
+            await Toast.ShowAsync("success", "Scheduled message updated successfully.");
+            NavigationManager.NavigateTo($"/Guilds/ScheduledMessages/{GuildId}");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to update scheduled message {MessageId} for guild {GuildId}", MessageId, GuildId);
+            _errorMessage = "An error occurred while updating the scheduled message. Please try again.";
+        }
+        finally
+        {
+            _isSaving = false;
+        }
+    }
+
+    private void ShowDeleteConfirmation()
+    {
+        _showDeleteConfirmation = true;
+    }
+
+    private async Task HandleDelete()
+    {
+        _errorMessage = null;
+        _isDeleting = true;
+
+        try
+        {
+            var deleted = await ScheduledMessageService.DeleteAsync(MessageId);
+
+            if (!deleted)
+            {
+                Logger.LogWarning("Failed to delete scheduled message {MessageId}", MessageId);
+                _errorMessage = "Failed to delete the scheduled message.";
+                return;
+            }
+
+            Logger.LogInformation("Successfully deleted scheduled message {MessageId} for guild {GuildId}",
+                MessageId, GuildId);
+
+            await Toast.ShowAsync("success", "Scheduled message deleted successfully.");
+            NavigationManager.NavigateTo($"/Guilds/ScheduledMessages/{GuildId}");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to delete scheduled message {MessageId} for guild {GuildId}", MessageId, GuildId);
+            _errorMessage = "An error occurred while deleting the scheduled message. Please try again.";
+        }
+        finally
+        {
+            _isDeleting = false;
+        }
+    }
+
+    private string GetStatusDisplay()
+    {
+        if (!_isEnabled) return "Paused";
+        if (_frequency == ScheduleFrequency.Once && _message?.LastExecutedAt.HasValue == true) return "Expired";
+        return "Active";
+    }
+
+    private string GetStatusBadgeClass()
+    {
+        return GetStatusDisplay() switch
+        {
+            "Active" => "bg-success/20 text-success",
+            "Paused" => "bg-warning/20 text-warning",
+            "Expired" => "bg-bg-tertiary text-text-tertiary",
+            _ => "bg-bg-tertiary text-text-tertiary"
+        };
+    }
+
+    private string GetStatusDotClass()
+    {
+        return GetStatusDisplay() switch
+        {
+            "Active" => "bg-success",
+            "Paused" => "bg-warning",
+            "Expired" => "bg-text-tertiary",
+            _ => "bg-text-tertiary"
+        };
+    }
+
+    private ValidationState GetValidationState(string fieldName)
+    {
+        return _validationErrors.ContainsKey(fieldName) ? ValidationState.Error : ValidationState.None;
+    }
+
+    private string? GetValidationMessage(string fieldName)
+    {
+        return _validationErrors.TryGetValue(fieldName, out var message) ? message : null;
+    }
+}

--- a/src/DiscordBot.Bot/Pages/Admin/Users/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Users/Index.cshtml
@@ -13,7 +13,7 @@
         </div>
         @if (Model.ViewModel.CanCreateUsers)
         {
-            <a asp-page="Create" class="btn btn-primary">
+            <a href="/Admin/Users/Create" class="btn btn-primary">
                 <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
                 </svg>
@@ -205,7 +205,7 @@
                                         <a asp-page="Details" asp-route-id="@user.Id" class="text-accent-blue hover:text-accent-blue/80">
                                             View
                                         </a>
-                                        <a asp-page="Edit" asp-route-id="@user.Id" class="text-accent-blue hover:text-accent-blue/80">
+                                        <a href="/Admin/Users/@user.Id/Edit" class="text-accent-blue hover:text-accent-blue/80">
                                             Edit
                                         </a>
                                     </div>

--- a/src/DiscordBot.Bot/Pages/Guilds/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Index.cshtml
@@ -221,7 +221,7 @@
                                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
                                             </svg>
                                         </a>
-                                        <a asp-page="Edit" asp-route-id="@guild.Id" class="p-2 text-text-secondary hover:text-accent-orange hover:bg-bg-hover rounded transition-colors" title="Configure">
+                                        <a href="/Guilds/Edit/@guild.Id" class="p-2 text-text-secondary hover:text-accent-orange hover:bg-bg-hover rounded transition-colors" title="Configure">
                                             <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
                                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
@@ -330,7 +330,7 @@
                             </svg>
                             View
                         </a>
-                        <a asp-page="Edit" asp-route-id="@guild.Id" class="flex-1 inline-flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-text-secondary hover:text-text-primary border border-border-primary hover:bg-bg-hover rounded-lg transition-colors">
+                        <a href="/Guilds/Edit/@guild.Id" class="flex-1 inline-flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-text-secondary hover:text-text-primary border border-border-primary hover:bg-bg-hover rounded-lg transition-colors">
                             <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />

--- a/src/DiscordBot.Bot/Pages/Guilds/ScheduledMessages/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/ScheduledMessages/Index.cshtml
@@ -125,9 +125,7 @@
                                     <div class="flex items-center justify-end gap-1 row-actions">
                                         <!-- Edit Button -->
                                         <a
-                                            asp-page="Edit"
-                                            asp-route-guildId="@Model.ViewModel.GuildId"
-                                            asp-route-id="@message.Id"
+                                            href="/Guilds/ScheduledMessages/Edit/@Model.ViewModel.GuildId/@message.Id"
                                             class="p-2 text-text-secondary hover:text-accent-blue hover:bg-accent-blue/10 rounded-md transition-colors"
                                             title="Edit"
                                         >
@@ -256,8 +254,7 @@
                 You haven't created any scheduled messages yet. Create your first one to automate messages in your server.
             </p>
             <a
-                asp-page="Create"
-                asp-route-guildId="@Model.ViewModel.GuildId"
+                href="/Guilds/ScheduledMessages/Create/@Model.ViewModel.GuildId"
                 class="inline-flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium text-white bg-accent-orange border border-accent-orange rounded-md hover:bg-accent-orange-hover transition-colors"
             >
                 <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">


### PR DESCRIPTION
## Summary
- Migrates 6 Razor Pages to Blazor components with form validation, toast notifications, and shared component library
- **UserCreate.razor** — Create user form with email, password, role selection, welcome email toggle
- **UserEdit.razor** — Edit user form with reset password, unlink Discord (confirmation modals), self-edit protection
- **GuildEdit.razor** — Guild general settings (active toggle) + audio settings (enabled, auto-leave timeout, queue)
- **GuildWelcome.razor** — Welcome message configuration with token insertion, embed color picker, channel selection
- **ScheduledMessageCreate.razor** — Scheduled message form with frequency selection, cron validation, channel selection
- **ScheduledMessageEdit.razor** — Edit + delete scheduled messages with status display and metadata
- Updates navigation links in 5 existing pages to use plain `href` instead of `asp-page` tag helpers

## Test plan
- [ ] Navigate to Admin > Users > Create, fill form, submit — verify user created with toast
- [ ] Navigate to Admin > Users > Edit for existing user — verify edit, reset password, unlink Discord
- [ ] Edit self — verify role and active toggles are disabled
- [ ] Navigate to Guild > Edit — verify general and audio settings save
- [ ] Navigate to Guild > Welcome — verify enable toggle, channel selection, token insertion, embed color
- [ ] Navigate to Guild > Scheduled Messages > Create — verify all frequency types, cron validation
- [ ] Navigate to Guild > Scheduled Messages > Edit — verify pre-population, save, and delete
- [ ] Verify all navigation links work from Index pages and GuildDetails
- [ ] Verify validation messages appear for required fields
- [ ] Verify toast notifications on success and error alerts on failure

Closes #1629

🤖 Generated with [Claude Code](https://claude.com/claude-code)