### PR TITLE
feat: add full-screen mode to Soundboard Portal

### DIFF
--- a/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml
@@ -408,9 +408,35 @@
     }
 
     .search-container {
-        position: relative;
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
         margin-bottom: 1.5rem;
         flex-shrink: 0; /* Keep search bar fixed at top */
+    }
+
+    .search-input-wrapper {
+        position: relative;
+        flex: 1;
+    }
+
+    .fullscreen-toggle-btn {
+        padding: 0.5rem;
+        background: transparent;
+        border: 1px solid var(--color-border-primary);
+        color: var(--color-text-secondary);
+        flex-shrink: 0;
+        border-radius: 0.5rem;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: var(--transition-fast);
+    }
+
+    .fullscreen-toggle-btn:hover {
+        background-color: var(--color-bg-hover);
+        color: var(--color-text-primary);
     }
 
     .search-icon {
@@ -847,13 +873,20 @@ else
 
                 <!-- Search Bar -->
                 <div class="search-container">
-                    <svg class="search-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-                    </svg>
-                    <input type="text" id="searchInput" class="search-input" placeholder="Search sounds..." style="padding-right: 2.5rem;">
-                    <button type="button" id="searchClearBtn" class="search-clear-btn" title="Clear search">
-                        <svg style="width: 16px; height: 16px;" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                    <div class="search-input-wrapper">
+                        <svg class="search-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                        </svg>
+                        <input type="text" id="searchInput" class="search-input" placeholder="Search sounds..." style="padding-right: 2.5rem;">
+                        <button type="button" id="searchClearBtn" class="search-clear-btn" title="Clear search">
+                            <svg style="width: 16px; height: 16px;" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                        </button>
+                    </div>
+                    <button type="button" id="fullscreenToggle" class="fullscreen-toggle-btn" title="Enter full screen" aria-label="Enter full screen">
+                        <svg style="width: 20px; height: 20px;" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5v-4m0 4h-4m4 0l-5-5" />
                         </svg>
                     </button>
                 </div>
@@ -894,6 +927,16 @@ else
     </div>
 </main>
 
+<!-- Full-Screen Floating Toolbar -->
+<div id="fullscreenToolbar" class="fullscreen-toolbar">
+    <input type="text" id="fullscreenSearchInput" class="fullscreen-search" placeholder="Search sounds...">
+    <button type="button" id="fullscreenExitBtn" class="toolbar-btn" title="Exit full screen (Esc)" aria-label="Exit full screen">
+        <svg style="width: 20px; height: 20px;" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9 9V4.5M9 9H4.5M9 9L3.75 3.75M9 15v4.5M9 15H4.5M9 15l-5.25 5.25M15 9h4.5M15 9V4.5M15 9l5.25-5.25M15 15h4.5M15 15v4.5m0-4.5l5.25 5.25" />
+        </svg>
+    </button>
+</div>
+
     <!-- Hidden file input for upload -->
     <input type="file" id="fileInput" accept="audio/mp3,audio/wav,audio/ogg,.mp3,.wav,.ogg" class="hidden">
 } @* End of IsAuthenticated else block *@
@@ -917,6 +960,8 @@ else
         let currentlyPlaying = null;
         let searchDebounceTimer = null;
         let signalRConnected = false;
+        let isFullscreen = localStorage.getItem('soundboard_fullscreen_' + window.guildId) === 'true';
+        let fullscreenAutoHideTimer = null;
 
         // ========================================
         // Toast Notification System
@@ -987,6 +1032,7 @@ else
             PortalToast.init();
             initializeFavorites();
             setupEventHandlers();
+            initializeFullscreen();
             await initSignalR();
         });
 
@@ -1300,6 +1346,48 @@ else
 
             // Upload form handlers
             setupUploadHandlers();
+
+            // Fullscreen toggle button
+            document.getElementById('fullscreenToggle').addEventListener('click', toggleFullscreen);
+
+            // Fullscreen exit button
+            document.getElementById('fullscreenExitBtn').addEventListener('click', exitFullscreen);
+
+            // Fullscreen search input - sync with main search
+            const fsSearch = document.getElementById('fullscreenSearchInput');
+            fsSearch.addEventListener('input', function() {
+                document.getElementById('searchInput').value = this.value;
+                clearBtn.classList.toggle('visible', this.value.length > 0);
+                clearTimeout(searchDebounceTimer);
+                if (this.value === '') {
+                    filterSounds();
+                } else {
+                    searchDebounceTimer = setTimeout(filterSounds, 150);
+                }
+                resetFullscreenAutoHide();
+            });
+
+            // Auto-hide toolbar on mouse/touch activity
+            document.addEventListener('mousemove', function() {
+                if (isFullscreen) resetFullscreenAutoHide();
+            });
+            document.addEventListener('touchstart', function() {
+                if (isFullscreen) resetFullscreenAutoHide();
+            });
+
+            // Escape key to exit fullscreen
+            document.addEventListener('keydown', function(e) {
+                if (e.key === 'Escape' && isFullscreen) {
+                    exitFullscreen();
+                }
+            });
+
+            // Listen for browser fullscreen change
+            document.addEventListener('fullscreenchange', function() {
+                if (!document.fullscreenElement && isFullscreen) {
+                    exitFullscreen();
+                }
+            });
         }
 
         // ========================================
@@ -1694,6 +1782,91 @@ else
                     uploadFile();
                 }
             });
+        }
+
+        // ========================================
+        // Full-Screen Mode
+        // ========================================
+        function initializeFullscreen() {
+            if (isFullscreen) {
+                enterFullscreen();
+            }
+        }
+
+        function toggleFullscreen() {
+            if (isFullscreen) {
+                exitFullscreen();
+            } else {
+                enterFullscreen();
+            }
+        }
+
+        function enterFullscreen() {
+            isFullscreen = true;
+            document.body.classList.add('portal-fullscreen');
+            localStorage.setItem('soundboard_fullscreen_' + window.guildId, 'true');
+
+            // Update toggle button label
+            const toggle = document.getElementById('fullscreenToggle');
+            toggle.setAttribute('title', 'Exit full screen');
+            toggle.setAttribute('aria-label', 'Exit full screen');
+
+            // Sync fullscreen search with main search
+            const mainSearch = document.getElementById('searchInput');
+            const fsSearch = document.getElementById('fullscreenSearchInput');
+            if (mainSearch && fsSearch) {
+                fsSearch.value = mainSearch.value;
+            }
+
+            resetFullscreenAutoHide();
+
+            // Try Fullscreen API for true fullscreen on mobile
+            if (document.documentElement.requestFullscreen) {
+                document.documentElement.requestFullscreen().catch(() => {});
+            }
+        }
+
+        function exitFullscreen() {
+            isFullscreen = false;
+            document.body.classList.remove('portal-fullscreen');
+            localStorage.setItem('soundboard_fullscreen_' + window.guildId, 'false');
+
+            // Update toggle button label
+            const toggle = document.getElementById('fullscreenToggle');
+            toggle.setAttribute('title', 'Enter full screen');
+            toggle.setAttribute('aria-label', 'Enter full screen');
+
+            // Sync search back to main input
+            const mainSearch = document.getElementById('searchInput');
+            const fsSearch = document.getElementById('fullscreenSearchInput');
+            if (mainSearch && fsSearch) {
+                mainSearch.value = fsSearch.value;
+                const clearBtn = document.getElementById('searchClearBtn');
+                clearBtn.classList.toggle('visible', mainSearch.value.length > 0);
+            }
+
+            clearTimeout(fullscreenAutoHideTimer);
+
+            // Exit browser fullscreen if active
+            if (document.fullscreenElement) {
+                document.exitFullscreen().catch(() => {});
+            }
+        }
+
+        function resetFullscreenAutoHide() {
+            const toolbar = document.getElementById('fullscreenToolbar');
+            if (!toolbar) return;
+
+            toolbar.classList.remove('auto-hidden');
+            clearTimeout(fullscreenAutoHideTimer);
+
+            fullscreenAutoHideTimer = setTimeout(() => {
+                if (isFullscreen) {
+                    const fsSearch = document.getElementById('fullscreenSearchInput');
+                    if (document.activeElement === fsSearch) return;
+                    toolbar.classList.add('auto-hidden');
+                }
+            }, 3000);
         }
     </script>
 }

--- a/src/DiscordBot.Bot/wwwroot/css/portal.css
+++ b/src/DiscordBot.Bot/wwwroot/css/portal.css
@@ -688,6 +688,143 @@ html.portal-page body {
 }
 
 /* -----------------------------------------------
+   Full-Screen Mode
+   ----------------------------------------------- */
+
+/* Transitions for elements that can animate (gap, border-radius, padding) */
+.main-container {
+    transition: height var(--transition-smooth), padding var(--transition-smooth);
+}
+
+.portal-content {
+    transition: gap var(--transition-smooth);
+}
+
+.sound-grid-wrapper {
+    transition: border-radius var(--transition-smooth), border-color var(--transition-smooth);
+}
+
+body.portal-fullscreen .portal-header {
+    display: none;
+}
+
+body.portal-fullscreen .portal-audio-warning {
+    display: none;
+}
+
+body.portal-fullscreen .main-container {
+    height: 100vh;
+    max-width: none;
+    padding: 0;
+}
+
+body.portal-fullscreen .sidebar {
+    display: none;
+}
+
+body.portal-fullscreen .portal-content {
+    gap: 0;
+}
+
+body.portal-fullscreen .sound-grid-wrapper {
+    border-radius: 0;
+    border: none;
+}
+
+body.portal-fullscreen .sound-grid {
+    padding: 1rem;
+}
+
+/* Override mobile breakpoint scroll behavior when fullscreen is active.
+   :has() is needed because the mobile breakpoint sets overflow:auto on <html>. */
+body.portal-fullscreen,
+html.portal-page:has(body.portal-fullscreen) {
+    overflow: hidden !important;
+    height: 100% !important;
+}
+
+/* Hide fullscreen toolbar when not in fullscreen */
+body:not(.portal-fullscreen) .fullscreen-toolbar {
+    display: none;
+}
+
+/* Floating fullscreen toolbar */
+.fullscreen-toolbar {
+    position: fixed;
+    top: 0.75rem;
+    right: 0.75rem;
+    z-index: var(--z-modal-backdrop);
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem;
+    background-color: color-mix(in srgb, var(--color-bg-secondary) 92%, transparent);
+    backdrop-filter: blur(8px);
+    border: 1px solid var(--color-border-primary);
+    border-radius: 0.5rem;
+    box-shadow: var(--shadow-xl);
+    opacity: 1;
+    transition: opacity 0.3s ease;
+}
+
+.fullscreen-toolbar.auto-hidden {
+    opacity: 0;
+    pointer-events: none;
+}
+
+.fullscreen-toolbar .toolbar-btn {
+    background: transparent;
+    border: none;
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    padding: 0.75rem;
+    border-radius: 0.375rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: var(--transition-fast);
+}
+
+.fullscreen-toolbar .toolbar-btn:hover {
+    background-color: var(--color-bg-hover);
+    color: var(--color-text-primary);
+}
+
+.fullscreen-toolbar .fullscreen-search {
+    width: 200px;
+    background-color: var(--color-bg-primary);
+    border: 1px solid var(--color-border-primary);
+    border-radius: 0.375rem;
+    padding: 0.375rem 0.625rem;
+    font-size: 0.8125rem;
+    color: var(--color-text-primary);
+}
+
+.fullscreen-toolbar .fullscreen-search::placeholder {
+    color: var(--color-text-secondary);
+}
+
+/* Fullscreen grid responsive overrides */
+@media (max-width: 768px) {
+    body.portal-fullscreen .sound-grid {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 0.75rem;
+    }
+}
+
+@media (min-width: 769px) and (max-width: 1023px) {
+    body.portal-fullscreen .sound-grid {
+        grid-template-columns: repeat(3, 1fr);
+    }
+}
+
+@media (min-width: 1024px) {
+    body.portal-fullscreen .sound-grid {
+        grid-template-columns: repeat(5, 1fr);
+    }
+}
+
+/* -----------------------------------------------
    Reduced Motion
    ----------------------------------------------- */
 @media (prefers-reduced-motion: reduce) {
@@ -710,5 +847,12 @@ html.portal-page body {
 
     .portal-toast.dismissing {
         animation: none;
+    }
+
+    .main-container,
+    .portal-content,
+    .sound-grid-wrapper,
+    .fullscreen-toolbar {
+        transition: none;
     }
 }


### PR DESCRIPTION
## Summary

- Adds a full-screen toggle button next to the search bar that hides the portal header, sidebar, and tab navigation, expanding the sound grid to fill the viewport
- Includes a floating auto-hiding toolbar (3s timeout) with search input and exit button that appears on mouse/touch activity
- Persists full-screen preference per guild in `localStorage` using the existing favorites pattern
- Supports Escape key, browser Fullscreen API (for true mobile fullscreen), and responsive grid columns (2 on mobile, 3 on tablet, 5 on desktop)
- Theme-aware toolbar using `color-mix()` with `--color-bg-secondary` and `backdrop-filter: blur`

Closes #1379

## Test plan

- [ ] Click the expand button next to search bar — portal chrome hides, grid fills viewport
- [ ] Click exit button in floating toolbar or press Escape — returns to normal layout
- [ ] Toolbar auto-hides after 3 seconds of inactivity, reappears on mouse/touch
- [ ] Toolbar search syncs with main search in both directions
- [ ] Refresh page while in fullscreen — preference is restored
- [ ] Switch guilds — fullscreen preference is per-guild
- [ ] Test on mobile viewport (2 columns) and desktop (5 columns)
- [ ] Test with purple-dusk (light) theme — toolbar background adapts
- [ ] Sound playback, favorites, and SignalR updates continue to work in fullscreen
- [ ] Verify `prefers-reduced-motion` disables transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)