### PR TITLE
fix: replace performance dashboard placeholders with real metrics

### DIFF
--- a/src/DiscordBot.Bot/Controllers/PerformanceTabsController.cs
+++ b/src/DiscordBot.Bot/Controllers/PerformanceTabsController.cs
@@ -236,13 +236,13 @@ public class PerformanceTabsController : Controller
         {
             workingSetMB = process.WorkingSet64 / 1024 / 1024;
         }
-        var maxMemoryMB = 1024;
+        var maxMemoryMB = (long)(GC.GetGCMemoryInfo().TotalAvailableMemoryBytes / 1024 / 1024);
         var memoryUsagePercent = (workingSetMB * 100.0) / maxMemoryMB;
 
         var apiUsage = _apiRequestTracker.GetUsageStatistics(1);
         var totalApiRequests = apiUsage.Sum(u => u.RequestCount);
-        var apiLimit = 50;
-        var apiUsagePercent = totalApiRequests > 0 ? Math.Min((totalApiRequests * 100.0) / apiLimit, 100) : 0;
+        var rateLimitEvents = _apiRequestTracker.GetRateLimitEvents(1);
+        var rateLimitHits = rateLimitEvents.Count;
 
         var overallHealthStatus = DetermineOverallStatus(overallStatus, activeAlerts.Count);
 
@@ -260,8 +260,10 @@ public class PerformanceTabsController : Controller
             MemoryUsagePercent = memoryUsagePercent,
             MemoryUsageFormatted = $"{workingSetMB} MB / {maxMemoryMB} MB",
             CpuUsagePercent = _cpuHistoryService.GetCurrentCpu(),
-            ApiRateLimitFormatted = $"{totalApiRequests} / {apiLimit} requests",
-            ApiRateLimitPercent = apiUsagePercent
+            ApiRateLimitFormatted = rateLimitHits > 0
+                ? $"{totalApiRequests} requests ({rateLimitHits} rate limited)"
+                : $"{totalApiRequests} requests (last hour)",
+            ApiRateLimitPercent = rateLimitHits > 0 ? Math.Min(rateLimitHits * 10.0, 100) : 0
         };
     }
 

--- a/src/DiscordBot.Bot/Pages/Admin/Performance/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/Index.cshtml.cs
@@ -200,14 +200,14 @@ public class IndexModel : PageModel
             {
                 workingSetMB = process.WorkingSet64 / 1024 / 1024;
             }
-            var maxMemoryMB = 1024; // Placeholder - could be from config or system info
+            var maxMemoryMB = (long)(GC.GetGCMemoryInfo().TotalAvailableMemoryBytes / 1024 / 1024);
             var memoryUsagePercent = (workingSetMB * 100.0) / maxMemoryMB;
 
             // Get API metrics
             var apiUsage = _apiRequestTracker.GetUsageStatistics(1); // Last hour
             var totalApiRequests = apiUsage.Sum(u => u.RequestCount);
-            var apiLimit = 50; // Placeholder - Discord's per-second rate limit varies by endpoint
-            var apiUsagePercent = totalApiRequests > 0 ? Math.Min((totalApiRequests * 100.0) / apiLimit, 100) : 0;
+            var rateLimitEvents = _apiRequestTracker.GetRateLimitEvents(1);
+            var rateLimitHits = rateLimitEvents.Count;
 
             // Determine overall status based on alerts and health
             var overallHealthStatus = DetermineOverallStatus(overallStatus, activeAlerts.Count);
@@ -227,8 +227,10 @@ public class IndexModel : PageModel
                 MemoryUsagePercent = memoryUsagePercent,
                 MemoryUsageFormatted = $"{workingSetMB} MB / {maxMemoryMB} MB",
                 CpuUsagePercent = _cpuHistoryService.GetCurrentCpu(),
-                ApiRateLimitFormatted = $"{totalApiRequests} / {apiLimit} requests",
-                ApiRateLimitPercent = apiUsagePercent
+                ApiRateLimitFormatted = rateLimitHits > 0
+                    ? $"{totalApiRequests} requests ({rateLimitHits} rate limited)"
+                    : $"{totalApiRequests} requests (last hour)",
+                ApiRateLimitPercent = rateLimitHits > 0 ? Math.Min(rateLimitHits * 10.0, 100) : 0
             };
 
             // Create the shell view model

--- a/src/DiscordBot.Bot/Services/BusinessMetricsUpdateService.cs
+++ b/src/DiscordBot.Bot/Services/BusinessMetricsUpdateService.cs
@@ -16,6 +16,7 @@ public class BusinessMetricsUpdateService : MonitoredBackgroundService
     private readonly BusinessMetrics _businessMetrics;
     private readonly SloMetrics _sloMetrics;
     private readonly IOptions<BackgroundServicesOptions> _bgOptions;
+    private readonly IApiRequestTracker _apiRequestTracker;
 
     public override string ServiceName => "Business Metrics Update Service";
 
@@ -30,6 +31,7 @@ public class BusinessMetricsUpdateService : MonitoredBackgroundService
         BusinessMetrics businessMetrics,
         SloMetrics sloMetrics,
         IOptions<BackgroundServicesOptions> bgOptions,
+        IApiRequestTracker apiRequestTracker,
         ILogger<BusinessMetricsUpdateService> logger)
         : base(serviceProvider, logger)
     {
@@ -37,6 +39,7 @@ public class BusinessMetricsUpdateService : MonitoredBackgroundService
         _businessMetrics = businessMetrics;
         _sloMetrics = sloMetrics;
         _bgOptions = bgOptions;
+        _apiRequestTracker = apiRequestTracker;
     }
 
     protected override async Task ExecuteMonitoredAsync(CancellationToken stoppingToken)
@@ -175,11 +178,14 @@ public class BusinessMetricsUpdateService : MonitoredBackgroundService
             cancellationToken: cancellationToken);
         _sloMetrics.UpdateCommandSuccessRate24h((double)successRate24h.SuccessRate);
 
-        // API success rate (last 24 hours)
-        // Note: This would require tracking API request logs similar to command logs
-        // For now, we'll use a placeholder or calculate from command success rate
-        // TODO: Implement API request logging for accurate API success rate
-        _sloMetrics.UpdateApiSuccessRate24h((double)successRate24h.SuccessRate);
+        // API success rate (last 24 hours) - computed from actual API request tracking
+        var apiUsage = _apiRequestTracker.GetUsageStatistics(24);
+        var totalApiRequests = apiUsage.Sum(u => u.RequestCount);
+        var totalApiErrors = apiUsage.Sum(u => u.ErrorCount);
+        var apiSuccessRate = totalApiRequests > 0
+            ? (totalApiRequests - totalApiErrors) / (double)totalApiRequests * 100
+            : 100.0;
+        _sloMetrics.UpdateApiSuccessRate24h(apiSuccessRate);
 
         // P99 latency (last 1 hour)
         // Calculate p99 from command performance data


### PR DESCRIPTION
## Summary
- **Memory limit (#1744):** Replaced hardcoded 1024 MB with `GC.GetGCMemoryInfo().TotalAvailableMemoryBytes` which auto-detects container cgroup limits or system memory
- **API rate limit (#1745):** Replaced misleading "X / 50 requests" gauge with actual rate limit event tracking — now shows request count and rate limit hits from `ApiRequestTracker`
- **API success rate (#1747):** Replaced placeholder that duplicated command success rate with real API success rate computed from `ApiRequestTracker.GetUsageStatistics()` error counts

Closes #1744, closes #1745, closes #1747

## Test plan
- [ ] Verify memory gauge shows actual system/container memory limit (not 1024 MB)
- [ ] Verify API section shows request count with "(last hour)" or "(N rate limited)" suffix
- [ ] Verify SLO API success rate metric differs from command success rate when API errors exist
- [ ] Verify dashboard renders correctly when no API requests have been tracked yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)