### PR TITLE
feat: implement channel engagement tracking from message logs

### DIFF
--- a/src/DiscordBot.Bot/Pages/Guilds/Analytics/Engagement.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Guilds/Analytics/Engagement.cshtml.cs
@@ -1,6 +1,7 @@
 using DiscordBot.Bot.Configuration;
 using DiscordBot.Bot.ViewModels.Components;
 using DiscordBot.Bot.ViewModels.Pages;
+using DiscordBot.Core.DTOs;
 using DiscordBot.Core.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -157,8 +158,7 @@ public class EngagementModel : PageModel
     }
 
     /// <summary>
-    /// Gets channel engagement metrics (placeholder implementation).
-    /// This will be replaced with actual service call once channel tracking is implemented.
+    /// Gets channel engagement metrics from the analytics service.
     /// </summary>
     /// <param name="guildId">Guild ID.</param>
     /// <param name="start">Start date.</param>
@@ -173,9 +173,12 @@ public class EngagementModel : PageModel
     {
         _logger.LogDebug("Retrieving channel engagement metrics for guild {GuildId}", guildId);
 
-        // TODO: Implement actual channel engagement tracking
-        // For now, return empty list - this will be populated once channel message tracking is added
-        await Task.CompletedTask;
-        return new List<ChannelEngagementDto>();
+        var channelEngagement = await _engagementAnalyticsService.GetChannelEngagementAsync(
+            guildId,
+            start,
+            end,
+            cancellationToken);
+
+        return channelEngagement.ToList();
     }
 }

--- a/src/DiscordBot.Bot/Services/EngagementAnalyticsService.cs
+++ b/src/DiscordBot.Bot/Services/EngagementAnalyticsService.cs
@@ -1,5 +1,6 @@
 using DiscordBot.Bot.Tracing;
 using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Enums;
 using DiscordBot.Core.Interfaces;
 using Microsoft.Extensions.Logging;
 
@@ -226,6 +227,87 @@ public class EngagementAnalyticsService : IEngagementAnalyticsService
         catch (Exception ex)
         {
             BotActivitySource.RecordException(activity, ex);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Gets channel engagement metrics showing message counts, unique authors, and engagement rates.
+    /// </summary>
+    public async Task<IReadOnlyList<ChannelEngagementDto>> GetChannelEngagementAsync(
+        ulong guildId,
+        DateTime start,
+        DateTime end,
+        CancellationToken ct = default)
+    {
+        using var activity = BotActivitySource.StartServiceActivity(
+            "engagement_analytics",
+            "get_channel_engagement",
+            guildId: guildId);
+
+        try
+        {
+            _logger.LogDebug(
+                "Generating channel engagement metrics for guild {GuildId} from {Start} to {End}",
+                guildId, start, end);
+
+            // Get all guild messages from the repository (need raw data for grouping)
+            var query = _messageLogRepository.GetGuildMessagesAsync(
+                guildId,
+                since: start,
+                limit: int.MaxValue,
+                cancellationToken: ct);
+
+            var messages = await query;
+
+            // Filter to the date range (GetGuildMessagesAsync uses "since" but we need an upper bound too)
+            var filteredMessages = messages
+                .Where(m => m.Timestamp >= start && m.Timestamp < end)
+                .Where(m => m.Source == MessageSource.ServerChannel)
+                .ToList();
+
+            if (filteredMessages.Count == 0)
+            {
+                _logger.LogDebug("No server channel messages found for guild {GuildId}", guildId);
+                BotActivitySource.SetSuccess(activity);
+                return Array.Empty<ChannelEngagementDto>();
+            }
+
+            // Get guild member count for engagement rate calculation
+            var memberCount = await _guildMemberRepository.GetMemberCountAsync(guildId, activeOnly: true, cancellationToken: ct);
+
+            if (memberCount == 0)
+            {
+                _logger.LogWarning("Guild {GuildId} has no active members for engagement rate calculation", guildId);
+                memberCount = 1; // Prevent division by zero
+            }
+
+            // Group by channel and calculate metrics
+            var channelMetrics = filteredMessages
+                .GroupBy(m => m.ChannelId)
+                .Select(g => new ChannelEngagementDto
+                {
+                    ChannelId = g.Key,
+                    ChannelName = g.First().ChannelName ?? "unknown",
+                    MessageCount = g.LongCount(),
+                    UniqueAuthors = g.Select(m => m.AuthorId).Distinct().Count(),
+                    EngagementRate = (decimal)g.Select(m => m.AuthorId).Distinct().Count() / memberCount * 100m
+                })
+                .OrderByDescending(x => x.MessageCount)
+                .Take(20)
+                .ToList();
+
+            _logger.LogDebug(
+                "Generated channel engagement metrics for {Count} channels in guild {GuildId}",
+                channelMetrics.Count, guildId);
+
+            BotActivitySource.SetSuccess(activity);
+            return channelMetrics;
+        }
+        catch (Exception ex)
+        {
+            BotActivitySource.RecordException(activity, ex);
+            _logger.LogError(ex, "Error generating channel engagement metrics for guild {GuildId}", guildId);
             throw;
         }
     }

--- a/src/DiscordBot.Bot/ViewModels/Pages/EngagementAnalyticsViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Pages/EngagementAnalyticsViewModel.cs
@@ -52,34 +52,3 @@ public record EngagementAnalyticsViewModel
     /// </summary>
     public DateTime EndDate { get; init; }
 }
-
-/// <summary>
-/// Channel engagement metrics for a single channel.
-/// </summary>
-public record ChannelEngagementDto
-{
-    /// <summary>
-    /// Discord channel snowflake ID.
-    /// </summary>
-    public ulong ChannelId { get; init; }
-
-    /// <summary>
-    /// Channel name (e.g., "general", "off-topic").
-    /// </summary>
-    public string ChannelName { get; init; } = string.Empty;
-
-    /// <summary>
-    /// Total number of messages in this channel.
-    /// </summary>
-    public long MessageCount { get; init; }
-
-    /// <summary>
-    /// Number of unique members who posted in this channel.
-    /// </summary>
-    public int UniqueAuthors { get; init; }
-
-    /// <summary>
-    /// Engagement rate: percentage of guild members who posted in this channel.
-    /// </summary>
-    public decimal EngagementRate { get; init; }
-}

--- a/src/DiscordBot.Core/DTOs/ChannelEngagementDto.cs
+++ b/src/DiscordBot.Core/DTOs/ChannelEngagementDto.cs
@@ -1,0 +1,32 @@
+namespace DiscordBot.Core.DTOs;
+
+/// <summary>
+/// Data transfer object for channel engagement metrics.
+/// </summary>
+public record ChannelEngagementDto
+{
+    /// <summary>
+    /// Discord channel snowflake ID.
+    /// </summary>
+    public ulong ChannelId { get; init; }
+
+    /// <summary>
+    /// Channel name (e.g., "general", "off-topic").
+    /// </summary>
+    public string ChannelName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Total number of messages in this channel.
+    /// </summary>
+    public long MessageCount { get; init; }
+
+    /// <summary>
+    /// Number of unique members who posted in this channel.
+    /// </summary>
+    public int UniqueAuthors { get; init; }
+
+    /// <summary>
+    /// Engagement rate: percentage of guild members who posted in this channel.
+    /// </summary>
+    public decimal EngagementRate { get; init; }
+}

--- a/src/DiscordBot.Core/Interfaces/IEngagementAnalyticsService.cs
+++ b/src/DiscordBot.Core/Interfaces/IEngagementAnalyticsService.cs
@@ -36,4 +36,14 @@ public interface IEngagementAnalyticsService
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Daily retention metrics for members who joined in the time period.</returns>
     Task<IReadOnlyList<NewMemberRetentionDto>> GetNewMemberRetentionAsync(ulong guildId, DateTime start, DateTime end, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets channel engagement metrics showing message counts, unique authors, and engagement rates.
+    /// </summary>
+    /// <param name="guildId">Discord guild snowflake ID.</param>
+    /// <param name="start">Start of the time period (inclusive).</param>
+    /// <param name="end">End of the time period (inclusive).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Channel engagement metrics ordered by message count (top 20 channels).</returns>
+    Task<IReadOnlyList<ChannelEngagementDto>> GetChannelEngagementAsync(ulong guildId, DateTime start, DateTime end, CancellationToken ct = default);
 }


### PR DESCRIPTION
## Summary
- Added `GetChannelEngagementAsync` to `IEngagementAnalyticsService` and implemented it in `EngagementAnalyticsService`
- Queries `MessageLog` table grouped by `ChannelId`, filtering to `ServerChannel` messages within the date range
- Computes message count, unique authors, and engagement rate (authors / guild members) per channel
- Returns top 20 channels ordered by message count
- Moved `ChannelEngagementDto` to `DiscordBot.Core.DTOs` for cross-layer access
- Replaced the stub in `Engagement.cshtml.cs` with actual service call

Closes #1749

## Test plan
- [ ] Verify channel engagement chart appears on the analytics engagement page when message data exists
- [ ] Verify channels are sorted by message count descending
- [ ] Verify engagement rate calculation looks reasonable (unique authors / total members)
- [ ] Verify page still renders correctly when no messages exist (empty state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)