### PR TITLE
fix: wire Guild Details CanEdit to actual guild permissions

### DIFF
--- a/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/Details.cshtml.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Options;
+using System.Security.Claims;
 
 // ReSharper disable MemberCanBePrivate.Global
 
@@ -32,6 +33,7 @@ public class DetailsModel : PageModel
     private readonly ISoundRepository _soundRepository;
     private readonly ITtsMessageRepository _ttsMessageRepository;
     private readonly IAssistantGuildSettingsService _assistantGuildSettingsService;
+    private readonly IGuildMembershipService _guildMembershipService;
     private readonly AssistantOptions _assistantOptions;
     private readonly ILogger<DetailsModel> _logger;
 
@@ -49,6 +51,7 @@ public class DetailsModel : PageModel
         ISoundRepository soundRepository,
         ITtsMessageRepository ttsMessageRepository,
         IAssistantGuildSettingsService assistantGuildSettingsService,
+        IGuildMembershipService guildMembershipService,
         IOptions<AssistantOptions> assistantOptions,
         ILogger<DetailsModel> logger)
     {
@@ -63,6 +66,7 @@ public class DetailsModel : PageModel
         _soundRepository = soundRepository;
         _ttsMessageRepository = ttsMessageRepository;
         _assistantGuildSettingsService = assistantGuildSettingsService;
+        _guildMembershipService = guildMembershipService;
         _assistantOptions = assistantOptions.Value;
         _logger = logger;
     }
@@ -374,8 +378,14 @@ public class DetailsModel : PageModel
         // Build view model
         ViewModel = GuildDetailViewModel.FromDto(guild, recentCommandsResponse.Items);
 
-        // TODO: Set CanEdit based on user's guild-specific permissions
-        // For now, all moderators can view but edit capability depends on future authorization
+        // Set CanEdit based on user's actual guild and application permissions
+        var currentUserId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!string.IsNullOrEmpty(currentUserId))
+        {
+            var isGuildAdmin = await _guildMembershipService.IsGuildAdminAsync(currentUserId, guildId, cancellationToken);
+            var isAppAdmin = User.IsInRole("Admin") || User.IsInRole("SuperAdmin");
+            ViewModel.CanEdit = isGuildAdmin || isAppAdmin;
+        }
 
         // Populate guild layout ViewModels
         Breadcrumb = new GuildBreadcrumbViewModel

--- a/src/DiscordBot.Bot/ViewModels/Pages/GuildDetailViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Pages/GuildDetailViewModel.cs
@@ -61,7 +61,7 @@ public record GuildDetailViewModel
     /// <summary>
     /// Gets whether the current user can edit this guild's settings.
     /// </summary>
-    public bool CanEdit { get; init; }
+    public bool CanEdit { get; set; }
 
     /// <summary>
     /// Creates a <see cref="GuildDetailViewModel"/> from a <see cref="GuildDto"/>.
@@ -82,7 +82,7 @@ public record GuildDetailViewModel
             Prefix = dto.Prefix,
             Settings = GuildSettingsViewModel.Parse(dto.Settings),
             RecentCommandLogs = recentLogs?.Select(RecentCommandLogItem.FromDto).ToList() ?? (IReadOnlyList<RecentCommandLogItem>)Array.Empty<RecentCommandLogItem>(),
-            CanEdit = true // Will be set by PageModel based on authorization
+            CanEdit = false // Will be set by PageModel based on actual guild permissions
         };
     }
 }


### PR DESCRIPTION
## Summary
- Default `CanEdit` to `false` in `GuildDetailViewModel.FromDto()` instead of `true`
- Check `IGuildMembershipService.IsGuildAdminAsync()` for Discord guild-level admin permissions (Owner, Administrator, Manage Guild)
- Also allow app-level Admin/SuperAdmin roles to edit
- Changed `CanEdit` from `init` to `set` to allow page model to update after construction

Closes #1751

## Test plan
- [ ] Verify non-admin moderators see guild details but NOT the "Edit Settings" button
- [ ] Verify guild administrators (with Administrator or Manage Guild permission) see the edit button
- [ ] Verify app-level Admin/SuperAdmin users always see the edit button
- [ ] Verify users with no guild role don't see edit controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)