### PR TITLE
feat: migrate settings and config pages to Blazor (#1632)

### DIFF
--- a/src/DiscordBot.Bot/Components/Pages/Admin/AdminSettings.razor
+++ b/src/DiscordBot.Bot/Components/Pages/Admin/AdminSettings.razor
@@ -1,0 +1,1256 @@
+@page "/Admin/Settings"
+@attribute [Authorize(Policy = "RequireAdmin")]
+@rendermode InteractiveServer
+@using DiscordBot.Bot.Components.Interop
+@using DiscordBot.Bot.Services
+@using DiscordBot.Bot.ViewModels.Pages
+@using DiscordBot.Core.DTOs
+@using DiscordBot.Core.Enums
+@using DiscordBot.Core.Interfaces
+@using Microsoft.AspNetCore.Authorization
+@using System.Text.Json
+@inject ISettingsService SettingsService
+@inject ICommandModuleConfigurationService CommandModuleConfigurationService
+@inject IThemeService ThemeService
+@inject IAuthorizationService AuthorizationService
+@inject IAuditLogQueue AuditLogQueue
+@inject IBotService BotService
+@inject ToastInterop Toast
+@inject AuthenticationStateProvider AuthenticationStateProvider
+@inject ILogger<AdminSettings> Logger
+
+<PageTitle>Settings - Discord Bot Admin</PageTitle>
+
+@if (_isLoading)
+{
+    <div class="flex items-center justify-center py-12">
+        <div class="text-text-secondary">Loading...</div>
+    </div>
+}
+else
+{
+    <!-- Restart Required Banner -->
+    @if (_isRestartPending)
+    {
+        <div class="mb-6 bg-warning/10 border border-warning/30 rounded-lg p-4">
+            <div class="flex items-start gap-3">
+                <svg class="w-5 h-5 text-warning flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                </svg>
+                <div class="flex-1">
+                    <p class="text-sm font-semibold text-warning">Restart Required</p>
+                    <p class="text-sm text-text-secondary mt-1">
+                        One or more settings have been changed that require a bot restart to take effect.
+                        Go to the <button type="button" @onclick='() => _activeTab = "BotControl"' class="underline hover:no-underline text-warning">Bot Control</button> tab to restart.
+                    </p>
+                </div>
+            </div>
+        </div>
+    }
+
+    <!-- Page Header -->
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+        <div>
+            <h1 class="text-2xl lg:text-3xl font-bold text-text-primary">Settings</h1>
+            <p class="text-text-secondary mt-1">Manage your bot configuration and preferences</p>
+        </div>
+        <div class="flex items-center gap-3">
+            <Button Text="Reset All"
+                    Variant="ButtonVariant.Secondary"
+                    IconLeft="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                    OnClick="ShowResetAllModal" />
+            <Button Text="Save All"
+                    Variant="ButtonVariant.Primary"
+                    IconLeft="M5 13l4 4L19 7"
+                    IsLoading="_isSavingAll"
+                    LoadingText="Saving..."
+                    OnClick="SaveAllAsync" />
+        </div>
+    </div>
+
+    <!-- Settings Navigation Tabs -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg p-2 mb-6">
+        <div class="flex flex-wrap gap-2" role="tablist" aria-label="Settings sections">
+            <button class="settings-tab @(_activeTab == "General" ? "active" : "")"
+                    role="tab"
+                    aria-selected="@(_activeTab == "General" ? "true" : "false")"
+                    @onclick='() => _activeTab = "General"'>
+                <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                </svg>
+                General
+            </button>
+            <button class="settings-tab @(_activeTab == "Features" ? "active" : "")"
+                    role="tab"
+                    aria-selected="@(_activeTab == "Features" ? "true" : "false")"
+                    @onclick='() => _activeTab = "Features"'>
+                <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01" />
+                </svg>
+                Features
+            </button>
+            <button class="settings-tab @(_activeTab == "Commands" ? "active" : "")"
+                    role="tab"
+                    aria-selected="@(_activeTab == "Commands" ? "true" : "false")"
+                    @onclick='() => _activeTab = "Commands"'>
+                <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                </svg>
+                Commands
+            </button>
+            <button class="settings-tab @(_activeTab == "Advanced" ? "active" : "")"
+                    role="tab"
+                    aria-selected="@(_activeTab == "Advanced" ? "true" : "false")"
+                    @onclick='() => _activeTab = "Advanced"'>
+                <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
+                </svg>
+                Advanced
+            </button>
+            <button class="settings-tab @(_activeTab == "BotControl" ? "active" : "")"
+                    role="tab"
+                    aria-selected="@(_activeTab == "BotControl" ? "true" : "false")"
+                    @onclick='() => _activeTab = "BotControl"'>
+                <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2zM9 9h6v6H9V9z" />
+                </svg>
+                Bot Control
+            </button>
+            @if (_isSuperAdmin)
+            {
+                <button class="settings-tab @(_activeTab == "Appearance" ? "active" : "")"
+                        role="tab"
+                        aria-selected="@(_activeTab == "Appearance" ? "true" : "false")"
+                        @onclick='() => _activeTab = "Appearance"'>
+                    <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01" />
+                    </svg>
+                    Appearance
+                </button>
+            }
+        </div>
+    </div>
+
+    <!-- General Settings Tab -->
+    @if (_activeTab == "General")
+    {
+        <SettingsCategorySection Title="General Settings"
+                                 Description="Configure your bot's basic settings and behavior"
+                                 Settings="_generalSettings"
+                                 SettingValues="_settingValues"
+                                 OnSettingChanged="OnSettingValueChanged"
+                                 OnSave="() => SaveCategoryAsync(SettingCategory.General)"
+                                 OnReset="() => ShowResetCategoryModal(SettingCategory.General)"
+                                 IsSaving="_isSavingGeneral" />
+    }
+
+    <!-- Features Settings Tab -->
+    @if (_activeTab == "Features")
+    {
+        <SettingsCategorySection Title="Features Settings"
+                                 Description="Enable or disable global bot features"
+                                 Settings="_featuresSettings"
+                                 SettingValues="_settingValues"
+                                 OnSettingChanged="OnSettingValueChanged"
+                                 OnSave="() => SaveCategoryAsync(SettingCategory.Features)"
+                                 OnReset="() => ShowResetCategoryModal(SettingCategory.Features)"
+                                 IsSaving="_isSavingFeatures" />
+    }
+
+    <!-- Commands Settings Tab -->
+    @if (_activeTab == "Commands")
+    {
+        <div class="bg-bg-secondary border border-border-primary rounded-lg mb-6">
+            <div class="px-6 py-4 border-b border-border-primary">
+                <h2 class="text-lg font-semibold text-text-primary">Command Modules</h2>
+                <p class="text-sm text-text-secondary mt-1">Enable or disable Discord slash command modules. Changes require a bot restart to take effect.</p>
+            </div>
+            <div class="p-6 space-y-8">
+                @foreach (var category in _commandCategoryOrder)
+                {
+                    if (_commandModulesByCategory.TryGetValue(category, out var modules) && modules.Count > 0)
+                    {
+                        var isCoreCategory = category == "Core";
+                        <div>
+                            <div class="flex items-center gap-2 mb-4">
+                                <h3 class="text-base font-semibold text-text-primary">@category Commands</h3>
+                                @if (isCoreCategory)
+                                {
+                                    <span class="inline-flex items-center gap-1 px-2 py-0.5 bg-info/10 border border-info text-info text-xs font-medium rounded">
+                                        <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+                                        </svg>
+                                        Always Enabled
+                                    </span>
+                                }
+                            </div>
+                            @if (_commandCategoryDescriptions.TryGetValue(category, out var categoryDesc))
+                            {
+                                <p class="text-sm text-text-secondary mb-4">@categoryDesc</p>
+                            }
+                            <div class="space-y-3">
+                                @foreach (var module in modules)
+                                {
+                                    var moduleName = module.ModuleName;
+                                    var isEnabled = _commandModuleStates.GetValueOrDefault(moduleName, module.IsEnabled);
+                                    <div class="flex items-start gap-4 p-4 bg-bg-primary rounded-lg border border-border-primary @(isCoreCategory ? "opacity-75" : "")">
+                                        <FormToggle Id="@($"module_{moduleName}")"
+                                                    Name="@($"CommandModules[{moduleName}]")"
+                                                    IsChecked="isEnabled"
+                                                    IsCheckedChanged="(val) => OnCommandModuleChanged(moduleName, val)"
+                                                    IsDisabled="isCoreCategory" />
+                                        <div class="flex-1 min-w-0">
+                                            <label for="@($"module_{moduleName}")" class="block text-sm font-semibold text-text-primary @(isCoreCategory ? "cursor-not-allowed" : "cursor-pointer")">
+                                                @module.DisplayName
+                                            </label>
+                                            @if (!string.IsNullOrEmpty(module.Description))
+                                            {
+                                                <p class="text-xs text-text-secondary mt-1">@module.Description</p>
+                                            }
+                                        </div>
+                                        @if (module.RequiresRestart && !isCoreCategory)
+                                        {
+                                            <div class="flex-shrink-0">
+                                                <span class="inline-flex items-center gap-1 px-2 py-1 bg-warning/10 border border-warning text-warning text-xs font-medium rounded">
+                                                    <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                                                    </svg>
+                                                    Restart Required
+                                                </span>
+                                            </div>
+                                        }
+                                    </div>
+                                }
+                            </div>
+                        </div>
+                    }
+                }
+            </div>
+            <div class="px-6 py-4 border-t border-border-primary">
+                <div class="flex justify-end gap-3">
+                    <Button Text="Save Changes"
+                            Variant="ButtonVariant.Primary"
+                            IsLoading="_isSavingCommands"
+                            LoadingText="Saving..."
+                            OnClick="SaveCommandModulesAsync" />
+                </div>
+            </div>
+        </div>
+    }
+
+    <!-- Advanced Settings Tab -->
+    @if (_activeTab == "Advanced")
+    {
+        <SettingsCategorySection Title="Advanced Settings"
+                                 Description="Configure data retention policies"
+                                 Settings="_advancedSettings"
+                                 SettingValues="_settingValues"
+                                 OnSettingChanged="OnSettingValueChanged"
+                                 OnSave="() => SaveCategoryAsync(SettingCategory.Advanced)"
+                                 OnReset="() => ShowResetCategoryModal(SettingCategory.Advanced)"
+                                 IsSaving="_isSavingAdvanced" />
+    }
+
+    <!-- Bot Control Tab -->
+    @if (_activeTab == "BotControl")
+    {
+        <!-- Main Content Grid -->
+        <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
+            <!-- Bot Status Card -->
+            <div class="lg:col-span-2">
+                <div class="bg-bg-secondary border border-border-primary rounded-lg">
+                    <div class="px-6 py-4 border-b border-border-primary">
+                        <h2 class="text-lg font-semibold text-text-primary">Bot Status</h2>
+                        <p class="text-sm text-text-secondary mt-1">Real-time bot connection status</p>
+                    </div>
+                    <div class="p-6">
+                        <div class="grid grid-cols-2 md:grid-cols-4 gap-6">
+                            <div>
+                                <p class="text-sm font-medium text-text-tertiary mb-1">Status</p>
+                                <div class="flex items-center gap-2">
+                                    <span class="w-2.5 h-2.5 rounded-full @(_botStatus?.ConnectionState == "Connected" ? "bg-success animate-pulse" : "bg-error")"></span>
+                                    <span class="text-lg font-semibold text-text-primary">@(_botStatus?.ConnectionState ?? "Unknown")</span>
+                                </div>
+                            </div>
+                            <div>
+                                <p class="text-sm font-medium text-text-tertiary mb-1">Uptime</p>
+                                <span class="text-lg font-semibold text-text-primary">@(_botStatus?.UptimeFormatted ?? "--")</span>
+                            </div>
+                            <div>
+                                <p class="text-sm font-medium text-text-tertiary mb-1">Latency</p>
+                                <span class="text-lg font-semibold text-text-primary">@(_botStatus?.LatencyMs ?? 0) ms</span>
+                            </div>
+                            <div>
+                                <p class="text-sm font-medium text-text-tertiary mb-1">Servers</p>
+                                <span class="text-lg font-semibold text-text-primary">@(_botStatus?.GuildCount ?? 0)</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Quick Actions Card -->
+            <div>
+                <div class="bg-bg-secondary border border-border-primary rounded-lg">
+                    <div class="px-6 py-4 border-b border-border-primary">
+                        <h2 class="text-lg font-semibold text-text-primary">Actions</h2>
+                        <p class="text-sm text-text-secondary mt-1">Bot lifecycle controls</p>
+                    </div>
+                    <div class="p-6 space-y-4">
+                        <button type="button"
+                                @onclick="ShowRestartModal"
+                                class="w-full flex items-center justify-center gap-2 px-4 py-3 bg-warning hover:bg-amber-600 active:bg-amber-700 text-text-inverse font-semibold text-sm rounded-lg transition-colors">
+                            <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                            </svg>
+                            Restart Bot
+                        </button>
+                        <p class="text-xs text-text-tertiary text-center">
+                            Restarts the Discord connection without stopping the application.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Configuration Card -->
+        <div class="mb-6">
+            <div class="bg-bg-secondary border border-border-primary rounded-lg">
+                <div class="px-6 py-4 border-b border-border-primary">
+                    <h2 class="text-lg font-semibold text-text-primary">Configuration</h2>
+                    <p class="text-sm text-text-secondary mt-1">Current bot configuration (read-only)</p>
+                </div>
+                <div class="p-6">
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                        <div class="space-y-1">
+                            <p class="text-sm font-medium text-text-tertiary">Bot Token</p>
+                            <p class="text-sm font-mono text-text-primary bg-bg-primary px-3 py-2 rounded-md border border-border-primary">
+                                @(_botConfiguration?.TokenMasked ?? "--")
+                            </p>
+                        </div>
+                        <div class="space-y-1">
+                            <p class="text-sm font-medium text-text-tertiary">Test Guild ID</p>
+                            <p class="text-sm font-mono text-text-primary bg-bg-primary px-3 py-2 rounded-md border border-border-primary">
+                                @(_botConfiguration is { HasTestGuild: true } ? _botConfiguration.TestGuildId.ToString() : "Not configured")
+                            </p>
+                        </div>
+                        <div class="space-y-1">
+                            <p class="text-sm font-medium text-text-tertiary">Database Provider</p>
+                            <p class="text-sm text-text-primary bg-bg-primary px-3 py-2 rounded-md border border-border-primary">
+                                @(_botConfiguration?.DatabaseProvider ?? "--")
+                            </p>
+                        </div>
+                        <div class="space-y-1">
+                            <p class="text-sm font-medium text-text-tertiary">Default Rate Limit</p>
+                            <p class="text-sm text-text-primary bg-bg-primary px-3 py-2 rounded-md border border-border-primary">
+                                @(_botConfiguration?.DefaultRateLimitInvokes ?? 0) invokes / @(_botConfiguration?.DefaultRateLimitPeriodSeconds ?? 0) seconds
+                            </p>
+                        </div>
+                        <div class="space-y-1">
+                            <p class="text-sm font-medium text-text-tertiary">Discord.NET Version</p>
+                            <p class="text-sm text-text-primary bg-bg-primary px-3 py-2 rounded-md border border-border-primary">
+                                @(_botConfiguration?.DiscordNetVersion ?? "--")
+                            </p>
+                        </div>
+                        <div class="space-y-1">
+                            <p class="text-sm font-medium text-text-tertiary">Application Version</p>
+                            <p class="text-sm text-text-primary bg-bg-primary px-3 py-2 rounded-md border border-border-primary">
+                                @(_botConfiguration?.AppVersion ?? "--")
+                            </p>
+                        </div>
+                        <div class="space-y-1">
+                            <p class="text-sm font-medium text-text-tertiary">.NET Runtime</p>
+                            <p class="text-sm text-text-primary bg-bg-primary px-3 py-2 rounded-md border border-border-primary">
+                                @(_botConfiguration?.RuntimeVersion ?? "--")
+                            </p>
+                        </div>
+                        <div class="space-y-1">
+                            <p class="text-sm font-medium text-text-tertiary">Started At (UTC)</p>
+                            <p class="text-sm text-text-primary bg-bg-primary px-3 py-2 rounded-md border border-border-primary">
+                                @(_botStatus?.StartTime.ToString("yyyy-MM-dd HH:mm:ss") ?? "--")
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Bot Shutdown Danger Zone -->
+        <div class="border-2 border-error rounded-lg p-6 bg-error/5">
+            <div class="flex items-start gap-4">
+                <div class="flex-shrink-0 w-10 h-10 rounded-full bg-error/20 flex items-center justify-center">
+                    <svg class="w-5 h-5 text-error" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                    </svg>
+                </div>
+                <div class="flex-1">
+                    <h3 class="text-lg font-semibold text-error">Bot Shutdown</h3>
+                    <p class="text-sm text-text-secondary mt-1">
+                        Shutting down the bot will stop all functionality. The bot will need to be manually restarted from the server.
+                        This action is irreversible and requires typing confirmation.
+                    </p>
+                    <div class="mt-4">
+                        <Button Text="Shutdown Bot"
+                                Variant="ButtonVariant.Danger"
+                                IconLeft="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636"
+                                OnClick="ShowShutdownModal" />
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
+
+    <!-- Appearance Tab (SuperAdmin only) -->
+    @if (_activeTab == "Appearance" && _isSuperAdmin)
+    {
+        <div class="bg-bg-secondary border border-border-primary rounded-lg mb-6">
+            <div class="px-6 py-4 border-b border-border-primary">
+                <h2 class="text-lg font-semibold text-text-primary">Appearance Settings</h2>
+                <p class="text-sm text-text-secondary mt-1">Configure the default theme for your application</p>
+            </div>
+            <div class="p-6">
+                <div class="max-w-md">
+                    <FormSelect Id="SelectedThemeId"
+                                Name="SelectedThemeId"
+                                Label="Default Theme"
+                                SelectedValue="@_selectedThemeId?.ToString()"
+                                SelectedValueChanged="OnThemeChanged"
+                                Options="_themeOptions"
+                                HelpText="This will be the default theme for all users who haven't set a personal preference." />
+                </div>
+            </div>
+            <div class="px-6 py-4 border-t border-border-primary">
+                <div class="flex justify-end gap-3">
+                    <Button Text="Reset"
+                            Variant="ButtonVariant.Secondary"
+                            OnClick="ResetAppearanceAsync" />
+                    <Button Text="Save Changes"
+                            Variant="ButtonVariant.Primary"
+                            IsLoading="_isSavingAppearance"
+                            LoadingText="Saving..."
+                            OnClick="SaveAppearanceAsync" />
+                </div>
+            </div>
+        </div>
+    }
+
+    <!-- Danger Zone (page bottom) -->
+    @if (_activeTab != "BotControl")
+    {
+        <div class="border-2 border-error rounded-lg p-6 bg-error/5">
+            <div class="flex items-start gap-4">
+                <div class="flex-shrink-0 w-10 h-10 rounded-full bg-error/20 flex items-center justify-center">
+                    <svg class="w-5 h-5 text-error" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                    </svg>
+                </div>
+                <div class="flex-1">
+                    <h3 class="text-lg font-semibold text-error">Danger Zone</h3>
+                    <p class="text-sm text-text-secondary mt-1">
+                        Resetting all settings will restore all configuration to default values. This action cannot be undone.
+                    </p>
+                    <div class="mt-4">
+                        <Button Text="Reset All Settings to Defaults"
+                                Variant="ButtonVariant.Danger"
+                                IconLeft="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                                OnClick="ShowResetAllModal" />
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
+
+    <!-- Modals -->
+    <ConfirmationModal Id="resetCategoryModal"
+                       Title="Reset Category"
+                       Message="Are you sure you want to reset this category to default values? This action cannot be undone."
+                       ConfirmText="Reset Category"
+                       CancelText="Cancel"
+                       Variant="ConfirmationVariant.Warning"
+                       IsVisible="_showResetCategoryModal"
+                       IsVisibleChanged="(val) => _showResetCategoryModal = val"
+                       OnConfirm="ResetCategoryAsync" />
+
+    <ConfirmationModal Id="resetAllModal"
+                       Title="Reset All Settings"
+                       Message="Are you sure you want to reset ALL settings to their default values? This will affect all categories and cannot be undone."
+                       ConfirmText="Reset All Settings"
+                       CancelText="Cancel"
+                       Variant="ConfirmationVariant.Danger"
+                       IsVisible="_showResetAllModal"
+                       IsVisibleChanged="(val) => _showResetAllModal = val"
+                       OnConfirm="ResetAllAsync" />
+
+    <ConfirmationModal Id="restartModal"
+                       Title="Restart Bot"
+                       Message="Are you sure you want to restart the bot? This will briefly disconnect the bot from all servers. The bot will automatically reconnect after a few seconds."
+                       ConfirmText="Restart Bot"
+                       CancelText="Cancel"
+                       Variant="ConfirmationVariant.Warning"
+                       IsVisible="_showRestartModal"
+                       IsVisibleChanged="(val) => _showRestartModal = val"
+                       OnConfirm="RestartBotAsync" />
+
+    <TypedConfirmationModal Id="shutdownModal"
+                            Title="Shutdown Bot"
+                            Message="This action will completely shut down the bot. The bot will NOT restart automatically and will need to be manually started from the server. This action is critical and should only be used when necessary."
+                            RequiredText="SHUTDOWN"
+                            InputLabel="Type SHUTDOWN to confirm"
+                            ConfirmText="Shutdown Bot"
+                            CancelText="Cancel"
+                            Variant="ConfirmationVariant.Danger"
+                            IsVisible="_showShutdownModal"
+                            IsVisibleChanged="(val) => _showShutdownModal = val"
+                            OnConfirm="ShutdownBotAsync" />
+}
+
+<style>
+    .settings-tab {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.75rem 1rem;
+        font-size: 0.875rem;
+        font-weight: 500;
+        color: #a8a5a3;
+        border-radius: 0.5rem;
+        cursor: pointer;
+        transition: all 0.15s ease-out;
+        border: none;
+        background: transparent;
+    }
+
+    .settings-tab:hover {
+        background-color: #2f3336;
+        color: #d7d3d0;
+    }
+
+    .settings-tab.active {
+        background-color: #cb4e1b;
+        color: white;
+    }
+
+    .settings-tab svg {
+        width: 1.25rem;
+        height: 1.25rem;
+    }
+</style>
+
+@code {
+    // Tab state
+    private string _activeTab = "General";
+    private bool _isLoading = true;
+    private bool _isSuperAdmin;
+    private string _currentUserId = "Unknown";
+
+    // Settings data
+    private IReadOnlyList<SettingDto> _generalSettings = Array.Empty<SettingDto>();
+    private IReadOnlyList<SettingDto> _featuresSettings = Array.Empty<SettingDto>();
+    private IReadOnlyList<SettingDto> _advancedSettings = Array.Empty<SettingDto>();
+    private Dictionary<string, string> _settingValues = new();
+
+    // Command modules
+    private Dictionary<string, IReadOnlyList<CommandModuleConfigurationDto>> _commandModulesByCategory = new();
+    private Dictionary<string, bool> _commandModuleStates = new();
+    private static readonly string[] _commandCategoryOrder = { "Admin", "Moderation", "Features", "Audio", "Utility", "Core" };
+    private static readonly Dictionary<string, string> _commandCategoryDescriptions = new()
+    {
+        ["Admin"] = "Server administration and configuration commands",
+        ["Moderation"] = "User moderation and enforcement commands",
+        ["Features"] = "Optional feature commands",
+        ["Audio"] = "Voice channel and audio playback commands",
+        ["Utility"] = "Information and utility commands",
+        ["Core"] = "Essential bot commands (always enabled)"
+    };
+
+    // Bot control
+    private BotStatusViewModel? _botStatus;
+    private BotConfigurationDto? _botConfiguration;
+
+    // Theme (Appearance)
+    private int? _selectedThemeId;
+    private List<SelectOption> _themeOptions = new();
+
+    // Restart state
+    private bool _isRestartPending;
+
+    // Saving states
+    private bool _isSavingAll;
+    private bool _isSavingGeneral;
+    private bool _isSavingFeatures;
+    private bool _isSavingAdvanced;
+    private bool _isSavingCommands;
+    private bool _isSavingAppearance;
+
+    // Modal visibility
+    private bool _showResetCategoryModal;
+    private bool _showResetAllModal;
+    private bool _showRestartModal;
+    private bool _showShutdownModal;
+    private SettingCategory _resetCategory;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+            _currentUserId = authState.User.Identity?.Name ?? "Unknown";
+
+            Logger.LogDebug("Settings page accessed by user {UserId}", _currentUserId);
+
+            // Check SuperAdmin for Appearance tab
+            var authResult = await AuthorizationService.AuthorizeAsync(authState.User, "RequireSuperAdmin");
+            _isSuperAdmin = authResult.Succeeded;
+
+            await LoadSettingsAsync();
+            await LoadCommandModulesAsync();
+            LoadBotControlData();
+
+            if (_isSuperAdmin)
+            {
+                await LoadThemeDataAsync();
+            }
+
+            _isRestartPending = SettingsService.IsRestartPending || CommandModuleConfigurationService.IsRestartPending;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error loading settings page");
+            await Toast.ShowAsync("error", "Failed to load settings. Please try again.");
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    private async Task LoadSettingsAsync()
+    {
+        _generalSettings = await SettingsService.GetSettingsByCategoryAsync(SettingCategory.General);
+        _featuresSettings = await SettingsService.GetSettingsByCategoryAsync(SettingCategory.Features);
+        _advancedSettings = await SettingsService.GetSettingsByCategoryAsync(SettingCategory.Advanced);
+
+        // Populate the values dictionary
+        _settingValues.Clear();
+        foreach (var setting in _generalSettings.Concat(_featuresSettings).Concat(_advancedSettings))
+        {
+            _settingValues[setting.Key] = setting.Value;
+        }
+
+        Logger.LogDebug("Settings loaded: General={GeneralCount}, Features={FeaturesCount}, Advanced={AdvancedCount}",
+            _generalSettings.Count, _featuresSettings.Count, _advancedSettings.Count);
+    }
+
+    private async Task LoadCommandModulesAsync()
+    {
+        var allModules = await CommandModuleConfigurationService.GetAllModulesAsync();
+        _commandModulesByCategory = allModules
+            .GroupBy(m => m.Category)
+            .ToDictionary(
+                g => g.Key,
+                g => (IReadOnlyList<CommandModuleConfigurationDto>)g.OrderBy(m => m.DisplayName).ToList());
+
+        _commandModuleStates.Clear();
+        foreach (var module in allModules)
+        {
+            _commandModuleStates[module.ModuleName] = module.IsEnabled;
+        }
+    }
+
+    private void LoadBotControlData()
+    {
+        var status = BotService.GetStatus();
+        _botStatus = BotStatusViewModel.FromDto(status);
+        _botConfiguration = BotService.GetConfiguration();
+    }
+
+    private async Task LoadThemeDataAsync()
+    {
+        try
+        {
+            var themes = await ThemeService.GetActiveThemesAsync();
+            var currentDefault = await ThemeService.GetDefaultThemeAsync();
+
+            _themeOptions = themes.Select(t => new SelectOption
+            {
+                Value = t.Id.ToString(),
+                Text = t.DisplayName
+            }).ToList();
+
+            _selectedThemeId = currentDefault?.Id;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error loading theme data for Appearance tab");
+            _themeOptions = new List<SelectOption>();
+        }
+    }
+
+    private void OnSettingValueChanged((string Key, string Value) change)
+    {
+        _settingValues[change.Key] = change.Value;
+    }
+
+    private void OnCommandModuleChanged(string moduleName, bool isEnabled)
+    {
+        _commandModuleStates[moduleName] = isEnabled;
+    }
+
+    private void OnThemeChanged(string? value)
+    {
+        _selectedThemeId = int.TryParse(value, out var id) ? id : null;
+    }
+
+    // --- Save operations ---
+
+    private bool IsCategorySaving(SettingCategory category) => category switch
+    {
+        SettingCategory.General => _isSavingGeneral,
+        SettingCategory.Features => _isSavingFeatures,
+        SettingCategory.Advanced => _isSavingAdvanced,
+        _ => false
+    };
+
+    private void SetCategorySaving(SettingCategory category, bool value)
+    {
+        switch (category)
+        {
+            case SettingCategory.General: _isSavingGeneral = value; break;
+            case SettingCategory.Features: _isSavingFeatures = value; break;
+            case SettingCategory.Advanced: _isSavingAdvanced = value; break;
+        }
+    }
+
+    private async Task SaveCategoryAsync(SettingCategory category)
+    {
+        if (IsCategorySaving(category)) return;
+        SetCategorySaving(category, true);
+
+        try
+        {
+            var categorySettings = category switch
+            {
+                SettingCategory.General => _generalSettings,
+                SettingCategory.Features => _featuresSettings,
+                SettingCategory.Advanced => _advancedSettings,
+                _ => Array.Empty<SettingDto>()
+            };
+
+            var settingsToSave = new Dictionary<string, string>();
+            foreach (var setting in categorySettings)
+            {
+                if (_settingValues.TryGetValue(setting.Key, out var value))
+                {
+                    settingsToSave[setting.Key] = value;
+                }
+            }
+
+            var updateDto = new SettingsUpdateDto { Settings = settingsToSave };
+            var result = await SettingsService.UpdateSettingsAsync(updateDto, _currentUserId);
+
+            if (result.Success)
+            {
+                Logger.LogInformation("Settings saved successfully for category {Category} by user {UserId}. Updated keys: {Keys}",
+                    category, _currentUserId, string.Join(", ", result.UpdatedKeys));
+
+                if (result.Changes.Count > 0)
+                {
+                    AuditLogQueue.Enqueue(new AuditLogCreateDto
+                    {
+                        Category = AuditLogCategory.Configuration,
+                        Action = AuditLogAction.SettingChanged,
+                        ActorType = AuditLogActorType.User,
+                        ActorId = _currentUserId,
+                        Details = JsonSerializer.Serialize(new
+                        {
+                            SettingsCategory = category.ToString(),
+                            Changes = result.Changes.Select(c => new
+                            {
+                                Key = c.Key,
+                                DisplayName = c.Value.DisplayName,
+                                OldValue = c.Value.OldValue,
+                                NewValue = c.Value.NewValue
+                            }),
+                            RestartRequired = result.RestartRequired
+                        })
+                    });
+                }
+
+                var message = result.Changes.Count > 0
+                    ? $"Settings saved successfully. {result.Changes.Count} setting(s) updated."
+                    : "No changes detected.";
+                await Toast.ShowAsync("success", message);
+
+                if (result.RestartRequired)
+                {
+                    _isRestartPending = true;
+                }
+            }
+            else
+            {
+                Logger.LogWarning("Settings save failed for category {Category} by user {UserId}. Errors: {Errors}",
+                    category, _currentUserId, string.Join(", ", result.Errors));
+                await Toast.ShowAsync("error", "Failed to save settings: " + string.Join(", ", result.Errors));
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Exception occurred while saving settings for category {Category}, requested by {UserId}",
+                category, _currentUserId);
+            await Toast.ShowAsync("error", "An error occurred while saving settings. Please check logs for details.");
+        }
+        finally
+        {
+            SetCategorySaving(category, false);
+        }
+    }
+
+    private async Task SaveAllAsync()
+    {
+        if (_isSavingAll) return;
+        _isSavingAll = true;
+
+        try
+        {
+            var updateDto = new SettingsUpdateDto { Settings = new Dictionary<string, string>(_settingValues) };
+            var result = await SettingsService.UpdateSettingsAsync(updateDto, _currentUserId);
+
+            if (result.Success)
+            {
+                Logger.LogInformation("All settings saved successfully by user {UserId}. Updated keys: {Keys}",
+                    _currentUserId, string.Join(", ", result.UpdatedKeys));
+
+                if (result.Changes.Count > 0)
+                {
+                    AuditLogQueue.Enqueue(new AuditLogCreateDto
+                    {
+                        Category = AuditLogCategory.Configuration,
+                        Action = AuditLogAction.SettingChanged,
+                        ActorType = AuditLogActorType.User,
+                        ActorId = _currentUserId,
+                        Details = JsonSerializer.Serialize(new
+                        {
+                            SettingsCategory = "All",
+                            Changes = result.Changes.Select(c => new
+                            {
+                                Key = c.Key,
+                                DisplayName = c.Value.DisplayName,
+                                OldValue = c.Value.OldValue,
+                                NewValue = c.Value.NewValue
+                            }),
+                            RestartRequired = result.RestartRequired
+                        })
+                    });
+                }
+
+                var message = result.Changes.Count > 0
+                    ? $"All settings saved successfully. {result.Changes.Count} setting(s) updated."
+                    : "No changes detected.";
+                await Toast.ShowAsync("success", message);
+
+                if (result.RestartRequired)
+                {
+                    _isRestartPending = true;
+                }
+            }
+            else
+            {
+                Logger.LogWarning("Save all settings failed for user {UserId}. Errors: {Errors}",
+                    _currentUserId, string.Join(", ", result.Errors));
+                await Toast.ShowAsync("error", "Failed to save all settings: " + string.Join(", ", result.Errors));
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Exception occurred while saving all settings, requested by {UserId}", _currentUserId);
+            await Toast.ShowAsync("error", "An error occurred while saving settings. Please check logs for details.");
+        }
+        finally
+        {
+            _isSavingAll = false;
+        }
+    }
+
+    private async Task SaveCommandModulesAsync()
+    {
+        if (_isSavingCommands) return;
+        _isSavingCommands = true;
+
+        try
+        {
+            // Get current states for audit logging
+            var currentModules = await CommandModuleConfigurationService.GetAllModulesAsync();
+            var currentStates = currentModules.ToDictionary(m => m.ModuleName, m => m.IsEnabled);
+
+            var updateDto = new CommandModuleConfigurationUpdateDto
+            {
+                Modules = new Dictionary<string, bool>(_commandModuleStates)
+            };
+
+            var result = await CommandModuleConfigurationService.UpdateModulesAsync(updateDto, _currentUserId);
+
+            if (result.Success || result.UpdatedModules.Count > 0)
+            {
+                Logger.LogInformation("Command module settings saved successfully by user {UserId}. Updated modules: {Modules}",
+                    _currentUserId, string.Join(", ", result.UpdatedModules));
+
+                foreach (var moduleName in result.UpdatedModules)
+                {
+                    var previousState = currentStates.GetValueOrDefault(moduleName, true);
+                    var newState = _commandModuleStates.GetValueOrDefault(moduleName, true);
+
+                    AuditLogQueue.Enqueue(new AuditLogCreateDto
+                    {
+                        Category = AuditLogCategory.Configuration,
+                        Action = AuditLogAction.SettingChanged,
+                        ActorType = AuditLogActorType.User,
+                        ActorId = _currentUserId,
+                        Details = JsonSerializer.Serialize(new
+                        {
+                            SettingsCategory = "Commands",
+                            ModuleName = moduleName,
+                            Change = new
+                            {
+                                Key = $"CommandModule:{moduleName}:IsEnabled",
+                                DisplayName = $"Command module '{moduleName}'",
+                                OldValue = previousState.ToString(),
+                                NewValue = newState.ToString()
+                            },
+                            Description = $"Command module '{moduleName}' {(newState ? "enabled" : "disabled")}",
+                            RestartRequired = result.RequiresRestart
+                        })
+                    });
+                }
+
+                var message = result.UpdatedModules.Count > 0
+                    ? $"Command module settings saved successfully. {result.UpdatedModules.Count} module(s) updated."
+                    : "No changes detected.";
+                await Toast.ShowAsync("success", message);
+
+                if (result.RequiresRestart)
+                {
+                    _isRestartPending = true;
+                }
+            }
+            else
+            {
+                Logger.LogWarning("Command module settings save failed for user {UserId}. Errors: {Errors}",
+                    _currentUserId, string.Join(", ", result.Errors));
+                await Toast.ShowAsync("error", "Failed to save command module settings: " + string.Join(", ", result.Errors));
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Exception occurred while saving command module settings, requested by {UserId}", _currentUserId);
+            await Toast.ShowAsync("error", "An error occurred while saving command module settings.");
+        }
+        finally
+        {
+            _isSavingCommands = false;
+        }
+    }
+
+    private async Task SaveAppearanceAsync()
+    {
+        if (_isSavingAppearance) return;
+        _isSavingAppearance = true;
+
+        try
+        {
+            if (!_selectedThemeId.HasValue)
+            {
+                await Toast.ShowAsync("error", "No theme selected.");
+                return;
+            }
+
+            var selectedTheme = await ThemeService.GetThemeByIdAsync(_selectedThemeId.Value);
+            if (selectedTheme == null)
+            {
+                await Toast.ShowAsync("error", "Selected theme not found.");
+                return;
+            }
+
+            var previousDefault = await ThemeService.GetDefaultThemeAsync();
+            var success = await ThemeService.SetDefaultThemeAsync(_selectedThemeId.Value);
+
+            if (success)
+            {
+                Logger.LogInformation("Default theme changed from {OldTheme} to {NewTheme} by user {UserId}",
+                    previousDefault?.DisplayName ?? "none", selectedTheme.DisplayName, _currentUserId);
+
+                AuditLogQueue.Enqueue(new AuditLogCreateDto
+                {
+                    Category = AuditLogCategory.Configuration,
+                    Action = AuditLogAction.SettingChanged,
+                    ActorType = AuditLogActorType.User,
+                    ActorId = _currentUserId,
+                    Details = JsonSerializer.Serialize(new
+                    {
+                        SettingsCategory = "Appearance",
+                        Change = new
+                        {
+                            Key = "DefaultTheme",
+                            DisplayName = "Default Theme",
+                            OldValue = previousDefault?.DisplayName ?? "Discord Dark",
+                            NewValue = selectedTheme.DisplayName
+                        }
+                    })
+                });
+
+                await Toast.ShowAsync("success", $"Default theme updated. New users will see {selectedTheme.DisplayName} theme.");
+            }
+            else
+            {
+                await Toast.ShowAsync("error", "Failed to update default theme.");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Exception occurred while saving appearance settings, requested by {UserId}", _currentUserId);
+            await Toast.ShowAsync("error", "An error occurred while saving appearance settings.");
+        }
+        finally
+        {
+            _isSavingAppearance = false;
+        }
+    }
+
+    private async Task ResetAppearanceAsync()
+    {
+        try
+        {
+            var previousDefault = await ThemeService.GetDefaultThemeAsync();
+            var systemDefault = await ThemeService.GetThemeByKeyAsync("discord-dark");
+
+            if (systemDefault == null)
+            {
+                await Toast.ShowAsync("error", "System default theme not found.");
+                return;
+            }
+
+            var success = await ThemeService.SetDefaultThemeAsync(systemDefault.Id);
+
+            if (success)
+            {
+                _selectedThemeId = systemDefault.Id;
+
+                Logger.LogInformation("Default theme reset from {OldTheme} to {NewTheme} by user {UserId}",
+                    previousDefault?.DisplayName ?? "none", systemDefault.DisplayName, _currentUserId);
+
+                AuditLogQueue.Enqueue(new AuditLogCreateDto
+                {
+                    Category = AuditLogCategory.Configuration,
+                    Action = AuditLogAction.SettingChanged,
+                    ActorType = AuditLogActorType.User,
+                    ActorId = _currentUserId,
+                    Details = JsonSerializer.Serialize(new
+                    {
+                        SettingsCategory = "Appearance",
+                        Operation = "Reset",
+                        Change = new
+                        {
+                            Key = "DefaultTheme",
+                            DisplayName = "Default Theme",
+                            OldValue = previousDefault?.DisplayName ?? "Discord Dark",
+                            NewValue = systemDefault.DisplayName
+                        }
+                    })
+                });
+
+                await Toast.ShowAsync("success", $"Default theme reset to {systemDefault.DisplayName}.");
+            }
+            else
+            {
+                await Toast.ShowAsync("error", "Failed to reset default theme.");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Exception occurred while resetting appearance settings, requested by {UserId}", _currentUserId);
+            await Toast.ShowAsync("error", "An error occurred while resetting appearance settings.");
+        }
+    }
+
+    // --- Reset operations ---
+
+    private void ShowResetCategoryModal(SettingCategory category)
+    {
+        _resetCategory = category;
+        _showResetCategoryModal = true;
+    }
+
+    private async Task ResetCategoryAsync()
+    {
+        try
+        {
+            var result = await SettingsService.ResetCategoryAsync(_resetCategory, _currentUserId);
+
+            if (result.Success)
+            {
+                Logger.LogInformation("Category {Category} reset to defaults by user {UserId}", _resetCategory, _currentUserId);
+
+                AuditLogQueue.Enqueue(new AuditLogCreateDto
+                {
+                    Category = AuditLogCategory.Configuration,
+                    Action = AuditLogAction.SettingChanged,
+                    ActorType = AuditLogActorType.User,
+                    ActorId = _currentUserId,
+                    Details = JsonSerializer.Serialize(new
+                    {
+                        Operation = "ResetCategory",
+                        SettingsCategory = _resetCategory.ToString(),
+                        RestartRequired = result.RestartRequired
+                    })
+                });
+
+                await Toast.ShowAsync("success", $"{_resetCategory} settings have been reset to defaults.");
+                await LoadSettingsAsync();
+
+                if (result.RestartRequired)
+                {
+                    _isRestartPending = true;
+                }
+            }
+            else
+            {
+                await Toast.ShowAsync("error", $"Failed to reset {_resetCategory} settings: " + string.Join(", ", result.Errors));
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Exception occurred while resetting category {Category}, requested by {UserId}",
+                _resetCategory, _currentUserId);
+            await Toast.ShowAsync("error", "An error occurred while resetting settings.");
+        }
+    }
+
+    private void ShowResetAllModal()
+    {
+        _showResetAllModal = true;
+    }
+
+    private async Task ResetAllAsync()
+    {
+        try
+        {
+            Logger.LogCritical("Reset ALL settings requested by user {UserId}", _currentUserId);
+
+            var result = await SettingsService.ResetAllAsync(_currentUserId);
+
+            if (result.Success)
+            {
+                Logger.LogWarning("All settings reset to defaults by user {UserId}", _currentUserId);
+
+                AuditLogQueue.Enqueue(new AuditLogCreateDto
+                {
+                    Category = AuditLogCategory.Configuration,
+                    Action = AuditLogAction.SettingChanged,
+                    ActorType = AuditLogActorType.User,
+                    ActorId = _currentUserId,
+                    Details = JsonSerializer.Serialize(new
+                    {
+                        Operation = "ResetAll",
+                        RestartRequired = result.RestartRequired
+                    })
+                });
+
+                await Toast.ShowAsync("success", "All settings have been reset to defaults.");
+                await LoadSettingsAsync();
+
+                if (result.RestartRequired)
+                {
+                    _isRestartPending = true;
+                }
+            }
+            else
+            {
+                await Toast.ShowAsync("error", "Failed to reset all settings: " + string.Join(", ", result.Errors));
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Exception occurred while resetting all settings, requested by {UserId}", _currentUserId);
+            await Toast.ShowAsync("error", "An error occurred while resetting settings.");
+        }
+    }
+
+    // --- Bot control operations ---
+
+    private void ShowRestartModal()
+    {
+        _showRestartModal = true;
+    }
+
+    private async Task RestartBotAsync()
+    {
+        try
+        {
+            Logger.LogWarning("Bot restart requested by user {UserId}", _currentUserId);
+            await BotService.RestartAsync();
+            Logger.LogInformation("Bot restart completed successfully, initiated by {UserId}", _currentUserId);
+
+            AuditLogQueue.Enqueue(new AuditLogCreateDto
+            {
+                Category = AuditLogCategory.System,
+                Action = AuditLogAction.Updated,
+                ActorType = AuditLogActorType.User,
+                ActorId = _currentUserId,
+                Details = JsonSerializer.Serialize(new
+                {
+                    Operation = "BotRestart",
+                    Description = "Bot restart initiated by administrator",
+                    Timestamp = DateTime.UtcNow
+                })
+            });
+
+            await Toast.ShowAsync("success", "Bot is restarting...");
+
+            // Refresh status after a brief delay
+            await Task.Delay(2000);
+            LoadBotControlData();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to restart bot, requested by {UserId}", _currentUserId);
+            await Toast.ShowAsync("error", "Failed to restart bot. Please check logs for details.");
+        }
+    }
+
+    private void ShowShutdownModal()
+    {
+        _showShutdownModal = true;
+    }
+
+    private async Task ShutdownBotAsync()
+    {
+        try
+        {
+            Logger.LogCritical("Bot SHUTDOWN requested by user {UserId}", _currentUserId);
+
+            AuditLogQueue.Enqueue(new AuditLogCreateDto
+            {
+                Category = AuditLogCategory.System,
+                Action = AuditLogAction.BotStopped,
+                ActorType = AuditLogActorType.User,
+                ActorId = _currentUserId,
+                Details = JsonSerializer.Serialize(new
+                {
+                    Operation = "ManualShutdown",
+                    Reason = "Administrator initiated shutdown",
+                    Timestamp = DateTime.UtcNow
+                })
+            });
+
+            await BotService.ShutdownAsync();
+            Logger.LogCritical("Bot shutdown initiated by {UserId}", _currentUserId);
+
+            await Toast.ShowAsync("success", "Bot is shutting down...");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to shutdown bot, requested by {UserId}", _currentUserId);
+            await Toast.ShowAsync("error", "Failed to shutdown bot. Please check logs for details.");
+        }
+    }
+}

--- a/src/DiscordBot.Bot/Components/Pages/Admin/SettingsCategorySection.razor
+++ b/src/DiscordBot.Bot/Components/Pages/Admin/SettingsCategorySection.razor
@@ -1,0 +1,108 @@
+@using DiscordBot.Core.DTOs
+@using DiscordBot.Core.Enums
+
+<div class="bg-bg-secondary border border-border-primary rounded-lg mb-6">
+    <div class="px-6 py-4 border-b border-border-primary">
+        <h2 class="text-lg font-semibold text-text-primary">@Title</h2>
+        <p class="text-sm text-text-secondary mt-1">@Description</p>
+    </div>
+    <div class="p-6">
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            @foreach (var setting in Settings)
+            {
+                var currentValue = SettingValues.GetValueOrDefault(setting.Key, setting.Value);
+                <div>
+                    @if (setting.DataType == SettingDataType.Boolean)
+                    {
+                        <FormToggle Id="@($"setting_{setting.Key}")"
+                                    Name="@setting.Key"
+                                    Label="@setting.DisplayName"
+                                    Description="@GetSettingDescription(setting)"
+                                    IsChecked="@(string.Equals(currentValue, "true", StringComparison.OrdinalIgnoreCase))"
+                                    IsCheckedChanged="(val) => OnToggleChanged(setting.Key, val)" />
+                    }
+                    else if (setting.DataType == SettingDataType.String && setting.AllowedValues is { Count: > 0 })
+                    {
+                        <FormSelect Id="@($"setting_{setting.Key}")"
+                                    Name="@setting.Key"
+                                    Label="@setting.DisplayName"
+                                    HelpText="@GetSettingDescription(setting)"
+                                    SelectedValue="@currentValue"
+                                    SelectedValueChanged="(val) => OnSelectChanged(setting.Key, val)"
+                                    Options="@(setting.AllowedValues.Select(v => new SelectOption { Value = v, Text = v }).ToList())" />
+                    }
+                    else if (setting.DataType == SettingDataType.Integer || setting.DataType == SettingDataType.Decimal)
+                    {
+                        <FormInput Id="@($"setting_{setting.Key}")"
+                                   Name="@setting.Key"
+                                   Label="@setting.DisplayName"
+                                   HelpText="@GetSettingDescription(setting)"
+                                   Type="number"
+                                   Value="@currentValue"
+                                   ValueChanged="(val) => OnInputChanged(setting.Key, val)" />
+                    }
+                    else
+                    {
+                        <FormInput Id="@($"setting_{setting.Key}")"
+                                   Name="@setting.Key"
+                                   Label="@setting.DisplayName"
+                                   HelpText="@GetSettingDescription(setting)"
+                                   Type="text"
+                                   Value="@currentValue"
+                                   ValueChanged="(val) => OnInputChanged(setting.Key, val)" />
+                    }
+                </div>
+            }
+        </div>
+    </div>
+    <div class="px-6 py-4 border-t border-border-primary">
+        <div class="flex justify-end gap-3">
+            <Button Text="Reset"
+                    Variant="ButtonVariant.Secondary"
+                    OnClick="OnReset" />
+            <Button Text="Save Changes"
+                    Variant="ButtonVariant.Primary"
+                    IsLoading="IsSaving"
+                    LoadingText="Saving..."
+                    OnClick="OnSave" />
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter, EditorRequired] public string Title { get; set; } = string.Empty;
+    [Parameter, EditorRequired] public string Description { get; set; } = string.Empty;
+    [Parameter, EditorRequired] public IReadOnlyList<SettingDto> Settings { get; set; } = Array.Empty<SettingDto>();
+    [Parameter, EditorRequired] public Dictionary<string, string> SettingValues { get; set; } = new();
+    [Parameter] public EventCallback<(string Key, string Value)> OnSettingChanged { get; set; }
+    [Parameter] public EventCallback OnSave { get; set; }
+    [Parameter] public EventCallback OnReset { get; set; }
+    [Parameter] public bool IsSaving { get; set; }
+
+    private string GetSettingDescription(SettingDto setting)
+    {
+        var desc = setting.Description ?? string.Empty;
+        if (setting.RequiresRestart)
+        {
+            desc = string.IsNullOrEmpty(desc)
+                ? "Requires restart"
+                : $"{desc} (requires restart)";
+        }
+        return desc;
+    }
+
+    private async Task OnToggleChanged(string key, bool value)
+    {
+        await OnSettingChanged.InvokeAsync((key, value.ToString().ToLowerInvariant()));
+    }
+
+    private async Task OnSelectChanged(string key, string? value)
+    {
+        await OnSettingChanged.InvokeAsync((key, value ?? string.Empty));
+    }
+
+    private async Task OnInputChanged(string key, string? value)
+    {
+        await OnSettingChanged.InvokeAsync((key, value ?? string.Empty));
+    }
+}

--- a/src/DiscordBot.Bot/Components/Pages/Guilds/GuildAssistantSettings.razor
+++ b/src/DiscordBot.Bot/Components/Pages/Guilds/GuildAssistantSettings.razor
@@ -1,0 +1,429 @@
+@page "/Guilds/AssistantSettings/{GuildId:long}"
+@rendermode InteractiveServer
+@attribute [Authorize(Policy = "RequireAdmin")]
+@attribute [Authorize(Policy = "GuildAccess")]
+@layout GuildLayout
+@using Discord.WebSocket
+@using DiscordBot.Bot.Components.Interop
+@using DiscordBot.Bot.ViewModels.Components
+@using DiscordBot.Core.Configuration
+@using DiscordBot.Core.Interfaces
+@using Microsoft.Extensions.Options
+@inject IAssistantGuildSettingsService AssistantSettingsService
+@inject IGuildService GuildService
+@inject DiscordSocketClient DiscordClient
+@inject IOptions<AssistantOptions> AssistantOptions
+@inject ISettingsService SettingsService
+@inject ToastInterop Toast
+@inject ILogger<GuildAssistantSettings> Logger
+
+<PageTitle>Assistant Settings - Discord Bot Admin</PageTitle>
+
+@if (_guild is null && !_notFound)
+{
+    <div class="flex items-center justify-center py-12">
+        <div class="text-text-secondary">Loading...</div>
+    </div>
+}
+else if (_notFound)
+{
+    <div class="flex flex-col items-center justify-center py-12 space-y-4">
+        <div class="text-text-secondary text-lg">Guild not found</div>
+        <a href="/Guilds" class="text-accent-blue hover:text-accent-blue-hover transition-colors text-sm">Back to Guilds</a>
+    </div>
+}
+else
+{
+    <!-- Breadcrumb -->
+    <GuildBreadcrumb Items="@_breadcrumbItems" />
+
+    <!-- Guild Header -->
+    <GuildHeader GuildId="(ulong)GuildId"
+                 GuildName="@_guild!.Name"
+                 GuildIconUrl="@_guild.IconUrl"
+                 PageTitle="AI Assistant Settings"
+                 PageDescription="@($"Configure AI assistant for {_guild.Name}")"
+                 Actions="@_headerActions" />
+
+    <!-- Global Status Warning -->
+    @if (!_globallyEnabled)
+    {
+        <div class="mb-6">
+            <Alert Variant="AlertVariant.Warning"
+                   Message="The AI assistant is globally disabled. Guild-level settings will take effect once the feature is enabled globally." />
+        </div>
+    }
+
+    <!-- Error Alert -->
+    @if (!string.IsNullOrEmpty(_errorMessage))
+    {
+        <div class="mb-6">
+            <Alert Variant="AlertVariant.Error" Title="Error" Message="@_errorMessage" IsDismissible="true" />
+        </div>
+    }
+
+    <!-- Enable Toggle Card -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg p-6 mb-6">
+        <FormToggle Id="assistant-enabled"
+                    Name="IsEnabled"
+                    Label="Enable AI Assistant"
+                    Description="Allow users to ask questions by mentioning the bot"
+                    IsChecked="_isEnabled"
+                    IsCheckedChanged="OnEnabledChanged" />
+    </div>
+
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
+        <!-- Configuration Form Column -->
+        <div class="lg:col-span-2 space-y-6">
+            <!-- Main Configuration Form -->
+            <div class="bg-bg-secondary border border-border-primary rounded-lg relative">
+                @if (!_isEnabled)
+                {
+                    <div class="absolute inset-0 bg-bg-secondary/60 z-10 rounded-lg pointer-events-none"></div>
+                }
+
+                <div class="p-6 space-y-6">
+                    <!-- Channel Selection -->
+                    <div>
+                        <label class="block text-sm font-medium text-text-primary mb-2">Allowed Channels</label>
+                        <p class="text-xs text-text-secondary mb-3">Select channels where the assistant can respond. Leave empty to allow all channels.</p>
+
+                        <div class="max-h-64 overflow-y-auto border border-border-primary rounded-md bg-bg-primary">
+                            @if (_availableChannels.Count > 0)
+                            {
+                                @foreach (var channel in _availableChannels)
+                                {
+                                    <label class="flex items-center gap-3 px-4 py-2.5 hover:bg-bg-hover cursor-pointer border-b border-border-secondary last:border-b-0">
+                                        <input type="checkbox"
+                                               checked="@channel.IsSelected"
+                                               @onchange="@(e => OnChannelToggled(channel.Id, (bool)(e.Value ?? false)))"
+                                               disabled="@(!_isEnabled)"
+                                               class="w-4 h-4 rounded border-border-primary text-accent-orange focus:ring-accent-orange focus:ring-offset-bg-primary" />
+                                        <svg class="w-4 h-4 text-text-tertiary flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                            @if (channel.Type == "Announcement")
+                                            {
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" />
+                                            }
+                                            else
+                                            {
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14" />
+                                            }
+                                        </svg>
+                                        <span class="text-sm text-text-primary">@channel.Name</span>
+                                        <span class="text-xs text-text-tertiary">@channel.Type</span>
+                                    </label>
+                                }
+                            }
+                            else
+                            {
+                                <div class="px-4 py-6 text-center text-text-secondary text-sm">
+                                    No text channels available
+                                </div>
+                            }
+                        </div>
+                        <p class="text-xs text-text-tertiary mt-2">
+                            @_availableChannels.Count(c => c.IsSelected) of @_availableChannels.Count channels selected
+                        </p>
+                    </div>
+
+                    <!-- Rate Limit Override -->
+                    <div class="max-w-xs">
+                        <FormInput Id="rate-limit-override"
+                                   Name="RateLimitOverride"
+                                   Label="Rate Limit Override"
+                                   Type="number"
+                                   Placeholder="@($"{_defaultRateLimit} (default)")"
+                                   Value="@_rateLimitOverrideStr"
+                                   ValueChanged="OnRateLimitChanged"
+                                   HelpText="@($"Maximum questions per user per {_rateLimitWindowMinutes} minute window. Leave empty to use the default ({_defaultRateLimit}).")"
+                                   IsDisabled="!_isEnabled"
+                                   ValidationState="@_rateLimitValidationState"
+                                   ValidationMessage="@_rateLimitValidationMessage" />
+                    </div>
+                </div>
+            </div>
+
+            <!-- Form Actions -->
+            <div class="flex flex-col sm:flex-row gap-3">
+                <Button Text="Save Settings"
+                        Variant="ButtonVariant.Primary"
+                        IsLoading="_isSaving"
+                        LoadingText="Saving..."
+                        OnClick="SaveAsync"
+                        IconLeft="M5 13l4 4L19 7" />
+                <a href="@($"/Guilds/Details/{GuildId}")"
+                   class="btn btn-secondary inline-flex items-center justify-center gap-2">
+                    Cancel
+                </a>
+                <a href="@($"/Guilds/AssistantMetrics/{GuildId}")"
+                   class="btn btn-glass inline-flex items-center justify-center gap-2 ml-auto">
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+                    </svg>
+                    View Metrics
+                </a>
+            </div>
+        </div>
+
+        <!-- Help Panel Column -->
+        <div class="space-y-6">
+            <!-- How It Works -->
+            <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden">
+                <div class="px-6 py-4 border-b border-border-primary">
+                    <h3 class="text-sm font-semibold text-text-primary flex items-center gap-2">
+                        <svg class="w-5 h-5 text-accent-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        </svg>
+                        How It Works
+                    </h3>
+                </div>
+                <div class="p-6 space-y-4 text-sm text-text-secondary">
+                    <p>
+                        When enabled, users can ask questions by mentioning the bot:
+                    </p>
+                    <div class="bg-bg-primary border border-border-primary rounded-md p-3 font-mono text-xs">
+                        <span class="text-accent-blue">@@BotName</span> How do I use the soundboard?
+                    </div>
+                    <p>
+                        The bot uses AI to answer questions about its features and commands.
+                    </p>
+                </div>
+            </div>
+
+            <!-- Consent Notice -->
+            <div class="bg-info-bg border border-info-border rounded-lg p-4">
+                <div class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-info flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20">
+                        <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd" />
+                    </svg>
+                    <div class="text-sm text-info">
+                        <p class="font-semibold mb-1">User Consent Required</p>
+                        <p class="text-info/90">
+                            Users must grant consent via <code class="px-1 py-0.5 bg-info/20 rounded font-mono text-xs">/consent</code> before using the assistant. Questions and responses are logged for debugging.
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Rate Limiting Info -->
+            <div class="bg-bg-secondary border border-border-primary rounded-lg p-4">
+                <h4 class="text-sm font-semibold text-text-primary mb-2">Rate Limiting</h4>
+                <p class="text-xs text-text-secondary">
+                    Rate limits prevent API cost abuse. Each user can ask @_defaultRateLimit questions per @_rateLimitWindowMinutes minutes (by default).
+                    Admins can bypass this limit.
+                </p>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter] public long GuildId { get; set; }
+
+    private Core.DTOs.GuildDto? _guild;
+    private List<BreadcrumbItem>? _breadcrumbItems;
+    private List<HeaderAction>? _headerActions;
+
+    // Form state
+    private bool _isEnabled;
+    private string? _rateLimitOverrideStr;
+    private List<ChannelSelectItem> _availableChannels = new();
+
+    // Config values
+    private int _defaultRateLimit;
+    private int _rateLimitWindowMinutes;
+    private bool _globallyEnabled;
+
+    // Validation
+    private ValidationState _rateLimitValidationState = ValidationState.None;
+    private string? _rateLimitValidationMessage;
+    private string? _errorMessage;
+
+    // UI state
+    private bool _isSaving;
+    private bool _notFound;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var guildId = (ulong)GuildId;
+
+        Logger.LogInformation("User accessing assistant settings page for guild {GuildId}", guildId);
+
+        var guildDto = await GuildService.GetGuildByIdAsync(guildId);
+        if (guildDto is null)
+        {
+            Logger.LogWarning("Guild {GuildId} not found", guildId);
+            _notFound = true;
+            return;
+        }
+
+        _guild = guildDto;
+
+        // Load configuration defaults
+        _defaultRateLimit = AssistantOptions.Value.DefaultRateLimit;
+        _rateLimitWindowMinutes = AssistantOptions.Value.RateLimitWindowMinutes;
+
+        // Check global status
+        _globallyEnabled = await SettingsService.GetSettingValueAsync<bool>("Assistant:GloballyEnabled");
+
+        // Get assistant settings
+        var settings = await AssistantSettingsService.GetOrCreateSettingsAsync(guildId);
+        var allowedChannelIds = settings.GetAllowedChannelIdsList();
+
+        _isEnabled = settings.IsEnabled;
+        _rateLimitOverrideStr = settings.RateLimitOverride?.ToString();
+
+        // Load text channels from Discord
+        LoadTextChannels(guildId, allowedChannelIds);
+
+        // Build breadcrumb
+        _breadcrumbItems = new List<BreadcrumbItem>
+        {
+            new() { Label = "Home", Url = "/" },
+            new() { Label = "Servers", Url = "/Guilds" },
+            new() { Label = guildDto.Name, Url = $"/Guilds/Details/{GuildId}" },
+            new() { Label = "AI Assistant Settings", IsCurrent = true }
+        };
+
+        // Build header actions
+        _headerActions = new List<HeaderAction>
+        {
+            new()
+            {
+                Label = "View Metrics",
+                Url = $"/Guilds/AssistantMetrics/{GuildId}",
+                Style = HeaderActionStyle.Link,
+                Icon = "M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+            }
+        };
+    }
+
+    private void LoadTextChannels(ulong guildId, List<ulong> selectedChannelIds)
+    {
+        var socketGuild = DiscordClient.GetGuild(guildId);
+        if (socketGuild is null)
+        {
+            Logger.LogWarning("Could not fetch Discord guild {GuildId} from client", guildId);
+            return;
+        }
+
+        _availableChannels = socketGuild.TextChannels
+            .Where(c => c is not null)
+            .OrderBy(c => c.Position)
+            .Select(c => new ChannelSelectItem
+            {
+                Id = c.Id,
+                Name = c.Name,
+                Position = c.Position,
+                Type = c is SocketNewsChannel ? "Announcement" : "Text",
+                IsSelected = selectedChannelIds.Contains(c.Id)
+            })
+            .ToList();
+    }
+
+    private void OnEnabledChanged(bool value)
+    {
+        _isEnabled = value;
+        ClearValidation();
+    }
+
+    private void OnChannelToggled(ulong channelId, bool isChecked)
+    {
+        var channel = _availableChannels.FirstOrDefault(c => c.Id == channelId);
+        if (channel is not null)
+        {
+            channel.IsSelected = isChecked;
+        }
+    }
+
+    private void OnRateLimitChanged(string? value)
+    {
+        _rateLimitOverrideStr = value;
+        ClearValidation();
+    }
+
+    private void ClearValidation()
+    {
+        _rateLimitValidationState = ValidationState.None;
+        _rateLimitValidationMessage = null;
+        _errorMessage = null;
+    }
+
+    private bool Validate()
+    {
+        ClearValidation();
+
+        if (!string.IsNullOrWhiteSpace(_rateLimitOverrideStr))
+        {
+            if (!int.TryParse(_rateLimitOverrideStr, out var rateLimitValue))
+            {
+                _rateLimitValidationState = ValidationState.Error;
+                _rateLimitValidationMessage = "Rate limit must be a valid number.";
+                return false;
+            }
+
+            if (rateLimitValue < 1 || rateLimitValue > 100)
+            {
+                _rateLimitValidationState = ValidationState.Error;
+                _rateLimitValidationMessage = "Rate limit must be between 1 and 100.";
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private async Task SaveAsync()
+    {
+        if (_isSaving) return;
+        if (!Validate()) return;
+
+        _isSaving = true;
+        _errorMessage = null;
+
+        try
+        {
+            var guildId = (ulong)GuildId;
+
+            // Get current settings
+            var settings = await AssistantSettingsService.GetOrCreateSettingsAsync(guildId);
+
+            // Update settings
+            settings.IsEnabled = _isEnabled;
+            settings.RateLimitOverride = string.IsNullOrWhiteSpace(_rateLimitOverrideStr)
+                ? null
+                : int.Parse(_rateLimitOverrideStr);
+
+            // Set allowed channels
+            var selectedChannelIds = _availableChannels
+                .Where(c => c.IsSelected)
+                .Select(c => c.Id)
+                .ToList();
+            settings.SetAllowedChannelIdsList(selectedChannelIds);
+
+            // Save
+            await AssistantSettingsService.UpdateSettingsAsync(settings);
+
+            Logger.LogInformation("Successfully updated assistant settings for guild {GuildId}", guildId);
+            await Toast.ShowAsync("success", "Assistant settings saved successfully.");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error saving assistant settings for guild {GuildId}", (ulong)GuildId);
+            _errorMessage = "An unexpected error occurred while saving. Please try again.";
+        }
+        finally
+        {
+            _isSaving = false;
+        }
+    }
+
+    private class ChannelSelectItem
+    {
+        public ulong Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public int Position { get; set; }
+        public string Type { get; set; } = "Text";
+        public bool IsSelected { get; set; }
+    }
+}

--- a/src/DiscordBot.Bot/Components/Pages/Guilds/GuildAudioSettings.razor
+++ b/src/DiscordBot.Bot/Components/Pages/Guilds/GuildAudioSettings.razor
@@ -1,0 +1,994 @@
+@page "/Guilds/AudioSettings/{GuildId:long}"
+@rendermode InteractiveServer
+@attribute [Authorize(Policy = "RequireAdmin")]
+@attribute [Authorize(Policy = "GuildAccess")]
+@layout GuildLayout
+@using DiscordBot.Core.Configuration
+@using DiscordBot.Core.Entities
+@using DiscordBot.Core.Interfaces
+@using Discord.WebSocket
+@using Microsoft.Extensions.Options
+@inject IGuildAudioSettingsService AudioSettingsService
+@inject IGuildService GuildService
+@inject ISoundService SoundService
+@inject DiscordSocketClient DiscordClient
+@inject IOptions<SoundboardOptions> SoundboardOptions
+@inject ISettingsService SettingsService
+@inject ITtsSettingsService TtsSettingsService
+@inject ToastInterop Toast
+@inject ILogger<GuildAudioSettings> Logger
+
+<PageTitle>Audio Settings - Discord Bot Admin</PageTitle>
+
+@if (_loading)
+{
+    <div class="flex items-center justify-center py-12">
+        <div class="text-text-secondary">Loading...</div>
+    </div>
+}
+else if (_notFound)
+{
+    <div class="flex flex-col items-center justify-center py-12 space-y-4">
+        <div class="text-text-secondary text-lg">Guild not found</div>
+        <a href="/Guilds" class="text-accent-blue hover:text-accent-blue-hover transition-colors text-sm">Back to Guilds</a>
+    </div>
+}
+else
+{
+    <!-- Breadcrumb -->
+    <GuildBreadcrumb Items="@_breadcrumbItems" />
+
+    <!-- Guild Header -->
+    <GuildHeader GuildId="(ulong)GuildId"
+                 GuildName="@_guild!.Name"
+                 GuildIconUrl="@_guild.IconUrl"
+                 PageTitle="Audio"
+                 PageDescription="@($"Configure audio settings for {_guild.Name}")" />
+
+    <!-- Audio Tabs Navigation -->
+    <nav class="flex gap-2 mb-6" aria-label="Audio sections">
+        <a href="/Guilds/Soundboard/@GuildId"
+           class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-full transition-colors bg-bg-secondary text-text-secondary border border-border-primary hover:text-text-primary hover:border-border-focus">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
+            </svg>
+            Soundboard
+            @if (_soundCount > 0)
+            {
+                <span class="inline-flex items-center justify-center px-2 py-0.5 text-xs font-medium rounded-full bg-info/15 text-info">@_soundCount</span>
+            }
+        </a>
+        <a href="/Guilds/TextToSpeech/@GuildId"
+           class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-full transition-colors bg-bg-secondary text-text-secondary border border-border-primary hover:text-text-primary hover:border-border-focus">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z" />
+            </svg>
+            Text-to-Speech
+        </a>
+        <a href="/Guilds/VOX/@GuildId"
+           class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-full transition-colors bg-bg-secondary text-text-secondary border border-border-primary hover:text-text-primary hover:border-border-focus">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.34 15.84c-.688-.06-1.386-.09-2.09-.09H7.5a4.5 4.5 0 1 1 0-9h.75c.704 0 1.402-.03 2.09-.09m0 9.18c.253.962.584 1.892.985 2.783.247.55.06 1.21-.463 1.511l-.657.38c-.551.318-1.26.117-1.527-.461a20.845 20.845 0 0 1-1.44-4.282m3.102.069a18.03 18.03 0 0 1-.59-4.59c0-1.586.205-3.124.59-4.59m0 9.18a23.848 23.848 0 0 1 8.835 2.535M10.34 6.66a23.847 23.847 0 0 0 8.835-2.535m0 0A23.74 23.74 0 0 0 18.795 3m.38 1.125a23.91 23.91 0 0 1 1.014 5.395m-1.014 8.855c-.118.38-.245.754-.38 1.125m.38-1.125a23.91 23.91 0 0 0 1.014-5.395m0-3.46c.495.413.811 1.035.811 1.73 0 .695-.316 1.317-.811 1.73m0-3.46a24.347 24.347 0 0 1 0 3.46" />
+            </svg>
+            VOX
+        </a>
+        <a href="/Guilds/AudioSettings/@GuildId"
+           class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-full transition-colors bg-accent-blue/15 text-accent-blue border border-accent-blue/30">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+            </svg>
+            Settings
+        </a>
+    </nav>
+
+    <!-- Audio Globally Disabled Warning -->
+    @if (_isAudioGloballyDisabled)
+    {
+        <div class="mb-6 max-w-4xl mx-auto">
+            <Alert Variant="AlertVariant.Warning"
+                   Title="Audio Features Disabled"
+                   Message="Audio features have been disabled globally by an administrator. Audio commands will not work until audio is re-enabled in Settings."
+                   IsDismissible="false" />
+        </div>
+    }
+
+    <div class="max-w-4xl mx-auto">
+        <!-- General Settings Section -->
+        <section class="bg-bg-secondary border border-border-primary rounded-lg mb-6">
+            <div class="flex items-center gap-3 px-6 py-4 border-b border-border-primary">
+                <div class="w-8 h-8 flex items-center justify-center rounded-lg" style="background: var(--color-accent-blue-muted); color: var(--color-accent-blue);">
+                    <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                    </svg>
+                </div>
+                <div>
+                    <h2 class="text-lg font-semibold text-text-primary">General Settings</h2>
+                    <p class="text-xs text-text-tertiary">Core audio feature configuration</p>
+                </div>
+            </div>
+            <div class="p-6 space-y-1">
+                <!-- Audio Enabled -->
+                <div class="flex justify-between items-start py-4 border-b border-border-secondary">
+                    <div class="flex-1 pr-4">
+                        <div class="text-sm font-medium text-text-primary mb-0.5">Audio Features Enabled</div>
+                        <div class="text-xs text-text-tertiary">Enable or disable all audio and soundboard features for this server</div>
+                    </div>
+                    <FormToggle Id="audioEnabled"
+                                Name="AudioEnabled"
+                                IsChecked="_audioEnabled"
+                                IsCheckedChanged="OnAudioEnabledChanged" />
+                </div>
+
+                <!-- Auto-leave Timeout -->
+                <div class="flex justify-between items-start py-4 border-b border-border-secondary">
+                    <div class="flex-1 pr-4">
+                        <div class="text-sm font-medium text-text-primary mb-0.5">Auto-leave Timeout</div>
+                        <div class="text-xs text-text-tertiary">Minutes of inactivity before the bot automatically leaves the voice channel. Set to 0 to stay indefinitely.</div>
+                    </div>
+                    <div class="flex items-center gap-2">
+                        <input type="number" id="autoLeaveTimeout"
+                               class="w-24 py-2 px-3 text-sm bg-bg-primary border border-border-primary rounded-md text-text-primary focus:outline-none focus:ring-[3px] focus:border-accent-blue focus:ring-accent-blue/15"
+                               min="0" max="60"
+                               value="@_autoLeaveTimeout"
+                               @onchange="OnAutoLeaveTimeoutChanged" />
+                        <span class="text-xs text-text-tertiary">minutes</span>
+                    </div>
+                </div>
+
+                <!-- Queue Enabled -->
+                <div class="flex justify-between items-start py-4 border-b border-border-secondary">
+                    <div class="flex-1 pr-4">
+                        <div class="text-sm font-medium text-text-primary mb-0.5">Queue Mode</div>
+                        <div class="text-xs text-text-tertiary">When enabled, sounds queue up and play in order. When disabled, new sounds replace the currently playing sound.</div>
+                    </div>
+                    <FormToggle Id="queueEnabled"
+                                Name="QueueEnabled"
+                                IsChecked="_queueEnabled"
+                                IsCheckedChanged="OnQueueEnabledChanged" />
+                </div>
+
+                <!-- Enable Member Portal -->
+                <div class="flex justify-between items-start py-4 border-b border-border-secondary">
+                    <div class="flex-1 pr-4">
+                        <div class="text-sm font-medium text-text-primary mb-0.5">Member Portal</div>
+                        <div class="text-xs text-text-tertiary">Allow guild members to access the soundboard portal page. When disabled, only admins can access the portal.</div>
+                    </div>
+                    <FormToggle Id="enableMemberPortal"
+                                Name="EnableMemberPortal"
+                                IsChecked="_enableMemberPortal"
+                                IsCheckedChanged="OnEnableMemberPortalChanged" />
+                </div>
+
+                <!-- Silent Playback -->
+                <div class="flex justify-between items-start py-4 border-b border-border-secondary">
+                    <div class="flex-1 pr-4">
+                        <div class="text-sm font-medium text-text-primary mb-0.5">Silent Playback</div>
+                        <div class="text-xs text-text-tertiary">Suppress "Now Playing" and "Sound Queued" confirmation messages for /play commands. Error messages are always shown regardless of this setting.</div>
+                    </div>
+                    <FormToggle Id="silentPlayback"
+                                Name="SilentPlayback"
+                                IsChecked="_silentPlayback"
+                                IsCheckedChanged="OnSilentPlaybackChanged" />
+                </div>
+
+                <!-- Portal Links (shown when Member Portal is enabled) -->
+                @if (_enableMemberPortal)
+                {
+                    <div class="flex justify-between items-start py-4 px-4 -mx-6 bg-bg-tertiary border-t border-dashed border-border-secondary border-b border-b-border-secondary">
+                        <div class="flex-1 pr-4">
+                            <div class="text-sm font-medium text-text-primary mb-0.5">Portal Links</div>
+                            <div class="text-xs text-text-tertiary">Open the member portal pages. These links open in a new tab using Discord OAuth authentication.</div>
+                        </div>
+                        <div class="flex flex-wrap gap-2">
+                            <a href="/Portal/Soundboard/@GuildId" target="_blank" rel="noopener noreferrer"
+                               class="inline-flex items-center gap-1.5 px-3 py-2 text-[0.8125rem] font-medium text-text-primary bg-bg-tertiary border border-border-primary rounded-md hover:bg-bg-hover hover:border-border-focus hover:text-accent-blue transition-all no-underline">
+                                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
+                                </svg>
+                                Soundboard Portal
+                                <svg class="w-3 h-3 opacity-50" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                                </svg>
+                            </a>
+                            <a href="/Portal/TTS/@GuildId" target="_blank" rel="noopener noreferrer"
+                               class="inline-flex items-center gap-1.5 px-3 py-2 text-[0.8125rem] font-medium text-text-primary bg-bg-tertiary border border-border-primary rounded-md hover:bg-bg-hover hover:border-border-focus hover:text-accent-blue transition-all no-underline">
+                                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z" />
+                                </svg>
+                                TTS Portal
+                                <svg class="w-3 h-3 opacity-50" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                                </svg>
+                            </a>
+                            <a href="/Portal/VOX/@GuildId" target="_blank" rel="noopener noreferrer"
+                               class="inline-flex items-center gap-1.5 px-3 py-2 text-[0.8125rem] font-medium text-text-primary bg-bg-tertiary border border-border-primary rounded-md hover:bg-bg-hover hover:border-border-focus hover:text-accent-blue transition-all no-underline">
+                                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.34 15.84c-.688-.06-1.386-.09-2.09-.09H7.5a4.5 4.5 0 1 1 0-9h.75c.704 0 1.402-.03 2.09-.09m0 9.18c.253.962.584 1.892.985 2.783.247.55.06 1.21-.463 1.511l-.657.38c-.551.318-1.26.117-1.527-.461a20.845 20.845 0 0 1-1.44-4.282m3.102.069a18.03 18.03 0 0 1-.59-4.59c0-1.586.205-3.124.59-4.59m0 9.18a23.848 23.848 0 0 1 8.835 2.535M10.34 6.66a23.847 23.847 0 0 0 8.835-2.535m0 0A23.74 23.74 0 0 0 18.795 3m.38 1.125a23.91 23.91 0 0 1 1.014 5.395m-1.014 8.855c-.118.38-.245.754-.38 1.125m.38-1.125a23.91 23.91 0 0 0 1.014-5.395m0-3.46c.495.413.811 1.035.811 1.73 0 .695-.316 1.317-.811 1.73m0-3.46a24.347 24.347 0 0 1 0 3.46" />
+                                </svg>
+                                VOX Portal
+                                <svg class="w-3 h-3 opacity-50" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                                </svg>
+                            </a>
+                        </div>
+                    </div>
+                }
+
+                <!-- Sound Storage Path (Read-only) -->
+                <div class="flex justify-between items-start py-4">
+                    <div class="flex-1 pr-4">
+                        <div class="text-sm font-medium text-text-primary mb-0.5">Sound Storage Path</div>
+                        <div class="text-xs text-text-tertiary">The folder where audio files for this server are stored</div>
+                    </div>
+                    <div class="flex items-center gap-2 px-3 py-2 bg-bg-tertiary border border-border-secondary rounded-lg text-sm text-text-secondary">
+                        <svg class="w-4 h-4 text-text-tertiary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+                        </svg>
+                        <code class="font-mono text-text-primary">@_soundFolderPath</code>
+                    </div>
+                </div>
+
+                <!-- Save General Settings Button -->
+                <div class="mt-4 pt-4 border-t border-border-secondary flex justify-end">
+                    <Button Text="Save General Settings"
+                            Variant="ButtonVariant.Primary"
+                            IsLoading="_isSavingGeneral"
+                            LoadingText="Saving..."
+                            OnClick="SaveGeneralSettingsAsync"
+                            IconLeft="M5 13l4 4L19 7" />
+                </div>
+            </div>
+        </section>
+
+        <!-- Limits Section -->
+        <section class="bg-bg-secondary border border-border-primary rounded-lg mb-6">
+            <div class="flex items-center gap-3 px-6 py-4 border-b border-border-primary">
+                <div class="w-8 h-8 flex items-center justify-center rounded-lg" style="background: var(--color-warning-bg); color: var(--color-warning);">
+                    <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                    </svg>
+                </div>
+                <div>
+                    <h2 class="text-lg font-semibold text-text-primary">Limits</h2>
+                    <p class="text-xs text-text-tertiary">Resource limits for audio files and storage</p>
+                </div>
+            </div>
+            <div class="p-6 space-y-1">
+                <!-- Max Duration -->
+                <div class="flex justify-between items-start py-4 border-b border-border-secondary">
+                    <div class="flex-1 pr-4">
+                        <div class="text-sm font-medium text-text-primary mb-0.5">Maximum Sound Duration</div>
+                        <div class="text-xs text-text-tertiary">The maximum length allowed for uploaded sound files (1-300 seconds)</div>
+                    </div>
+                    <div class="flex items-center gap-2">
+                        <input type="number" id="maxDuration"
+                               class="w-24 py-2 px-3 text-sm bg-bg-primary border border-border-primary rounded-md text-text-primary focus:outline-none focus:ring-[3px] focus:border-accent-blue focus:ring-accent-blue/15"
+                               min="1" max="300"
+                               value="@_maxDurationSeconds"
+                               @onchange="OnMaxDurationChanged" />
+                        <span class="text-xs text-text-tertiary">seconds</span>
+                    </div>
+                </div>
+
+                <!-- Max File Size -->
+                <div class="flex justify-between items-start py-4 border-b border-border-secondary">
+                    <div class="flex-1 pr-4">
+                        <div class="text-sm font-medium text-text-primary mb-0.5">Maximum File Size</div>
+                        <div class="text-xs text-text-tertiary">The maximum file size allowed for uploaded audio files (1-50 MB)</div>
+                    </div>
+                    <div class="flex items-center gap-2">
+                        <input type="number" id="maxFileSize"
+                               class="w-24 py-2 px-3 text-sm bg-bg-primary border border-border-primary rounded-md text-text-primary focus:outline-none focus:ring-[3px] focus:border-accent-blue focus:ring-accent-blue/15"
+                               min="1" max="50"
+                               value="@_maxFileSizeMB"
+                               @onchange="OnMaxFileSizeChanged" />
+                        <span class="text-xs text-text-tertiary">MB</span>
+                    </div>
+                </div>
+
+                <!-- Max Sounds Per Guild -->
+                <div class="flex justify-between items-start py-4">
+                    <div class="flex-1 pr-4">
+                        <div class="text-sm font-medium text-text-primary mb-0.5">Maximum Sounds</div>
+                        <div class="text-xs text-text-tertiary">The maximum number of sounds this server can store (1-500)</div>
+                    </div>
+                    <div class="flex items-center gap-2">
+                        <input type="number" id="maxSounds"
+                               class="w-24 py-2 px-3 text-sm bg-bg-primary border border-border-primary rounded-md text-text-primary focus:outline-none focus:ring-[3px] focus:border-accent-blue focus:ring-accent-blue/15"
+                               min="1" max="500"
+                               value="@_maxSoundsPerGuild"
+                               @onchange="OnMaxSoundsChanged" />
+                        <span class="text-xs text-text-tertiary">sounds</span>
+                    </div>
+                </div>
+
+                <!-- Save Limits Button -->
+                <div class="mt-4 pt-4 border-t border-border-secondary flex justify-end">
+                    <Button Text="Save Limit Settings"
+                            Variant="ButtonVariant.Primary"
+                            IsLoading="_isSavingLimits"
+                            LoadingText="Saving..."
+                            OnClick="SaveLimitSettingsAsync"
+                            IconLeft="M5 13l4 4L19 7" />
+                </div>
+            </div>
+        </section>
+
+        <!-- TTS Settings Section -->
+        <section class="bg-bg-secondary border border-border-primary rounded-lg mb-6">
+            <div class="flex items-center gap-3 px-6 py-4 border-b border-border-primary">
+                <div class="w-8 h-8 flex items-center justify-center rounded-lg" style="background: var(--color-info-bg); color: var(--color-info);">
+                    <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z" />
+                    </svg>
+                </div>
+                <div>
+                    <h2 class="text-lg font-semibold text-text-primary">TTS Settings</h2>
+                    <p class="text-xs text-text-tertiary">Configure SSML and advanced TTS features</p>
+                </div>
+            </div>
+            <div class="p-6 space-y-1">
+                <!-- SSML Enabled -->
+                <div class="flex justify-between items-start py-4 border-b border-border-secondary">
+                    <div class="flex-1 pr-4">
+                        <div class="text-sm font-medium text-text-primary mb-0.5">Enable SSML Mode</div>
+                        <div class="text-xs text-text-tertiary">Allow SSML (Speech Synthesis Markup Language) for advanced voice control including prosody, emphasis, and styles</div>
+                    </div>
+                    <FormToggle Id="ssmlEnabled"
+                                Name="SsmlEnabled"
+                                IsChecked="_ssmlEnabled"
+                                IsCheckedChanged="OnSsmlEnabledChanged" />
+                </div>
+
+                @if (_ssmlEnabled)
+                {
+                    <!-- Strict SSML Validation -->
+                    <div class="flex justify-between items-start py-4 border-b border-border-secondary">
+                        <div class="flex-1 pr-4">
+                            <div class="text-sm font-medium text-text-primary mb-0.5">Strict SSML Validation</div>
+                            <div class="text-xs text-text-tertiary">When enabled, invalid SSML will be rejected. When disabled, invalid SSML falls back to plain text.</div>
+                        </div>
+                        <FormToggle Id="strictSsmlValidation"
+                                    Name="StrictSsmlValidation"
+                                    IsChecked="_strictSsmlValidation"
+                                    IsCheckedChanged="OnStrictSsmlValidationChanged" />
+                    </div>
+
+                    <!-- Max SSML Complexity -->
+                    <div class="flex justify-between items-start py-4 border-b border-border-secondary">
+                        <div class="flex-1 pr-4">
+                            <div class="text-sm font-medium text-text-primary mb-0.5">Max SSML Complexity</div>
+                            <div class="text-xs text-text-tertiary">Maximum complexity score for SSML elements. Higher values allow more nested elements and prosody modifications (10-200).</div>
+                        </div>
+                        <div class="flex items-center gap-2">
+                            <input type="number" id="maxSsmlComplexity"
+                                   class="w-24 py-2 px-3 text-sm bg-bg-primary border border-border-primary rounded-md text-text-primary focus:outline-none focus:ring-[3px] focus:border-accent-blue focus:ring-accent-blue/15"
+                                   min="10" max="200"
+                                   value="@_maxSsmlComplexity"
+                                   @onchange="OnMaxSsmlComplexityChanged" />
+                        </div>
+                    </div>
+
+                    <!-- Default Style -->
+                    <div class="flex justify-between items-start py-4">
+                        <div class="flex-1 pr-4">
+                            <div class="text-sm font-medium text-text-primary mb-0.5">Default Style</div>
+                            <div class="text-xs text-text-tertiary">Default speaking style for voices that support it (applies when no style is specified in SSML)</div>
+                        </div>
+                        <FormSelect Id="defaultStyle"
+                                    Name="DefaultStyle"
+                                    SelectedValue="@_defaultStyle"
+                                    SelectedValueChanged="OnDefaultStyleChanged"
+                                    Options="@_styleOptions"
+                                    Placeholder="" />
+                    </div>
+                }
+
+                <!-- Save TTS Settings Button -->
+                <div class="mt-4 pt-4 border-t border-border-secondary flex justify-end">
+                    <Button Text="Save TTS Settings"
+                            Variant="ButtonVariant.Primary"
+                            IsLoading="_isSavingTts"
+                            LoadingText="Saving..."
+                            OnClick="SaveTtsSettingsAsync"
+                            IconLeft="M5 13l4 4L19 7" />
+                </div>
+            </div>
+        </section>
+
+        <!-- Command Permissions Section -->
+        <section class="bg-bg-secondary border border-border-primary rounded-lg mb-6">
+            <div class="flex items-center gap-3 px-6 py-4 border-b border-border-primary">
+                <div class="w-8 h-8 flex items-center justify-center rounded-lg" style="background: var(--color-success-bg); color: var(--color-success);">
+                    <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+                    </svg>
+                </div>
+                <div>
+                    <h2 class="text-lg font-semibold text-text-primary">Command Permissions</h2>
+                    <p class="text-xs text-text-tertiary">Restrict audio commands to specific roles. Leave empty to allow everyone.</p>
+                </div>
+            </div>
+            <div class="p-6">
+                @foreach (var command in SoundboardCommands)
+                {
+                    var cmd = command;
+                    var allowedRoleIds = GetAllowedRoleIdsForCommand(cmd);
+                    <div class="bg-bg-tertiary border border-border-secondary rounded-lg p-4 mb-3 last:mb-0">
+                        <div class="inline-flex items-center gap-1 px-2 py-1 bg-bg-hover rounded-md font-mono text-[0.8125rem] font-medium text-accent-blue mb-3">
+                            @GetCommandIconMarkup(cmd)
+                            /@cmd
+                        </div>
+                        <p class="text-xs text-text-tertiary mb-3">@GetCommandDescription(cmd)</p>
+
+                        <!-- Role selector -->
+                        <div class="relative">
+                            <div class="flex items-center justify-between w-full min-h-[2.5rem] px-3 py-2 bg-bg-primary border border-border-primary rounded-lg cursor-pointer hover:border-border-focus transition-colors"
+                                 tabindex="0"
+                                 @onclick="() => ToggleRoleDropdown(cmd)"
+                                 @onclick:stopPropagation="true">
+                                <div class="flex flex-wrap gap-1.5">
+                                    @if (allowedRoleIds.Count == 0)
+                                    {
+                                        <span class="text-sm text-text-tertiary">Everyone can use this command</span>
+                                    }
+                                    else
+                                    {
+                                        @foreach (var roleId in allowedRoleIds)
+                                        {
+                                            var role = _availableRoles.FirstOrDefault(r => r.Id == roleId);
+                                            if (role != null)
+                                            {
+                                                var capturedRoleId = roleId;
+                                                <div class="inline-flex items-center gap-1 px-2 py-0.5 bg-accent-blue/15 text-accent-blue rounded-full text-xs font-medium">
+                                                    @role.Name
+                                                    <span class="flex items-center justify-center w-4 h-4 rounded-full hover:bg-accent-blue hover:text-white cursor-pointer transition-colors"
+                                                          @onclick="() => RemoveRoleFromCommand(cmd, capturedRoleId)"
+                                                          @onclick:stopPropagation="true">
+                                                        <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                                                        </svg>
+                                                    </span>
+                                                </div>
+                                            }
+                                        }
+                                    }
+                                </div>
+                                <svg class="w-4 h-4 text-text-tertiary flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                                </svg>
+                            </div>
+
+                            @if (_openDropdownCommand == cmd)
+                            {
+                                <div class="absolute top-[calc(100%+0.25rem)] left-0 right-0 bg-bg-secondary border border-border-primary rounded-lg shadow-lg z-50 max-h-48 overflow-y-auto">
+                                    @if (_availableRoles.Count == 0)
+                                    {
+                                        <div class="px-4 py-2 text-sm text-text-tertiary">No roles available</div>
+                                    }
+                                    else
+                                    {
+                                        @foreach (var role in _availableRoles)
+                                        {
+                                            var isSelected = allowedRoleIds.Contains(role.Id);
+                                            var capturedRole = role;
+                                            <div class="flex items-center gap-2 px-3 py-2.5 cursor-pointer transition-colors hover:bg-bg-hover @(isSelected ? "bg-accent-blue/10" : "")"
+                                                 @onclick="() => ToggleRoleForCommand(cmd, capturedRole.Id)"
+                                                 @onclick:stopPropagation="true">
+                                                <span class="w-3 h-3 rounded-full flex-shrink-0"
+                                                      style="background: @(GetRoleColor(capturedRole.Color));"></span>
+                                                <span class="text-sm text-text-primary">@capturedRole.Name</span>
+                                            </div>
+                                        }
+                                    }
+                                </div>
+                            }
+                        </div>
+                    </div>
+                }
+            </div>
+        </section>
+
+        <!-- Reset to Defaults -->
+        <div class="flex items-center justify-between pt-4 mb-8">
+            <Button Text="Reset to Defaults"
+                    Variant="ButtonVariant.Secondary"
+                    IsLoading="_isResetting"
+                    LoadingText="Resetting..."
+                    OnClick="ResetToDefaultsAsync"
+                    IconLeft="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter] public long GuildId { get; set; }
+
+    // Data
+    private Core.DTOs.GuildDto? _guild;
+    private List<BreadcrumbItem>? _breadcrumbItems;
+    private List<RoleInfo> _availableRoles = new();
+    private string _soundFolderPath = string.Empty;
+    private int _soundCount;
+    private bool _isAudioGloballyDisabled;
+
+    // Command permissions state
+    private Dictionary<string, List<ulong>> _commandRoles = new();
+    private string? _openDropdownCommand;
+    private string? _savingCommand;
+
+    // General settings form state
+    private bool _audioEnabled;
+    private int _autoLeaveTimeout;
+    private bool _queueEnabled;
+    private bool _enableMemberPortal;
+    private bool _silentPlayback;
+
+    // Limits form state
+    private int _maxDurationSeconds;
+    private int _maxFileSizeMB;
+    private int _maxSoundsPerGuild;
+
+    // TTS form state
+    private bool _ssmlEnabled;
+    private bool _strictSsmlValidation;
+    private int _maxSsmlComplexity;
+    private string? _defaultStyle;
+
+    // Style options
+    private readonly List<SelectOption> _styleOptions = new()
+    {
+        new() { Value = "", Text = "(None)" },
+        new() { Value = "cheerful", Text = "Cheerful" },
+        new() { Value = "excited", Text = "Excited" },
+        new() { Value = "friendly", Text = "Friendly" },
+        new() { Value = "sad", Text = "Sad" },
+        new() { Value = "angry", Text = "Angry" },
+        new() { Value = "whispering", Text = "Whispering" },
+        new() { Value = "shouting", Text = "Shouting" },
+        new() { Value = "newscast", Text = "Newscast" }
+    };
+
+    // UI state
+    private bool _loading = true;
+    private bool _notFound;
+    private bool _isSavingGeneral;
+    private bool _isSavingLimits;
+    private bool _isSavingTts;
+    private bool _isResetting;
+
+    // Soundboard commands
+    private static readonly string[] SoundboardCommands = { "join", "leave", "play", "sounds", "stop" };
+
+    protected override async Task OnInitializedAsync()
+    {
+        var guildId = (ulong)GuildId;
+
+        Logger.LogInformation("User accessing audio settings for guild {GuildId}", guildId);
+
+        try
+        {
+            // Check if audio is globally disabled
+            var isGloballyEnabled = await SettingsService.GetSettingValueAsync<bool?>("Features:AudioEnabled") ?? true;
+            _isAudioGloballyDisabled = !isGloballyEnabled;
+
+            // Load guild
+            _guild = await GuildService.GetGuildByIdAsync(guildId);
+            if (_guild is null)
+            {
+                Logger.LogWarning("Guild {GuildId} not found", guildId);
+                _notFound = true;
+                return;
+            }
+
+            // Load audio settings
+            var settings = await AudioSettingsService.GetSettingsAsync(guildId);
+            _audioEnabled = settings.AudioEnabled;
+            _autoLeaveTimeout = settings.AutoLeaveTimeoutMinutes;
+            _queueEnabled = settings.QueueEnabled;
+            _enableMemberPortal = settings.EnableMemberPortal;
+            _silentPlayback = settings.SilentPlayback;
+            _maxDurationSeconds = settings.MaxDurationSeconds;
+            _maxFileSizeMB = (int)(settings.MaxFileSizeBytes / (1024 * 1024));
+            _maxSoundsPerGuild = settings.MaxSoundsPerGuild;
+
+            // Build command roles dictionary
+            foreach (var cmd in SoundboardCommands)
+            {
+                var restriction = settings.CommandRoleRestrictions
+                    .FirstOrDefault(r => r.CommandName.Equals(cmd, StringComparison.OrdinalIgnoreCase));
+                _commandRoles[cmd] = restriction?.AllowedRoleIds?.ToList() ?? new List<ulong>();
+            }
+
+            // Load TTS settings
+            var ttsSettings = await TtsSettingsService.GetOrCreateSettingsAsync(guildId);
+            _ssmlEnabled = ttsSettings.SsmlEnabled;
+            _strictSsmlValidation = ttsSettings.StrictSsmlValidation;
+            _maxSsmlComplexity = ttsSettings.MaxSsmlComplexity;
+            _defaultStyle = ttsSettings.DefaultStyle ?? "";
+
+            // Load guild roles from Discord
+            var discordGuild = DiscordClient.GetGuild(guildId);
+            if (discordGuild != null)
+            {
+                _availableRoles = discordGuild.Roles
+                    .Where(r => !r.IsEveryone && !r.IsManaged)
+                    .OrderByDescending(r => r.Position)
+                    .Select(r => new RoleInfo
+                    {
+                        Id = r.Id,
+                        Name = r.Name,
+                        Color = r.Color.ToString()
+                    })
+                    .ToList();
+            }
+
+            // Sound folder path
+            _soundFolderPath = Path.Combine(SoundboardOptions.Value.BasePath, guildId.ToString());
+
+            // Sound count for tab badge
+            _soundCount = await SoundService.GetSoundCountAsync(guildId);
+
+            // Breadcrumb
+            _breadcrumbItems = new List<BreadcrumbItem>
+            {
+                new() { Label = "Home", Url = "/" },
+                new() { Label = "Servers", Url = "/Guilds" },
+                new() { Label = _guild.Name, Url = $"/Guilds/Details/{GuildId}" },
+                new() { Label = "Audio", Url = $"/Guilds/Soundboard/{GuildId}" },
+                new() { Label = "Settings", IsCurrent = true }
+            };
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error loading audio settings for guild {GuildId}", guildId);
+            _notFound = true;
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    // --- General Settings Handlers ---
+
+    private void OnAudioEnabledChanged(bool value) => _audioEnabled = value;
+    private void OnAutoLeaveTimeoutChanged(ChangeEventArgs e)
+    {
+        if (int.TryParse(e.Value?.ToString(), out var val))
+            _autoLeaveTimeout = val;
+    }
+    private void OnQueueEnabledChanged(bool value) => _queueEnabled = value;
+    private void OnEnableMemberPortalChanged(bool value) => _enableMemberPortal = value;
+    private void OnSilentPlaybackChanged(bool value) => _silentPlayback = value;
+
+    private async Task SaveGeneralSettingsAsync()
+    {
+        if (_isSavingGeneral) return;
+
+        // Validate
+        if (_autoLeaveTimeout < 0 || _autoLeaveTimeout > 60)
+        {
+            await Toast.ShowAsync("error", "Auto-leave timeout must be between 0 and 60 minutes.");
+            return;
+        }
+
+        _isSavingGeneral = true;
+        try
+        {
+            var guildId = (ulong)GuildId;
+            await AudioSettingsService.UpdateSettingsAsync(guildId, settings =>
+            {
+                settings.AudioEnabled = _audioEnabled;
+                settings.AutoLeaveTimeoutMinutes = _autoLeaveTimeout;
+                settings.QueueEnabled = _queueEnabled;
+                settings.EnableMemberPortal = _enableMemberPortal;
+                settings.SilentPlayback = _silentPlayback;
+            });
+
+            Logger.LogInformation("General audio settings saved for guild {GuildId}", guildId);
+            await Toast.ShowAsync("success", "General settings saved successfully.");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to save general audio settings for guild {GuildId}", (ulong)GuildId);
+            await Toast.ShowAsync("error", "Failed to save settings. Please try again.");
+        }
+        finally
+        {
+            _isSavingGeneral = false;
+        }
+    }
+
+    // --- Limits Handlers ---
+
+    private void OnMaxDurationChanged(ChangeEventArgs e)
+    {
+        if (int.TryParse(e.Value?.ToString(), out var val))
+            _maxDurationSeconds = val;
+    }
+    private void OnMaxFileSizeChanged(ChangeEventArgs e)
+    {
+        if (int.TryParse(e.Value?.ToString(), out var val))
+            _maxFileSizeMB = val;
+    }
+    private void OnMaxSoundsChanged(ChangeEventArgs e)
+    {
+        if (int.TryParse(e.Value?.ToString(), out var val))
+            _maxSoundsPerGuild = val;
+    }
+
+    private async Task SaveLimitSettingsAsync()
+    {
+        if (_isSavingLimits) return;
+
+        // Validate
+        var errors = new List<string>();
+        if (_maxDurationSeconds < 1 || _maxDurationSeconds > 300)
+            errors.Add("Max duration must be between 1 and 300 seconds.");
+        if (_maxFileSizeMB < 1 || _maxFileSizeMB > 50)
+            errors.Add("Max file size must be between 1 and 50 MB.");
+        if (_maxSoundsPerGuild < 1 || _maxSoundsPerGuild > 500)
+            errors.Add("Max sounds must be between 1 and 500.");
+
+        if (errors.Count > 0)
+        {
+            await Toast.ShowAsync("error", string.Join(" ", errors));
+            return;
+        }
+
+        _isSavingLimits = true;
+        try
+        {
+            var guildId = (ulong)GuildId;
+            await AudioSettingsService.UpdateSettingsAsync(guildId, settings =>
+            {
+                settings.MaxDurationSeconds = _maxDurationSeconds;
+                settings.MaxFileSizeBytes = (long)_maxFileSizeMB * 1024 * 1024;
+                settings.MaxSoundsPerGuild = _maxSoundsPerGuild;
+            });
+
+            Logger.LogInformation("Limit settings saved for guild {GuildId}", guildId);
+            await Toast.ShowAsync("success", "Limit settings saved successfully.");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to save limit settings for guild {GuildId}", (ulong)GuildId);
+            await Toast.ShowAsync("error", "Failed to save settings. Please try again.");
+        }
+        finally
+        {
+            _isSavingLimits = false;
+        }
+    }
+
+    // --- TTS Settings Handlers ---
+
+    private void OnSsmlEnabledChanged(bool value) => _ssmlEnabled = value;
+    private void OnStrictSsmlValidationChanged(bool value) => _strictSsmlValidation = value;
+    private void OnMaxSsmlComplexityChanged(ChangeEventArgs e)
+    {
+        if (int.TryParse(e.Value?.ToString(), out var val))
+            _maxSsmlComplexity = val;
+    }
+    private void OnDefaultStyleChanged(string? value) => _defaultStyle = value;
+
+    private async Task SaveTtsSettingsAsync()
+    {
+        if (_isSavingTts) return;
+
+        // Validate
+        if (_maxSsmlComplexity < 10 || _maxSsmlComplexity > 200)
+        {
+            await Toast.ShowAsync("error", "Max SSML complexity must be between 10 and 200.");
+            return;
+        }
+
+        _isSavingTts = true;
+        try
+        {
+            var guildId = (ulong)GuildId;
+            var ttsSettings = await TtsSettingsService.GetOrCreateSettingsAsync(guildId);
+            ttsSettings.SsmlEnabled = _ssmlEnabled;
+            ttsSettings.StrictSsmlValidation = _strictSsmlValidation;
+            ttsSettings.MaxSsmlComplexity = _maxSsmlComplexity;
+            ttsSettings.DefaultStyle = string.IsNullOrWhiteSpace(_defaultStyle) ? null : _defaultStyle;
+            ttsSettings.UpdatedAt = DateTime.UtcNow;
+
+            await TtsSettingsService.UpdateSettingsAsync(ttsSettings);
+
+            Logger.LogInformation("TTS settings saved for guild {GuildId}", guildId);
+            await Toast.ShowAsync("success", "TTS settings saved successfully.");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to save TTS settings for guild {GuildId}", (ulong)GuildId);
+            await Toast.ShowAsync("error", "Failed to save settings. Please try again.");
+        }
+        finally
+        {
+            _isSavingTts = false;
+        }
+    }
+
+    // --- Command Permissions Handlers ---
+
+    private List<ulong> GetAllowedRoleIdsForCommand(string command)
+    {
+        return _commandRoles.TryGetValue(command, out var roles) ? roles : new List<ulong>();
+    }
+
+    private void ToggleRoleDropdown(string command)
+    {
+        _openDropdownCommand = _openDropdownCommand == command ? null : command;
+    }
+
+    private async Task ToggleRoleForCommand(string command, ulong roleId)
+    {
+        if (!_commandRoles.ContainsKey(command))
+            _commandRoles[command] = new List<ulong>();
+
+        var roles = _commandRoles[command];
+        if (roles.Contains(roleId))
+        {
+            roles.Remove(roleId);
+        }
+        else
+        {
+            roles.Add(roleId);
+        }
+
+        await SaveCommandPermissionsAsync(command);
+    }
+
+    private async Task RemoveRoleFromCommand(string command, ulong roleId)
+    {
+        if (_commandRoles.TryGetValue(command, out var roles))
+        {
+            roles.Remove(roleId);
+            await SaveCommandPermissionsAsync(command);
+        }
+    }
+
+    private async Task SaveCommandPermissionsAsync(string command)
+    {
+        if (_savingCommand == command) return;
+        _savingCommand = command;
+
+        var guildId = (ulong)GuildId;
+        var roleIds = GetAllowedRoleIdsForCommand(command);
+
+        try
+        {
+            // Get current settings to find existing restrictions
+            var settings = await AudioSettingsService.GetSettingsAsync(guildId);
+            var restriction = settings.CommandRoleRestrictions
+                .FirstOrDefault(r => r.CommandName.Equals(command, StringComparison.OrdinalIgnoreCase));
+
+            // Remove all existing roles for this command
+            if (restriction != null)
+            {
+                foreach (var existingRoleId in restriction.AllowedRoleIds.ToList())
+                {
+                    await AudioSettingsService.RemoveCommandRestrictionAsync(guildId, command, existingRoleId);
+                }
+            }
+
+            // Add new roles
+            foreach (var roleId in roleIds)
+            {
+                await AudioSettingsService.AddCommandRestrictionAsync(guildId, command, roleId);
+            }
+
+            Logger.LogInformation("Command roles updated for '{CommandName}' in guild {GuildId}: {RoleCount} roles",
+                command, guildId, roleIds.Count);
+            await Toast.ShowAsync("success", $"/{command} permissions saved.");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to update command roles for '{CommandName}' in guild {GuildId}",
+                command, guildId);
+            await Toast.ShowAsync("error", "Failed to save permissions. Please try again.");
+        }
+        finally
+        {
+            _savingCommand = null;
+        }
+    }
+
+    // --- Reset to Defaults ---
+
+    private async Task ResetToDefaultsAsync()
+    {
+        if (_isResetting) return;
+
+        _isResetting = true;
+        try
+        {
+            var guildId = (ulong)GuildId;
+            await AudioSettingsService.UpdateSettingsAsync(guildId, settings =>
+            {
+                settings.AudioEnabled = true;
+                settings.AutoLeaveTimeoutMinutes = 5;
+                settings.QueueEnabled = true;
+                settings.EnableMemberPortal = false;
+                settings.SilentPlayback = false;
+                settings.MaxDurationSeconds = 30;
+                settings.MaxFileSizeBytes = 5_242_880; // 5 MB
+                settings.MaxSoundsPerGuild = 50;
+                settings.CommandRoleRestrictions.Clear();
+            });
+
+            // Update local state
+            _audioEnabled = true;
+            _autoLeaveTimeout = 5;
+            _queueEnabled = true;
+            _enableMemberPortal = false;
+            _silentPlayback = false;
+            _maxDurationSeconds = 30;
+            _maxFileSizeMB = 5;
+            _maxSoundsPerGuild = 50;
+            foreach (var cmd in SoundboardCommands)
+            {
+                _commandRoles[cmd] = new List<ulong>();
+            }
+
+            Logger.LogInformation("Audio settings reset to defaults for guild {GuildId}", guildId);
+            await Toast.ShowAsync("success", "Audio settings have been reset to defaults.");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to reset audio settings for guild {GuildId}", (ulong)GuildId);
+            await Toast.ShowAsync("error", "Failed to reset settings. Please try again.");
+        }
+        finally
+        {
+            _isResetting = false;
+        }
+    }
+
+    // --- Helpers ---
+
+    private static string GetCommandDescription(string command) => command.ToLower() switch
+    {
+        "join" => "Join a voice channel",
+        "leave" => "Leave the current voice channel",
+        "play" => "Play a sound from the soundboard",
+        "sounds" => "List available sounds in the soundboard",
+        "stop" => "Stop the currently playing sound and clear the queue",
+        _ => "Execute this command"
+    };
+
+    private static MarkupString GetCommandIconMarkup(string command)
+    {
+        var iconPath = command.ToLower() switch
+        {
+            "join" => "<path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M15.536 8.464a5 5 0 010 7.072m2.828-9.9a9 9 0 010 12.728M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z\" />",
+            "leave" => "<path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z\" /><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M17 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2\" />",
+            "play" => "<path d=\"M8 5v14l11-7z\" fill=\"currentColor\" />",
+            "sounds" => "<path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M4 6h16M4 10h16M4 14h16M4 18h16\" />",
+            "stop" => "<path d=\"M5 3h14a2 2 0 012 2v14a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2z\" fill=\"currentColor\" />",
+            _ => "<path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M13 10V3L4 14h7v7l9-11h-7z\" />"
+        };
+        return new MarkupString($"<svg class=\"w-3.5 h-3.5\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\">{iconPath}</svg>");
+    }
+
+    private static string GetRoleColor(string color)
+    {
+        if (string.IsNullOrEmpty(color) || color == "0")
+            return "#99AAB5";
+        return color.StartsWith('#') ? color : $"#{color}";
+    }
+
+    /// <summary>
+    /// Represents a Discord role for display purposes.
+    /// </summary>
+    private class RoleInfo
+    {
+        public ulong Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Color { get; set; } = string.Empty;
+    }
+}

--- a/src/DiscordBot.Bot/Components/Pages/Guilds/GuildModerationSettings.razor
+++ b/src/DiscordBot.Bot/Components/Pages/Guilds/GuildModerationSettings.razor
@@ -1,0 +1,943 @@
+@page "/Guilds/ModerationSettings/{GuildId:long}"
+@attribute [Authorize(Policy = "RequireAdmin")]
+@attribute [Authorize(Policy = "GuildAccess")]
+@layout GuildLayout
+@rendermode InteractiveServer
+@using DiscordBot.Core.DTOs
+@using DiscordBot.Core.Enums
+@using DiscordBot.Core.Interfaces
+@using DiscordBot.Bot.ViewModels.Pages
+@using Discord.WebSocket
+@inject IGuildModerationConfigService ConfigService
+@inject IModTagService ModTagService
+@inject IGuildService GuildService
+@inject IFlaggedEventService FlaggedEventService
+@inject DiscordSocketClient DiscordClient
+@inject ToastInterop Toast
+@inject ILogger<GuildModerationSettings> Logger
+
+<PageTitle>Moderation Settings - Discord Bot Admin</PageTitle>
+
+@if (_guild is null && !_notFound)
+{
+    <div class="flex items-center justify-center py-12">
+        <div class="text-text-secondary">Loading...</div>
+    </div>
+}
+else if (_notFound)
+{
+    <div class="flex flex-col items-center justify-center py-12 space-y-4">
+        <div class="text-text-secondary text-lg">Guild not found</div>
+        <a href="/Guilds" class="text-accent-blue hover:text-accent-blue-hover transition-colors text-sm">Back to Guilds</a>
+    </div>
+}
+else
+{
+    <!-- Breadcrumb -->
+    <GuildBreadcrumb Items="@_breadcrumbItems" />
+
+    <!-- Guild Header -->
+    <GuildHeader GuildId="(ulong)GuildId"
+                 GuildName="@_guild!.Name"
+                 GuildIconUrl="@_guild.IconUrl"
+                 PageTitle="Moderation Settings"
+                 PageDescription="Configure auto-moderation rules for this server"
+                 Actions="@_headerActions" />
+
+    <!-- Error Alert -->
+    @if (!string.IsNullOrEmpty(_errorMessage))
+    {
+        <div class="mb-6">
+            <Alert Variant="AlertVariant.Error" Title="Error" Message="@_errorMessage" IsDismissible="true" />
+        </div>
+    }
+
+    <!-- Tab Navigation -->
+    <div class="settings-tabs mb-6" role="tablist" aria-label="Moderation settings sections">
+        <button type="button" class="settings-tab @(_activeTab == "overview" ? "settings-tab-active" : "")" role="tab" aria-selected="@(_activeTab == "overview")" @onclick='() => _activeTab = "overview"'>
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+            </svg>
+            Overview
+        </button>
+        <button type="button" class="settings-tab @(_activeTab == "spam" ? "settings-tab-active" : "")" role="tab" aria-selected="@(_activeTab == "spam")" @onclick='() => _activeTab = "spam"'>
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+            </svg>
+            Spam
+        </button>
+        <button type="button" class="settings-tab @(_activeTab == "content" ? "settings-tab-active" : "")" role="tab" aria-selected="@(_activeTab == "content")" @onclick='() => _activeTab = "content"'>
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.618 5.984A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016zM12 9v2m0 4h.01" />
+            </svg>
+            Content
+        </button>
+        <button type="button" class="settings-tab @(_activeTab == "raid" ? "settings-tab-active" : "")" role="tab" aria-selected="@(_activeTab == "raid")" @onclick='() => _activeTab = "raid"'>
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+            </svg>
+            Raid
+        </button>
+        <button type="button" class="settings-tab @(_activeTab == "tags" ? "settings-tab-active" : "")" role="tab" aria-selected="@(_activeTab == "tags")" @onclick='() => _activeTab = "tags"'>
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
+            </svg>
+            Tags
+        </button>
+    </div>
+
+    <!-- Tab Content Container -->
+    <div class="bg-bg-secondary border border-border-primary rounded-lg">
+
+        @* ===== Overview Tab ===== *@
+        @if (_activeTab == "overview")
+        {
+            <div class="p-6" role="tabpanel">
+                <!-- Mode Toggle -->
+                <div class="mb-8">
+                    <h3 class="text-lg font-semibold text-text-primary mb-2">Configuration Mode</h3>
+                    <p class="text-sm text-text-secondary mb-4">Choose between simplified presets or advanced custom configuration.</p>
+                    <div class="mode-toggle">
+                        <button type="button" class="mode-toggle-btn @(_mode == ConfigMode.Simple ? "mode-toggle-btn-active" : "")" @onclick="() => _mode = ConfigMode.Simple">Simple</button>
+                        <button type="button" class="mode-toggle-btn @(_mode == ConfigMode.Advanced ? "mode-toggle-btn-active" : "")" @onclick="() => _mode = ConfigMode.Advanced">Advanced</button>
+                    </div>
+                </div>
+
+                <!-- Simple Mode: Presets -->
+                @if (_mode == ConfigMode.Simple)
+                {
+                    <div class="mb-8">
+                        <h3 class="text-lg font-semibold text-text-primary mb-4">Protection Level</h3>
+                        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                            <!-- Relaxed -->
+                            <button type="button" class="text-left p-4 bg-bg-tertiary border-2 rounded-lg transition-colors @(_simplePreset == "Relaxed" ? "border-accent-orange" : "border-border-primary")" @onclick='() => _simplePreset = "Relaxed"'>
+                                <div class="flex items-center gap-2 mb-2">
+                                    <div class="w-3 h-3 rounded-full bg-success"></div>
+                                    <span class="font-semibold text-text-primary">Relaxed</span>
+                                </div>
+                                <p class="text-sm text-text-secondary">Minimal intervention. Only catches obvious spam and severe violations.</p>
+                            </button>
+                            <!-- Moderate -->
+                            <button type="button" class="text-left p-4 bg-bg-tertiary border-2 rounded-lg transition-colors @(_simplePreset == "Moderate" ? "border-accent-orange" : "border-border-primary")" @onclick='() => _simplePreset = "Moderate"'>
+                                <div class="flex items-center gap-2 mb-2">
+                                    <div class="w-3 h-3 rounded-full bg-warning"></div>
+                                    <span class="font-semibold text-text-primary">Moderate</span>
+                                </div>
+                                <p class="text-sm text-text-secondary">Balanced protection. Flags suspicious activity for review.</p>
+                            </button>
+                            <!-- Strict -->
+                            <button type="button" class="text-left p-4 bg-bg-tertiary border-2 rounded-lg transition-colors @(_simplePreset == "Strict" ? "border-accent-orange" : "border-border-primary")" @onclick='() => _simplePreset = "Strict"'>
+                                <div class="flex items-center gap-2 mb-2">
+                                    <div class="w-3 h-3 rounded-full bg-error"></div>
+                                    <span class="font-semibold text-text-primary">Strict</span>
+                                </div>
+                                <p class="text-sm text-text-secondary">Maximum protection. Aggressive detection with auto-actions enabled.</p>
+                            </button>
+                        </div>
+                    </div>
+                }
+
+                <!-- Advanced Mode: Configuration Guide -->
+                @if (_mode == ConfigMode.Advanced)
+                {
+                    <div class="mb-8">
+                        <div class="p-4 bg-bg-tertiary border border-border-primary rounded-lg">
+                            <div class="flex items-start gap-3">
+                                <svg class="w-6 h-6 text-accent-orange flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                </svg>
+                                <div>
+                                    <h4 class="font-semibold text-text-primary mb-1">Advanced Configuration Mode</h4>
+                                    <p class="text-sm text-text-secondary mb-3">
+                                        Configure each moderation feature individually using the tabs below.
+                                        Each tab provides granular control over thresholds, actions, and exclusions.
+                                    </p>
+                                    <div class="flex flex-wrap gap-2">
+                                        <button type="button" @onclick='() => _activeTab = "spam"' class="px-3 py-1.5 text-sm bg-bg-secondary border border-border-primary rounded-lg hover:border-accent-orange transition-colors">
+                                            Spam Detection
+                                        </button>
+                                        <button type="button" @onclick='() => _activeTab = "content"' class="px-3 py-1.5 text-sm bg-bg-secondary border border-border-primary rounded-lg hover:border-accent-orange transition-colors">
+                                            Content Filter
+                                        </button>
+                                        <button type="button" @onclick='() => _activeTab = "raid"' class="px-3 py-1.5 text-sm bg-bg-secondary border border-border-primary rounded-lg hover:border-accent-orange transition-colors">
+                                            Raid Protection
+                                        </button>
+                                        <button type="button" @onclick='() => _activeTab = "tags"' class="px-3 py-1.5 text-sm bg-bg-secondary border border-border-primary rounded-lg hover:border-accent-orange transition-colors">
+                                            Tags
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                }
+
+                <!-- Quick Stats -->
+                <div>
+                    <h3 class="text-lg font-semibold text-text-primary mb-4">Activity Summary (Last 24h)</h3>
+                    <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+                        <div class="history-stat-card">
+                            <span class="history-stat-value">@_eventsFlagged</span>
+                            <span class="history-stat-label">Events Flagged</span>
+                        </div>
+                        <div class="history-stat-card">
+                            <span class="history-stat-value text-success">@_autoActions</span>
+                            <span class="history-stat-label">Auto-Actions</span>
+                        </div>
+                        <div class="history-stat-card">
+                            <span class="history-stat-value">@_activeRules</span>
+                            <span class="history-stat-label">Active Rules</span>
+                        </div>
+                        <div class="history-stat-card">
+                            <span class="history-stat-value text-warning">@_falsePositives</span>
+                            <span class="history-stat-label">False Positives</span>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Save Button -->
+                <div class="mt-8 pt-6 border-t border-border-secondary flex justify-end">
+                    <Button Text="Save Overview Settings"
+                            Variant="ButtonVariant.Primary"
+                            IsLoading="_isSavingOverview"
+                            LoadingText="Saving..."
+                            OnClick="SaveOverviewAsync" />
+                </div>
+            </div>
+        }
+
+        @* ===== Spam Tab ===== *@
+        @if (_activeTab == "spam")
+        {
+            <div class="p-6" role="tabpanel">
+                <!-- Enable Toggle -->
+                <div class="flex items-center justify-between mb-6 pb-6 border-b border-border-secondary">
+                    <div>
+                        <h3 class="text-lg font-semibold text-text-primary">Spam Detection</h3>
+                        <p class="text-sm text-text-secondary">Detect and flag spam messages automatically</p>
+                    </div>
+                    <FormToggle Id="spam-enabled"
+                                Name="SpamEnabled"
+                                IsChecked="_spamEnabled"
+                                IsCheckedChanged="v => _spamEnabled = v" />
+                </div>
+
+                <!-- Settings Grid -->
+                <div class="space-y-6">
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <FormInput Id="spam-max-messages"
+                                   Name="MaxMessagesPerWindow"
+                                   Label="Message Rate Threshold"
+                                   Description="Flag when user sends this many messages..."
+                                   Type="number"
+                                   Value="@_spamMaxMessages.ToString()"
+                                   ValueChanged="v => _spamMaxMessages = int.TryParse(v, out var r) ? r : _spamMaxMessages" />
+                        <FormInput Id="spam-window-seconds"
+                                   Name="SpamWindowSeconds"
+                                   Label="Time Window (seconds)"
+                                   Description="...within this time period"
+                                   Type="number"
+                                   Value="@_spamWindowSeconds.ToString()"
+                                   ValueChanged="v => _spamWindowSeconds = int.TryParse(v, out var r) ? r : _spamWindowSeconds" />
+                    </div>
+
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <FormInput Id="spam-max-mentions"
+                                   Name="MaxMentionsPerMessage"
+                                   Label="Max Mentions Per Message"
+                                   Description="Maximum mentions allowed per message"
+                                   Type="number"
+                                   Value="@_spamMaxMentions.ToString()"
+                                   ValueChanged="v => _spamMaxMentions = int.TryParse(v, out var r) ? r : _spamMaxMentions" />
+                        <FormInput Id="spam-duplicate-threshold"
+                                   Name="DuplicateMessageThreshold"
+                                   Label="Similarity Threshold (%)"
+                                   Description="Messages this similar count as duplicates"
+                                   Type="number"
+                                   Value="@_spamDuplicateThresholdPercent.ToString()"
+                                   ValueChanged="v => _spamDuplicateThresholdPercent = int.TryParse(v, out var r) ? r : _spamDuplicateThresholdPercent" />
+                    </div>
+
+                    <FormSelect Id="spam-auto-action"
+                                Name="SpamAutoAction"
+                                Label="Auto-Action on Detection"
+                                Description="Automatically take action when spam is detected"
+                                SelectedValue="@(((int)_spamAutoAction).ToString())"
+                                SelectedValueChanged="v => _spamAutoAction = Enum.TryParse<AutoAction>(v, out var r) ? r : _spamAutoAction"
+                                Options="@_autoActionOptions" />
+                </div>
+
+                <!-- Save Button -->
+                <div class="mt-8 pt-6 border-t border-border-secondary flex justify-end">
+                    <Button Text="Save Spam Settings"
+                            Variant="ButtonVariant.Primary"
+                            IsLoading="_isSavingSpam"
+                            LoadingText="Saving..."
+                            OnClick="SaveSpamAsync" />
+                </div>
+            </div>
+        }
+
+        @* ===== Content Tab ===== *@
+        @if (_activeTab == "content")
+        {
+            <div class="p-6" role="tabpanel">
+                <!-- Enable Toggle -->
+                <div class="flex items-center justify-between mb-6 pb-6 border-b border-border-secondary">
+                    <div>
+                        <h3 class="text-lg font-semibold text-text-primary">Content Filter</h3>
+                        <p class="text-sm text-text-secondary">Block harmful, offensive, or unwanted content</p>
+                    </div>
+                    <FormToggle Id="content-enabled"
+                                Name="ContentEnabled"
+                                IsChecked="_contentEnabled"
+                                IsCheckedChanged="v => _contentEnabled = v" />
+                </div>
+
+                <!-- Settings -->
+                <div class="space-y-6">
+                    <!-- Custom Blocklist -->
+                    <div class="space-y-1.5">
+                        <label for="content-prohibited-words" class="block text-sm font-medium text-text-primary">Custom Blocklist</label>
+                        <p class="text-xs text-text-tertiary mb-2">Words and phrases to block (comma-separated)</p>
+                        <textarea id="content-prohibited-words"
+                                  rows="3"
+                                  placeholder="Enter words or phrases..."
+                                  class="w-full px-3 py-2 text-sm bg-bg-primary border border-border-primary rounded-lg text-text-primary placeholder-text-tertiary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors resize-none"
+                                  @bind="_prohibitedWordsText"
+                                  @bind:event="oninput"></textarea>
+                    </div>
+
+                    <!-- Block Invite Links -->
+                    <FormToggle Id="content-block-invites"
+                                Name="BlockInviteLinks"
+                                Label="Block Discord Invite Links"
+                                Description="Prevent users from posting Discord server invites"
+                                IsChecked="_contentBlockInvites"
+                                IsCheckedChanged="v => _contentBlockInvites = v" />
+
+                    <!-- Auto Action -->
+                    <FormSelect Id="content-auto-action"
+                                Name="ContentAutoAction"
+                                Label="Auto-Action on Detection"
+                                SelectedValue="@(((int)_contentAutoAction).ToString())"
+                                SelectedValueChanged="v => _contentAutoAction = Enum.TryParse<AutoAction>(v, out var r) ? r : _contentAutoAction"
+                                Options="@_contentAutoActionOptions" />
+                </div>
+
+                <!-- Save Button -->
+                <div class="mt-8 pt-6 border-t border-border-secondary flex justify-end">
+                    <Button Text="Save Content Settings"
+                            Variant="ButtonVariant.Primary"
+                            IsLoading="_isSavingContent"
+                            LoadingText="Saving..."
+                            OnClick="SaveContentAsync" />
+                </div>
+            </div>
+        }
+
+        @* ===== Raid Tab ===== *@
+        @if (_activeTab == "raid")
+        {
+            <div class="p-6" role="tabpanel">
+                <!-- Enable Toggle -->
+                <div class="flex items-center justify-between mb-6 pb-6 border-b border-border-secondary">
+                    <div>
+                        <h3 class="text-lg font-semibold text-text-primary">Raid Protection</h3>
+                        <p class="text-sm text-text-secondary">Detect and respond to coordinated attacks</p>
+                    </div>
+                    <FormToggle Id="raid-enabled"
+                                Name="RaidEnabled"
+                                IsChecked="_raidEnabled"
+                                IsCheckedChanged="v => _raidEnabled = v" />
+                </div>
+
+                <!-- Settings -->
+                <div class="space-y-6">
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <FormInput Id="raid-max-joins"
+                                   Name="MaxJoinsPerWindow"
+                                   Label="Mass Join Threshold"
+                                   Description="Trigger when this many users join..."
+                                   Type="number"
+                                   Value="@_raidMaxJoins.ToString()"
+                                   ValueChanged="v => _raidMaxJoins = int.TryParse(v, out var r) ? r : _raidMaxJoins" />
+                        <FormInput Id="raid-window-seconds"
+                                   Name="RaidWindowSeconds"
+                                   Label="Time Window (seconds)"
+                                   Description="...within this time period"
+                                   Type="number"
+                                   Value="@_raidWindowSeconds.ToString()"
+                                   ValueChanged="v => _raidWindowSeconds = int.TryParse(v, out var r) ? r : _raidWindowSeconds" />
+                    </div>
+
+                    <FormInput Id="raid-min-account-age"
+                               Name="MinAccountAgeHours"
+                               Label="Minimum Account Age (hours)"
+                               Description="Require accounts to be older than this (0 = no restriction)"
+                               Type="number"
+                               Value="@_raidMinAccountAge.ToString()"
+                               ValueChanged="v => _raidMinAccountAge = int.TryParse(v, out var r) ? r : _raidMinAccountAge" />
+
+                    <FormSelect Id="raid-auto-action"
+                                Name="RaidAutoAction"
+                                Label="Auto-Action on Raid Detection"
+                                Description="Action to take when a raid is detected"
+                                SelectedValue="@(((int)_raidAutoAction).ToString())"
+                                SelectedValueChanged="v => _raidAutoAction = Enum.TryParse<RaidAutoAction>(v, out var r) ? r : _raidAutoAction"
+                                Options="@_raidAutoActionOptions" />
+                </div>
+
+                <!-- Save Button -->
+                <div class="mt-8 pt-6 border-t border-border-secondary flex justify-end">
+                    <Button Text="Save Raid Settings"
+                            Variant="ButtonVariant.Primary"
+                            IsLoading="_isSavingRaid"
+                            LoadingText="Saving..."
+                            OnClick="SaveRaidAsync" />
+                </div>
+            </div>
+        }
+
+        @* ===== Tags Tab ===== *@
+        @if (_activeTab == "tags")
+        {
+            <div class="p-6" role="tabpanel">
+                <div class="flex items-center justify-between mb-6">
+                    <div>
+                        <h3 class="text-lg font-semibold text-text-primary">User Tags</h3>
+                        <p class="text-sm text-text-secondary">Define custom tags for categorizing users</p>
+                    </div>
+                    <button type="button"
+                            class="inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-text-secondary bg-bg-tertiary border border-border-primary rounded-lg hover:bg-bg-hover transition-colors"
+                            @onclick="() => _showImportModal = true">
+                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
+                        </svg>
+                        Import Templates
+                    </button>
+                </div>
+
+                <!-- Existing Tags -->
+                <div class="space-y-3 mb-6">
+                    @if (_tags.Count == 0)
+                    {
+                        <div class="text-center py-8 text-text-tertiary text-sm">
+                            No tags defined yet. Add a tag below or import templates.
+                        </div>
+                    }
+                    else
+                    {
+                        @foreach (var tag in _tags)
+                        {
+                            <div class="flex items-center justify-between p-3 bg-bg-tertiary rounded-lg">
+                                <div class="flex items-center gap-3">
+                                    <span class="user-tag @GetTagColorClass(tag.Category)">@tag.Name</span>
+                                    <span class="text-sm text-text-secondary">Used @tag.UserCount times</span>
+                                </div>
+                                <div class="flex items-center gap-2">
+                                    <button type="button"
+                                            class="p-1.5 text-text-tertiary hover:text-error hover:bg-error-bg rounded transition-colors"
+                                            title="Delete"
+                                            @onclick="() => DeleteTagAsync(tag.Name)">
+                                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                                        </svg>
+                                    </button>
+                                </div>
+                            </div>
+                        }
+                    }
+                </div>
+
+                <!-- Add New Tag Form -->
+                <div class="p-4 bg-bg-tertiary rounded-lg">
+                    <h4 class="font-medium text-text-primary mb-4">Add New Tag</h4>
+                    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                        <FormInput Id="new-tag-name"
+                                   Name="NewTagName"
+                                   Label="Tag Name"
+                                   Placeholder="e.g., VIP, Trusted, etc."
+                                   Value="@_newTagName"
+                                   ValueChanged="v => _newTagName = v" />
+                        <FormSelect Id="new-tag-color"
+                                    Name="NewTagColor"
+                                    Label="Color"
+                                    SelectedValue="@(((int)_newTagCategory).ToString())"
+                                    SelectedValueChanged="v => _newTagCategory = Enum.TryParse<TagCategory>(v, out var r) ? r : _newTagCategory"
+                                    Options="@_tagCategoryOptions" />
+                        <div class="flex items-end">
+                            <Button Text="Add Tag"
+                                    Variant="ButtonVariant.Primary"
+                                    IsLoading="_isCreatingTag"
+                                    LoadingText="Adding..."
+                                    OnClick="CreateTagAsync" />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        }
+    </div>
+
+    <!-- Import Templates Confirmation Modal -->
+    <ConfirmationModal Id="importTemplatesModal"
+                       Title="Import Template Tags"
+                       Message="This will import a set of commonly used moderation tags into your guild. Existing tags with the same name will not be duplicated."
+                       ConfirmText="Import"
+                       Variant="ConfirmationVariant.Warning"
+                       IsVisible="_showImportModal"
+                       IsVisibleChanged="v => _showImportModal = v"
+                       OnConfirm="ImportTemplatesAsync" />
+}
+
+@code {
+    [Parameter] public long GuildId { get; set; }
+
+    // Core data
+    private GuildDto? _guild;
+    private List<BreadcrumbItem>? _breadcrumbItems;
+    private List<HeaderAction>? _headerActions;
+    private GuildModerationConfigDto _config = new();
+    private List<ModTagDto> _tags = new();
+
+    // UI state
+    private string _activeTab = "overview";
+    private bool _notFound;
+    private bool _isSavingOverview;
+    private bool _isSavingSpam;
+    private bool _isSavingContent;
+    private bool _isSavingRaid;
+    private bool _isCreatingTag;
+    private bool _showImportModal;
+    private string? _errorMessage;
+
+    // Overview fields
+    private ConfigMode _mode;
+    private string? _simplePreset;
+
+    // Stats
+    private int _eventsFlagged;
+    private int _autoActions;
+    private int _activeRules;
+    private int _falsePositives;
+
+    // Spam fields
+    private bool _spamEnabled;
+    private int _spamMaxMessages;
+    private int _spamWindowSeconds;
+    private int _spamMaxMentions;
+    private int _spamDuplicateThresholdPercent;
+    private AutoAction _spamAutoAction;
+
+    // Content fields
+    private bool _contentEnabled;
+    private string _prohibitedWordsText = string.Empty;
+    private bool _contentBlockInvites;
+    private AutoAction _contentAutoAction;
+
+    // Raid fields
+    private bool _raidEnabled;
+    private int _raidMaxJoins;
+    private int _raidWindowSeconds;
+    private int _raidMinAccountAge;
+    private RaidAutoAction _raidAutoAction;
+
+    // Tag creation fields
+    private string _newTagName = string.Empty;
+    private TagCategory _newTagCategory = TagCategory.Positive;
+
+    // Select options
+    private List<SelectOption> _autoActionOptions = new()
+    {
+        new() { Value = "0", Text = "None (Flag Only)" },
+        new() { Value = "1", Text = "Delete Message" },
+        new() { Value = "2", Text = "Warn User" },
+        new() { Value = "3", Text = "Mute User (1 hour)" },
+        new() { Value = "4", Text = "Kick User" },
+        new() { Value = "5", Text = "Ban User" }
+    };
+
+    private List<SelectOption> _contentAutoActionOptions = new()
+    {
+        new() { Value = "0", Text = "None (Flag Only)" },
+        new() { Value = "1", Text = "Delete Message" },
+        new() { Value = "2", Text = "Warn User" },
+        new() { Value = "3", Text = "Delete + Mute User" },
+        new() { Value = "5", Text = "Delete + Ban User" }
+    };
+
+    private List<SelectOption> _raidAutoActionOptions = new()
+    {
+        new() { Value = "0", Text = "None" },
+        new() { Value = "1", Text = "Alert Only" },
+        new() { Value = "2", Text = "Lock Invites" },
+        new() { Value = "3", Text = "Lock Server" }
+    };
+
+    private List<SelectOption> _tagCategoryOptions = new()
+    {
+        new() { Value = "0", Text = "Positive (Green)" },
+        new() { Value = "1", Text = "Negative (Red)" },
+        new() { Value = "2", Text = "Neutral (Blue)" }
+    };
+
+    protected override async Task OnInitializedAsync()
+    {
+        var guildId = (ulong)GuildId;
+
+        Logger.LogDebug("Moderation settings page accessed for guild {GuildId}", guildId);
+
+        var guildDto = await GuildService.GetGuildByIdAsync(guildId);
+        if (guildDto is null)
+        {
+            Logger.LogWarning("Guild {GuildId} not found", guildId);
+            _notFound = true;
+            return;
+        }
+
+        _guild = guildDto;
+
+        _headerActions = new List<HeaderAction>
+        {
+            new()
+            {
+                Label = "View Flagged Events",
+                Url = $"/Guilds/FlaggedEvents/{GuildId}",
+                Style = HeaderActionStyle.Secondary,
+                Icon = "M3 21v-4m0 0V5a2 2 0 012-2h6.5l1 1H21l-3 6 3 6h-8.5l-1-1H5a2 2 0 00-2 2zm9-13.5V9"
+            }
+        };
+
+        // Load moderation config and tags
+        _config = await ConfigService.GetConfigAsync(guildId);
+        var tags = await ModTagService.GetGuildTagsAsync(guildId);
+        _tags = tags.ToList();
+
+        // Populate form fields from config
+        PopulateFieldsFromConfig(_config);
+
+        // Load statistics
+        await LoadStatisticsAsync(guildId);
+
+        // Calculate active rules
+        _activeRules = CalculateActiveRulesCount(_config);
+
+        // Breadcrumb
+        _breadcrumbItems = new List<BreadcrumbItem>
+        {
+            new() { Label = "Home", Url = "/" },
+            new() { Label = "Servers", Url = "/Guilds" },
+            new() { Label = guildDto.Name, Url = $"/Guilds/Details/{GuildId}" },
+            new() { Label = "Moderation Settings", IsCurrent = true }
+        };
+    }
+
+    private void PopulateFieldsFromConfig(GuildModerationConfigDto config)
+    {
+        // Overview
+        _mode = config.Mode;
+        _simplePreset = config.SimplePreset;
+
+        // Spam
+        _spamEnabled = config.SpamConfig.Enabled;
+        _spamMaxMessages = config.SpamConfig.MaxMessagesPerWindow;
+        _spamWindowSeconds = config.SpamConfig.WindowSeconds;
+        _spamMaxMentions = config.SpamConfig.MaxMentionsPerMessage;
+        _spamDuplicateThresholdPercent = (int)(config.SpamConfig.DuplicateMessageThreshold * 100);
+        _spamAutoAction = config.SpamConfig.AutoAction;
+
+        // Content
+        _contentEnabled = config.ContentFilterConfig.Enabled;
+        _prohibitedWordsText = string.Join(", ", config.ContentFilterConfig.ProhibitedWords);
+        _contentBlockInvites = config.ContentFilterConfig.BlockInviteLinks;
+        _contentAutoAction = config.ContentFilterConfig.AutoAction;
+
+        // Raid
+        _raidEnabled = config.RaidProtectionConfig.Enabled;
+        _raidMaxJoins = config.RaidProtectionConfig.MaxJoinsPerWindow;
+        _raidWindowSeconds = config.RaidProtectionConfig.WindowSeconds;
+        _raidMinAccountAge = config.RaidProtectionConfig.MinAccountAgeHours;
+        _raidAutoAction = config.RaidProtectionConfig.AutoAction;
+    }
+
+    private async Task SaveOverviewAsync()
+    {
+        if (_isSavingOverview) return;
+        _isSavingOverview = true;
+        _errorMessage = null;
+
+        try
+        {
+            var guildId = (ulong)GuildId;
+
+            _config.Mode = _mode;
+            _config.SimplePreset = _simplePreset;
+
+            if (_mode == ConfigMode.Simple && !string.IsNullOrEmpty(_simplePreset))
+            {
+                _config = await ConfigService.ApplyPresetAsync(guildId, _simplePreset);
+                PopulateFieldsFromConfig(_config);
+                _activeRules = CalculateActiveRulesCount(_config);
+            }
+            else
+            {
+                _config = await ConfigService.UpdateConfigAsync(guildId, _config);
+            }
+
+            Logger.LogInformation("Overview settings saved for guild {GuildId}", guildId);
+            await Toast.ShowAsync("success", "Overview settings saved successfully.");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to save overview settings for guild {GuildId}", (ulong)GuildId);
+            _errorMessage = "Failed to save overview settings. Please try again.";
+        }
+        finally
+        {
+            _isSavingOverview = false;
+        }
+    }
+
+    private async Task SaveSpamAsync()
+    {
+        if (_isSavingSpam) return;
+        _isSavingSpam = true;
+        _errorMessage = null;
+
+        try
+        {
+            var guildId = (ulong)GuildId;
+
+            _config.SpamConfig = new SpamDetectionConfigDto
+            {
+                Enabled = _spamEnabled,
+                MaxMessagesPerWindow = _spamMaxMessages,
+                WindowSeconds = _spamWindowSeconds,
+                MaxMentionsPerMessage = _spamMaxMentions,
+                DuplicateMessageThreshold = _spamDuplicateThresholdPercent / 100.0,
+                AutoAction = _spamAutoAction
+            };
+
+            _config = await ConfigService.UpdateConfigAsync(guildId, _config);
+            _activeRules = CalculateActiveRulesCount(_config);
+
+            Logger.LogInformation("Spam settings saved for guild {GuildId}", guildId);
+            await Toast.ShowAsync("success", "Spam detection settings saved successfully.");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to save spam settings for guild {GuildId}", (ulong)GuildId);
+            _errorMessage = "Failed to save spam detection settings. Please try again.";
+        }
+        finally
+        {
+            _isSavingSpam = false;
+        }
+    }
+
+    private async Task SaveContentAsync()
+    {
+        if (_isSavingContent) return;
+        _isSavingContent = true;
+        _errorMessage = null;
+
+        try
+        {
+            var guildId = (ulong)GuildId;
+
+            var words = _prohibitedWordsText
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Where(w => !string.IsNullOrWhiteSpace(w))
+                .ToList();
+
+            _config.ContentFilterConfig = new ContentFilterConfigDto
+            {
+                Enabled = _contentEnabled,
+                ProhibitedWords = words,
+                BlockInviteLinks = _contentBlockInvites,
+                AutoAction = _contentAutoAction
+            };
+
+            _config = await ConfigService.UpdateConfigAsync(guildId, _config);
+            _activeRules = CalculateActiveRulesCount(_config);
+
+            Logger.LogInformation("Content filter settings saved for guild {GuildId}", guildId);
+            await Toast.ShowAsync("success", "Content filter settings saved successfully.");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to save content filter settings for guild {GuildId}", (ulong)GuildId);
+            _errorMessage = "Failed to save content filter settings. Please try again.";
+        }
+        finally
+        {
+            _isSavingContent = false;
+        }
+    }
+
+    private async Task SaveRaidAsync()
+    {
+        if (_isSavingRaid) return;
+        _isSavingRaid = true;
+        _errorMessage = null;
+
+        try
+        {
+            var guildId = (ulong)GuildId;
+
+            _config.RaidProtectionConfig = new RaidProtectionConfigDto
+            {
+                Enabled = _raidEnabled,
+                MaxJoinsPerWindow = _raidMaxJoins,
+                WindowSeconds = _raidWindowSeconds,
+                MinAccountAgeHours = _raidMinAccountAge,
+                AutoAction = _raidAutoAction
+            };
+
+            _config = await ConfigService.UpdateConfigAsync(guildId, _config);
+            _activeRules = CalculateActiveRulesCount(_config);
+
+            Logger.LogInformation("Raid protection settings saved for guild {GuildId}", guildId);
+            await Toast.ShowAsync("success", "Raid protection settings saved successfully.");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to save raid protection settings for guild {GuildId}", (ulong)GuildId);
+            _errorMessage = "Failed to save raid protection settings. Please try again.";
+        }
+        finally
+        {
+            _isSavingRaid = false;
+        }
+    }
+
+    private async Task CreateTagAsync()
+    {
+        if (_isCreatingTag) return;
+        if (string.IsNullOrWhiteSpace(_newTagName))
+        {
+            await Toast.ShowAsync("error", "Tag name is required.");
+            return;
+        }
+
+        _isCreatingTag = true;
+        _errorMessage = null;
+
+        try
+        {
+            var guildId = (ulong)GuildId;
+
+            var dto = new ModTagCreateDto
+            {
+                GuildId = guildId,
+                Name = _newTagName.Trim(),
+                Category = _newTagCategory
+            };
+
+            var tag = await ModTagService.CreateTagAsync(guildId, dto);
+            _tags.Add(tag);
+
+            _newTagName = string.Empty;
+            _newTagCategory = TagCategory.Positive;
+
+            Logger.LogInformation("Tag {TagName} created for guild {GuildId}", dto.Name, guildId);
+            await Toast.ShowAsync("success", "Tag created successfully.");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to create tag for guild {GuildId}", (ulong)GuildId);
+            _errorMessage = "Failed to create tag. Please try again.";
+        }
+        finally
+        {
+            _isCreatingTag = false;
+        }
+    }
+
+    private async Task DeleteTagAsync(string tagName)
+    {
+        try
+        {
+            var guildId = (ulong)GuildId;
+            var success = await ModTagService.DeleteTagAsync(guildId, tagName);
+
+            if (success)
+            {
+                _tags.RemoveAll(t => t.Name == tagName);
+                Logger.LogInformation("Tag {TagName} deleted for guild {GuildId}", tagName, guildId);
+                await Toast.ShowAsync("success", "Tag deleted successfully.");
+            }
+            else
+            {
+                await Toast.ShowAsync("error", "Tag not found.");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to delete tag {TagName} for guild {GuildId}", tagName, (ulong)GuildId);
+            await Toast.ShowAsync("error", "Failed to delete tag. Please try again.");
+        }
+    }
+
+    private async Task ImportTemplatesAsync()
+    {
+        try
+        {
+            var guildId = (ulong)GuildId;
+            var templateNames = new[] { "default" };
+
+            var count = await ModTagService.ImportTemplateTagsAsync(guildId, templateNames);
+
+            // Refresh tags list
+            var tags = await ModTagService.GetGuildTagsAsync(guildId);
+            _tags = tags.ToList();
+
+            Logger.LogInformation("{Count} template tags imported for guild {GuildId}", count, guildId);
+            await Toast.ShowAsync("success", $"{count} template tags imported successfully.");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to import template tags for guild {GuildId}", (ulong)GuildId);
+            await Toast.ShowAsync("error", "Failed to import template tags. Please try again.");
+        }
+    }
+
+    private async Task LoadStatisticsAsync(ulong guildId)
+    {
+        try
+        {
+            // Use a small page size - we only need recent counts, not full records
+            var (events, totalCount) = await FlaggedEventService.GetPendingEventsAsync(guildId, 1, 100);
+            var since = DateTime.UtcNow.AddHours(-24);
+
+            var eventsList = events.ToList();
+            _eventsFlagged = eventsList.Count(e => e.CreatedAt >= since);
+            _autoActions = eventsList.Count(e => e.CreatedAt >= since && !string.IsNullOrEmpty(e.ActionTaken));
+            _falsePositives = eventsList.Count(e => e.CreatedAt >= since && e.Status == FlaggedEventStatus.Dismissed);
+
+            Logger.LogDebug("Loaded statistics for guild {GuildId}: Events={Events}, AutoActions={AutoActions}, FalsePositives={FalsePositives}",
+                guildId, _eventsFlagged, _autoActions, _falsePositives);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Failed to load statistics for guild {GuildId}", guildId);
+        }
+    }
+
+    private int CalculateActiveRulesCount(GuildModerationConfigDto config)
+    {
+        int count = 0;
+        if (config.SpamConfig.Enabled) count++;
+        if (config.ContentFilterConfig.Enabled) count++;
+        if (config.RaidProtectionConfig.Enabled) count++;
+        return count;
+    }
+
+    private static string GetTagColorClass(TagCategory category) => category switch
+    {
+        TagCategory.Positive => "user-tag-success",
+        TagCategory.Negative => "user-tag-danger",
+        TagCategory.Neutral => "user-tag-info",
+        _ => ""
+    };
+}


### PR DESCRIPTION
## Summary

- Migrated 4 settings/config Razor Pages to Blazor Server components with full feature parity
- **AdminSettings.razor** + **SettingsCategorySection.razor**: Full admin settings page with 6 tabs (General, Features, Commands, Advanced, BotControl, Appearance). Dynamic settings rendering based on `SettingDataType`, command module toggles grouped by category, bot status/configuration display, confirmation modals for restart/shutdown/reset, and audit logging. `SettingsCategorySection` is a reusable sub-component.
- **GuildAudioSettings.razor**: Guild audio settings with 4 sections (General, Limits, TTS, Command Permissions). Per-section save buttons, audio sub-tab pill navigation, role multi-select dropdowns for command permissions, portal links conditional on `EnableMemberPortal`, and reset to defaults.
- **GuildAssistantSettings.razor**: Assistant settings with enable toggle, channel selection checkboxes, rate limit input, and help sidebar in a 2-column layout matching the existing design.
- **GuildModerationSettings.razor**: Moderation settings with 5 tabs (Overview, Spam, Content, Raid, Tags). Preset cards for simple mode, detection config per tab, and tag management with create/delete/import templates.

All pages use native Blazor tab switching (no JavaScript), toast notifications via `ToastInterop`, proper authorization policies, `GuildLayout` with breadcrumbs, and `InteractiveServer` rendermode.

## Code Review Fixes Applied

- Fixed magic number theme ID in `ResetAppearanceAsync` (now uses `GetThemeByKeyAsync("discord-dark")`)
- Split shared `_isSaving` into per-tab booleans (`_isSavingOverview`, `_isSavingSpam`, etc.)
- Added concurrency guard for command permission auto-save
- Reduced stats query page size from 1000 to 100

## Review Status

- Code Review: APPROVED after fixes (1 review cycle, all Critical/Major issues resolved)
- UI Review: SKIPPED
- Unresolved items: none

Closes #1632