### PR TITLE
fix: unclip guild selector dropdown on Search page

### DIFF
--- a/src/DiscordBot.Bot/Pages/Search.cshtml
+++ b/src/DiscordBot.Bot/Pages/Search.cshtml
@@ -449,9 +449,9 @@
             <!-- Pages Section -->
             @if (Model.ViewModel.Pages.Any())
             {
-                <div class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden">
+                <div class="bg-bg-secondary border border-border-primary rounded-lg">
                     <!-- Section Header -->
-                    <div class="px-6 py-4 border-b border-border-primary bg-bg-tertiary">
+                    <div class="px-6 py-4 border-b border-border-primary bg-bg-tertiary rounded-t-lg">
                         <div class="flex items-center justify-between">
                             <div class="flex items-center gap-3">
                                 <svg class="w-5 h-5 text-text-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor">


### PR DESCRIPTION
## Summary

- Removed `overflow-hidden` from the Pages section container in `Search.cshtml` (line 452) so the guild context selector dropdown renders fully visible
- Added `rounded-t-lg` to the section header to preserve rounded corner appearance without relying on overflow clipping

Closes #1723

## Test plan

- [ ] Navigate to Search page, search for a term that returns guild-context pages
- [ ] Click "Select guild" dropdown — verify it renders fully visible, not clipped
- [ ] Verify the Pages section still has proper rounded corners on the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)