### PR TITLE
refactor: extract Discord interaction timeout to shared constant

### DIFF
--- a/src/DiscordBot.Bot/Controllers/PerformanceTabsController.cs
+++ b/src/DiscordBot.Bot/Controllers/PerformanceTabsController.cs
@@ -359,7 +359,7 @@ public class PerformanceTabsController : Controller
         var p50 = aggregates.Any() ? aggregates.Average(a => a.P50Ms) : 0;
 
         var timeouts = slowest
-            .Where(s => s.DurationMs > 3000)
+            .Where(s => s.DurationMs > DiscordConstants.InteractionTimeoutMs)
             .GroupBy(s => s.CommandName)
             .Select(g => new CommandTimeoutDto
             {

--- a/src/DiscordBot.Bot/DiscordConstants.cs
+++ b/src/DiscordBot.Bot/DiscordConstants.cs
@@ -1,0 +1,13 @@
+namespace DiscordBot.Bot;
+
+/// <summary>
+/// Constants for Discord interaction behavior and limits.
+/// </summary>
+public static class DiscordConstants
+{
+    /// <summary>
+    /// Discord's interaction response timeout threshold in milliseconds.
+    /// Discord requires a response within 3000ms or the interaction will timeout.
+    /// </summary>
+    public const int InteractionTimeoutMs = 3000;
+}

--- a/src/DiscordBot.Bot/Pages/Admin/Performance/Commands.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/Commands.cshtml.cs
@@ -98,9 +98,9 @@ public class CommandsModel : PageModel
         var p95 = aggregates.Any() ? aggregates.Max(a => a.P95Ms) : 0;
         var p50 = aggregates.Any() ? aggregates.Average(a => a.P50Ms) : 0;
 
-        // Identify timeouts (commands > 3000ms - Discord's interaction timeout)
+        // Identify timeouts (commands > Discord interaction timeout)
         var timeouts = slowest
-            .Where(s => s.DurationMs > 3000)
+            .Where(s => s.DurationMs > DiscordConstants.InteractionTimeoutMs)
             .GroupBy(s => s.CommandName)
             .Select(g => new CommandTimeoutDto
             {

--- a/src/DiscordBot.Bot/Pages/Admin/Performance/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/Index.cshtml.cs
@@ -404,7 +404,7 @@ public class IndexModel : PageModel
             var p50 = aggregates.Any() ? aggregates.Average(a => a.P50Ms) : 0;
 
             var timeouts = slowest
-                .Where(s => s.DurationMs > 3000)
+                .Where(s => s.DurationMs > DiscordConstants.InteractionTimeoutMs)
                 .GroupBy(s => s.CommandName)
                 .Select(g => new CommandTimeoutDto
                 {


### PR DESCRIPTION
## Summary
- Added `DiscordConstants.InteractionTimeoutMs` constant (3000ms) to replace magic numbers
- Updated all three occurrences in performance pages and controller

Closes #1746

## Test plan
- [ ] Verify performance dashboard still correctly identifies slow commands (> 3000ms)
- [ ] Verify commands page timeout filtering works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)