### PR TITLE
fix: wire TTS stop button to cancel in-progress audio playback

### DIFF
--- a/src/DiscordBot.Bot/Controllers/PortalTtsController.cs
+++ b/src/DiscordBot.Bot/Controllers/PortalTtsController.cs
@@ -49,6 +49,9 @@ public class PortalTtsController : ControllerBase
     // Track whether TTS is currently playing per guild
     private static readonly ConcurrentDictionary<ulong, bool> _ttsPlaybackState = new();
 
+    // Track active playback cancellation tokens per guild for stop support
+    private static readonly ConcurrentDictionary<ulong, CancellationTokenSource> _playbackCancellationTokens = new();
+
     private const int MaxDisplayMessageLength = 50;
 
     /// <summary>
@@ -364,6 +367,24 @@ public class PortalTtsController : ControllerBase
         // Mark TTS as playing
         _ttsPlaybackState.AddOrUpdate(guildId, true, (k, v) => true);
 
+        // Create a cancellation token that can be triggered by the stop endpoint
+        // Link it with the request token so both HTTP disconnect and stop button work
+        // Do NOT use 'using' — lifetime is managed explicitly via TryRemove in finally/StopPlayback
+        var playbackCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        // Atomically swap in the new CTS, capturing any previous one for disposal
+        CancellationTokenSource? previousCts = null;
+        _playbackCancellationTokens.AddOrUpdate(guildId, playbackCts, (_, existing) =>
+        {
+            previousCts = existing;
+            return playbackCts;
+        });
+        if (previousCts != null)
+        {
+            await previousCts.CancelAsync();
+            previousCts.Dispose();
+        }
+
         // Play the audio using the TTS playback service
         TtsPlaybackResult playbackResult;
         try
@@ -375,11 +396,19 @@ public class PortalTtsController : ControllerBase
                 request.Message,
                 request.Voice,
                 audioStream,
-                cancellationToken);
+                playbackCts.Token);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            // Cancelled by the stop endpoint, not by HTTP disconnect — return success
+            _logger.LogInformation("TTS playback was stopped by user for guild {GuildId}", guildId);
+            return Ok(new { Message = "Playback stopped" });
         }
         finally
         {
-            // Clear TTS playback state and message tracking after streaming completes
+            // Whoever wins TryRemove owns disposal — prevents double-dispose with StopPlayback
+            if (_playbackCancellationTokens.TryRemove(guildId, out var removedCts))
+                removedCts.Dispose();
             _ttsPlaybackState.TryRemove(guildId, out _);
             _currentMessages.TryRemove(guildId, out _);
         }
@@ -588,6 +617,13 @@ public class PortalTtsController : ControllerBase
         if (isSoundboardPlaying)
         {
             await _playbackService.StopAsync(guildId, cancellationToken);
+        }
+
+        // Cancel active TTS playback if in progress
+        if (_playbackCancellationTokens.TryRemove(guildId, out var cts))
+        {
+            await cts.CancelAsync();
+            cts.Dispose();
         }
 
         // Clear TTS playback state and message tracking

--- a/src/DiscordBot.Bot/Services/Tts/TtsPlaybackService.cs
+++ b/src/DiscordBot.Bot/Services/Tts/TtsPlaybackService.cs
@@ -108,12 +108,21 @@ public class TtsPlaybackService : ITtsPlaybackService
 
                 streamScope.SetSuccess();
             }
+            catch (OperationCanceledException)
+            {
+                _logger.LogInformation("TTS audio streaming cancelled for guild {GuildId}", guildId);
+                throw; // Let the caller decide how to handle cancellation
+            }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to stream TTS audio for guild {GuildId}", guildId);
                 streamScope.RecordException(ex);
                 throw;
             }
+        }
+        catch (OperationCanceledException)
+        {
+            throw; // Propagate cancellation so the controller can distinguish stop vs error
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- Add per-guild `CancellationTokenSource` tracking to `PortalTtsController` so the stop endpoint can signal the active playback loop to abort
- Use a linked CTS so both HTTP disconnect and stop button trigger cancellation
- Propagate `OperationCanceledException` from `TtsPlaybackService.PlayAsync` instead of swallowing it, so the controller can distinguish intentional stop from real errors
- Atomic CTS swap via `AddOrUpdate` and `TryRemove`-based disposal ownership to prevent races and double-dispose

## Files changed
- `src/DiscordBot.Bot/Controllers/PortalTtsController.cs` — CTS lifecycle management in `SendTts` and `StopPlayback`
- `src/DiscordBot.Bot/Services/Tts/TtsPlaybackService.cs` — Re-throw `OperationCanceledException` from streaming loop

## Test plan
- [ ] Send a TTS message, click Stop before it finishes — audio should stop immediately
- [ ] Send a TTS message, let it complete naturally — should work as before
- [ ] Verify no `ObjectDisposedException` under rapid send/stop cycling
- [ ] Verify HTTP client disconnect still cancels playback correctly

Closes #1507

🤖 Generated with [Claude Code](https://claude.com/claude-code)