### PR TITLE
fix: read database provider from config instead of hardcoding SQLite

### DIFF
--- a/src/DiscordBot.Bot/Services/BotService.cs
+++ b/src/DiscordBot.Bot/Services/BotService.cs
@@ -3,6 +3,7 @@ using Discord.WebSocket;
 using DiscordBot.Bot.Tracing;
 using DiscordBot.Core.DTOs;
 using DiscordBot.Core.Interfaces;
+using DiscordBot.Infrastructure.Configuration;
 using Microsoft.Extensions.Options;
 using System.Reflection;
 
@@ -18,6 +19,7 @@ public class BotService : IBotService
     private readonly IDashboardUpdateService _dashboardUpdateService;
     private readonly ILogger<BotService> _logger;
     private readonly BotConfiguration _config;
+    private readonly string _databaseProviderName;
     private static readonly DateTime _startTime = DateTime.UtcNow;
 
     /// <summary>
@@ -28,18 +30,25 @@ public class BotService : IBotService
     /// <param name="dashboardUpdateService">The dashboard update service.</param>
     /// <param name="logger">The logger.</param>
     /// <param name="config">The bot configuration.</param>
+    /// <param name="dbSettings">The database settings.</param>
+    /// <param name="configuration">The application configuration.</param>
     public BotService(
         DiscordSocketClient client,
         IHostApplicationLifetime lifetime,
         IDashboardUpdateService dashboardUpdateService,
         ILogger<BotService> logger,
-        IOptions<BotConfiguration> config)
+        IOptions<BotConfiguration> config,
+        IOptions<DatabaseSettings> dbSettings,
+        IConfiguration configuration)
     {
         _client = client;
         _lifetime = lifetime;
         _dashboardUpdateService = dashboardUpdateService;
         _logger = logger;
         _config = config.Value;
+
+        var connectionString = configuration.GetConnectionString("DefaultConnection") ?? string.Empty;
+        _databaseProviderName = dbSettings.Value.GetProviderDisplayName(connectionString);
     }
 
     /// <inheritdoc/>
@@ -205,7 +214,7 @@ public class BotService : IBotService
                 TokenMasked = maskedToken,
                 TestGuildId = _config.TestGuildId,
                 HasTestGuild = _config.TestGuildId.HasValue,
-                DatabaseProvider = "SQLite", // TODO: Get from actual configuration
+                DatabaseProvider = _databaseProviderName,
                 DiscordNetVersion = discordNetVersion,
                 AppVersion = appVersion,
                 RuntimeVersion = Environment.Version.ToString(),

--- a/src/DiscordBot.Infrastructure/Configuration/DatabaseSettings.cs
+++ b/src/DiscordBot.Infrastructure/Configuration/DatabaseSettings.cs
@@ -33,4 +33,26 @@ public class DatabaseSettings
     /// When null, the provider is auto-detected from the connection string.
     /// </summary>
     public string? Provider { get; set; }
+
+    /// <summary>
+    /// Determines whether the configured provider is PostgreSQL, using the explicit
+    /// <see cref="Provider"/> setting first, then falling back to connection string heuristics.
+    /// </summary>
+    /// <param name="connectionString">The connection string to inspect when Provider is not set.</param>
+    /// <returns><c>true</c> if the provider is PostgreSQL; <c>false</c> for SQLite.</returns>
+    public bool IsPostgreSql(string connectionString)
+    {
+        if (!string.IsNullOrEmpty(Provider))
+            return Provider.Equals("PostgreSql", StringComparison.OrdinalIgnoreCase);
+
+        return connectionString.Contains("Host=", StringComparison.OrdinalIgnoreCase)
+            || connectionString.Contains("Server=", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Returns the display name of the active database provider ("PostgreSQL" or "SQLite").
+    /// </summary>
+    /// <param name="connectionString">The connection string to inspect when Provider is not set.</param>
+    public string GetProviderDisplayName(string connectionString)
+        => IsPostgreSql(connectionString) ? "PostgreSQL" : "SQLite";
 }

--- a/src/DiscordBot.Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/DiscordBot.Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -36,10 +36,9 @@ public static class ServiceCollectionExtensions
 
         var dbSettings = configuration.GetSection(DatabaseSettings.SectionName).Get<DatabaseSettings>()
             ?? new DatabaseSettings();
-        var isPostgreSql = dbSettings.Provider?.Equals("PostgreSql", StringComparison.OrdinalIgnoreCase) == true
-            || (string.IsNullOrEmpty(dbSettings.Provider) && IsPostgreSqlConnectionString(connectionString));
+        var isPostgreSql = dbSettings.IsPostgreSql(connectionString);
 
-        var providerName = isPostgreSql ? "PostgreSQL" : "SQLite";
+        var providerName = dbSettings.GetProviderDisplayName(connectionString);
         Log.Information("Database provider: {Provider}", providerName);
 
         if (isPostgreSql)
@@ -114,15 +113,4 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
-    /// <summary>
-    /// Heuristic to detect PostgreSQL connection strings.
-    /// PostgreSQL strings typically contain Host= or Server=, while SQLite strings reference file paths.
-    /// Note: Npgsql accepts "Data Source=" as an alias for "Host=", making pure keyword matching
-    /// unreliable — this is why the explicit Database:Provider config is the primary mechanism.
-    /// </summary>
-    private static bool IsPostgreSqlConnectionString(string connectionString)
-    {
-        return connectionString.Contains("Host=", StringComparison.OrdinalIgnoreCase)
-            || connectionString.Contains("Server=", StringComparison.OrdinalIgnoreCase);
-    }
 }


### PR DESCRIPTION
## Summary
- Extracted database provider detection logic from `ServiceCollectionExtensions` into shared `DatabaseSettings.IsPostgreSql()` and `GetProviderDisplayName()` methods
- `BotService` now resolves the actual database provider at construction time using the same detection logic as startup (explicit `Database:Provider` config → connection string heuristic fallback)
- Removed the duplicated `IsPostgreSqlConnectionString` private method from `ServiceCollectionExtensions`

Closes #1748

## Test plan
- [ ] Verify admin dashboard shows "SQLite" when running with SQLite config
- [ ] Verify admin dashboard shows "PostgreSQL" when `Database:Provider` is set to `PostgreSql`
- [ ] Verify auto-detection works via connection string heuristic (Host=/Server= → PostgreSQL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)