### PR TITLE
Layout polish: cleanup and visual improvements

### DIFF
--- a/docs/layout-polish-phases.md
+++ b/docs/layout-polish-phases.md
@@ -1,0 +1,54 @@
+# Layout Polish — Phased Implementation
+
+Phases for implementing the 23 fixes from `layout-polish-plan.md`.
+
+## Phase 1: Zero-Risk Quick Wins (CSS-only + markup cleanup)
+
+No behavior changes, purely additive or removing dead code.
+
+| # | Fix | Files |
+|---|-----|-------|
+| 2 | Remove duplicate `tab-panel.css` include | `_GuildLayout.cshtml` |
+| 5 | Remove dead "Support" section | `_Sidebar.cshtml` |
+| 7 | Remove notification dropdown footer | `_Navbar.cshtml` |
+| 8 | Add `<meta name="theme-color">` | `_Layout.cshtml` |
+| 9 | Guard breadcrumb partial invocation | `_Layout.cshtml` |
+| 11 | Replace hardcoded sidebar active color with CSS var | `site.css` |
+| 16 | Accent color on active sidebar icon | `site.css` |
+| 23 | Add `will-change` to main content | `site.css` |
+
+## Phase 2: Visual Polish (CSS + minor markup)
+
+Styling changes that improve appearance but don't alter structure or behavior.
+
+| # | Fix | Files |
+|---|-----|-------|
+| 13 | Navbar shadow for depth | `site.css` |
+| 14 | Bolder sidebar active indicator | `site.css` |
+| 15 | More visible section headers | `site.css` |
+| 17 | Subtler search bar styling | `_Navbar.cshtml` |
+| 19 | Chevron hover feedback on avatar | `_Navbar.cshtml` |
+| 20 | Sidebar footer card visual weight | `_Sidebar.cshtml`, `site.css` |
+| 22 | Tighten content padding | `_Layout.cshtml`, `_Breadcrumb.cshtml` |
+
+## Phase 3: Structural Improvements (behavior changes)
+
+These change how things work, so they need more care and visual QA.
+
+| # | Fix | Files |
+|---|-----|-------|
+| 3 | Different icon for desktop sidebar toggle | `_Navbar.cshtml` |
+| 6 | Remove navbar bot status pill (keep sidebar one) | `_Navbar.cshtml` |
+| 10 | Add max-width to main content | `_Layout.cshtml` |
+| 18 | Better bot status pill contrast (only if #6 keeps pill) | `site.css` |
+
+## Phase 4: Deferred / Needs Discussion
+
+Requires build tooling changes or architectural decisions. Each can be a separate PR.
+
+| # | Fix | Notes |
+|---|-----|-------|
+| 1 | Bundle JS scripts | Needs build pipeline (webpack/esbuild/vite) |
+| 4 | Refactor sidebar active state detection | Touches every page model or needs tag helper |
+| 12 | Local SignalR fallback | Needs npm + fallback script pattern |
+| 21 | Custom heading font | Needs font loading strategy, performance tradeoff |

--- a/docs/layout-polish-plan.md
+++ b/docs/layout-polish-plan.md
@@ -1,0 +1,352 @@
+# Layout Polish Plan
+
+Improvements and fixes identified from a comprehensive review of `_Layout.cshtml`, `_Navbar.cshtml`, `_Sidebar.cshtml`, `_Breadcrumb.cshtml`, `_GuildLayout.cshtml`, `_LayoutLanding.cshtml`, `_MobileSearchOverlay.cshtml`, `_ToastContainer.cshtml`, and `site.css`.
+
+## Structural / Code Fixes
+
+### 1. Script Loading — 12 separate `<script>` tags
+
+**File:** `_Layout.cshtml:68-98`
+
+Loads 12 JS files synchronously at end of `<body>`. Each is a separate HTTP request that blocks parsing sequentially.
+
+**Fix:** Bundle into 2-3 logical groups (e.g., `core.js` for navigation/toast/loading, `features.js` for search/notifications/preview, `realtime.js` for SignalR/dashboard-hub). Or at minimum add `defer` to non-dependent scripts. The SignalR CDN link should also use `integrity` for security.
+
+---
+
+### 2. Duplicate `tab-panel.css` include
+
+**Files:** `_Layout.cshtml:20`, `_GuildLayout.cshtml:60`
+
+`_Layout.cshtml` loads `tab-panel.css` globally, and `_GuildLayout.cshtml` loads it again in its `@section Styles`. One is redundant.
+
+**Fix:** Remove the include from `_GuildLayout.cshtml:60` since the parent layout already loads it.
+
+---
+
+### 3. Navbar hamburger icon is identical for mobile and desktop toggles
+
+**File:** `_Navbar.cshtml:14-16` (mobile) and `_Navbar.cshtml:26-28` (desktop)
+
+Both use the same three-line hamburger SVG. No visual cue differentiates "open mobile drawer" from "collapse/expand sidebar."
+
+**Fix:** Use a `<<`/`>>` chevron or sidebar-collapse icon for the desktop toggle (`#sidebarCollapseToggle`). Example: a left-pointing double-chevron when expanded, right-pointing when collapsed.
+
+---
+
+### 4. Sidebar active state detection is fragile
+
+**File:** `_Sidebar.cshtml:15,28,42,54,68,81,101,110,121,131,140,158`
+
+Every link re-derives active state from `ViewContext.RouteData.Values["page"]` with string matching. Doesn't handle nested routes reliably (e.g., `/Admin/Logs/Detail/123` may not match `StartsWith("/Admin/Logs")`).
+
+**Fix:** Set `ViewData["ActiveNavItem"]` from each page model and match against it in the sidebar. Or create a tag helper that handles hierarchical matching.
+
+---
+
+### 5. Sidebar "Support" section is dead weight
+
+**File:** `_Sidebar.cshtml:200-210`
+
+A disabled "Documentation" link with a "Soon" badge. Dead UI creates a sense of incompleteness.
+
+**Fix:** Either remove the section entirely or link to the existing docs site.
+
+---
+
+### 6. Bot status duplicated in navbar and sidebar
+
+**Files:** `_Navbar.cshtml:77-80` (navbar pill), `_Sidebar.cshtml:212-227` (sidebar footer)
+
+Two status indicators for the same thing. The sidebar version is richer (includes version number).
+
+**Fix:** Remove the navbar status pill and keep only the sidebar version. Reclaim the navbar space.
+
+---
+
+### 7. Notification dropdown "Close" button is underwhelming
+
+**File:** `_Navbar.cshtml:124-132`
+
+The footer has a "Close" button where it used to say "View All." The `TODO` on line 124 acknowledges a missing notification center page. Clicking outside already closes the dropdown.
+
+**Fix:** Remove the notification dropdown footer entirely until the notifications page exists.
+
+---
+
+### 8. Missing `<meta>` tags
+
+**File:** `_Layout.cshtml` `<head>`
+
+No `<meta name="description">` or `<meta name="theme-color">`.
+
+**Fix:** Add `<meta name="theme-color" content="#1d2022">` so mobile browser chrome matches the dark theme. Optionally add a description meta tag.
+
+---
+
+### 9. Breadcrumb partial invoked on every page even when empty
+
+**File:** `_Layout.cshtml:54`, `_Breadcrumb.cshtml:3`
+
+When `ViewData["Breadcrumbs"]` is null (most pages), the partial still gets invoked and renders nothing. Wasted partial invocation.
+
+**Fix:** Guard with `@if (ViewData["Breadcrumbs"] != null)` in `_Layout.cshtml` before calling the partial.
+
+---
+
+### 10. Main content has no max-width — ultrawide readability problem
+
+**File:** `_Layout.cshtml:52`
+
+`p-6 lg:p-8` with no width constraint. Content stretches edge-to-edge on ultrawide monitors. The guild layout already constrains to `max-w-7xl`.
+
+**Fix:** Add `max-w-screen-xl mx-auto` (or `max-w-7xl mx-auto`) to the inner content div in `_Layout.cshtml:52`.
+
+---
+
+### 11. Hardcoded color in active sidebar state
+
+**File:** `site.css:1179`
+
+`background-color: rgba(203, 78, 27, 0.12)` hardcodes the accent-orange RGB instead of using `var(--color-accent-orange-muted)`. Won't adapt to the Purple Dusk theme.
+
+**Fix:** Replace with `background-color: var(--color-accent-orange-muted);` (already defined as `rgba(203, 78, 27, 0.2)` in dark theme and `rgba(97, 73, 120, 0.2)` in Purple Dusk).
+
+---
+
+### 12. CDN dependency for SignalR without fallback
+
+**File:** `_Layout.cshtml:68`
+
+SignalR loaded from `cdn.jsdelivr.net`. If the CDN is down, real-time features break silently.
+
+**Fix:** Bundle SignalR locally via npm, or add a `<script>` fallback pattern that loads from a local copy if the CDN fails.
+
+---
+
+## Visual Polish
+
+### 13. Navbar feels flat — no visual separation from content
+
+**File:** `site.css:1113-1118`
+
+Uses `bg-secondary` + `1px border-bottom` + `backdrop-filter: blur(8px)`. On dark theme `bg-secondary` (#262a2d) and `bg-primary` (#1d2022) are close — the border is subtle. The blur does nothing because the navbar is opaque.
+
+**Fix:** Either make the navbar semi-transparent so blur works:
+```css
+.navbar-redesign {
+  background-color: rgba(38, 42, 45, 0.85);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+}
+```
+Or keep it opaque but add a shadow for depth:
+```css
+.navbar-redesign {
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+}
+```
+
+---
+
+### 14. Sidebar active indicator is thin and easy to miss
+
+**File:** `site.css:1177-1192`
+
+Active state uses a 3px-wide, 24px-tall orange bar on the left edge with faint `rgba(..., 0.12)` background. The indicator is subtle.
+
+**Fix:** Make active background more noticeable (bump alpha to `0.18`) and make the left bar span the full link height:
+```css
+.sidebar-link-redesign.active {
+  background-color: var(--color-accent-orange-muted);
+}
+
+.sidebar-link-redesign.active::before {
+  /* Remove fixed height/translateY, use inset instead */
+  top: 4px;
+  bottom: 4px;
+  height: auto;
+  transform: none;
+}
+```
+
+---
+
+### 15. Sidebar section headers barely visible
+
+**File:** `site.css:1195-1202`
+
+At `0.6875rem` (11px) and `color: text-tertiary` (#7a7876), these labels visually disappear.
+
+**Fix:** Bump to `0.75rem`, increase letter-spacing to `0.08em`, and optionally add a structural left accent:
+```css
+.sidebar-section-header {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+}
+```
+
+---
+
+### 16. Sidebar icons have no color differentiation on active state
+
+**File:** `site.css` (no rule exists for active icon color)
+
+Every sidebar icon uses the same `text-secondary` color. When active, only the text and background change — the icon stays muted.
+
+**Fix:** Add accent color to the active icon:
+```css
+.sidebar-link-redesign.active svg {
+  color: var(--color-accent-orange);
+}
+```
+
+---
+
+### 17. Search bar is visually heavy
+
+**File:** `_Navbar.cshtml:54`
+
+The search input has a visible border and `bg-bg-primary` fill. On the dark navbar, the lighter background creates a bright rectangle that draws disproportionate attention.
+
+**Fix:** Use a subtler recessed style (like VS Code / GitHub):
+```css
+/* In _Navbar.cshtml, change the input classes: */
+/* From: bg-bg-primary border border-border-primary */
+/* To:   bg-bg-tertiary border border-transparent */
+/* Keep: focus:border-border-focus focus:ring-1 focus:ring-border-focus */
+```
+
+---
+
+### 18. Bot status pill in navbar is hard to read
+
+**File:** `_Navbar.cshtml:77-80`, `site.css:1326-1344`
+
+Green text on 15% green background at `0.75rem` (12px) is low contrast.
+
+**Fix:** If keeping (see #6 to remove it), increase font to `0.8125rem` and use higher-contrast coloring:
+```css
+.bot-status-indicator.online {
+  background-color: rgba(16, 185, 129, 0.2);
+  color: #34d399; /* lighter green for better contrast */
+  font-size: 0.8125rem;
+}
+```
+
+---
+
+### 19. User avatar dropdown chevron lacks hover feedback
+
+**File:** `_Navbar.cshtml:168-170`
+
+The chevron is static `text-text-secondary`. The parent button has hover styles but the chevron doesn't respond.
+
+**Fix:** Add `group` to the button and `group-hover:text-text-primary` to the chevron:
+```html
+<button ... class="group flex items-center gap-2 ...">
+  ...
+  <svg class="... text-text-secondary group-hover:text-text-primary transition-colors">
+```
+
+---
+
+### 20. Sidebar footer bot status card feels disconnected
+
+**File:** `_Sidebar.cshtml:212-227`
+
+Uses `bg-bg-primary/50` which is nearly invisible against the sidebar. No visual weight.
+
+**Fix:** Give it more presence:
+```html
+<div class="bot-status-container p-3 bg-bg-primary rounded-lg border border-border-secondary">
+```
+And consider a green left-border to echo online status:
+```css
+.bot-status-container {
+  border-left: 2px solid var(--color-success);
+}
+```
+
+---
+
+### 21. Font stack is system defaults — functional but generic
+
+**File:** `tailwind.config.js:77-88`
+
+Standard system font stack reads as "default Tailwind project."
+
+**Fix:** Consider loading Inter or Geist Sans for headings only via `<link rel="preload">`. Even just heading differentiation gives the UI a more intentional feel:
+```css
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Inter', var(--font-sans);
+}
+```
+
+---
+
+### 22. Content padding is generous — pushes content below the fold
+
+**Files:** `_Layout.cshtml:52` (`p-6 lg:p-8`), `_Breadcrumb.cshtml` (`mb-6`)
+
+With sidebar, navbar, content padding, and breadcrumb margin, there's ~112px of vertical space before actual page content on desktop. Combined with the breadcrumb's `mb-6` that's 48px of whitespace above content.
+
+**Fix:** Tighten spacing:
+```html
+<!-- _Layout.cshtml -->
+<div class="p-4 lg:p-6">
+```
+And reduce breadcrumb bottom margin to `mb-4`.
+
+---
+
+### 23. No transition on sidebar collapse for main content paint optimization
+
+**File:** `site.css:1218-1224`
+
+The sidebar and main content both transition `0.2s ease-out`, which is correct. But the main content repaint during margin-left animation can jank on slower machines.
+
+**Fix:** Add `will-change: margin-left` to `.main-content-redesign` to hint the browser to optimize:
+```css
+.main-content-redesign {
+  will-change: margin-left;
+}
+```
+
+---
+
+## Summary by Priority
+
+### Quick Wins (minutes each)
+| # | Fix | Files |
+|---|-----|-------|
+| 2 | Remove duplicate `tab-panel.css` | `_GuildLayout.cshtml` |
+| 8 | Add `<meta name="theme-color">` | `_Layout.cshtml` |
+| 9 | Guard breadcrumb partial invocation | `_Layout.cshtml` |
+| 11 | Replace hardcoded sidebar active color | `site.css` |
+| 13 | Add navbar shadow for depth | `site.css` |
+| 16 | Accent color on active sidebar icon | `site.css` |
+| 19 | Chevron hover feedback on avatar | `_Navbar.cshtml` |
+| 23 | Add `will-change` to main content | `site.css` |
+
+### Medium Effort (small edits across 1-2 files)
+| # | Fix | Files |
+|---|-----|-------|
+| 3 | Different icon for desktop sidebar toggle | `_Navbar.cshtml` |
+| 5 | Remove dead "Support" section | `_Sidebar.cshtml` |
+| 6 | Remove duplicate navbar status pill | `_Navbar.cshtml` |
+| 7 | Remove notification dropdown footer | `_Navbar.cshtml` |
+| 10 | Add max-width to main content | `_Layout.cshtml` |
+| 14 | Bolder sidebar active indicator | `site.css` |
+| 15 | More visible section headers | `site.css` |
+| 17 | Subtler search bar styling | `_Navbar.cshtml` |
+| 18 | Better bot status pill contrast | `site.css` |
+| 20 | Sidebar footer card visual weight | `_Sidebar.cshtml`, `site.css` |
+| 22 | Tighten content padding | `_Layout.cshtml`, `_Breadcrumb.cshtml` |
+
+### Larger Effort (requires planning or build tooling)
+| # | Fix | Files |
+|---|-----|-------|
+| 1 | Bundle JS scripts | `_Layout.cshtml`, build config |
+| 4 | Refactor sidebar active state detection | `_Sidebar.cshtml`, page models |
+| 12 | Local SignalR fallback | `_Layout.cshtml`, npm/build |
+| 21 | Custom heading font | `_Layout.cshtml`, `tailwind.config.js`, `site.css` |

--- a/src/DiscordBot.Bot/Pages/Shared/_Breadcrumb.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/_Breadcrumb.cshtml
@@ -2,7 +2,7 @@
     var breadcrumbs = ViewData["Breadcrumbs"] as List<(string Text, string Url)>;
     if (breadcrumbs != null && breadcrumbs.Any())
     {
-        <nav aria-label="Breadcrumb" class="breadcrumb mb-6">
+        <nav aria-label="Breadcrumb" class="breadcrumb mb-4">
             <ol class="breadcrumb-list flex items-center gap-2 text-sm">
                 @for (int i = 0; i < breadcrumbs.Count; i++)
                 {

--- a/src/DiscordBot.Bot/Pages/Shared/_GuildLayout.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/_GuildLayout.cshtml
@@ -57,7 +57,6 @@
 </div>
 
 @section Styles {
-    <link rel="stylesheet" href="~/css/tab-panel.css" asp-append-version="true" />
     @await RenderSectionAsync("Styles", required: false)
 }
 

--- a/src/DiscordBot.Bot/Pages/Shared/_Layout.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/_Layout.cshtml
@@ -4,6 +4,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#1d2022" />
     <title>@ViewData["Title"] - Discord Bot Admin</title>
     <!-- Blocking theme application script - runs before first paint to prevent flash -->
     <script>
@@ -49,9 +50,12 @@
 
     <!-- Main Content Area -->
     <main id="main-content" class="main-content-redesign">
-        <div class="p-6 lg:p-8">
+        <div class="p-4 lg:p-6 max-w-screen-2xl mx-auto">
             <!-- Breadcrumb Navigation -->
-            @await Html.PartialAsync("_Breadcrumb")
+            @if (ViewData["Breadcrumbs"] != null)
+            {
+                @await Html.PartialAsync("_Breadcrumb")
+            }
 
             <!-- Page Content -->
             @RenderBody()

--- a/src/DiscordBot.Bot/Pages/Shared/_Navbar.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/_Navbar.cshtml
@@ -23,8 +23,8 @@
       class="hidden lg:flex p-2 rounded-lg text-text-secondary hover:text-text-primary hover:bg-bg-hover transition-colors"
       aria-label="Toggle sidebar"
     >
-      <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+      <svg class="w-5 h-5 transition-transform" id="sidebarCollapseIcon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 19l-7-7 7-7m8 14l-7-7 7-7" />
       </svg>
     </button>
 
@@ -51,7 +51,7 @@
         id="navbar-search"
         name="q"
         placeholder="Search servers, commands, logs..."
-        class="w-full pl-10 pr-24 py-2 text-sm bg-bg-primary border border-border-primary rounded-lg text-text-primary placeholder-text-tertiary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors"
+        class="w-full pl-10 pr-24 py-2 text-sm bg-bg-tertiary border border-transparent rounded-lg text-text-primary placeholder-text-tertiary focus:border-border-focus focus:ring-1 focus:ring-border-focus transition-colors"
       />
       <!-- Keyboard Shortcut Hint (desktop only) -->
       <div class="absolute right-3 top-1/2 -translate-y-1/2 hidden lg:flex items-center gap-0.5 pointer-events-none">
@@ -72,12 +72,6 @@
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
       </svg>
     </button>
-
-    <!-- Bot Status (Desktop) -->
-    <div class="hidden lg:flex bot-status-indicator online">
-      <span class="status-dot pulse"></span>
-      <span>Online</span>
-    </div>
 
     <!-- Connection status is now shown via toast notifications (see dashboard-realtime.js) -->
 
@@ -120,16 +114,6 @@
           <!-- Notifications will be rendered here by JavaScript -->
         </div>
 
-        <!-- Footer -->
-        @* TODO: Create /Admin/Notifications page (issue #XXX) *@
-        <div class="notification-dropdown-footer">
-          <button onclick="NotificationBell.close()" class="notification-view-all" title="Full notification center coming soon">
-            Close
-            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
-        </div>
       </div>
 
       <!-- Screen reader announcements -->
@@ -149,7 +133,7 @@
         <button
           id="userMenuButton"
           onclick="toggleUserMenu()"
-          class="flex items-center gap-2 p-1.5 rounded-lg hover:bg-bg-hover transition-colors"
+          class="group flex items-center gap-2 p-1.5 rounded-lg hover:bg-bg-hover transition-colors"
           aria-label="User menu"
           aria-expanded="false"
           aria-haspopup="menu"
@@ -165,7 +149,7 @@
               @initials
             </div>
           }
-          <svg class="hidden sm:block w-4 h-4 text-text-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+          <svg class="hidden sm:block w-4 h-4 text-text-secondary group-hover:text-text-primary transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
           </svg>
         </button>

--- a/src/DiscordBot.Bot/Pages/Shared/_Sidebar.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/_Sidebar.cshtml
@@ -197,21 +197,9 @@
     <!-- Spacer -->
     <div class="flex-1"></div>
 
-    <!-- Support Section (Coming Soon) -->
-    <div class="space-y-1 mt-4" role="group" aria-labelledby="support-nav-heading">
-      <h2 id="support-nav-heading" class="sidebar-section-header">Support</h2>
-      <span class="sidebar-link-redesign sidebar-link-disabled opacity-50 cursor-not-allowed" aria-disabled="true" title="Coming Soon">
-        <svg class="w-5 h-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
-        </svg>
-        <span class="sidebar-link-text">Documentation</span>
-        <span class="sidebar-badge-redesign">Soon</span>
-      </span>
-    </div>
-
     <!-- Bot Status Footer -->
     <div class="bot-status-footer mt-4 pt-4 border-t border-border-secondary" role="status" aria-label="Bot status">
-      <div class="bot-status-container p-3 bg-bg-primary/50 rounded-lg">
+      <div class="bot-status-container p-3 bg-bg-primary rounded-lg border border-border-secondary">
         <div class="bot-status-content flex items-center gap-3">
           <div class="w-10 h-10 rounded-lg bg-success/15 flex items-center justify-center flex-shrink-0">
             <svg class="w-5 h-5 text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/src/DiscordBot.Bot/wwwroot/css/site.css
+++ b/src/DiscordBot.Bot/wwwroot/css/site.css
@@ -1115,6 +1115,7 @@
     background-color: var(--color-bg-secondary);
     border-bottom: 1px solid var(--color-border-primary);
     backdrop-filter: blur(8px);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
   }
 
   /* Dashboard Redesign - Enhanced Sidebar */
@@ -1176,17 +1177,22 @@
 
   .sidebar-link-redesign.active {
     color: var(--color-text-primary);
-    background-color: rgba(203, 78, 27, 0.12);
+    background-color: var(--color-accent-orange-muted);
+  }
+
+  .sidebar-link-redesign.active svg {
+    color: var(--color-accent-orange);
   }
 
   .sidebar-link-redesign.active::before {
     content: '';
     position: absolute;
     left: 0;
-    top: 50%;
-    transform: translateY(-50%);
+    top: 4px;
+    bottom: 4px;
+    height: auto;
+    transform: none;
     width: 3px;
-    height: 24px;
     background-color: var(--color-accent-orange);
     border-radius: 0 2px 2px 0;
   }
@@ -1194,11 +1200,11 @@
   /* Dashboard Redesign - Sidebar Section Header */
   .sidebar-section-header {
     padding: 0.5rem 1rem;
-    font-size: 0.6875rem;
+    font-size: 0.75rem;
     font-weight: 600;
     color: var(--color-text-tertiary);
     text-transform: uppercase;
-    letter-spacing: 0.05em;
+    letter-spacing: 0.08em;
   }
 
   /* Dashboard Redesign - Sidebar Badge */
@@ -1221,6 +1227,7 @@
     min-height: calc(100vh - var(--navbar-height));
     background-color: var(--color-bg-primary);
     transition: margin-left 0.2s ease-out;
+    will-change: margin-left;
   }
 
   .sidebar-redesign.collapsed ~ .main-content-redesign {

--- a/src/DiscordBot.Bot/wwwroot/js/navigation.js
+++ b/src/DiscordBot.Bot/wwwroot/js/navigation.js
@@ -106,6 +106,12 @@ function toggleSidebarCollapse() {
     document.documentElement.classList.remove('sidebar-collapsed');
   }
 
+  // Rotate the collapse icon to indicate expand/collapse direction
+  const collapseIcon = document.getElementById('sidebarCollapseIcon');
+  if (collapseIcon) {
+    collapseIcon.style.transform = sidebarCollapsed ? 'rotate(180deg)' : '';
+  }
+
   // Persist state in localStorage
   try {
     localStorage.setItem(SIDEBAR_COLLAPSED_KEY, sidebarCollapsed.toString());
@@ -310,6 +316,11 @@ document.addEventListener('DOMContentLoaded', function() {
         sidebar.classList.add('collapsed');
         // Ensure html element also has the class (should already be set by inline script)
         document.documentElement.classList.add('sidebar-collapsed');
+        // Rotate collapse icon to indicate "expand" direction
+        const collapseIcon = document.getElementById('sidebarCollapseIcon');
+        if (collapseIcon) {
+          collapseIcon.style.transform = 'rotate(180deg)';
+        }
       }
     } else {
       // Ensure classes are removed if not collapsed


### PR DESCRIPTION
## Summary
- **18 layout fixes** across navbar, sidebar, main content, and CSS — organized in 3 phases
- Removes dead UI (support section, notification footer, duplicate CSS include, navbar status pill)
- Fixes theme-awareness (sidebar active color now uses CSS variable instead of hardcoded rgba)
- Visual polish (navbar shadow, bolder active indicator, subtler search bar, tighter padding, active icon accent)
- Structural improvements (chevron sidebar toggle icon, max-width on ultrawide content, breadcrumb guard)

## Changes by file
| File | Changes |
|------|---------|
| `_Layout.cshtml` | Add `theme-color` meta, guard breadcrumb partial, tighten padding, add `max-w-screen-2xl` |
| `_Navbar.cshtml` | Chevron icon for sidebar toggle, remove bot status pill, remove notification footer, subtler search bar, avatar chevron hover |
| `_Sidebar.cshtml` | Remove dead support section, solid bot status card with border |
| `_GuildLayout.cshtml` | Remove duplicate `tab-panel.css` include |
| `_Breadcrumb.cshtml` | Tighten bottom margin (`mb-6` → `mb-4`) |
| `site.css` | Navbar shadow, theme-aware active color, active icon accent, bolder indicator bar, visible section headers, `will-change` hint |
| `navigation.js` | Rotate collapse icon on sidebar toggle + restore on page load |

## Test plan
- [ ] Verify sidebar active state styling on all themes (dark + Purple Dusk)
- [ ] Verify sidebar collapse/expand with new chevron icon rotates correctly
- [ ] Verify search bar appearance on dark background
- [ ] Check ultrawide content doesn't stretch past 1536px
- [ ] Verify notification dropdown closes on outside click (footer removed)
- [ ] Check guild pages still load tab-panel styles correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)