### PR TITLE
fix: await LogPlayAsync to prevent ObjectDisposedException on portal sound play

### DIFF
--- a/src/DiscordBot.Bot/Services/SoundboardOrchestrationService.cs
+++ b/src/DiscordBot.Bot/Services/SoundboardOrchestrationService.cs
@@ -319,8 +319,8 @@ public class SoundboardOrchestrationService : ISoundboardOrchestrationService
             _logger.LogInformation("Successfully started playback of sound {SoundName} ({SoundId}) in guild {GuildId}",
                 sound.Name, sound.Id, guildId);
 
-            // Log play event (fire-and-forget - don't block on logging)
-            _ = _soundService.LogPlayAsync(sound.Id, guildId, userId, cancellationToken);
+            // Log play event
+            await _soundService.LogPlayAsync(sound.Id, guildId, userId, cancellationToken);
 
             BotActivitySource.SetSuccess(activity);
 


### PR DESCRIPTION
## Summary
- Awaits `LogPlayAsync` instead of fire-and-forget in `SoundboardOrchestrationService.PlaySoundAsync()`, keeping the call within the HTTP request scope so the `DbContext` is still alive when `SaveChangesAsync` runs
- Fixes silent loss of portal sound play log entries

## Root Cause
The fire-and-forget `_ = _soundService.LogPlayAsync(...)` allowed the HTTP response to return and dispose the scoped `PostgresBotDbContext` before the background task could write to it.

## Test plan
- [ ] Play a sound from the web portal while bot is in voice channel
- [ ] Verify no `ObjectDisposedException` in logs
- [ ] Verify play log entry is written to database
- [ ] Verify Discord command play logging still works

Closes #1739

🤖 Generated with [Claude Code](https://claude.com/claude-code)