### PR TITLE
fix: add favicon to guild portal layout

### DIFF
--- a/src/DiscordBot.Bot/Pages/Portal/_PortalLayout.cshtml
+++ b/src/DiscordBot.Bot/Pages/Portal/_PortalLayout.cshtml
@@ -5,6 +5,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#1d2022">
+    <link rel="icon" type="image/svg+xml" href="~/images/logo.svg" />
     <title>@ViewData["Title"] - Discord Bot Portal</title>
     <!-- Blocking theme application script - runs before first paint to prevent flash -->
     <script>


### PR DESCRIPTION
## Summary
- Added missing `<link rel="icon">` tag to `_PortalLayout.cshtml` so portal pages display the site favicon (`logo.svg`) in the browser tab
- Matches the existing pattern in `_Layout.cshtml:8`

Closes #1721

## Test plan
- [ ] Open any portal page (e.g., `/Portal/{guildId}`) and verify the favicon appears in the browser tab
- [ ] Verify admin pages still show the favicon as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)