### PR TITLE
fix: broken links to migrated Blazor pages

### DIFF
--- a/src/DiscordBot.Bot/Pages/Admin/Users/Edit.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Users/Edit.cshtml
@@ -226,7 +226,7 @@
                     <h3 class="text-sm font-medium text-text-primary">View Activity Log</h3>
                     <p class="text-xs text-text-secondary mt-1">See detailed user activity and management history</p>
                 </div>
-                <a asp-page="Details" asp-route-id="@Model.Input.UserId" class="btn btn-secondary">
+                <a href="/Admin/Users/Details/@Model.Input.UserId" class="btn btn-secondary">
                     View Details
                 </a>
             </div>

--- a/src/DiscordBot.Bot/Pages/Admin/Users/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Users/Index.cshtml
@@ -202,7 +202,7 @@
                                 </td>
                                 <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                                     <div class="flex justify-end gap-2">
-                                        <a asp-page="Details" asp-route-id="@user.Id" class="text-accent-blue hover:text-accent-blue/80">
+                                        <a href="/Admin/Users/Details/@user.Id" class="text-accent-blue hover:text-accent-blue/80">
                                             View
                                         </a>
                                         <a asp-page="Edit" asp-route-id="@user.Id" class="text-accent-blue hover:text-accent-blue/80">

--- a/src/DiscordBot.Bot/Pages/Guilds/AssistantSettings.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/AssistantSettings.cshtml
@@ -144,7 +144,7 @@
                         </svg>
                         Save Settings
                     </button>
-                    <a asp-page="Details" asp-route-guildId="@Model.Guild.Id"
+                    <a href="/Guilds/Details/@Model.Guild.Id"
                        class="btn btn-secondary inline-flex items-center justify-center gap-2">
                         Cancel
                     </a>

--- a/src/DiscordBot.Bot/Pages/Guilds/Edit.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Edit.cshtml
@@ -113,7 +113,7 @@
 
         <!-- Form Actions -->
         <div class="flex items-center justify-end gap-4">
-            <a asp-page="Details" asp-route-guildId="@Model.ViewModel.Id" class="btn btn-secondary">
+            <a href="/Guilds/Details/@Model.ViewModel.Id" class="btn btn-secondary">
                 Cancel
             </a>
             <button type="submit" class="btn btn-primary">

--- a/src/DiscordBot.Bot/Pages/Guilds/Edit.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/Edit.cshtml.cs
@@ -218,7 +218,7 @@ public class EditModel : PageModel
         _logger.LogInformation("Successfully updated guild {GuildId}", Input.GuildId);
         SuccessMessage = "Guild settings saved successfully.";
 
-        return RedirectToPage("Details", new { id = Input.GuildId });
+        return Redirect($"/Guilds/Details/{Input.GuildId}");
     }
 
     /// <summary>

--- a/src/DiscordBot.Bot/Pages/Guilds/ScheduledMessages/Create.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/ScheduledMessages/Create.cshtml
@@ -225,8 +225,7 @@
                         Create Message
                     </button>
                     <a
-                        asp-page="Index"
-                        asp-route-guildId="@Model.ViewModel.GuildId"
+                        href="/guilds/@Model.ViewModel.GuildId/scheduled-messages"
                         class="inline-flex items-center justify-center gap-2 px-6 py-2.5 text-sm font-medium text-text-primary bg-transparent border border-border-primary rounded-md hover:bg-bg-hover transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-border-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg-primary"
                     >
                         Cancel

--- a/src/DiscordBot.Bot/Pages/Guilds/ScheduledMessages/Create.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/ScheduledMessages/Create.cshtml.cs
@@ -282,7 +282,7 @@ public class CreateModel : PageModel
                 result.Id, Input.GuildId);
 
             SuccessMessage = "Scheduled message created successfully.";
-            return RedirectToPage("Index", new { guildId = Input.GuildId });
+            return Redirect($"/guilds/{Input.GuildId}/scheduled-messages");
         }
         catch (Exception ex)
         {

--- a/src/DiscordBot.Bot/Pages/Guilds/ScheduledMessages/Edit.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/ScheduledMessages/Edit.cshtml
@@ -225,8 +225,7 @@
                         Save Changes
                     </button>
                     <a
-                        asp-page="Index"
-                        asp-route-guildId="@Model.ViewModel.GuildId"
+                        href="/guilds/@Model.ViewModel.GuildId/scheduled-messages"
                         class="inline-flex items-center justify-center gap-2 px-6 py-2.5 text-sm font-medium text-text-primary bg-transparent border border-border-primary rounded-md hover:bg-bg-hover transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-border-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg-primary"
                     >
                         Cancel

--- a/src/DiscordBot.Bot/Pages/Guilds/ScheduledMessages/Edit.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/ScheduledMessages/Edit.cshtml.cs
@@ -349,7 +349,7 @@ public class EditModel : PageModel
                 id, guildId);
 
             SuccessMessage = "Scheduled message updated successfully.";
-            return RedirectToPage("Index", new { guildId });
+            return Redirect($"/guilds/{guildId}/scheduled-messages");
         }
         catch (Exception ex)
         {
@@ -424,19 +424,19 @@ public class EditModel : PageModel
             {
                 _logger.LogWarning("Failed to delete scheduled message {MessageId}", id);
                 ErrorMessage = "Failed to delete the scheduled message.";
-                return RedirectToPage("Index", new { guildId });
+                return Redirect($"/guilds/{guildId}/scheduled-messages");
             }
 
             _logger.LogInformation("Successfully deleted scheduled message {MessageId} for guild {GuildId}", id, guildId);
 
             SuccessMessage = "Scheduled message deleted successfully.";
-            return RedirectToPage("Index", new { guildId });
+            return Redirect($"/guilds/{guildId}/scheduled-messages");
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to delete scheduled message {MessageId} for guild {GuildId}", id, guildId);
             ErrorMessage = "An error occurred while deleting the scheduled message. Please try again.";
-            return RedirectToPage("Index", new { guildId });
+            return Redirect($"/guilds/{guildId}/scheduled-messages");
         }
     }
 

--- a/src/DiscordBot.Bot/Pages/Guilds/Welcome.cshtml
+++ b/src/DiscordBot.Bot/Pages/Guilds/Welcome.cshtml
@@ -266,7 +266,7 @@
                         </svg>
                         Save Configuration
                     </button>
-                    <a asp-page="Details" asp-route-guildId="@Model.ViewModel.GuildId"
+                    <a href="/Guilds/Details/@Model.ViewModel.GuildId"
                        class="btn btn-secondary inline-flex items-center justify-center gap-2">
                         Cancel
                     </a>


### PR DESCRIPTION
## Summary
- Replace `asp-page` tag helpers and `RedirectToPage()` calls that reference Razor Pages migrated to Blazor components
- Fixes Admin/Users pages (Details links), Guilds pages (Details links + Edit redirect), and ScheduledMessages pages (Index links + Create/Edit/Delete redirects)
- 10 files, 13 line changes across 3 independent bug reports

## Issues Fixed
Closes #1702, closes #1703, closes #1704

## Test plan
- [ ] Navigate to Admin/Users/Index — "View" links go to `/Admin/Users/Details/{id}`
- [ ] Submit Guilds/Edit form — redirects to `/Guilds/Details/{id}` (no 500 error)
- [ ] "Cancel" links on Guilds/Edit, Welcome, AssistantSettings go to guild details
- [ ] Create a scheduled message — redirects to `/guilds/{id}/scheduled-messages` (no 500 error)
- [ ] Edit/Delete a scheduled message — redirects to list
- [ ] "Cancel" links on ScheduledMessages Create/Edit pages work

🤖 Generated with [Claude Code](https://claude.com/claude-code)