### PR TITLE
fix: populate ModTag UserCount from database instead of stub

### DIFF
--- a/src/DiscordBot.Bot/Services/Moderation/ModTagService.cs
+++ b/src/DiscordBot.Bot/Services/Moderation/ModTagService.cs
@@ -404,9 +404,7 @@ public class ModTagService : IModTagService
     /// </summary>
     private async Task<ModTagDto> MapToDtoAsync(ModTag tag, CancellationToken ct = default)
     {
-        // Get count of users with this tag
-        var userTags = await _userTagRepository.GetByUserAsync(tag.GuildId, 0, ct); // This won't work - need a different method
-        // For now, we'll set UserCount to 0 - repository needs a GetByTagAsync method for proper count
+        var userCount = await _userTagRepository.GetUserCountByTagAsync(tag.Id, ct);
 
         return new ModTagDto
         {
@@ -418,7 +416,7 @@ public class ModTagService : IModTagService
             Description = tag.Description,
             IsFromTemplate = tag.IsFromTemplate,
             CreatedAt = tag.CreatedAt,
-            UserCount = 0 // TODO: Implement proper count once repository method is available
+            UserCount = userCount
         };
     }
 

--- a/src/DiscordBot.Core/Interfaces/IUserModTagRepository.cs
+++ b/src/DiscordBot.Core/Interfaces/IUserModTagRepository.cs
@@ -34,6 +34,16 @@ public interface IUserModTagRepository : IRepository<UserModTag>
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Gets the count of distinct users assigned a specific tag.
+    /// </summary>
+    /// <param name="tagId">Tag definition ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Number of users with the tag assigned.</returns>
+    Task<int> GetUserCountByTagAsync(
+        Guid tagId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets a specific tag assignment for removal.
     /// </summary>
     /// <param name="guildId">Discord guild ID.</param>

--- a/src/DiscordBot.Infrastructure/Data/Repositories/UserModTagRepository.cs
+++ b/src/DiscordBot.Infrastructure/Data/Repositories/UserModTagRepository.cs
@@ -62,6 +62,23 @@ public class UserModTagRepository : Repository<UserModTag>, IUserModTagRepositor
         return results;
     }
 
+    public async Task<int> GetUserCountByTagAsync(
+        Guid tagId,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Counting users with tag {TagId}", tagId);
+
+        var count = await DbSet
+            .AsNoTracking()
+            .Where(ut => ut.TagId == tagId)
+            .Select(ut => ut.UserId)
+            .Distinct()
+            .CountAsync(cancellationToken);
+
+        _logger.LogDebug("Tag {TagId} has {Count} users assigned", tagId, count);
+        return count;
+    }
+
     public async Task<bool> ExistsAsync(
         ulong guildId,
         ulong userId,


### PR DESCRIPTION
## Summary
- Added `GetUserCountByTagAsync` method to `IUserModTagRepository` and its implementation
- Updated `ModTagService.MapToDtoAsync` to query actual user count instead of hardcoding 0
- Uses `Distinct()` on `UserId` to count unique users per tag

Closes #1750

## Test plan
- [ ] Verify mod tags page shows correct user counts for tags with assigned users
- [ ] Verify tags with no users show 0
- [ ] Verify performance is acceptable (query uses existing `IX_UserModTags_TagId_AppliedAt` index)

🤖 Generated with [Claude Code](https://claude.com/claude-code)