### PR TITLE
feat: guild context selector for search results (#1710)

### DIFF
--- a/src/DiscordBot.Bot/Pages/Search.cshtml
+++ b/src/DiscordBot.Bot/Pages/Search.cshtml
@@ -481,33 +481,73 @@
                     <div class="divide-y divide-border-primary">
                         @foreach (var pageItem in Model.ViewModel.Pages)
                         {
-                            <a href="@pageItem.Url" class="block px-6 py-4 hover:bg-bg-hover transition-colors">
-                                <div class="flex items-center justify-between gap-4">
-                                    <div class="flex-1 min-w-0">
-                                        <div class="flex items-center gap-3 flex-wrap">
-                                            <h3 class="font-semibold text-text-primary"><highlight text="@pageItem.Title" search-term="@Model.ViewModel.SearchTerm" /></h3>
-                                            @if (!string.IsNullOrEmpty(pageItem.BadgeText))
-                                            {
-                                                var pageBadgeVariant = ParseBadgeVariant(pageItem.BadgeVariant);
-                                                var pageBadge = new BadgeViewModel
+                            if (pageItem.RequiresGuildContext)
+                            {
+                                <div class="px-6 py-4">
+                                    <div class="flex items-center justify-between gap-4">
+                                        <div class="flex-1 min-w-0">
+                                            <div class="flex items-center gap-3 flex-wrap">
+                                                <h3 class="font-semibold text-text-primary"><highlight text="@pageItem.Title" search-term="@Model.ViewModel.SearchTerm" /></h3>
+                                                @if (!string.IsNullOrEmpty(pageItem.BadgeText))
                                                 {
-                                                    Text = pageItem.BadgeText,
-                                                    Variant = pageBadgeVariant,
-                                                    Size = BadgeSize.Small
-                                                };
-                                                <partial name="Shared/Components/_Badge" model="pageBadge" />
+                                                    var pageBadgeVariant = ParseBadgeVariant(pageItem.BadgeVariant);
+                                                    var pageBadge = new BadgeViewModel
+                                                    {
+                                                        Text = pageItem.BadgeText,
+                                                        Variant = pageBadgeVariant,
+                                                        Size = BadgeSize.Small
+                                                    };
+                                                    <partial name="Shared/Components/_Badge" model="pageBadge" />
+                                                }
+                                            </div>
+                                            @if (!string.IsNullOrEmpty(pageItem.Description))
+                                            {
+                                                <p class="text-sm text-text-secondary mt-1"><highlight text="@pageItem.Description" search-term="@Model.ViewModel.SearchTerm" max-length="100" /></p>
+                                            }
+                                            <div class="mt-2">
+                                                @{
+                                                    var selectorModel = new GuildContextSelectorViewModel
+                                                    {
+                                                        RouteTemplate = pageItem.RouteTemplate ?? string.Empty,
+                                                        Guilds = Model.UserGuilds
+                                                    };
+                                                }
+                                                <partial name="Shared/Components/_GuildContextSelector" model="selectorModel" />
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            }
+                            else
+                            {
+                                <a href="@pageItem.Url" class="block px-6 py-4 hover:bg-bg-hover transition-colors">
+                                    <div class="flex items-center justify-between gap-4">
+                                        <div class="flex-1 min-w-0">
+                                            <div class="flex items-center gap-3 flex-wrap">
+                                                <h3 class="font-semibold text-text-primary"><highlight text="@pageItem.Title" search-term="@Model.ViewModel.SearchTerm" /></h3>
+                                                @if (!string.IsNullOrEmpty(pageItem.BadgeText))
+                                                {
+                                                    var pageBadgeVariant2 = ParseBadgeVariant(pageItem.BadgeVariant);
+                                                    var pageBadge2 = new BadgeViewModel
+                                                    {
+                                                        Text = pageItem.BadgeText,
+                                                        Variant = pageBadgeVariant2,
+                                                        Size = BadgeSize.Small
+                                                    };
+                                                    <partial name="Shared/Components/_Badge" model="pageBadge2" />
+                                                }
+                                            </div>
+                                            @if (!string.IsNullOrEmpty(pageItem.Description))
+                                            {
+                                                <p class="text-sm text-text-secondary mt-1"><highlight text="@pageItem.Description" search-term="@Model.ViewModel.SearchTerm" max-length="100" /></p>
                                             }
                                         </div>
-                                        @if (!string.IsNullOrEmpty(pageItem.Description))
-                                        {
-                                            <p class="text-sm text-text-secondary mt-1"><highlight text="@pageItem.Description" search-term="@Model.ViewModel.SearchTerm" max-length="100" /></p>
-                                        }
+                                        <svg class="w-5 h-5 text-text-tertiary flex-shrink-0 hidden sm:block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                                        </svg>
                                     </div>
-                                    <svg class="w-5 h-5 text-text-tertiary flex-shrink-0 hidden sm:block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                                    </svg>
-                                </div>
-                            </a>
+                                </a>
+                            }
                         }
                     </div>
                 </div>

--- a/src/DiscordBot.Bot/Pages/Search.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Search.cshtml.cs
@@ -1,7 +1,11 @@
+using DiscordBot.Bot.ViewModels.Components;
 using DiscordBot.Bot.ViewModels.Pages;
 using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Entities;
 using DiscordBot.Core.Interfaces;
+using Discord.WebSocket;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
@@ -16,15 +20,24 @@ public class SearchModel : PageModel
 {
     private readonly ISearchService _searchService;
     private readonly IAuthorizationService _authorizationService;
+    private readonly IUserDiscordGuildService _userDiscordGuildService;
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly DiscordSocketClient _discordClient;
     private readonly ILogger<SearchModel> _logger;
 
     public SearchModel(
         ISearchService searchService,
         IAuthorizationService authorizationService,
+        IUserDiscordGuildService userDiscordGuildService,
+        UserManager<ApplicationUser> userManager,
+        DiscordSocketClient discordClient,
         ILogger<SearchModel> logger)
     {
         _searchService = searchService;
         _authorizationService = authorizationService;
+        _userDiscordGuildService = userDiscordGuildService;
+        _userManager = userManager;
+        _discordClient = discordClient;
         _logger = logger;
     }
 
@@ -38,6 +51,11 @@ public class SearchModel : PageModel
     /// The view model containing all search results.
     /// </summary>
     public SearchResultsViewModel ViewModel { get; set; } = new();
+
+    /// <summary>
+    /// Guild selector items for guild-scoped page results, intersected with bot's active guilds.
+    /// </summary>
+    public IReadOnlyList<GuildSelectorItem> UserGuilds { get; set; } = [];
 
     public async Task<IActionResult> OnGetAsync(CancellationToken cancellationToken)
     {
@@ -121,10 +139,38 @@ public class SearchModel : PageModel
             ScheduledMessagesViewAllUrl = unifiedResult.ScheduledMessages.ViewAllUrl
         };
 
+        // Load user guilds if any page results require guild context
+        if (ViewModel.Pages.Any(p => p.RequiresGuildContext))
+        {
+            UserGuilds = await LoadUserGuildsAsync(cancellationToken);
+        }
+
         _logger.LogInformation("Search completed. Found {TotalResults} total results across all categories",
             unifiedResult.TotalResultCount);
 
         return Page();
+    }
+
+    private async Task<IReadOnlyList<GuildSelectorItem>> LoadUserGuildsAsync(CancellationToken cancellationToken)
+    {
+        var appUser = await _userManager.GetUserAsync(User);
+        if (appUser == null)
+            return [];
+
+        var userGuilds = await _userDiscordGuildService.GetUserGuildsAsync(appUser.Id, cancellationToken);
+        var botGuildIds = _discordClient.Guilds.Select(g => g.Id).ToHashSet();
+
+        return userGuilds
+            .Where(g => botGuildIds.Contains(g.GuildId))
+            .Select(g => new GuildSelectorItem
+            {
+                GuildId = g.GuildId.ToString(),
+                GuildName = g.GuildName,
+                GuildIconUrl = g.GuildIconUrl
+            })
+            .OrderBy(g => g.GuildName)
+            .ToList()
+            .AsReadOnly();
     }
 
     /// <summary>

--- a/src/DiscordBot.Bot/Pages/Shared/Components/_GuildContextSelector.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/Components/_GuildContextSelector.cshtml
@@ -1,0 +1,72 @@
+@model DiscordBot.Bot.ViewModels.Components.GuildContextSelectorViewModel
+@{
+    var selectorId = $"guild-selector-{Guid.NewGuid():N}";
+}
+
+@if (Model.Guilds.Count == 0)
+{
+    <span class="text-sm text-text-tertiary italic">No guilds available</span>
+}
+else if (Model.Guilds.Count == 1)
+{
+    var guild = Model.Guilds[0];
+    var url = Model.RouteTemplate.Replace("{guildId}", guild.GuildId);
+    <a href="@url" class="inline-flex items-center gap-2 text-sm font-medium text-accent-blue hover:text-accent-blue-hover transition-colors">
+        @if (!string.IsNullOrEmpty(guild.GuildIconUrl))
+        {
+            <img src="@guild.GuildIconUrl" alt="" class="w-4 h-4 rounded-full" />
+        }
+        <span>Open in @guild.GuildName</span>
+        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6" />
+        </svg>
+    </a>
+}
+else
+{
+    <div class="relative inline-block" id="@selectorId">
+        <button type="button"
+                class="inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-accent-blue bg-accent-blue/10 border border-accent-blue/20 rounded-lg hover:bg-accent-blue/20 transition-colors"
+                onclick="(function(el) { var dd = el.nextElementSibling; dd.classList.toggle('hidden'); })(this)">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
+            </svg>
+            <span>Select guild</span>
+            <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            </svg>
+        </button>
+        <div class="hidden absolute left-0 z-50 mt-1 w-56 bg-bg-secondary border border-border-primary rounded-lg shadow-lg overflow-hidden">
+            @foreach (var guild in Model.Guilds)
+            {
+                var guildUrl = Model.RouteTemplate.Replace("{guildId}", guild.GuildId);
+                <a href="@guildUrl"
+                   class="flex items-center gap-3 px-4 py-2.5 text-sm text-text-primary hover:bg-bg-hover transition-colors">
+                    @if (!string.IsNullOrEmpty(guild.GuildIconUrl))
+                    {
+                        <img src="@guild.GuildIconUrl" alt="" class="w-5 h-5 rounded-full flex-shrink-0" />
+                    }
+                    else
+                    {
+                        <div class="w-5 h-5 rounded-full bg-bg-tertiary flex items-center justify-center flex-shrink-0">
+                            <span class="text-xs font-medium text-text-secondary">@guild.GuildName.FirstOrDefault()</span>
+                        </div>
+                    }
+                    <span class="truncate">@guild.GuildName</span>
+                </a>
+            }
+        </div>
+    </div>
+    <script>
+        (function() {
+            var container = document.getElementById('@selectorId');
+            if (!container) return;
+            document.addEventListener('click', function(e) {
+                if (!container.contains(e.target)) {
+                    var dd = container.querySelector('div');
+                    if (dd) dd.classList.add('hidden');
+                }
+            });
+        })();
+    </script>
+}

--- a/src/DiscordBot.Bot/Services/PageMetadataService.cs
+++ b/src/DiscordBot.Bot/Services/PageMetadataService.cs
@@ -59,7 +59,9 @@ public class PageMetadataService : IPageMetadataService
                 Description = "View detailed server information",
                 Section = "Guild",
                 IconName = "information-circle",
-                Keywords = new[] { "server info", "details", "guild info" }
+                Keywords = new[] { "server info", "details", "guild info" },
+                RequiresGuildContext = true,
+                RouteTemplate = "/Guilds/Details/{guildId}"
             },
             new()
             {
@@ -68,7 +70,9 @@ public class PageMetadataService : IPageMetadataService
                 Description = "Edit guild configuration",
                 Section = "Guild",
                 IconName = "cog",
-                Keywords = new[] { "settings", "config", "configuration", "edit guild" }
+                Keywords = new[] { "settings", "config", "configuration", "edit guild" },
+                RequiresGuildContext = true,
+                RouteTemplate = "/Guilds/Edit/{guildId}"
             },
             new()
             {
@@ -77,7 +81,9 @@ public class PageMetadataService : IPageMetadataService
                 Description = "Configure welcome messages for new members",
                 Section = "Guild",
                 IconName = "hand-raised",
-                Keywords = new[] { "welcome", "greeting", "new members", "join message" }
+                Keywords = new[] { "welcome", "greeting", "new members", "join message" },
+                RequiresGuildContext = true,
+                RouteTemplate = "/Guilds/Welcome/{guildId}"
             },
             new()
             {
@@ -86,7 +92,9 @@ public class PageMetadataService : IPageMetadataService
                 Description = "Guild auto-moderation configuration",
                 Section = "Guild",
                 IconName = "shield-check",
-                Keywords = new[] { "moderation", "auto-mod", "filters", "rules" }
+                Keywords = new[] { "moderation", "auto-mod", "filters", "rules" },
+                RequiresGuildContext = true,
+                RouteTemplate = "/Guilds/ModerationSettings/{guildId}"
             },
             new()
             {
@@ -95,7 +103,9 @@ public class PageMetadataService : IPageMetadataService
                 Description = "Manage scheduled and recurring messages",
                 Section = "Guild",
                 IconName = "clock",
-                Keywords = new[] { "automated", "recurring", "scheduled", "messages", "automation" }
+                Keywords = new[] { "automated", "recurring", "scheduled", "messages", "automation" },
+                RequiresGuildContext = true,
+                RouteTemplate = "/Guilds/ScheduledMessages/{guildId}"
             },
             new()
             {
@@ -104,7 +114,9 @@ public class PageMetadataService : IPageMetadataService
                 Description = "Accountability and incident tracking",
                 Section = "Guild",
                 IconName = "eye",
-                Keywords = new[] { "accountability", "incidents", "rat watch", "tracking" }
+                Keywords = new[] { "accountability", "incidents", "rat watch", "tracking" },
+                RequiresGuildContext = true,
+                RouteTemplate = "/Guilds/RatWatch/{guildId}"
             },
             new()
             {
@@ -113,7 +125,9 @@ public class PageMetadataService : IPageMetadataService
                 Description = "Rat Watch metrics and analytics",
                 Section = "Guild",
                 IconName = "chart-pie",
-                Keywords = new[] { "rat watch stats", "analytics", "metrics", "reports" }
+                Keywords = new[] { "rat watch stats", "analytics", "metrics", "reports" },
+                RequiresGuildContext = true,
+                RouteTemplate = "/Guilds/RatWatch/Analytics/{guildId}"
             },
             new()
             {
@@ -122,7 +136,9 @@ public class PageMetadataService : IPageMetadataService
                 Description = "Browse and filter Rat Watch incidents",
                 Section = "Guild",
                 IconName = "exclamation-triangle",
-                Keywords = new[] { "incidents", "reports", "rat watch", "violations" }
+                Keywords = new[] { "incidents", "reports", "rat watch", "violations" },
+                RequiresGuildContext = true,
+                RouteTemplate = "/Guilds/RatWatch/Incidents/{guildId}"
             },
             new()
             {
@@ -131,7 +147,9 @@ public class PageMetadataService : IPageMetadataService
                 Description = "Guild member list with search and filter",
                 Section = "Guild",
                 IconName = "users",
-                Keywords = new[] { "users", "roster", "members", "directory" }
+                Keywords = new[] { "users", "roster", "members", "directory" },
+                RequiresGuildContext = true,
+                RouteTemplate = "/Guilds/Members/{guildId}"
             },
             new()
             {
@@ -140,7 +158,9 @@ public class PageMetadataService : IPageMetadataService
                 Description = "Manage guild reminders",
                 Section = "Guild",
                 IconName = "bell",
-                Keywords = new[] { "reminders", "notifications", "alerts" }
+                Keywords = new[] { "reminders", "notifications", "alerts" },
+                RequiresGuildContext = true,
+                RouteTemplate = "/Guilds/Reminders/{guildId}"
             },
             new()
             {
@@ -149,7 +169,9 @@ public class PageMetadataService : IPageMetadataService
                 Description = "Public Rat Watch leaderboard",
                 Section = "Guild",
                 IconName = "trophy",
-                Keywords = new[] { "leaderboard", "rankings", "top users", "rat watch" }
+                Keywords = new[] { "leaderboard", "rankings", "top users", "rat watch" },
+                RequiresGuildContext = true,
+                RouteTemplate = "/Guilds/Leaderboard/{guildId}"
             },
             new()
             {
@@ -158,7 +180,9 @@ public class PageMetadataService : IPageMetadataService
                 Description = "Guild soundboard management",
                 Section = "Guild",
                 IconName = "speaker-wave",
-                Keywords = new[] { "sounds", "audio", "soundboard", "sound effects" }
+                Keywords = new[] { "sounds", "audio", "soundboard", "sound effects" },
+                RequiresGuildContext = true,
+                RouteTemplate = "/Guilds/Soundboard/{guildId}"
             },
             new()
             {
@@ -167,7 +191,9 @@ public class PageMetadataService : IPageMetadataService
                 Description = "Guild audio configuration",
                 Section = "Guild",
                 IconName = "musical-note",
-                Keywords = new[] { "audio", "voice", "settings", "audio config" }
+                Keywords = new[] { "audio", "voice", "settings", "audio config" },
+                RequiresGuildContext = true,
+                RouteTemplate = "/Guilds/AudioSettings/{guildId}"
             },
             new()
             {
@@ -176,7 +202,9 @@ public class PageMetadataService : IPageMetadataService
                 Description = "Guild TTS message management",
                 Section = "Guild",
                 IconName = "microphone",
-                Keywords = new[] { "tts", "text to speech", "voice", "speech" }
+                Keywords = new[] { "tts", "text to speech", "voice", "speech" },
+                RequiresGuildContext = true,
+                RouteTemplate = "/Guilds/TextToSpeech/{guildId}"
             },
             new()
             {
@@ -185,7 +213,9 @@ public class PageMetadataService : IPageMetadataService
                 Description = "AI assistant configuration",
                 Section = "Guild",
                 IconName = "cpu-chip",
-                Keywords = new[] { "ai", "assistant", "claude", "bot settings" }
+                Keywords = new[] { "ai", "assistant", "claude", "bot settings" },
+                RequiresGuildContext = true,
+                RouteTemplate = "/Guilds/AssistantSettings/{guildId}"
             },
             new()
             {
@@ -194,7 +224,9 @@ public class PageMetadataService : IPageMetadataService
                 Description = "AI assistant usage metrics",
                 Section = "Guild",
                 IconName = "chart-bar",
-                Keywords = new[] { "ai metrics", "assistant stats", "usage", "analytics" }
+                Keywords = new[] { "ai metrics", "assistant stats", "usage", "analytics" },
+                RequiresGuildContext = true,
+                RouteTemplate = "/Guilds/AssistantMetrics/{guildId}"
             },
             new()
             {
@@ -203,7 +235,9 @@ public class PageMetadataService : IPageMetadataService
                 Description = "Auto-moderation flagged content",
                 Section = "Guild",
                 IconName = "flag",
-                Keywords = new[] { "flagged", "auto-mod", "violations", "moderation" }
+                Keywords = new[] { "flagged", "auto-mod", "violations", "moderation" },
+                RequiresGuildContext = true,
+                RouteTemplate = "/Guilds/FlaggedEvents/{guildId}"
             },
             new()
             {
@@ -212,7 +246,9 @@ public class PageMetadataService : IPageMetadataService
                 Description = "View flagged event details",
                 Section = "Guild",
                 IconName = "document-magnifying-glass",
-                Keywords = new[] { "flagged details", "event details", "violation" }
+                Keywords = new[] { "flagged details", "event details", "violation" },
+                RequiresGuildContext = true,
+                RouteTemplate = "/Guilds/FlaggedEvents/Details/{guildId}"
             },
             new()
             {
@@ -221,7 +257,9 @@ public class PageMetadataService : IPageMetadataService
                 Description = "Guild analytics overview",
                 Section = "Guild",
                 IconName = "chart-pie",
-                Keywords = new[] { "analytics", "stats", "guild metrics", "overview" }
+                Keywords = new[] { "analytics", "stats", "guild metrics", "overview" },
+                RequiresGuildContext = true,
+                RouteTemplate = "/Guilds/Analytics/{guildId}"
             },
             new()
             {
@@ -230,7 +268,9 @@ public class PageMetadataService : IPageMetadataService
                 Description = "Member engagement metrics",
                 Section = "Guild",
                 IconName = "users",
-                Keywords = new[] { "engagement", "activity", "member analytics", "participation" }
+                Keywords = new[] { "engagement", "activity", "member analytics", "participation" },
+                RequiresGuildContext = true,
+                RouteTemplate = "/Guilds/Analytics/Engagement/{guildId}"
             },
             new()
             {
@@ -239,7 +279,9 @@ public class PageMetadataService : IPageMetadataService
                 Description = "Moderation activity analytics",
                 Section = "Guild",
                 IconName = "shield-check",
-                Keywords = new[] { "moderation stats", "mod analytics", "enforcement" }
+                Keywords = new[] { "moderation stats", "mod analytics", "enforcement" },
+                RequiresGuildContext = true,
+                RouteTemplate = "/Guilds/Analytics/Moderation/{guildId}"
             },
             new()
             {
@@ -248,7 +290,9 @@ public class PageMetadataService : IPageMetadataService
                 Description = "Member moderation history",
                 Section = "Guild",
                 IconName = "user-minus",
-                Keywords = new[] { "member history", "user moderation", "warnings", "actions" }
+                Keywords = new[] { "member history", "user moderation", "warnings", "actions" },
+                RequiresGuildContext = true,
+                RouteTemplate = "/Guilds/Members/Moderation/{guildId}"
             },
 
             // Portal Pages (Member Access)

--- a/src/DiscordBot.Bot/Services/SearchService.cs
+++ b/src/DiscordBot.Bot/Services/SearchService.cs
@@ -584,7 +584,9 @@ public class SearchService : ISearchService
                 Description = x.Page.Description ?? string.Empty,
                 BadgeText = x.Page.Section ?? "Main",
                 BadgeVariant = GetSectionBadgeVariant(x.Page.Section),
-                Url = x.Page.Route,
+                Url = x.Page.RequiresGuildContext ? string.Empty : x.Page.Route,
+                RequiresGuildContext = x.Page.RequiresGuildContext,
+                RouteTemplate = x.Page.RouteTemplate,
                 RelevanceScore = Math.Min(x.Score, 100),
                 Metadata = new Dictionary<string, string>
                 {

--- a/src/DiscordBot.Bot/ViewModels/Components/GuildContextSelectorViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Components/GuildContextSelectorViewModel.cs
@@ -1,0 +1,14 @@
+namespace DiscordBot.Bot.ViewModels.Components;
+
+public record GuildContextSelectorViewModel
+{
+    public string RouteTemplate { get; init; } = string.Empty;
+    public IReadOnlyList<GuildSelectorItem> Guilds { get; init; } = [];
+}
+
+public record GuildSelectorItem
+{
+    public string GuildId { get; init; } = string.Empty;
+    public string GuildName { get; init; } = string.Empty;
+    public string? GuildIconUrl { get; init; }
+}

--- a/src/DiscordBot.Core/DTOs/PageMetadataDto.cs
+++ b/src/DiscordBot.Core/DTOs/PageMetadataDto.cs
@@ -9,4 +9,6 @@ public class PageMetadataDto
     public IReadOnlyList<string> Keywords { get; set; } = [];
     public string? IconName { get; set; }
     public string? Section { get; set; }
+    public bool RequiresGuildContext { get; set; }
+    public string? RouteTemplate { get; set; }
 }

--- a/src/DiscordBot.Core/DTOs/SearchDtos.cs
+++ b/src/DiscordBot.Core/DTOs/SearchDtos.cs
@@ -203,6 +203,16 @@ public class SearchResultItemDto
     public DateTime? Timestamp { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether this result requires a guild context to navigate.
+    /// </summary>
+    public bool RequiresGuildContext { get; set; }
+
+    /// <summary>
+    /// Gets or sets the route template with a {guildId} placeholder for guild-scoped pages.
+    /// </summary>
+    public string? RouteTemplate { get; set; }
+
+    /// <summary>
     /// Gets or sets additional metadata as key-value pairs.
     /// </summary>
     public Dictionary<string, string> Metadata { get; set; } = new();


### PR DESCRIPTION
## Summary

- Guild-scoped search results (Soundboard, TTS, Reminders, etc.) now show an inline guild selector instead of broken links that lack the required guild ID parameter
- Single-guild users see a direct "Open in [GuildName]" link; multi-guild users see a dropdown to choose which guild
- User guilds are intersected with the bot's active guilds to only show valid options

## Changes

- **DTOs**: Added `RequiresGuildContext` and `RouteTemplate` to `PageMetadataDto` and `SearchResultItemDto`
- **PageMetadataService**: All 22 Guild-section pages marked with `RequiresGuildContext=true` and route templates
- **SearchService**: Propagates guild context properties; sets empty URL for guild-scoped items
- **New**: `GuildContextSelectorViewModel` + `_GuildContextSelector.cshtml` partial (vanilla JS dropdown, no Alpine.js)
- **Search page**: Loads user guilds via `IUserDiscordGuildService`, renders selector for guild-scoped results

## Test plan

- [ ] Search for "soundboard" — guild-scoped result shows selector instead of broken link
- [ ] Single-guild user sees direct link; multi-guild user sees dropdown
- [ ] Non-guild pages (Dashboard, Admin, Commands, etc.) still show direct links
- [ ] Dropdown closes on outside click
- [ ] Guild IDs treated as strings in JS (snowflake safety)
- [ ] `dotnet build` compiles without C# errors
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)