### PR TITLE
fix: dashboard polish - broken links, missing styles, visual cleanup

### DIFF
--- a/src/DiscordBot.Bot/Pages/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Index.cshtml.cs
@@ -178,7 +178,7 @@ public class IndexModel : PageModel
         BotStatusBanner = new BotStatusBannerViewModel
         {
             IsOnline = statusDto.ConnectionState == "Connected",
-            StatusText = statusDto.ConnectionState == "Connected" ? "Bot is Online" : "Bot is Offline",
+            StatusText = statusDto.ConnectionState == "Connected" ? "Connected" : "Disconnected",
             ServerCount = guildList.Count,
             TotalMembers = totalMembers,
             UptimeDisplay = BotStatusViewModel.FormatUptime(statusDto.Uptime),
@@ -204,10 +204,10 @@ public class IndexModel : PageModel
 
         HeroMetrics = new List<HeroMetricCardViewModel>
         {
-            new() { Title = "Total Servers", Value = guildList.Count.ToString("N0"), TrendValue = "+0", TrendDirection = TrendDirection.Neutral, TrendLabel = "this week", AccentColor = CardAccent.Blue, IconSvg = serverIcon, ShowSparkline = false },
-            new() { Title = "Active Users", Value = activeUsers.ToString("N0"), DataAttribute = "data-active-users", TrendValue = "+0", TrendDirection = TrendDirection.Neutral, TrendLabel = "today", AccentColor = CardAccent.Success, IconSvg = usersIcon, ShowSparkline = false },
-            new() { Title = "Commands Today", Value = commandsToday.ToString("N0"), DataAttribute = "data-total-commands", TrendValue = "0%", TrendDirection = TrendDirection.Neutral, TrendLabel = "vs yesterday", AccentColor = CardAccent.Orange, IconSvg = commandIcon, ShowSparkline = false },
-            new() { Title = "Uptime", Value = uptimeDisplay, DataAttribute = "data-uptime-24h", TrendValue = "", TrendDirection = TrendDirection.Up, TrendLabel = "last 24h", AccentColor = CardAccent.Info, IconSvg = uptimeIcon, ShowSparkline = false }
+            new() { Title = "Total Servers", Value = guildList.Count.ToString("N0"), AccentColor = CardAccent.Blue, IconSvg = serverIcon, ShowSparkline = false },
+            new() { Title = "Active Users", Value = activeUsers.ToString("N0"), DataAttribute = "data-active-users", AccentColor = CardAccent.Success, IconSvg = usersIcon, ShowSparkline = false },
+            new() { Title = "Commands Today", Value = commandsToday.ToString("N0"), DataAttribute = "data-total-commands", AccentColor = CardAccent.Orange, IconSvg = commandIcon, ShowSparkline = false },
+            new() { Title = "Uptime", Value = uptimeDisplay, DataAttribute = "data-uptime-24h", AccentColor = CardAccent.Info, IconSvg = uptimeIcon, ShowSparkline = false }
         };
     }
 
@@ -345,7 +345,7 @@ public class IndexModel : PageModel
         ConnectedServers = new ConnectedServersWidgetViewModel
         {
             Title = "Connected Servers",
-            ViewAllUrl = "/Servers",
+            ViewAllUrl = "/Guilds",
             Servers = serverItems,
             TotalServerCount = guildList.Count
         };

--- a/src/DiscordBot.Bot/Pages/Shared/Components/_ActivityFeedTimeline.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/Components/_ActivityFeedTimeline.cshtml
@@ -8,7 +8,6 @@
     <div class="activity-item">
         <div class="bg-bg-primary/50 rounded-lg p-3">
             <div class="flex items-center gap-2 mb-1">
-                <span class="activity-icon text-sm"></span>
                 <span class="activity-timestamp text-xs text-text-tertiary font-mono"></span>
             </div>
             <p class="text-sm text-text-primary activity-description"></p>
@@ -57,7 +56,6 @@
                     <div class="activity-item @item.TypeClassName">
                         <div class="bg-bg-primary/50 rounded-lg p-3">
                             <div class="flex items-center gap-2 mb-1">
-                                <span class="activity-icon text-sm">@(item.Type == DiscordBot.Bot.ViewModels.Components.Enums.ActivityItemType.Success ? "🔧" : "⚠️")</span>
                                 <span class="activity-timestamp text-xs text-text-tertiary font-mono">@item.Timestamp.ToLocalTime().ToString("HH:mm:ss")</span>
                             </div>
                             <p class="text-sm text-text-primary activity-description">

--- a/src/DiscordBot.Bot/Pages/Shared/Components/_AuditLogCard.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/Components/_AuditLogCard.cshtml
@@ -1,7 +1,7 @@
 @model DiscordBot.Bot.ViewModels.Components.AuditLogCardViewModel
 
 <!-- Audit Log Card -->
-<div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden">
+<div class="bg-bg-secondary border border-border-primary rounded-xl overflow-hidden">
     <!-- Card Header -->
     <div class="flex items-center justify-between px-5 py-4 border-b border-border-primary">
         <div class="flex items-center gap-3">

--- a/src/DiscordBot.Bot/Pages/Shared/Components/_BotStatusBanner.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/Components/_BotStatusBanner.cshtml
@@ -14,7 +14,7 @@
         : "Not currently connected to Discord";
 }
 
-<div class="@bannerClass mb-8" data-bot-status-card data-is-online="@Model.IsOnline.ToString().ToLower()">
+<div class="@bannerClass" data-bot-status-card data-is-online="@Model.IsOnline.ToString().ToLower()">
     <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <!-- Status Info Section -->
         <div class="flex items-center gap-4">

--- a/src/DiscordBot.Bot/Pages/Shared/_Sidebar.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/_Sidebar.cshtml
@@ -69,7 +69,7 @@
         }
         <a href="/Admin/Performance" class="sidebar-link-redesign @(performanceActive ? "active" : "")" @(performanceActive ? "aria-current=page" : "")>
           <svg class="w-5 h-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
           </svg>
           <span class="sidebar-link-text">Bot Performance</span>
         </a>

--- a/src/DiscordBot.Bot/ViewModels/Components/ConnectedServersWidgetViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Components/ConnectedServersWidgetViewModel.cs
@@ -13,7 +13,7 @@ public record ConnectedServersWidgetViewModel
     /// <summary>
     /// Gets the URL to the full servers list page.
     /// </summary>
-    public string ViewAllUrl { get; init; } = "/Servers";
+    public string ViewAllUrl { get; init; } = "/Guilds";
 
     /// <summary>
     /// Gets the list of servers to display in the widget.

--- a/src/DiscordBot.Bot/tailwind.config.js
+++ b/src/DiscordBot.Bot/tailwind.config.js
@@ -38,6 +38,9 @@ module.exports = {
             active: 'var(--color-accent-blue-active)',
             muted: 'var(--color-accent-blue-muted)',
           },
+          purple: {
+            DEFAULT: 'var(--color-accent-purple)',
+          },
         },
         // Semantic colors - mapped to CSS variables for theme support
         success: {

--- a/src/DiscordBot.Bot/wwwroot/css/site.css
+++ b/src/DiscordBot.Bot/wwwroot/css/site.css
@@ -53,6 +53,7 @@
     --color-accent-orange-hover: #e5591f;
     --color-accent-orange-active: #b3440f;
     --color-accent-orange-muted: rgba(203, 78, 27, 0.2);
+    --color-accent-purple: #8b5cf6;
 
     /* Semantic colors */
     --color-success: #10b981;
@@ -127,6 +128,7 @@
     --color-accent-orange-hover: #7A5C8F;
     --color-accent-orange-active: #4F214A;
     --color-accent-orange-muted: rgba(97, 73, 120, 0.2);
+    --color-accent-purple: #7C3AED;
 
     /* Blue → Pink mapping (secondary accent)
        Maps existing accent-blue Tailwind classes to pink.


### PR DESCRIPTION
## Summary
- **Bug fixes**: Add missing `accent-purple` design token (AuditLogCard was rendering unstyled), fix broken `/Servers` → `/Guilds` link on Connected Servers widget, remove duplicate `mb-8` margin on Bot Status Banner
- **Visual polish**: Differentiate status badge text from heading, remove emoji icons from activity feed in favor of CSS timeline dots, hide placeholder trend data on hero metrics, replace heart icon with chart-bar for Bot Performance sidebar, normalize AuditLogCard border-radius to `rounded-xl`
- 8 files changed across components, view models, Tailwind config, and CSS

## Test plan
- [ ] `dotnet build` passes with no errors
- [ ] Dashboard loads correctly with all components rendering
- [ ] Audit log card shows purple-tinted icon backgrounds and text
- [ ] "View All" on Connected Servers navigates to `/Guilds`
- [ ] No double spacing under Bot Status Banner
- [ ] Activity timeline renders clean dot indicators without emojis
- [ ] Hero metrics show values only, no "0%" placeholder trends
- [ ] Sidebar Bot Performance icon is a bar chart, not a heart

🤖 Generated with [Claude Code](https://claude.com/claude-code)