### PR TITLE
refactor: portal pages full overhaul - shared CSS & unified landing

### DIFF
--- a/src/DiscordBot.Bot/Pages/Portal/Shared/_PortalAudioDisabledWarning.cshtml
+++ b/src/DiscordBot.Bot/Pages/Portal/Shared/_PortalAudioDisabledWarning.cshtml
@@ -1,0 +1,13 @@
+@using DiscordBot.Bot.ViewModels.Components
+
+@* Audio disabled warning for portal pages. Displays when audio features are globally turned off. *@
+<div class="portal-audio-warning">
+    @await Html.PartialAsync("../../Shared/Components/_Alert", new AlertViewModel
+    {
+        Variant = AlertVariant.Warning,
+        Title = "Audio Features Disabled",
+        Message = "Audio features have been temporarily disabled. Audio cannot be played at this time.",
+        ShowIcon = true,
+        IsDismissible = false
+    })
+</div>

--- a/src/DiscordBot.Bot/Pages/Portal/Shared/_PortalHeader.cshtml
+++ b/src/DiscordBot.Bot/Pages/Portal/Shared/_PortalHeader.cshtml
@@ -39,113 +39,6 @@
     };
 }
 
-<style>
-    /* Portal Header */
-    .portal-header {
-        background-color: var(--color-bg-secondary);
-        border-bottom: 1px solid var(--color-border-primary);
-    }
-
-    .portal-header .header-content {
-        max-width: 1600px;
-        margin: 0 auto;
-        padding: 1rem 1.5rem 0;
-    }
-
-    .header-top {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        margin-bottom: 1rem;
-    }
-
-    .header-left {
-        display: flex;
-        align-items: center;
-        gap: 1rem;
-        padding-right: 1em;
-    }
-
-    .guild-icon {
-        width: 48px;
-        height: 48px;
-        border-radius: 50%;
-        flex-shrink: 0;
-        overflow: hidden;
-        border: 2px solid var(--color-border-primary);
-    }
-
-    .guild-icon img {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-    }
-
-    .guild-icon-fallback {
-        width: 100%;
-        height: 100%;
-        background-color: var(--color-discord);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        font-size: 1.25rem;
-        font-weight: bold;
-        color: white;
-    }
-
-    .header-text h1 {
-        font-size: 1.125rem;
-        font-weight: bold;
-        color: var(--color-text-primary);
-        margin: 0;
-    }
-
-    .header-text p {
-        font-size: 0.875rem;
-        color: var(--color-text-secondary);
-        margin: 0;
-    }
-
-    .status-badge {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.5rem;
-        padding: 0.5rem 1rem;
-        border-radius: 0.375rem;
-        font-size: 0.875rem;
-        font-weight: 500;
-    }
-
-    .status-badge.online {
-        background-color: rgba(87, 171, 90, 0.1);
-        color: var(--color-success);
-    }
-
-    .status-badge.offline {
-        background-color: rgba(168, 165, 163, 0.1);
-        color: var(--color-text-secondary);
-    }
-
-    .status-dot {
-        width: 8px;
-        height: 8px;
-        border-radius: 50%;
-        background-color: currentColor;
-    }
-
-    @@media (max-width: 640px) {
-        .portal-header .header-content {
-            padding: 1rem 1rem 0;
-        }
-
-        .header-top {
-            flex-direction: column;
-            align-items: flex-start;
-            gap: 0.75rem;
-        }
-    }
-</style>
-
 <!-- Portal Header -->
 <header class="portal-header">
     <div class="header-content">
@@ -160,7 +53,7 @@
                     else
                     {
                         <div class="guild-icon-fallback">
-                            @Model.GuildName.Substring(0, 1).ToUpper()
+                            @(Model.GuildName.Length > 0 ? Model.GuildName[0].ToString().ToUpper() : "?")
                         </div>
                     }
                 </div>

--- a/src/DiscordBot.Bot/Pages/Portal/Shared/_PortalLanding.cshtml
+++ b/src/DiscordBot.Bot/Pages/Portal/Shared/_PortalLanding.cshtml
@@ -1,0 +1,54 @@
+@model DiscordBot.Bot.ViewModels.Portal.PortalLandingViewModel
+
+<div class="landing-container">
+    <div class="landing-card">
+        <!-- Guild Icon -->
+        <div class="landing-guild-icon">
+            @if (!string.IsNullOrEmpty(Model.GuildIconUrl))
+            {
+                <img src="@Model.GuildIconUrl" alt="@Model.GuildName" />
+            }
+            else
+            {
+                <span class="landing-guild-icon-placeholder">@(Model.GuildName.Length > 0 ? Model.GuildName[0].ToString().ToUpper() : "?")</span>
+            }
+        </div>
+
+        <!-- Guild Name -->
+        <h1 class="landing-guild-name">@Model.GuildName</h1>
+
+        <!-- Portal Badge -->
+        <span class="landing-portal-badge">@Model.PortalBadgeText</span>
+
+        <!-- Description -->
+        <p class="landing-description">
+            @Model.DescriptionText
+        </p>
+
+        <!-- Discord Login Button -->
+        <a href="@Model.LoginUrl" class="landing-discord-button">
+            <svg class="landing-discord-logo" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189z"/>
+            </svg>
+            Sign in with Discord
+        </a>
+
+        <!-- Permissions Notice -->
+        <div class="landing-permissions-notice">
+            <div class="landing-permissions-title">What we'll request</div>
+            <div class="landing-permissions-item">
+                <span class="landing-permission-icon">&#10003;</span>
+                <span>Access to see your server memberships</span>
+            </div>
+            <div class="landing-permissions-item">
+                <span class="landing-permission-icon">&#10003;</span>
+                <span>Your Discord username and avatar</span>
+            </div>
+        </div>
+
+        <!-- Footer -->
+        <p class="landing-footer-text">
+            By logging in, you agree to our <a href="/Account/Privacy">Privacy Policy</a>
+        </p>
+    </div>
+</div>

--- a/src/DiscordBot.Bot/Pages/Portal/Shared/_PortalUnauthorized.cshtml
+++ b/src/DiscordBot.Bot/Pages/Portal/Shared/_PortalUnauthorized.cshtml
@@ -1,0 +1,14 @@
+@model DiscordBot.Bot.ViewModels.Portal.PortalUnauthorizedViewModel
+
+<div class="portal-unauthorized">
+    <div class="unauthorized-content">
+        <div class="unauthorized-icon">
+            <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+            </svg>
+        </div>
+        <h2>Access Restricted</h2>
+        <p>You must be a member of <strong>@Model.GuildName</strong> to access this portal.</p>
+        <a href="/" class="btn-secondary">Return Home</a>
+    </div>
+</div>

--- a/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml
@@ -1,429 +1,18 @@
 @page "{guildId:long}"
 @model DiscordBot.Bot.Pages.Portal.Soundboard.IndexModel
+@using DiscordBot.Bot.ViewModels.Portal
 @{
     ViewData["Title"] = Model.IsAuthenticated ? "Soundboard" : "Verify Your Membership";
 }
 
 <style>
     /* ===============================================
-       Landing Page Styles (Unauthenticated View)
+       Soundboard Page-Specific Styles
+       Shared styles (landing, header, layout, sidebar,
+       toasts, responsive) are in portal.css.
        =============================================== */
-    .landing-container {
-        min-height: 100vh;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        padding: 1rem;
-        background-color: var(--color-bg-primary);
-    }
 
-    .landing-card {
-        width: 100%;
-        max-width: 480px;
-        background-color: var(--color-bg-secondary);
-        border: 1px solid var(--color-border-primary);
-        border-radius: 0.5rem;
-        padding: 2.5rem 2rem;
-        text-align: center;
-        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-    }
-
-    .landing-guild-icon {
-        width: 120px;
-        height: 120px;
-        margin: 0 auto 1.5rem;
-        border-radius: 50%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        border: 2px solid var(--color-border-primary);
-        box-shadow: 0 4px 12px rgba(203, 78, 27, 0.3);
-        overflow: hidden;
-        background: linear-gradient(135deg, var(--color-accent-orange) 0%, var(--color-accent-orange-hover) 100%);
-    }
-
-    .landing-guild-icon img {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-    }
-
-    .landing-guild-icon-placeholder {
-        font-size: 3rem;
-        color: white;
-    }
-
-    .landing-guild-name {
-        font-size: 1.75rem;
-        font-weight: 600;
-        color: var(--color-text-primary);
-        margin-bottom: 0.5rem;
-        word-wrap: break-word;
-        word-break: break-word;
-    }
-
-    .landing-portal-badge {
-        display: inline-block;
-        font-size: 0.75rem;
-        font-weight: 500;
-        color: var(--color-accent-orange);
-        background-color: rgba(203, 78, 27, 0.1);
-        border: 1px solid rgba(203, 78, 27, 0.3);
-        padding: 0.375rem 0.75rem;
-        border-radius: 999px;
-        margin-bottom: 1.5rem;
-    }
-
-    .landing-description {
-        font-size: 1rem;
-        color: var(--color-text-primary);
-        margin-bottom: 1.5rem;
-        line-height: 1.6;
-    }
-
-    .landing-description-highlight {
-        color: var(--color-accent-orange);
-        font-weight: 500;
-    }
-
-    .landing-discord-button {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        gap: 0.75rem;
-        width: 100%;
-        padding: 0.875rem 1.5rem;
-        background-color: var(--color-discord);
-        color: white;
-        border: none;
-        border-radius: 0.5rem;
-        font-size: 1rem;
-        font-weight: 600;
-        cursor: pointer;
-        transition: all 0.2s;
-        text-decoration: none;
-        margin-bottom: 1.5rem;
-    }
-
-    .landing-discord-button:hover {
-        background-color: var(--color-discord-hover);
-        transform: translateY(-2px);
-        box-shadow: 0 4px 12px rgba(88, 101, 242, 0.4);
-        color: white;
-        text-decoration: none;
-    }
-
-    .landing-discord-button:active {
-        transform: translateY(0);
-    }
-
-    .landing-discord-logo {
-        width: 20px;
-        height: 20px;
-    }
-
-    .landing-permissions-notice {
-        background-color: var(--color-bg-primary);
-        border: 1px solid var(--color-border-primary);
-        border-radius: 0.5rem;
-        padding: 1rem;
-        margin-bottom: 1.5rem;
-        text-align: left;
-    }
-
-    .landing-permissions-title {
-        font-size: 0.875rem;
-        font-weight: 600;
-        color: var(--color-text-primary);
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-        margin-bottom: 0.5rem;
-    }
-
-    .landing-permissions-item {
-        display: flex;
-        align-items: flex-start;
-        gap: 0.5rem;
-        margin-bottom: 0.5rem;
-        font-size: 0.813rem;
-        color: var(--color-text-secondary);
-        line-height: 1.5;
-    }
-
-    .landing-permissions-item:last-child {
-        margin-bottom: 0;
-    }
-
-    .landing-permission-icon {
-        color: var(--color-accent-orange);
-        font-weight: bold;
-        flex-shrink: 0;
-        margin-top: 0.125rem;
-    }
-
-    .landing-footer-text {
-        font-size: 0.813rem;
-        color: var(--color-text-secondary);
-        line-height: 1.5;
-    }
-
-    .landing-footer-text a {
-        color: var(--color-accent-orange);
-        text-decoration: none;
-        transition: color 0.2s;
-    }
-
-    .landing-footer-text a:hover {
-        color: var(--color-accent-orange-hover);
-        text-decoration: underline;
-    }
-
-    /* Landing page responsive */
-    @@media (max-width: 480px) {
-        .landing-card {
-            padding: 2rem 1.5rem;
-        }
-
-        .landing-guild-icon {
-            width: 100px;
-            height: 100px;
-        }
-
-        .landing-guild-icon-placeholder {
-            font-size: 2.5rem;
-        }
-
-        .landing-guild-name {
-            font-size: 1.5rem;
-            margin-bottom: 0.375rem;
-        }
-
-        .landing-description {
-            font-size: 0.9375rem;
-            margin-bottom: 1.25rem;
-        }
-
-        .landing-discord-button {
-            padding: 0.75rem 1.25rem;
-            font-size: 0.9375rem;
-        }
-    }
-
-    @@media (max-width: 360px) {
-        .landing-card {
-            padding: 1.5rem 1.25rem;
-        }
-
-        .landing-guild-icon {
-            width: 80px;
-            height: 80px;
-            margin-bottom: 1rem;
-        }
-
-        .landing-guild-icon-placeholder {
-            font-size: 2rem;
-        }
-
-        .landing-guild-name {
-            font-size: 1.25rem;
-            margin-bottom: 0.25rem;
-        }
-
-        .landing-portal-badge {
-            font-size: 0.7rem;
-            padding: 0.25rem 0.625rem;
-        }
-
-        .landing-description {
-            font-size: 0.875rem;
-            margin-bottom: 1rem;
-        }
-
-        .landing-permissions-notice {
-            padding: 0.75rem;
-        }
-
-        .landing-permissions-title {
-            font-size: 0.75rem;
-        }
-
-        .landing-permissions-item {
-            font-size: 0.75rem;
-        }
-    }
-
-    /* ===============================================
-       Soundboard Styles (Authenticated View)
-       =============================================== */
-    :root {
-        --portal-header-height: 106px; /* Header with nav tabs */
-    }
-
-    * {
-        margin: 0;
-        padding: 0;
-        box-sizing: border-box;
-    }
-
-    /* Prevent body/html scroll - portal pages fill viewport exactly */
-    html.portal-page,
-    html.portal-page body {
-        overflow: hidden;
-        height: 100%;
-    }
-
-    /* Header */
-    .portal-header {
-        background-color: var(--color-bg-primary);
-        border-bottom: 1px solid var(--color-border-primary);
-        padding: 1rem 1.5rem;
-    }
-
-    .portal-header .header-content {
-        max-width: 1600px;
-        margin: 0 auto;
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-    }
-
-    .header-left {
-        display: flex;
-        align-items: center;
-        gap: 1rem;
-    }
-
-    .bot-icon {
-        width: 40px;
-        height: 40px;
-        border-radius: 0.5rem;
-        background-color: var(--color-accent-orange);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        flex-shrink: 0;
-    }
-
-    .bot-icon svg {
-        width: 24px;
-        height: 24px;
-        color: white;
-    }
-
-    .header-text h1 {
-        font-size: 1.125rem;
-        font-weight: bold;
-        color: var(--color-text-primary);
-    }
-
-    .header-text p {
-        font-size: 0.875rem;
-        color: var(--color-text-secondary);
-    }
-
-    .status-badge {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.375rem;
-        padding: 0.375rem 0.75rem;
-        font-size: 0.75rem;
-        font-weight: 500;
-        border-radius: 9999px;
-    }
-
-    .status-badge.online {
-        background-color: rgba(87, 171, 90, 0.1);
-        color: var(--color-success);
-    }
-
-    .status-badge.offline {
-        background-color: rgba(239, 68, 68, 0.1);
-        color: var(--color-error);
-    }
-
-    .status-dot {
-        width: 6px;
-        height: 6px;
-        border-radius: 50%;
-        background-color: currentColor;
-    }
-
-    /* Main layout - constrained to viewport height */
-    .main-container {
-        max-width: 1600px;
-        margin: 0 auto;
-        padding: 1.5rem;
-        height: calc(100vh - var(--portal-header-height));
-        display: flex;
-        flex-direction: column;
-        overflow: hidden;
-    }
-
-    .portal-content {
-        display: flex;
-        gap: 1.5rem;
-        flex: 1 1 0; /* Grow, shrink, and use 0 basis to allow proper sizing */
-        min-height: 0; /* Critical: allows flex child to shrink below content size */
-    }
-
-    /* Sidebar - Fixed width on LEFT with internal scrolling */
-    .sidebar {
-        width: 300px;
-        flex: 0 0 300px;
-        min-height: 0;
-        background-color: var(--color-bg-secondary);
-        border: 1px solid var(--color-border-primary);
-        border-radius: 0.5rem;
-        padding: 1.25rem;
-        overflow-y: auto;
-        overflow-x: hidden;
-
-        /* Custom scrollbar - Firefox */
-        scrollbar-width: thin;
-        scrollbar-color: var(--color-border-primary) transparent;
-    }
-
-    /* Webkit scrollbar styling for sidebar */
-    .sidebar::-webkit-scrollbar {
-        width: 6px;
-        margin-right: 4px;
-    }
-
-    .sidebar::-webkit-scrollbar-track {
-        background: transparent;
-        margin: 6px 0; /* Add margin to keep scrollbar away from rounded corners */
-    }
-
-    .sidebar::-webkit-scrollbar-thumb {
-        background: var(--color-border-primary);
-        border-radius: 3px;
-    }
-
-    .sidebar::-webkit-scrollbar-thumb:hover {
-        background: var(--color-text-secondary);
-    }
-
-    .sidebar-panel {
-        padding-bottom: 1.25rem;
-        margin-bottom: 1.25rem;
-        border-bottom: 1px solid var(--color-border-primary);
-    }
-
-    .sidebar-panel:last-child {
-        margin-bottom: 0;
-        padding-bottom: 0;
-        border-bottom: none;
-    }
-
-    .sidebar-title {
-        font-size: 0.7rem;
-        font-weight: 600;
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-        color: var(--color-text-secondary);
-        margin-bottom: 0.75rem;
-    }
-
+    /* Voice Channel Connection */
     .connection-status {
         display: flex;
         align-items: center;
@@ -478,7 +67,7 @@
         font-size: 0.875rem;
         color: var(--color-text-primary);
         cursor: pointer;
-        transition: all 0.2s;
+        transition: var(--transition-normal);
         margin-bottom: 1rem;
         background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%23949ba4'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M19 9l-7 7-7-7'%3E%3C/path%3E%3C/svg%3E");
         background-repeat: no-repeat;
@@ -490,10 +79,10 @@
         border-color: var(--color-border-primary);
     }
 
-    .channel-select:focus {
+    .channel-select:focus-visible {
         outline: none;
         border-color: var(--color-accent-orange);
-        box-shadow: 0 0 0 2px rgba(203, 78, 27, 0.1);
+        box-shadow: 0 0 0 2px var(--color-accent-orange-muted);
     }
 
     .button-row {
@@ -513,7 +102,7 @@
         border-radius: 0.5rem;
         border: none;
         cursor: pointer;
-        transition: all 0.2s;
+        transition: var(--transition-normal);
         text-decoration: none;
     }
 
@@ -539,7 +128,7 @@
     }
 
     .btn-leave:hover:not(:disabled) {
-        background-color: var(--color-error);
+        background-color: #dc2626;
     }
 
     /* Upload Section */
@@ -550,7 +139,7 @@
         background-color: var(--color-bg-primary);
         text-align: center;
         cursor: pointer;
-        transition: all 0.2s;
+        transition: var(--transition-normal);
         margin-bottom: 1rem;
     }
 
@@ -561,7 +150,7 @@
 
     .dropzone.drag-over {
         border-color: var(--color-accent-orange);
-        background-color: rgba(203, 78, 27, 0.1);
+        background-color: var(--color-accent-orange-muted);
     }
 
     .dropzone.has-file {
@@ -616,7 +205,7 @@
         height: 36px;
         border-radius: 0.5rem;
         background-color: rgba(59, 130, 246, 0.1);
-        color: #3b82f6;
+        color: var(--color-accent-blue);
         display: flex;
         align-items: center;
         justify-content: center;
@@ -653,7 +242,7 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        transition: all 0.2s;
+        transition: var(--transition-normal);
         flex-shrink: 0;
     }
 
@@ -671,17 +260,17 @@
         font-size: 0.875rem;
         color: var(--color-text-primary);
         margin-bottom: 0.75rem;
-        transition: all 0.2s;
+        transition: var(--transition-normal);
     }
 
     .upload-name-input:hover {
         border-color: var(--color-border-primary);
     }
 
-    .upload-name-input:focus {
+    .upload-name-input:focus-visible {
         outline: none;
         border-color: var(--color-accent-orange);
-        box-shadow: 0 0 0 2px rgba(203, 78, 27, 0.1);
+        box-shadow: 0 0 0 2px var(--color-accent-orange-muted);
     }
 
     .upload-name-input::placeholder {
@@ -698,7 +287,7 @@
         font-size: 0.875rem;
         font-weight: 500;
         cursor: pointer;
-        transition: all 0.2s;
+        transition: var(--transition-normal);
         display: flex;
         align-items: center;
         justify-content: center;
@@ -843,17 +432,17 @@
         padding: 0.625rem 1rem 0.625rem 2.5rem;
         font-size: 0.875rem;
         color: var(--color-text-primary);
-        transition: all 0.2s;
+        transition: var(--transition-normal);
     }
 
     .search-input:hover {
         border-color: var(--color-border-primary);
     }
 
-    .search-input:focus {
+    .search-input:focus-visible {
         outline: none;
         border-color: var(--color-accent-orange);
-        box-shadow: 0 0 0 2px rgba(203, 78, 27, 0.1);
+        box-shadow: 0 0 0 2px var(--color-accent-orange-muted);
     }
 
     .search-input::placeholder {
@@ -882,113 +471,6 @@
 
     .search-clear-btn.visible {
         display: flex;
-    }
-
-    /* Toast container for portal */
-    .portal-toast-container {
-        position: fixed;
-        bottom: 1.5rem;
-        right: 1.5rem;
-        z-index: 9999;
-        display: flex;
-        flex-direction: column;
-        gap: 0.5rem;
-        max-width: 400px;
-    }
-
-    .portal-toast {
-        display: flex;
-        align-items: center;
-        gap: 0.75rem;
-        padding: 1rem 1.25rem;
-        border-radius: 0.5rem;
-        background-color: var(--color-bg-secondary);
-        border: 1px solid var(--color-border-primary);
-        box-shadow: 0 10px 25px rgba(0, 0, 0, 0.5);
-        animation: toast-slide-in 0.3s ease-out;
-    }
-
-    .portal-toast.success {
-        border-color: rgba(87, 171, 90, 0.3);
-    }
-
-    .portal-toast.error {
-        border-color: rgba(239, 68, 68, 0.3);
-    }
-
-    .portal-toast.warning {
-        border-color: rgba(251, 191, 36, 0.3);
-    }
-
-    .portal-toast.info {
-        border-color: rgba(59, 130, 246, 0.3);
-    }
-
-    .portal-toast-icon {
-        width: 20px;
-        height: 20px;
-        flex-shrink: 0;
-    }
-
-    .portal-toast.success .portal-toast-icon {
-        color: var(--color-success);
-    }
-
-    .portal-toast.error .portal-toast-icon {
-        color: var(--color-error);
-    }
-
-    .portal-toast.warning .portal-toast-icon {
-        color: var(--color-warning);
-    }
-
-    .portal-toast.info .portal-toast-icon {
-        color: #3b82f6;
-    }
-
-    .portal-toast-message {
-        flex: 1;
-        font-size: 0.875rem;
-        color: var(--color-text-primary);
-    }
-
-    .portal-toast-close {
-        background: none;
-        border: none;
-        cursor: pointer;
-        color: var(--color-text-secondary);
-        padding: 0.25rem;
-        transition: color 0.2s;
-    }
-
-    .portal-toast-close:hover {
-        color: var(--color-text-primary);
-    }
-
-    @@keyframes toast-slide-in {
-        from {
-            transform: translateX(100%);
-            opacity: 0;
-        }
-        to {
-            transform: translateX(0);
-            opacity: 1;
-        }
-    }
-
-    .portal-toast.dismissing {
-        animation: toast-slide-out 0.2s ease-in forwards;
-    }
-
-    @@keyframes toast-slide-out {
-        from {
-            transform: translateX(0);
-            opacity: 1;
-        }
-        to {
-            transform: translateX(100%);
-            opacity: 0;
-        }
     }
 
     /* Sound Grid - 4 columns desktop, 2 columns mobile with internal scrolling */
@@ -1031,7 +513,7 @@
         border-radius: 0.5rem;
         padding: 1rem;
         cursor: pointer;
-        transition: all 0.2s;
+        transition: var(--transition-normal);
         display: flex;
         flex-direction: column;
         align-items: center;
@@ -1043,11 +525,16 @@
         border-color: var(--color-border-primary);
         background-color: var(--color-bg-secondary);
         transform: translateY(-2px);
-        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+        box-shadow: var(--shadow-md);
+    }
+
+    .sound-card:focus-visible {
+        outline: 2px solid var(--color-accent-orange);
+        outline-offset: 2px;
     }
 
     .sound-card.playing {
-        border-color: #3b82f6;
+        border-color: var(--color-accent-blue);
         background-color: rgba(59, 130, 246, 0.1);
         animation: card-pulse 2s ease-in-out infinite;
     }
@@ -1067,11 +554,11 @@
 
     @@keyframes card-pulse {
         0%, 100% {
-            border-color: #3b82f6;
+            border-color: var(--color-accent-blue);
             box-shadow: 0 0 0 0 rgba(59, 130, 246, 0);
         }
         50% {
-            border-color: #60a5fa;
+            border-color: var(--color-accent-blue-hover);
             box-shadow: 0 0 12px 2px rgba(59, 130, 246, 0.4);
         }
     }
@@ -1094,7 +581,7 @@
         cursor: pointer;
         padding: 0.25rem;
         color: var(--color-text-secondary);
-        transition: all 0.2s;
+        transition: var(--transition-normal);
         display: flex;
         align-items: center;
         justify-content: center;
@@ -1117,15 +604,15 @@
         width: 48px;
         height: 48px;
         border-radius: 50%;
-        background-color: #3b82f6;
+        background-color: var(--color-accent-blue);
         display: flex;
         align-items: center;
         justify-content: center;
-        transition: all 0.2s;
+        transition: var(--transition-normal);
     }
 
     .sound-card:hover .play-icon-wrapper {
-        background-color: #2563eb;
+        background-color: var(--color-accent-blue-active);
         transform: scale(1.05);
     }
 
@@ -1173,50 +660,6 @@
         font-size: 0.875rem;
     }
 
-    .hidden {
-        display: none !important;
-    }
-
-    /* Toast notifications */
-    .toast-notification {
-        position: fixed;
-        bottom: 2rem;
-        left: 50%;
-        transform: translateX(-50%) translateY(100%);
-        padding: 0.75rem 1.5rem;
-        border-radius: 0.5rem;
-        font-size: 0.875rem;
-        font-weight: 500;
-        z-index: 9999;
-        opacity: 0;
-        transition: all 0.3s ease;
-    }
-
-    .toast-notification.show {
-        transform: translateX(-50%) translateY(0);
-        opacity: 1;
-    }
-
-    .toast-info {
-        background-color: #3b82f6;
-        color: white;
-    }
-
-    .toast-success {
-        background-color: var(--color-success);
-        color: white;
-    }
-
-    .toast-warning {
-        background-color: var(--color-warning);
-        color: var(--color-bg-primary);
-    }
-
-    .toast-error {
-        background-color: var(--color-error);
-        color: white;
-    }
-
     /* Highlight required field animation */
     .highlight-required {
         animation: highlight-pulse 0.5s ease-in-out 2;
@@ -1233,33 +676,8 @@
         }
     }
 
-    /* Responsive */
+    /* Page-specific responsive */
     @@media (max-width: 1023px) {
-        /* Allow normal scrolling on mobile/tablet */
-        html.portal-page,
-        html.portal-page body {
-            overflow: auto;
-            height: auto;
-        }
-
-        .main-container {
-            height: auto; /* Allow natural height on mobile */
-            min-height: calc(100vh - var(--portal-header-height));
-            overflow: visible;
-        }
-
-        .portal-content {
-            flex-direction: column;
-            overflow: visible;
-        }
-
-        .sidebar {
-            width: 100%;
-            flex: none;
-            max-height: none;
-            overflow: visible;
-        }
-
         .sound-panel {
             max-height: none;
             overflow: visible;
@@ -1283,18 +701,6 @@
     }
 
     @@media (max-width: 640px) {
-        .portal-header {
-            padding: 1rem;
-        }
-
-        .main-container {
-            padding: 1rem;
-        }
-
-        .portal-content {
-            gap: 1rem;
-        }
-
         .button-row {
             grid-template-columns: 1fr;
         }
@@ -1316,61 +722,14 @@
 
 @if (!Model.IsAuthenticated)
 {
-    <!-- ===============================================
-         Landing Page (Unauthenticated Users)
-         =============================================== -->
-    <div class="landing-container">
-        <div class="landing-card">
-            <!-- Guild Icon -->
-            <div class="landing-guild-icon">
-                @if (!string.IsNullOrEmpty(Model.GuildIconUrl))
-                {
-                    <img src="@Model.GuildIconUrl" alt="@Model.GuildName" />
-                }
-                else
-                {
-                    <span class="landing-guild-icon-placeholder">@(Model.GuildName.Length > 0 ? Model.GuildName[0].ToString().ToUpper() : "?")</span>
-                }
-            </div>
-
-            <!-- Guild Name -->
-            <h1 class="landing-guild-name">@Model.GuildName</h1>
-
-            <!-- Portal Badge -->
-            <span class="landing-portal-badge">Soundboard Portal</span>
-
-            <!-- Description -->
-            <p class="landing-description">
-                To access this soundboard, we need to verify you're a member of <span class="landing-description-highlight">this server</span>
-            </p>
-
-            <!-- Discord Login Button -->
-            <a href="@Model.LoginUrl" class="landing-discord-button">
-                <svg class="landing-discord-logo" fill="currentColor" viewBox="0 0 24 24">
-                    <path d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189z"/>
-                </svg>
-                Login with Discord
-            </a>
-
-            <!-- Permissions Notice -->
-            <div class="landing-permissions-notice">
-                <div class="landing-permissions-title">What we'll request</div>
-                <div class="landing-permissions-item">
-                    <span class="landing-permission-icon">✓</span>
-                    <span>Access to see your server memberships</span>
-                </div>
-                <div class="landing-permissions-item">
-                    <span class="landing-permission-icon">✓</span>
-                    <span>Your Discord username and avatar</span>
-                </div>
-            </div>
-
-            <!-- Footer -->
-            <p class="landing-footer-text">
-                By logging in, you agree to our <a href="/Account/Privacy">Privacy Policy</a>
-            </p>
-        </div>
-    </div>
+    @await Html.PartialAsync("../Shared/_PortalLanding", new PortalLandingViewModel
+    {
+        GuildName = Model.GuildName,
+        GuildIconUrl = Model.GuildIconUrl,
+        LoginUrl = Model.LoginUrl,
+        PortalBadgeText = "Soundboard Portal",
+        DescriptionText = "To access this soundboard, we need to verify you're a member of this server"
+    })
 }
 else
 {
@@ -1390,21 +749,7 @@ else
     <!-- Audio Globally Disabled Warning -->
     @if (Model.IsAudioGloballyDisabled)
     {
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-4">
-            <div class="bg-yellow-900/20 border border-yellow-600/50 rounded-lg p-4">
-                <div class="flex items-start gap-3">
-                    <div class="flex-shrink-0">
-                        <svg class="w-5 h-5 text-yellow-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-                        </svg>
-                    </div>
-                    <div>
-                        <h3 class="text-sm font-semibold text-yellow-500">Audio Features Disabled</h3>
-                        <p class="text-sm text-gray-400 mt-1">Audio features have been temporarily disabled. Sounds cannot be played at this time.</p>
-                    </div>
-                </div>
-            </div>
-        </div>
+        @await Html.PartialAsync("../Shared/_PortalAudioDisabledWarning")
     }
 
 <!-- Main Content -->
@@ -1517,8 +862,8 @@ else
                 <div id="soundGrid" class="sound-grid">
                     @foreach (var sound in Model.Sounds)
                     {
-                        <div class="sound-card" data-sound-id="@sound.Id" data-sound-name="@sound.Name">
-                            <button class="favorite-btn" data-sound-id="@sound.Id" title="Add to favorites">
+                        <div class="sound-card" data-sound-id="@sound.Id" data-sound-name="@sound.Name" role="button" tabindex="0" aria-label="Play @sound.Name">
+                            <button class="favorite-btn" data-sound-id="@sound.Id" title="Add to favorites" aria-pressed="false">
                                 <svg style="width: 20px; height: 20px;" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
                                 </svg>
@@ -1675,7 +1020,6 @@ else
 
                 // Connection state handlers
                 DashboardHub.on('reconnected', async () => {
-                    console.log('[Soundboard] SignalR reconnected, rejoining audio group');
                     await DashboardHub.joinGuildAudioGroup(window.guildId);
                     // Refresh status after reconnect
                     const status = await DashboardHub.getCurrentAudioStatus(window.guildId);
@@ -1685,7 +1029,6 @@ else
                 });
 
                 DashboardHub.on('disconnected', () => {
-                    console.warn('[Soundboard] SignalR disconnected');
                     signalRConnected = false;
                 });
 
@@ -1693,7 +1036,6 @@ else
                 const connected = await DashboardHub.connect();
                 if (connected) {
                     signalRConnected = true;
-                    console.log('[Soundboard] SignalR connected');
 
                     // Join the guild audio group to receive events
                     await DashboardHub.joinGuildAudioGroup(window.guildId);
@@ -1703,11 +1045,9 @@ else
                     if (status) {
                         syncFromAudioStatus(status);
                     }
-                } else {
-                    console.warn('[Soundboard] Failed to connect to SignalR, updates may be delayed');
                 }
             } catch (error) {
-                console.error('[Soundboard] SignalR initialization error:', error);
+                // SignalR initialization failed - updates may be delayed
             }
         }
 
@@ -1726,8 +1066,6 @@ else
 
         // Handle playback started event from SignalR
         function handlePlaybackStarted(data) {
-            console.log('[Soundboard] PlaybackStarted:', data.name);
-
             currentlyPlaying = data.soundId;
 
             // Update card state
@@ -1753,8 +1091,6 @@ else
 
         // Handle playback finished event from SignalR
         function handlePlaybackFinished(data) {
-            console.log('[Soundboard] PlaybackFinished:', data.soundId, 'cancelled:', data.wasCancelled);
-
             currentlyPlaying = null;
 
             // Remove playing state from cards
@@ -1771,20 +1107,16 @@ else
 
         // Handle audio connected event from SignalR
         function handleAudioConnected(data) {
-            console.log('[Soundboard] AudioConnected:', data.channelName, 'MemberCount:', data.memberCount);
             // Voice panel UI updates are now handled by voice-channel-panel.js
         }
 
         // Handle voice channel member count update from SignalR
         function handleVoiceChannelMemberCountUpdated(data) {
-            console.log('[Soundboard] VoiceChannelMemberCountUpdated:', data.channelId, 'MemberCount:', data.memberCount);
             // Voice panel UI updates are now handled by voice-channel-panel.js
         }
 
         // Handle audio disconnected event from SignalR
         function handleAudioDisconnected(data) {
-            console.log('[Soundboard] AudioDisconnected:', data.reason);
-
             // Clear playback state
             currentlyPlaying = null;
 
@@ -1797,12 +1129,9 @@ else
 
         // Handle sound uploaded event from SignalR (another user uploaded a sound)
         function handleSoundUploaded(data) {
-            console.log('[Soundboard] SoundUploaded:', data.name, data.soundId);
-
             // Check if this sound already exists (uploaded by this user)
             const existingCard = document.querySelector(`.sound-card[data-sound-id="${data.soundId}"]`);
             if (existingCard) {
-                console.log('[Soundboard] Sound already in grid, skipping');
                 return;
             }
 
@@ -1819,8 +1148,6 @@ else
 
         // Handle sound deleted event from SignalR (admin deleted a sound)
         function handleSoundDeleted(data) {
-            console.log('[Soundboard] SoundDeleted:', data.soundId);
-
             const grid = document.getElementById('soundGrid');
             const emptyState = document.getElementById('emptyState');
 
@@ -1864,35 +1191,9 @@ else
 
         // Handle queue updated event from SignalR
         function handleQueueUpdated(data) {
-            console.log('[Soundboard] QueueUpdated:', data.queue.length, 'items');
             // Currently the Portal doesn't display a queue UI, but the handler
             // prevents SignalR "No client method found" warnings.
             // Future enhancement: Display queue in the Now Playing panel
-        }
-
-        // Helper: Show toast notification
-        function showToast(message, type = 'info') {
-            // Remove existing toast if any
-            const existingToast = document.querySelector('.toast-notification');
-            if (existingToast) {
-                existingToast.remove();
-            }
-
-            const toast = document.createElement('div');
-            toast.className = `toast-notification toast-${type}`;
-            toast.textContent = message;
-            document.body.appendChild(toast);
-
-            // Trigger animation
-            requestAnimationFrame(() => {
-                toast.classList.add('show');
-            });
-
-            // Remove after 3 seconds
-            setTimeout(() => {
-                toast.classList.remove('show');
-                setTimeout(() => toast.remove(), 300);
-            }, 3000);
         }
 
         // Initialize favorites from localStorage
@@ -1975,6 +1276,16 @@ else
                     const soundName = this.getAttribute('data-sound-name');
                     playSound(soundId, soundName);
                 });
+
+                // Keyboard support for sound cards
+                card.addEventListener('keydown', function(e) {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        const soundId = this.getAttribute('data-sound-id');
+                        const soundName = this.getAttribute('data-sound-name');
+                        playSound(soundId, soundName);
+                    }
+                });
             });
 
             // Upload dropzone
@@ -2032,10 +1343,12 @@ else
             if (index === -1) {
                 favorites.push(soundId);
                 btn.classList.add('active');
+                btn.setAttribute('aria-pressed', 'true');
                 svg.setAttribute('fill', 'currentColor');
             } else {
                 favorites.splice(index, 1);
                 btn.classList.remove('active');
+                btn.setAttribute('aria-pressed', 'false');
                 svg.setAttribute('fill', 'none');
             }
 
@@ -2093,7 +1406,6 @@ else
             })
             .catch(error => {
                 if (error === 'not_connected') return;
-                console.error('Error playing sound:', error);
                 PortalToast.error(error.message || 'Failed to play sound. Please try again.');
             });
         }
@@ -2327,8 +1639,11 @@ else
             card.className = 'sound-card';
             card.setAttribute('data-sound-id', sound.id);
             card.setAttribute('data-sound-name', sound.name);
+            card.setAttribute('role', 'button');
+            card.setAttribute('tabindex', '0');
+            card.setAttribute('aria-label', `Play ${sound.name}`);
             card.innerHTML = `
-                <button class="favorite-btn" data-sound-id="${sound.id}" title="Add to favorites">
+                <button class="favorite-btn" data-sound-id="${sound.id}" title="Add to favorites" aria-pressed="false">
                     <svg style="width: 20px; height: 20px;" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
                     </svg>
@@ -2352,6 +1667,13 @@ else
                 playSound(sound.id, sound.name);
             });
 
+            card.addEventListener('keydown', function(e) {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    playSound(sound.id, sound.name);
+                }
+            });
+
             // Add to beginning of grid (newest first)
             grid.insertBefore(card, grid.firstChild);
 
@@ -2373,19 +1695,6 @@ else
                 }
             });
         }
-
-        // Add animate-spin class for loading spinners
-        const style = document.createElement('style');
-        style.textContent = `
-            .animate-spin {
-                animation: spin 1s linear infinite;
-            }
-            @@keyframes spin {
-                from { transform: rotate(0deg); }
-                to { transform: rotate(360deg); }
-            }
-        `;
-        document.head.appendChild(style);
     </script>
 }
 }

--- a/src/DiscordBot.Bot/Pages/Portal/TTS/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Portal/TTS/Index.cshtml
@@ -1,408 +1,17 @@
 @page "{guildId:long}"
 @model DiscordBot.Bot.Pages.Portal.TTS.IndexModel
 @using DiscordBot.Bot.ViewModels.Components
+@using DiscordBot.Bot.ViewModels.Portal
 @{
-    ViewData["Title"] = Model.IsAuthenticated ? "TTS Portal" : "Verify Your Membership";
+    ViewData["Title"] = Model.IsAuthenticated ? "Text-to-Speech" : "Verify Your Membership";
 }
 
 <style>
     /* ===============================================
-       Landing Page Styles (Unauthenticated View)
+       TTS Portal Page-Specific Styles
+       Shared styles (landing, header, layout, sidebar,
+       toasts, responsive) are in portal.css
        =============================================== */
-    .landing-container {
-        min-height: 100vh;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        padding: 1rem;
-        background-color: var(--color-bg-primary);
-    }
-
-    .landing-card {
-        width: 100%;
-        max-width: 480px;
-        background-color: var(--color-bg-secondary);
-        border: 1px solid var(--color-border-primary);
-        border-radius: 0.5rem;
-        padding: 2.5rem 2rem;
-        text-align: center;
-        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-    }
-
-    .landing-guild-icon {
-        width: 120px;
-        height: 120px;
-        margin: 0 auto 1.5rem;
-        border-radius: 50%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        border: 2px solid var(--color-border-primary);
-        box-shadow: 0 4px 12px rgba(203, 78, 27, 0.3);
-        overflow: hidden;
-        background: linear-gradient(135deg, var(--color-accent-orange) 0%, var(--color-accent-orange-hover) 100%);
-    }
-
-    .landing-guild-icon img {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-    }
-
-    .landing-guild-icon-placeholder {
-        font-size: 3rem;
-        color: white;
-    }
-
-    .landing-guild-name {
-        font-size: 1.75rem;
-        font-weight: 600;
-        color: var(--color-text-primary);
-        margin-bottom: 0.5rem;
-        word-wrap: break-word;
-        word-break: break-word;
-    }
-
-    .landing-portal-badge {
-        display: inline-block;
-        font-size: 0.75rem;
-        font-weight: 500;
-        color: var(--color-accent-orange);
-        background-color: rgba(203, 78, 27, 0.1);
-        border: 1px solid rgba(203, 78, 27, 0.3);
-        padding: 0.375rem 0.75rem;
-        border-radius: 999px;
-        margin-bottom: 1.5rem;
-    }
-
-    .landing-description {
-        font-size: 1rem;
-        color: var(--color-text-primary);
-        margin-bottom: 1.5rem;
-        line-height: 1.6;
-    }
-
-    .landing-description-highlight {
-        color: var(--color-accent-orange);
-        font-weight: 500;
-    }
-
-    .landing-discord-button {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        gap: 0.75rem;
-        width: 100%;
-        padding: 0.875rem 1.5rem;
-        background-color: var(--color-discord);
-        color: white;
-        border: none;
-        border-radius: 0.5rem;
-        font-size: 1rem;
-        font-weight: 600;
-        cursor: pointer;
-        transition: all 0.2s;
-        text-decoration: none;
-        margin-bottom: 1.5rem;
-    }
-
-    .landing-discord-button:hover {
-        background-color: var(--color-discord-hover);
-        transform: translateY(-2px);
-        box-shadow: 0 4px 12px rgba(88, 101, 242, 0.4);
-        color: white;
-        text-decoration: none;
-    }
-
-    .landing-discord-button:active {
-        transform: translateY(0);
-    }
-
-    .landing-discord-logo {
-        width: 20px;
-        height: 20px;
-    }
-
-    .landing-permissions-notice {
-        background-color: var(--color-bg-primary);
-        border: 1px solid var(--color-border-primary);
-        border-radius: 0.5rem;
-        padding: 1rem;
-        margin-bottom: 1.5rem;
-        text-align: left;
-    }
-
-    .landing-permissions-title {
-        font-size: 0.875rem;
-        font-weight: 600;
-        color: var(--color-text-primary);
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-        margin-bottom: 0.5rem;
-    }
-
-    .landing-permissions-item {
-        display: flex;
-        align-items: flex-start;
-        gap: 0.5rem;
-        margin-bottom: 0.5rem;
-        font-size: 0.813rem;
-        color: var(--color-text-secondary);
-        line-height: 1.5;
-    }
-
-    .landing-permissions-item:last-child {
-        margin-bottom: 0;
-    }
-
-    .landing-permission-icon {
-        color: var(--color-accent-orange);
-        font-weight: bold;
-        flex-shrink: 0;
-        margin-top: 0.125rem;
-    }
-
-    .landing-footer-text {
-        font-size: 0.813rem;
-        color: var(--color-text-secondary);
-        line-height: 1.5;
-    }
-
-    .landing-footer-text a {
-        color: var(--color-accent-orange);
-        text-decoration: none;
-        transition: color 0.2s;
-    }
-
-    .landing-footer-text a:hover {
-        color: var(--color-accent-orange-hover);
-        text-decoration: underline;
-    }
-
-    /* Landing page responsive */
-    @@media (max-width: 480px) {
-        .landing-card {
-            padding: 2rem 1.5rem;
-        }
-
-        .landing-guild-icon {
-            width: 100px;
-            height: 100px;
-        }
-
-        .landing-guild-icon-placeholder {
-            font-size: 2.5rem;
-        }
-
-        .landing-guild-name {
-            font-size: 1.5rem;
-            margin-bottom: 0.375rem;
-        }
-
-        .landing-description {
-            font-size: 0.9375rem;
-            margin-bottom: 1.25rem;
-        }
-
-        .landing-discord-button {
-            padding: 0.75rem 1.25rem;
-            font-size: 0.9375rem;
-        }
-    }
-
-    @@media (max-width: 360px) {
-        .landing-card {
-            padding: 1.5rem 1.25rem;
-        }
-
-        .landing-guild-icon {
-            width: 80px;
-            height: 80px;
-            margin-bottom: 1rem;
-        }
-
-        .landing-guild-icon-placeholder {
-            font-size: 2rem;
-        }
-
-        .landing-guild-name {
-            font-size: 1.25rem;
-            margin-bottom: 0.25rem;
-        }
-
-        .landing-portal-badge {
-            font-size: 0.7rem;
-            padding: 0.25rem 0.625rem;
-        }
-
-        .landing-description {
-            font-size: 0.875rem;
-            margin-bottom: 1rem;
-        }
-
-        .landing-permissions-notice {
-            padding: 0.75rem;
-        }
-
-        .landing-permissions-title {
-            font-size: 0.75rem;
-        }
-
-        .landing-permissions-item {
-            font-size: 0.75rem;
-        }
-    }
-
-    /* ===============================================
-       TTS Portal Styles (Authenticated View)
-       =============================================== */
-    :root {
-        --portal-header-height: 106px; /* Header with nav tabs */
-    }
-
-    * {
-        margin: 0;
-        padding: 0;
-        box-sizing: border-box;
-    }
-
-    /* Prevent body/html scroll - portal pages fill viewport exactly */
-    html.portal-page,
-    html.portal-page body {
-        overflow: hidden;
-        height: 100%;
-    }
-
-    /* Header */
-    .portal-header {
-        background-color: var(--color-bg-primary);
-        border-bottom: 1px solid var(--color-border-primary);
-        padding: 1rem 1.5rem;
-    }
-
-    .portal-header .header-content {
-        max-width: 1600px;
-        margin: 0 auto;
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-    }
-
-    .header-left {
-        display: flex;
-        align-items: center;
-        gap: 1rem;
-    }
-
-    .bot-icon {
-        width: 40px;
-        height: 40px;
-        border-radius: 0.5rem;
-        background-color: var(--color-accent-orange);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        flex-shrink: 0;
-    }
-
-    .bot-icon svg {
-        width: 24px;
-        height: 24px;
-        color: white;
-    }
-
-    .header-text h1 {
-        font-size: 1.125rem;
-        font-weight: bold;
-        color: var(--color-text-primary);
-    }
-
-    .header-text p {
-        font-size: 0.875rem;
-        color: var(--color-text-secondary);
-    }
-
-    .status-badge {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.375rem;
-        padding: 0.375rem 0.75rem;
-        font-size: 0.75rem;
-        font-weight: 500;
-        border-radius: 9999px;
-    }
-
-    .status-badge.online {
-        background-color: rgba(87, 171, 90, 0.1);
-        color: var(--color-success);
-    }
-
-    .status-badge.offline {
-        background-color: rgba(239, 68, 68, 0.1);
-        color: var(--color-error);
-    }
-
-    .status-dot {
-        width: 6px;
-        height: 6px;
-        border-radius: 50%;
-        background-color: currentColor;
-    }
-
-    /* Main layout - constrained to viewport height */
-    .main-container {
-        max-width: 1600px;
-        margin: 0 auto;
-        padding: 1.5rem;
-        height: calc(100vh - var(--portal-header-height));
-        display: flex;
-        flex-direction: column;
-        overflow: hidden;
-    }
-
-    .portal-content {
-        display: flex;
-        gap: 1.5rem;
-        flex: 1 1 0; /* Grow, shrink, and use 0 basis to allow proper sizing */
-        min-height: 0; /* Critical: allows flex child to shrink below content size */
-    }
-
-    /* Sidebar - Fixed width on LEFT with internal scrolling */
-    .sidebar {
-        width: 300px;
-        flex: 0 0 300px;
-        min-height: 0;
-        background-color: var(--color-bg-secondary);
-        border: 1px solid var(--color-border-primary);
-        border-radius: 0.5rem;
-        padding: 1.25rem;
-        overflow-y: auto;
-        overflow-x: hidden;
-
-        /* Custom scrollbar - Firefox */
-        scrollbar-width: thin;
-        scrollbar-color: var(--color-border-primary) transparent;
-    }
-
-    /* Webkit scrollbar styling for sidebar */
-    .sidebar::-webkit-scrollbar {
-        width: 6px;
-        margin-right: 4px;
-    }
-
-    .sidebar::-webkit-scrollbar-track {
-        background: transparent;
-        margin: 6px 0; /* Add margin to keep scrollbar away from rounded corners */
-    }
-
-    .sidebar::-webkit-scrollbar-thumb {
-        background: var(--color-border-primary);
-        border-radius: 3px;
-    }
-
-    .sidebar::-webkit-scrollbar-thumb:hover {
-        background: var(--color-text-secondary);
-    }
 
     /* TTS Form Panel - Flexible on RIGHT with internal scrolling */
     .tts-panel {
@@ -482,7 +91,7 @@
         color: var(--color-text-primary);
         font-family: inherit;
         resize: vertical;
-        transition: all 0.2s;
+        transition: var(--transition-normal);
     }
 
     .form-textarea:hover {
@@ -492,7 +101,7 @@
     .form-textarea:focus {
         outline: none;
         border-color: var(--color-accent-orange);
-        box-shadow: 0 0 0 2px rgba(203, 78, 27, 0.1);
+        box-shadow: 0 0 0 2px var(--color-accent-orange-muted);
     }
 
     .form-textarea::placeholder {
@@ -530,7 +139,7 @@
         font-size: 0.875rem;
         color: var(--color-text-primary);
         cursor: pointer;
-        transition: all 0.2s;
+        transition: var(--transition-normal);
         background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%23949ba4'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M19 9l-7 7-7-7'%3E%3C/path%3E%3C/svg%3E");
         background-repeat: no-repeat;
         background-position: right 0.5rem center;
@@ -544,7 +153,7 @@
     .form-select:focus {
         outline: none;
         border-color: var(--color-accent-orange);
-        box-shadow: 0 0 0 2px rgba(203, 78, 27, 0.1);
+        box-shadow: 0 0 0 2px var(--color-accent-orange-muted);
     }
 
 
@@ -582,9 +191,9 @@
         border-radius: 50%;
         background-color: var(--color-accent-orange);
         cursor: pointer;
-        transition: all 0.2s;
+        transition: var(--transition-normal);
         border: 2px solid var(--color-bg-secondary);
-        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+        box-shadow: var(--shadow-sm);
     }
 
     .form-range::-webkit-slider-thumb:hover {
@@ -603,8 +212,8 @@
         background-color: var(--color-accent-orange);
         cursor: pointer;
         border: 2px solid var(--color-bg-secondary);
-        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
-        transition: all 0.2s;
+        box-shadow: var(--shadow-sm);
+        transition: var(--transition-normal);
     }
 
     .form-range::-moz-range-thumb:hover {
@@ -637,7 +246,7 @@
         font-size: 0.875rem;
         font-weight: 500;
         cursor: pointer;
-        transition: all 0.2s;
+        transition: var(--transition-normal);
         display: flex;
         align-items: center;
         justify-content: center;
@@ -662,18 +271,6 @@
         height: 16px;
     }
 
-    /* Toast container for portal */
-    .portal-toast-container {
-        position: fixed;
-        bottom: 1.5rem;
-        right: 1.5rem;
-        z-index: 9999;
-        display: flex;
-        flex-direction: column;
-        gap: 0.5rem;
-        max-width: 400px;
-    }
-
     /* Collapsible Voice Settings */
     .collapsible-header {
         display: flex;
@@ -685,7 +282,7 @@
         border-radius: 0.5rem;
         cursor: pointer;
         min-height: 44px;
-        transition: all 0.2s;
+        transition: var(--transition-normal);
         user-select: none;
     }
 
@@ -703,7 +300,7 @@
         width: 20px;
         height: 20px;
         color: var(--color-text-secondary);
-        transition: transform 0.2s;
+        transition: transform var(--transition-normal);
     }
 
     .collapsible-chevron.expanded {
@@ -726,118 +323,8 @@
         max-height: 1000px;
     }
 
-    .portal-toast {
-        display: flex;
-        align-items: center;
-        gap: 0.75rem;
-        padding: 1rem 1.25rem;
-        border-radius: 0.5rem;
-        background-color: var(--color-bg-secondary);
-        border: 1px solid var(--color-border-primary);
-        box-shadow: 0 10px 25px rgba(0, 0, 0, 0.5);
-        animation: toast-slide-in 0.3s ease-out;
-    }
-
-    .portal-toast.success {
-        border-color: rgba(87, 171, 90, 0.3);
-    }
-
-    .portal-toast.error {
-        border-color: rgba(239, 68, 68, 0.3);
-    }
-
-    .portal-toast.warning {
-        border-color: rgba(251, 191, 36, 0.3);
-    }
-
-    .portal-toast.info {
-        border-color: rgba(59, 130, 246, 0.3);
-    }
-
-    .portal-toast-icon {
-        width: 20px;
-        height: 20px;
-        flex-shrink: 0;
-    }
-
-    .portal-toast.success .portal-toast-icon {
-        color: var(--color-success);
-    }
-
-    .portal-toast.error .portal-toast-icon {
-        color: var(--color-error);
-    }
-
-    .portal-toast.warning .portal-toast-icon {
-        color: var(--color-warning);
-    }
-
-    .portal-toast.info .portal-toast-icon {
-        color: #3b82f6;
-    }
-
-    .portal-toast-message {
-        flex: 1;
-        font-size: 0.875rem;
-        color: var(--color-text-primary);
-    }
-
-    .portal-toast-close {
-        background: none;
-        border: none;
-        cursor: pointer;
-        color: var(--color-text-secondary);
-        padding: 0.25rem;
-        transition: color 0.2s;
-    }
-
-    .portal-toast-close:hover {
-        color: var(--color-text-primary);
-    }
-
-    @@keyframes toast-slide-in {
-        from {
-            transform: translateX(100%);
-            opacity: 0;
-        }
-        to {
-            transform: translateX(0);
-            opacity: 1;
-        }
-    }
-
-    .portal-toast.dismissing {
-        animation: toast-slide-out 0.2s ease-in forwards;
-    }
-
-    @@keyframes toast-slide-out {
-        from {
-            transform: translateX(0);
-            opacity: 1;
-        }
-        to {
-            transform: translateX(100%);
-            opacity: 0;
-        }
-    }
-
-    .hidden {
-        display: none !important;
-    }
-
     /* Responsive */
     @@media (max-width: 767px) {
-        .portal-toast-container {
-            bottom: 1rem;
-            left: 1rem;
-            right: 1rem;
-            max-width: none;
-        }
-
-        .portal-toast {
-            width: 100%;
-        }
-
         /* Show collapsible voice settings on mobile */
         .mobile-collapsible-section {
             display: block !important;
@@ -876,31 +363,6 @@
     }
 
     @@media (max-width: 1023px) {
-        /* Allow normal scrolling on mobile/tablet */
-        html.portal-page,
-        html.portal-page body {
-            overflow: auto;
-            height: auto;
-        }
-
-        .main-container {
-            height: auto; /* Allow natural height on mobile */
-            min-height: calc(100vh - var(--portal-header-height));
-            overflow: visible;
-        }
-
-        .portal-content {
-            flex-direction: column;
-            overflow: visible;
-        }
-
-        .sidebar {
-            width: 100%;
-            flex: none;
-            max-height: none;
-            overflow: visible;
-        }
-
         .tts-panel {
             max-height: none;
             overflow: visible;
@@ -922,19 +384,6 @@
     }
 
     @@media (max-width: 640px) {
-        .portal-header {
-            padding: 1rem;
-        }
-
-        .main-container {
-            padding: 1rem;
-        }
-
-        .portal-content {
-            gap: 1rem;
-        }
-
-
         .tts-form-wrapper {
             padding: 1rem;
         }
@@ -943,61 +392,14 @@
 
 @if (!Model.IsAuthenticated)
 {
-    <!-- ===============================================
-         Landing Page (Unauthenticated Users)
-         =============================================== -->
-    <div class="landing-container">
-        <div class="landing-card">
-            <!-- Guild Icon -->
-            <div class="landing-guild-icon">
-                @if (!string.IsNullOrEmpty(Model.GuildIconUrl))
-                {
-                    <img src="@Model.GuildIconUrl" alt="@Model.GuildName" />
-                }
-                else
-                {
-                    <span class="landing-guild-icon-placeholder">@(Model.GuildName.Length > 0 ? Model.GuildName[0].ToString().ToUpper() : "?")</span>
-                }
-            </div>
-
-            <!-- Guild Name -->
-            <h1 class="landing-guild-name">@Model.GuildName</h1>
-
-            <!-- Portal Badge -->
-            <span class="landing-portal-badge">TTS Portal</span>
-
-            <!-- Description -->
-            <p class="landing-description">
-                To send TTS messages, we need to verify you're a member of <span class="landing-description-highlight">this server</span>
-            </p>
-
-            <!-- Discord Login Button -->
-            <a href="@Model.LoginUrl" class="landing-discord-button">
-                <svg class="landing-discord-logo" fill="currentColor" viewBox="0 0 24 24">
-                    <path d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189z"/>
-                </svg>
-                Login with Discord
-            </a>
-
-            <!-- Permissions Notice -->
-            <div class="landing-permissions-notice">
-                <div class="landing-permissions-title">What we'll request</div>
-                <div class="landing-permissions-item">
-                    <span class="landing-permission-icon">✓</span>
-                    <span>Access to see your server memberships</span>
-                </div>
-                <div class="landing-permissions-item">
-                    <span class="landing-permission-icon">✓</span>
-                    <span>Your Discord username and avatar</span>
-                </div>
-            </div>
-
-            <!-- Footer -->
-            <p class="landing-footer-text">
-                By logging in, you agree to our <a href="/Account/Privacy">Privacy Policy</a>
-            </p>
-        </div>
-    </div>
+    @await Html.PartialAsync("../Shared/_PortalLanding", new PortalLandingViewModel
+    {
+        GuildName = Model.GuildName,
+        GuildIconUrl = Model.GuildIconUrl,
+        LoginUrl = Model.LoginUrl,
+        PortalBadgeText = "Text-to-Speech Portal",
+        DescriptionText = "To send TTS messages, we need to verify you're a member of this server"
+    })
 }
 else
 {
@@ -1017,21 +419,7 @@ else
     <!-- Audio Globally Disabled Warning -->
     @if (Model.IsAudioGloballyDisabled)
     {
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-4">
-            <div class="bg-yellow-900/20 border border-yellow-600/50 rounded-lg p-4">
-                <div class="flex items-start gap-3">
-                    <div class="flex-shrink-0">
-                        <svg class="w-5 h-5 text-yellow-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-                        </svg>
-                    </div>
-                    <div>
-                        <h3 class="text-sm font-semibold text-yellow-500">Audio Features Disabled</h3>
-                        <p class="text-sm text-gray-400 mt-1">Audio features have been temporarily disabled. TTS messages cannot be sent at this time.</p>
-                    </div>
-                </div>
-            </div>
-        </div>
+        @await Html.PartialAsync("../Shared/_PortalAudioDisabledWarning")
     }
 
     <!-- Main Content -->
@@ -1259,7 +647,6 @@ else
     <script>
         // Pass guild ID to JavaScript as a string (critical for Discord snowflake IDs)
         window.guildId = '@Model.GuildId';
-        console.log('[PortalTTS] Scripts section rendered, guildId:', window.guildId);
 
         // Collapsible voice settings toggle
         function toggleVoiceSettings() {

--- a/src/DiscordBot.Bot/Pages/Portal/VOX/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Portal/VOX/Index.cshtml
@@ -4,8 +4,7 @@
 @using DiscordBot.Bot.ViewModels.Components
 
 @{
-    ViewData["Title"] = $"VOX - {Model.GuildName}";
-    Layout = "_PortalLayout";
+    ViewData["Title"] = Model.IsAuthenticated ? "VOX" : "Verify Your Membership";
 
     // Build portal header view model
     var portalHeader = new PortalHeaderViewModel
@@ -22,292 +21,8 @@
     <link rel="stylesheet" href="~/css/nav-tabs.css" asp-append-version="true" />
     <style>
         /* ===============================================
-           Landing Page Styles (Unauthenticated View)
-           =============================================== */
-        .portal-landing {
-            min-height: 100vh;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            padding: 2rem 1rem;
-            background-color: var(--color-bg-primary);
-        }
-
-        .landing-content {
-            width: 100%;
-            max-width: 800px;
-            text-align: center;
-        }
-
-        .landing-header {
-            margin-bottom: 2.5rem;
-        }
-
-        .landing-header h1 {
-            font-size: 2.25rem;
-            font-weight: 700;
-            color: var(--color-text-primary);
-            margin-bottom: 0.75rem;
-        }
-
-        .landing-header p {
-            font-size: 1.125rem;
-            color: var(--color-text-secondary);
-        }
-
-        .landing-features {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-            gap: 1.5rem;
-            margin-bottom: 2.5rem;
-        }
-
-        .feature-card {
-            background-color: var(--color-bg-secondary);
-            border: 1px solid var(--color-border-primary);
-            border-radius: 0.75rem;
-            padding: 1.5rem;
-            text-align: center;
-            transition: all 0.2s ease;
-        }
-
-        .feature-card:hover {
-            border-color: var(--color-accent-orange);
-            transform: translateY(-2px);
-            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-        }
-
-        .feature-icon {
-            width: 48px;
-            height: 48px;
-            margin: 0 auto 1rem;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            background: linear-gradient(135deg, var(--color-accent-orange) 0%, var(--color-accent-orange-hover) 100%);
-            border-radius: 0.75rem;
-            color: white;
-        }
-
-        .feature-icon svg {
-            width: 24px;
-            height: 24px;
-        }
-
-        .feature-card h3 {
-            font-size: 1rem;
-            font-weight: 600;
-            color: var(--color-text-primary);
-            margin-bottom: 0.5rem;
-        }
-
-        .feature-card p {
-            font-size: 0.875rem;
-            color: var(--color-text-secondary);
-            line-height: 1.5;
-            margin: 0;
-        }
-
-        .landing-cta {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            gap: 1rem;
-        }
-
-        .btn-primary {
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            gap: 0.75rem;
-            padding: 0.875rem 2rem;
-            background-color: var(--color-discord);
-            color: white;
-            border: none;
-            border-radius: 0.5rem;
-            font-size: 1rem;
-            font-weight: 600;
-            cursor: pointer;
-            transition: all 0.2s;
-            text-decoration: none;
-        }
-
-        .btn-primary:hover {
-            background-color: var(--color-discord-hover);
-            transform: translateY(-2px);
-            box-shadow: 0 4px 12px rgba(88, 101, 242, 0.4);
-            color: white;
-            text-decoration: none;
-        }
-
-        .btn-primary:active {
-            transform: translateY(0);
-        }
-
-        .btn-primary svg {
-            width: 20px;
-            height: 20px;
-        }
-
-        .landing-hint {
-            font-size: 0.875rem;
-            color: var(--color-text-secondary);
-            margin: 0;
-        }
-
-        /* Unauthorized view styles */
-        .portal-unauthorized {
-            min-height: 100vh;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            padding: 2rem 1rem;
-            background-color: var(--color-bg-primary);
-        }
-
-        .unauthorized-content {
-            text-align: center;
-            max-width: 400px;
-        }
-
-        .unauthorized-icon {
-            width: 80px;
-            height: 80px;
-            margin: 0 auto 1.5rem;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            background-color: rgba(239, 68, 68, 0.1);
-            border-radius: 50%;
-            color: var(--color-error);
-        }
-
-        .unauthorized-icon svg {
-            width: 40px;
-            height: 40px;
-        }
-
-        .unauthorized-content h2 {
-            font-size: 1.5rem;
-            font-weight: 600;
-            color: var(--color-text-primary);
-            margin-bottom: 0.75rem;
-        }
-
-        .unauthorized-content p {
-            font-size: 1rem;
-            color: var(--color-text-secondary);
-            margin-bottom: 1.5rem;
-            line-height: 1.5;
-        }
-
-        .btn-secondary {
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            padding: 0.75rem 1.5rem;
-            background-color: var(--color-bg-secondary);
-            color: var(--color-text-primary);
-            border: 1px solid var(--color-border-primary);
-            border-radius: 0.5rem;
-            font-size: 0.875rem;
-            font-weight: 500;
-            cursor: pointer;
-            transition: all 0.2s;
-            text-decoration: none;
-        }
-
-        .btn-secondary:hover {
-            background-color: var(--color-bg-hover);
-            border-color: var(--color-accent-orange);
-            color: var(--color-text-primary);
-            text-decoration: none;
-        }
-
-        /* Landing page responsive */
-        @@media (max-width: 640px) {
-            .landing-header h1 {
-                font-size: 1.75rem;
-            }
-
-            .landing-header p {
-                font-size: 1rem;
-            }
-
-            .landing-features {
-                grid-template-columns: 1fr;
-            }
-
-            .feature-card {
-                padding: 1.25rem;
-            }
-        }
-
-        /* ===============================================
            VOX Portal Styles (Authenticated View)
            =============================================== */
-        :root {
-            --portal-header-height: 70px;
-        }
-
-        /* Prevent body/html scroll - portal pages fill viewport exactly */
-        html.portal-page,
-        html.portal-page body {
-            overflow: hidden;
-            height: 100%;
-        }
-
-        /* Header - single row layout matching TTS/Soundboard */
-        .portal-header {
-            background-color: var(--color-bg-primary);
-            border-bottom: 1px solid var(--color-border-primary);
-            padding: 1rem 1.5rem;
-        }
-
-        .portal-header .header-content {
-            max-width: 1600px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            padding: 0;
-        }
-
-        .portal-header .header-top {
-            margin-bottom: 0;
-        }
-
-        /* Main layout - matches TTS/Soundboard portal pages */
-        .main-container {
-            max-width: 1600px;
-            margin: 0 auto;
-            padding: 1.5rem;
-            height: calc(100vh - var(--portal-header-height));
-            display: flex;
-            flex-direction: column;
-            overflow: hidden;
-        }
-
-        .portal-content {
-            display: flex;
-            gap: 1.5rem;
-            flex: 1 1 0;
-            min-height: 0;
-        }
-
-        .sidebar {
-            width: 300px;
-            flex: 0 0 300px;
-            min-height: 0;
-            background-color: var(--color-bg-secondary);
-            border: 1px solid var(--color-border-primary);
-            border-radius: 0.5rem;
-            padding: 1.25rem;
-            overflow-y: auto;
-            display: flex;
-            flex-direction: column;
-            gap: 1rem;
-        }
 
         .vox-panel {
             flex: 1;
@@ -395,18 +110,6 @@
             font-size: 0.875rem;
         }
 
-        /* Responsive */
-        @@media (max-width: 768px) {
-            .portal-content {
-                flex-direction: column;
-            }
-
-            .sidebar {
-                width: 100%;
-                flex: none;
-            }
-        }
-
         /* ==========================================
            VOX COMPOSER STYLES
            ========================================== */
@@ -442,7 +145,7 @@
             color: var(--color-text-primary);
             font-size: 0.9rem;
             font-family: var(--font-sans);
-            transition: all 0.15s ease-out;
+            transition: var(--transition-fast);
         }
 
         .vox-message-input:focus {
@@ -469,7 +172,7 @@
             border: 1px solid var(--color-border-primary);
             border-top: none;
             border-radius: 0 0 0.375rem 0.375rem;
-            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+            box-shadow: var(--shadow-md);
             display: none;
         }
 
@@ -577,7 +280,7 @@
             font-size: 0.9rem;
             font-weight: 600;
             cursor: pointer;
-            transition: all 0.15s ease-out;
+            transition: var(--transition-fast);
             display: flex;
             align-items: center;
             justify-content: center;
@@ -647,7 +350,7 @@
             border-radius: 0.375rem;
             color: var(--color-text-primary);
             font-size: 0.875rem;
-            transition: all 0.15s ease-out;
+            transition: var(--transition-fast);
         }
 
         .vox-clip-search:focus {
@@ -710,7 +413,7 @@
             border-radius: 0.375rem;
             color: var(--color-text-primary);
             cursor: pointer;
-            transition: all 0.15s ease-out;
+            transition: var(--transition-fast);
             display: flex;
             flex-direction: column;
             gap: 0.25rem;
@@ -721,7 +424,7 @@
             background-color: var(--color-bg-hover);
             border-color: var(--color-accent-blue);
             transform: translateY(-2px);
-            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+            box-shadow: var(--shadow-md);
         }
 
         .vox-clip-tile:active {
@@ -830,7 +533,7 @@
 
         .vox-az-letter.active {
             color: var(--color-accent-orange);
-            background-color: rgba(203, 78, 27, 0.2);
+            background-color: var(--color-accent-orange-muted);
             font-weight: 700;
         }
 
@@ -896,7 +599,7 @@
             background-color: var(--color-bg-tertiary);
             border: 2px solid var(--color-accent-orange);
             border-radius: 0.75rem;
-            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+            box-shadow: var(--shadow-xl);
             opacity: 0;
             pointer-events: none;
             transition: opacity 0.15s ease-out, transform 0.15s ease-out;
@@ -1149,7 +852,6 @@
                 renderClipGrid();
                 updateTokenPreview();
             } catch (error) {
-                console.error('Error loading clips:', error);
                 // Show error state in clip grid
                 if (voxEls.clipGrid) {
                     voxEls.clipGrid.innerHTML = '<div class="vox-token-empty">Failed to load clips</div>';
@@ -1390,9 +1092,7 @@
                 // Success - clear the message input
                 voxEls.messageInput.value = '';
                 updateTokenPreview();
-                console.log('VOX message sent successfully');
             } catch (error) {
-                console.error('Error playing VOX:', error);
                 // Display error inline instead of alert
                 if (voxEls.playBtnText) {
                     voxEls.playBtnText.textContent = 'Error: ' + (error.message || 'Failed to play').substring(0, 50);
@@ -1504,7 +1204,6 @@
                 voxState.sectionPositions.set(letter, header.offsetTop);
             });
 
-            console.log('[storeSectionPositions] Stored:', Object.fromEntries(voxState.sectionPositions));
         }
 
         function filterClipGrid() {
@@ -1579,8 +1278,6 @@
 
             // Use stored position (calculated before sticky behavior affects positions)
             const targetScroll = voxState.sectionPositions.get(letter);
-
-            console.log('[scrollToSection]', { letter, targetScroll, hasPosition: targetScroll !== undefined });
 
             if (targetScroll === undefined) return;
 
@@ -1827,73 +1524,21 @@
 
 @if (!Model.IsAuthenticated)
 {
-    <!-- Landing page for unauthenticated users -->
-    <div class="portal-landing">
-        <div class="landing-content">
-            <div class="landing-header">
-                <h1>VOX Audio Clips</h1>
-                <p>Access the VOX, FVOX, and HGrunt audio clip library</p>
-            </div>
-
-            <div class="landing-features">
-                <div class="feature-card">
-                    <div class="feature-icon">
-                        <svg class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.536 8.464a5 5 0 010 7.072m2.828-9.9a9 9 0 010 12.728M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z" />
-                        </svg>
-                    </div>
-                    <h3>Browse Clips</h3>
-                    <p>Search and preview audio clips from Half-Life's VOX system</p>
-                </div>
-
-                <div class="feature-card">
-                    <div class="feature-icon">
-                        <svg class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
-                        </svg>
-                    </div>
-                    <h3>Play in Voice</h3>
-                    <p>Play clips directly to voice channels with queue support</p>
-                </div>
-
-                <div class="feature-card">
-                    <div class="feature-icon">
-                        <svg class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
-                        </svg>
-                    </div>
-                    <h3>Three Groups</h3>
-                    <p>Access VOX, FVOX (female), and HGrunt (military) voice sets</p>
-                </div>
-            </div>
-
-            <div class="landing-cta">
-                <a href="@Model.LoginUrl" class="btn-primary">
-                    <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-                        <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515.074.074 0 00-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0 12.64 12.64 0 00-.617-1.25.077.077 0 00-.079-.037A19.736 19.736 0 003.677 4.37a.07.07 0 00-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 00.031.057 19.9 19.9 0 005.993 3.03.078.078 0 00.084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 00-.041-.106 13.107 13.107 0 01-1.872-.892.077.077 0 01-.008-.128 10.2 10.2 0 00.372-.292.074.074 0 01.077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 01.078.01c.12.098.246.198.373.292a.077.077 0 01-.006.127 12.299 12.299 0 01-1.873.892.077.077 0 00-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 00.084.028 19.839 19.839 0 006.002-3.03.077.077 0 00.032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 00-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/>
-                    </svg>
-                    Sign in with Discord
-                </a>
-                <p class="landing-hint">You must be a member of @Model.GuildName to access this portal</p>
-            </div>
-        </div>
-    </div>
+    @await Html.PartialAsync("../Shared/_PortalLanding", new PortalLandingViewModel
+    {
+        GuildName = Model.GuildName,
+        GuildIconUrl = Model.GuildIconUrl,
+        LoginUrl = Model.LoginUrl,
+        PortalBadgeText = "VOX Portal",
+        DescriptionText = "To access the VOX clip library, we need to verify you're a member of this server"
+    })
 }
 else if (!Model.IsAuthorized)
 {
-    <!-- User is authenticated but not a guild member -->
-    <div class="portal-unauthorized">
-        <div class="unauthorized-content">
-            <div class="unauthorized-icon">
-                <svg class="w-16 h-16" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
-                </svg>
-            </div>
-            <h2>Access Restricted</h2>
-            <p>You must be a member of <strong>@Model.GuildName</strong> to access this portal.</p>
-            <a href="/" class="btn-secondary">Return Home</a>
-        </div>
-    </div>
+    @await Html.PartialAsync("../Shared/_PortalUnauthorized", new PortalUnauthorizedViewModel
+    {
+        GuildName = Model.GuildName
+    })
 }
 else
 {

--- a/src/DiscordBot.Bot/Pages/Portal/_PortalLayout.cshtml
+++ b/src/DiscordBot.Bot/Pages/Portal/_PortalLayout.cshtml
@@ -4,6 +4,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#1d2022">
     <title>@ViewData["Title"] - Discord Bot Portal</title>
     <!-- Blocking theme application script - runs before first paint to prevent flash -->
     <script>
@@ -18,6 +19,7 @@
     <!-- Compiled Tailwind CSS (built from site.css via npm run build:css) -->
     <link rel="stylesheet" href="~/css/app.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/css/tab-panel.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/css/portal.css" asp-append-version="true" />
     @await RenderSectionAsync("Styles", required: false)
 </head>
 <body class="portal-page bg-bg-primary text-text-primary font-sans antialiased">

--- a/src/DiscordBot.Bot/ViewModels/Portal/PortalLandingViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Portal/PortalLandingViewModel.cs
@@ -1,0 +1,32 @@
+namespace DiscordBot.Bot.ViewModels.Portal;
+
+/// <summary>
+/// ViewModel for the shared portal landing page partial.
+/// </summary>
+public class PortalLandingViewModel
+{
+    /// <summary>
+    /// Gets or sets the guild display name.
+    /// </summary>
+    public string GuildName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the guild icon URL (null for fallback).
+    /// </summary>
+    public string? GuildIconUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Discord OAuth login URL.
+    /// </summary>
+    public string LoginUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the portal badge text (e.g., "Soundboard Portal", "TTS Portal", "VOX Portal").
+    /// </summary>
+    public string PortalBadgeText { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the description text shown below the badge.
+    /// </summary>
+    public string DescriptionText { get; set; } = string.Empty;
+}

--- a/src/DiscordBot.Bot/ViewModels/Portal/PortalUnauthorizedViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Portal/PortalUnauthorizedViewModel.cs
@@ -1,0 +1,13 @@
+namespace DiscordBot.Bot.ViewModels.Portal;
+
+/// <summary>
+/// ViewModel for the shared portal unauthorized view partial.
+/// Displayed when a user is authenticated but not a guild member.
+/// </summary>
+public class PortalUnauthorizedViewModel
+{
+    /// <summary>
+    /// Gets or sets the guild display name.
+    /// </summary>
+    public string GuildName { get; set; } = string.Empty;
+}

--- a/src/DiscordBot.Bot/wwwroot/css/portal.css
+++ b/src/DiscordBot.Bot/wwwroot/css/portal.css
@@ -1,0 +1,714 @@
+/* ============================================================
+   Portal Shared Stylesheet
+   Extracted shared styles from Soundboard, TTS, and VOX portals.
+   ============================================================ */
+
+/* -----------------------------------------------
+   Portal Layout Resets
+   ----------------------------------------------- */
+:root {
+    --portal-header-height: 106px;
+}
+
+html.portal-page,
+html.portal-page body {
+    overflow: hidden;
+    height: 100%;
+}
+
+/* -----------------------------------------------
+   Landing Page (Card Pattern)
+   ----------------------------------------------- */
+.landing-container {
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+    background-color: var(--color-bg-primary);
+}
+
+.landing-card {
+    width: 100%;
+    max-width: 480px;
+    background-color: var(--color-bg-secondary);
+    border: 1px solid var(--color-border-primary);
+    border-radius: 0.5rem;
+    padding: 2.5rem 2rem;
+    text-align: center;
+    box-shadow: var(--shadow-md);
+}
+
+.landing-guild-icon {
+    width: 120px;
+    height: 120px;
+    margin: 0 auto 1.5rem;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 2px solid var(--color-border-primary);
+    box-shadow: 0 4px 12px var(--glow-primary);
+    overflow: hidden;
+    background: linear-gradient(135deg, var(--color-accent-orange) 0%, var(--color-accent-orange-hover) 100%);
+}
+
+.landing-guild-icon img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.landing-guild-icon-placeholder {
+    font-size: 3rem;
+    color: white;
+}
+
+.landing-guild-name {
+    font-size: 1.75rem;
+    font-weight: 600;
+    color: var(--color-text-primary);
+    margin-bottom: 0.5rem;
+    word-wrap: break-word;
+    word-break: break-word;
+}
+
+.landing-portal-badge {
+    display: inline-block;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--color-accent-orange);
+    background-color: var(--color-accent-orange-muted);
+    border: 1px solid var(--glow-primary);
+    padding: 0.375rem 0.75rem;
+    border-radius: 999px;
+    margin-bottom: 1.5rem;
+}
+
+.landing-description {
+    font-size: 1rem;
+    color: var(--color-text-primary);
+    margin-bottom: 1.5rem;
+    line-height: 1.6;
+}
+
+.landing-description-highlight {
+    color: var(--color-accent-orange);
+    font-weight: 500;
+}
+
+.landing-discord-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    width: 100%;
+    padding: 0.875rem 1.5rem;
+    background-color: var(--color-discord);
+    color: white;
+    border: none;
+    border-radius: 0.5rem;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: var(--transition-normal);
+    text-decoration: none;
+    margin-bottom: 1.5rem;
+}
+
+.landing-discord-button:hover {
+    background-color: var(--color-discord-hover);
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(88, 101, 242, 0.4);
+    color: white;
+    text-decoration: none;
+}
+
+.landing-discord-button:active {
+    transform: translateY(0);
+}
+
+.landing-discord-logo {
+    width: 20px;
+    height: 20px;
+}
+
+.landing-permissions-notice {
+    background-color: var(--color-bg-primary);
+    border: 1px solid var(--color-border-primary);
+    border-radius: 0.5rem;
+    padding: 1rem;
+    margin-bottom: 1.5rem;
+    text-align: left;
+}
+
+.landing-permissions-title {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--color-text-primary);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 0.5rem;
+}
+
+.landing-permissions-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+    font-size: 0.813rem;
+    color: var(--color-text-secondary);
+    line-height: 1.5;
+}
+
+.landing-permissions-item:last-child {
+    margin-bottom: 0;
+}
+
+.landing-permission-icon {
+    color: var(--color-accent-orange);
+    font-weight: bold;
+    flex-shrink: 0;
+    margin-top: 0.125rem;
+}
+
+.landing-footer-text {
+    font-size: 0.813rem;
+    color: var(--color-text-secondary);
+    line-height: 1.5;
+}
+
+.landing-footer-text a {
+    color: var(--color-accent-orange);
+    text-decoration: none;
+    transition: color var(--transition-normal);
+}
+
+.landing-footer-text a:hover {
+    color: var(--color-accent-orange-hover);
+    text-decoration: underline;
+}
+
+/* Landing page responsive */
+@media (max-width: 480px) {
+    .landing-card {
+        padding: 2rem 1.5rem;
+    }
+
+    .landing-guild-icon {
+        width: 100px;
+        height: 100px;
+    }
+
+    .landing-guild-icon-placeholder {
+        font-size: 2.5rem;
+    }
+
+    .landing-guild-name {
+        font-size: 1.5rem;
+        margin-bottom: 0.375rem;
+    }
+
+    .landing-description {
+        font-size: 0.9375rem;
+        margin-bottom: 1.25rem;
+    }
+
+    .landing-discord-button {
+        padding: 0.75rem 1.25rem;
+        font-size: 0.9375rem;
+    }
+}
+
+@media (max-width: 360px) {
+    .landing-card {
+        padding: 1.5rem 1.25rem;
+    }
+
+    .landing-guild-icon {
+        width: 80px;
+        height: 80px;
+        margin-bottom: 1rem;
+    }
+
+    .landing-guild-icon-placeholder {
+        font-size: 2rem;
+    }
+
+    .landing-guild-name {
+        font-size: 1.25rem;
+        margin-bottom: 0.25rem;
+    }
+
+    .landing-portal-badge {
+        font-size: 0.7rem;
+        padding: 0.25rem 0.625rem;
+    }
+
+    .landing-description {
+        font-size: 0.875rem;
+        margin-bottom: 1rem;
+    }
+
+    .landing-permissions-notice {
+        padding: 0.75rem;
+    }
+
+    .landing-permissions-title {
+        font-size: 0.75rem;
+    }
+
+    .landing-permissions-item {
+        font-size: 0.75rem;
+    }
+}
+
+/* -----------------------------------------------
+   Unauthorized View
+   ----------------------------------------------- */
+.portal-unauthorized {
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem 1rem;
+    background-color: var(--color-bg-primary);
+}
+
+.unauthorized-content {
+    text-align: center;
+    max-width: 400px;
+}
+
+.unauthorized-icon {
+    width: 80px;
+    height: 80px;
+    margin: 0 auto 1.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--color-error-bg);
+    border-radius: 50%;
+    color: var(--color-error);
+}
+
+.unauthorized-icon svg {
+    width: 40px;
+    height: 40px;
+}
+
+.unauthorized-content h2 {
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: var(--color-text-primary);
+    margin-bottom: 0.75rem;
+}
+
+.unauthorized-content p {
+    font-size: 1rem;
+    color: var(--color-text-secondary);
+    margin-bottom: 1.5rem;
+    line-height: 1.5;
+}
+
+.btn-secondary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.75rem 1.5rem;
+    background-color: var(--color-bg-secondary);
+    color: var(--color-text-primary);
+    border: 1px solid var(--color-border-primary);
+    border-radius: 0.5rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: var(--transition-normal);
+    text-decoration: none;
+}
+
+.btn-secondary:hover {
+    background-color: var(--color-bg-hover);
+    border-color: var(--color-accent-orange);
+    color: var(--color-text-primary);
+    text-decoration: none;
+}
+
+/* -----------------------------------------------
+   Portal Header
+   ----------------------------------------------- */
+.portal-header {
+    background-color: var(--color-bg-secondary);
+    border-bottom: 1px solid var(--color-border-primary);
+}
+
+.portal-header .header-content {
+    max-width: 1600px;
+    margin: 0 auto;
+    padding: 1rem 1.5rem 0;
+}
+
+.header-top {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+}
+
+.header-left {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding-right: 1em;
+}
+
+.guild-icon {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    overflow: hidden;
+    border: 2px solid var(--color-border-primary);
+}
+
+.guild-icon img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.guild-icon-fallback {
+    width: 100%;
+    height: 100%;
+    background-color: var(--color-discord);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.25rem;
+    font-weight: bold;
+    color: white;
+}
+
+.header-text h1 {
+    font-size: 1.125rem;
+    font-weight: bold;
+    color: var(--color-text-primary);
+    margin: 0;
+}
+
+.header-text p {
+    font-size: 0.875rem;
+    color: var(--color-text-secondary);
+    margin: 0;
+}
+
+.status-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+}
+
+.status-badge.online {
+    background-color: var(--color-success-bg);
+    color: var(--color-success);
+}
+
+.status-badge.offline {
+    background-color: var(--color-error-bg);
+    color: var(--color-error);
+}
+
+.status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background-color: currentColor;
+}
+
+/* -----------------------------------------------
+   Authenticated Layout (Main Container + Sidebar)
+   ----------------------------------------------- */
+.main-container {
+    max-width: 1600px;
+    margin: 0 auto;
+    padding: 1.5rem;
+    height: calc(100vh - var(--portal-header-height));
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.portal-content {
+    display: flex;
+    gap: 1.5rem;
+    flex: 1 1 0;
+    min-height: 0;
+}
+
+.sidebar {
+    width: 300px;
+    flex: 0 0 300px;
+    min-height: 0;
+    background-color: var(--color-bg-secondary);
+    border: 1px solid var(--color-border-primary);
+    border-radius: 0.5rem;
+    padding: 1.25rem;
+    overflow-y: auto;
+    overflow-x: hidden;
+
+    /* Custom scrollbar - Firefox */
+    scrollbar-width: thin;
+    scrollbar-color: var(--color-border-primary) transparent;
+}
+
+/* Webkit scrollbar styling for sidebar */
+.sidebar::-webkit-scrollbar {
+    width: 6px;
+    margin-right: 4px;
+}
+
+.sidebar::-webkit-scrollbar-track {
+    background: transparent;
+    margin: 6px 0;
+}
+
+.sidebar::-webkit-scrollbar-thumb {
+    background: var(--color-border-primary);
+    border-radius: 3px;
+}
+
+.sidebar::-webkit-scrollbar-thumb:hover {
+    background: var(--color-text-secondary);
+}
+
+.sidebar-panel {
+    padding-bottom: 1.25rem;
+    margin-bottom: 1.25rem;
+    border-bottom: 1px solid var(--color-border-primary);
+}
+
+.sidebar-panel:last-child {
+    margin-bottom: 0;
+    padding-bottom: 0;
+    border-bottom: none;
+}
+
+.sidebar-title {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-secondary);
+    margin-bottom: 0.75rem;
+}
+
+/* -----------------------------------------------
+   Toast Styles (Portal-specific)
+   ----------------------------------------------- */
+.portal-toast-container {
+    position: fixed;
+    bottom: 1.5rem;
+    right: 1.5rem;
+    z-index: var(--z-toast);
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    max-width: 400px;
+}
+
+.portal-toast {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 1rem 1.25rem;
+    border-radius: 0.5rem;
+    background-color: var(--color-bg-secondary);
+    border: 1px solid var(--color-border-primary);
+    box-shadow: var(--shadow-xl);
+    animation: toast-slide-in 0.3s ease-out;
+}
+
+.portal-toast.success {
+    border-color: rgba(87, 171, 90, 0.3);
+}
+
+.portal-toast.error {
+    border-color: rgba(239, 68, 68, 0.3);
+}
+
+.portal-toast.warning {
+    border-color: rgba(251, 191, 36, 0.3);
+}
+
+.portal-toast.info {
+    border-color: rgba(59, 130, 246, 0.3);
+}
+
+.portal-toast-icon {
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+}
+
+.portal-toast.success .portal-toast-icon {
+    color: var(--color-success);
+}
+
+.portal-toast.error .portal-toast-icon {
+    color: var(--color-error);
+}
+
+.portal-toast.warning .portal-toast-icon {
+    color: var(--color-warning);
+}
+
+.portal-toast.info .portal-toast-icon {
+    color: var(--color-accent-blue);
+}
+
+.portal-toast-message {
+    flex: 1;
+    font-size: 0.875rem;
+    color: var(--color-text-primary);
+}
+
+.portal-toast-close {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--color-text-secondary);
+    padding: 0.25rem;
+    transition: color var(--transition-fast);
+}
+
+.portal-toast-close:hover {
+    color: var(--color-text-primary);
+}
+
+@keyframes toast-slide-in {
+    from {
+        transform: translateX(100%);
+        opacity: 0;
+    }
+    to {
+        transform: translateX(0);
+        opacity: 1;
+    }
+}
+
+.portal-toast.dismissing {
+    animation: toast-slide-out 0.2s ease-in forwards;
+}
+
+@keyframes toast-slide-out {
+    from {
+        transform: translateX(0);
+        opacity: 1;
+    }
+    to {
+        transform: translateX(100%);
+        opacity: 0;
+    }
+}
+
+/* -----------------------------------------------
+   Audio Disabled Warning
+   ----------------------------------------------- */
+.portal-audio-warning {
+    max-width: 1600px;
+    margin: 0 auto;
+    padding: 1rem 1.5rem 0;
+}
+
+/* -----------------------------------------------
+   Shared Responsive Breakpoints
+   ----------------------------------------------- */
+@media (max-width: 1023px) {
+    /* Allow normal scrolling on mobile/tablet */
+    html.portal-page,
+    html.portal-page body {
+        overflow: auto;
+        height: auto;
+    }
+
+    .main-container {
+        height: auto;
+        min-height: calc(100vh - var(--portal-header-height));
+        overflow: visible;
+    }
+
+    .portal-content {
+        flex-direction: column;
+        overflow: visible;
+    }
+
+    .sidebar {
+        width: 100%;
+        flex: none;
+        max-height: none;
+        overflow: visible;
+    }
+}
+
+@media (max-width: 767px) {
+    .portal-toast-container {
+        bottom: 1rem;
+        left: 1rem;
+        right: 1rem;
+        max-width: none;
+    }
+
+    .portal-toast {
+        width: 100%;
+    }
+}
+
+@media (max-width: 640px) {
+    .portal-header .header-content {
+        padding: 1rem 1rem 0;
+    }
+
+    .header-top {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.75rem;
+    }
+
+    .main-container {
+        padding: 1rem;
+    }
+
+    .portal-content {
+        gap: 1rem;
+    }
+}
+
+/* -----------------------------------------------
+   Reduced Motion
+   ----------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+    .landing-discord-button,
+    .portal-toast,
+    .portal-toast-close,
+    .status-dot,
+    .btn-secondary {
+        transition: none;
+        animation: none;
+    }
+
+    .landing-discord-button:hover {
+        transform: none;
+    }
+
+    .portal-toast {
+        animation: none;
+    }
+
+    .portal-toast.dismissing {
+        animation: none;
+    }
+}

--- a/src/DiscordBot.Bot/wwwroot/js/portal-tts.js
+++ b/src/DiscordBot.Bot/wwwroot/js/portal-tts.js
@@ -51,15 +51,11 @@
             guildId = guildIdElement.dataset.guildId;
         } else if (window.guildId) {
             guildId = window.guildId;
-            console.log('[PortalTTS] Using window.guildId fallback');
         }
 
         if (!guildId) {
-            console.log('[PortalTTS] No guild ID provided, skipping initialization');
             return;
         }
-
-        console.log('[PortalTTS] Initializing for guild:', guildId);
 
         setupEventHandlers();
         loadSavedVoice();
@@ -121,10 +117,9 @@
             const savedVoice = localStorage.getItem(CONFIG.STORAGE_KEY_VOICE);
             if (savedVoice && window.voiceSelector_setValue) {
                 window.voiceSelector_setValue('portalVoiceSelector', savedVoice, true);
-                console.log('[PortalTTS] Restored saved voice:', savedVoice);
             }
         } catch (error) {
-            console.warn('[PortalTTS] Failed to load saved voice:', error);
+            // Failed to load saved voice
         }
     }
 
@@ -132,10 +127,9 @@
         try {
             if (voice) {
                 localStorage.setItem(CONFIG.STORAGE_KEY_VOICE, voice);
-                console.log('[PortalTTS] Saved voice preference:', voice);
             }
         } catch (error) {
-            console.warn('[PortalTTS] Failed to save voice:', error);
+            // Failed to save voice
         }
     }
 
@@ -147,10 +141,9 @@
             const savedMode = localStorage.getItem('tts_mode_preference');
             if (savedMode && ['simple', 'standard', 'pro'].includes(savedMode)) {
                 currentMode = savedMode;
-                console.log('[PortalTTS] Restored saved mode:', savedMode);
             }
         } catch (error) {
-            console.warn('[PortalTTS] Failed to load saved mode:', error);
+            // Failed to load saved mode
         }
 
         // Always apply mode visibility on init (use requestAnimationFrame to ensure
@@ -166,7 +159,6 @@
     function observeConnectionState() {
         const panel = document.getElementById('voice-channel-panel');
         if (!panel) {
-            console.warn('[PortalTTS] Voice channel panel not found, cannot observe connection state');
             return;
         }
 
@@ -177,7 +169,6 @@
         const observer = new MutationObserver(function(mutations) {
             mutations.forEach(function(mutation) {
                 if (mutation.type === 'attributes' && mutation.attributeName === 'data-connected') {
-                    console.log('[PortalTTS] Connection state changed via voice panel');
                     updateCharacterCount(); // Update send button state
                 }
             });
@@ -188,7 +179,6 @@
             attributeFilter: ['data-connected']
         });
 
-        console.log('[PortalTTS] Observing connection state from voice panel');
     }
 
     function checkIsConnected() {
@@ -202,7 +192,6 @@
     async function sendTtsMessage() {
         const messageInput = document.getElementById('ttsMessage');
         if (!messageInput) {
-            console.error('[PortalTTS] Message input element not found');
             return;
         }
         const message = messageInput.value.trim();
@@ -280,7 +269,7 @@
 
             showToast('success', 'Message sent successfully');
         } catch (error) {
-            console.error('[PortalTTS] Send error:', error);
+            // Send error occurred
             showToast('error', error.message);
         } finally {
             isSending = false;
@@ -374,7 +363,7 @@
     function showToast(type, message) {
         const container = document.getElementById('portalToastContainer');
         if (!container) {
-            console.warn('[PortalTTS] Toast container not found');
+            // Toast container not found
             return;
         }
 
@@ -508,7 +497,7 @@
                 }
             }
         } catch (error) {
-            console.error('[PortalTTS] Error building SSML:', error);
+            // Error building SSML
         }
     }
 
@@ -643,5 +632,4 @@
         showToast: showToast
     };
 
-    console.log('[PortalTTS] Module loaded');
 })();


### PR DESCRIPTION
## Summary

- **Extract ~1,900 lines of duplicated inline CSS** from Soundboard, TTS, and VOX portals into a shared `portal.css` stylesheet using design system tokens
- **Unify all three landing pages** into a single `_PortalLanding` shared partial (card pattern), replacing VOX's feature-showcase with the consistent card design
- **Create shared partials** for unauthorized state (`_PortalUnauthorized`) and audio disabled warning (`_PortalAudioDisabledWarning` using `_Alert` component)
- **Fix bugs**: header `GuildName.Substring` crash, offline badge using wrong color, VOX header height mismatch (70px→106px), VOX mobile breakpoint (768px→1023px), `.btn-leave:hover` having no visual feedback
- **Accessibility**: Add `role="button"`, `tabindex="0"`, `aria-label`, `aria-pressed` on sound cards; upgrade `:focus` to `:focus-visible`
- **Cleanup**: Remove 16+ `console.log` calls, dead CSS, runtime-injected styles; normalize title format; replace hardcoded hex with design tokens

### Files Changed

| Type | File | Change |
|------|------|--------|
| New | `portal.css` (714 lines) | Shared portal stylesheet |
| New | `_PortalLanding.cshtml` | Unified card landing partial |
| New | `_PortalUnauthorized.cshtml` | Unauthorized state partial |
| New | `_PortalAudioDisabledWarning.cshtml` | Audio disabled warning using `_Alert` |
| New | `PortalLandingViewModel.cs` | Landing partial ViewModel |
| New | `PortalUnauthorizedViewModel.cs` | Unauthorized partial ViewModel |
| Mod | `_PortalLayout.cshtml` | Add `portal.css` link, `meta theme-color` |
| Mod | `_PortalHeader.cshtml` | Remove `<style>` block, fix substring crash |
| Mod | `Soundboard/Index.cshtml` | 2,391→1,700 lines (-691) |
| Mod | `TTS/Index.cshtml` | 1,342→729 lines (-613) |
| Mod | `VOX/Index.cshtml` | 2,032→1,677 lines (-355) |
| Mod | `portal-tts.js` | Remove console.log calls |

**Net: +966 / -1,902 lines**

## Test plan

- [ ] Build: `dotnet build` passes with 0 errors
- [ ] Visual test each portal (unauthenticated): all three show card-pattern landing with guild icon, badge, permissions, privacy link
- [ ] Visual test each portal (authenticated, bot online): header consistent (same height, bg color, status badge)
- [ ] Visual test (authenticated, audio disabled): Soundboard and TTS show audio disabled warning
- [ ] Theme test: switch to Purple Dusk theme - all tokens adapt (no hardcoded hex)
- [ ] Mobile test (< 1023px): all three stack sidebar above content at same breakpoint
- [ ] Accessibility: tab through Soundboard sound cards - keyboard navigable with Enter/Space
- [ ] Reduced motion: enable `prefers-reduced-motion` in dev tools - no animations fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)