### PR TITLE
fix: add missing alerts.js script on standalone Alerts page

### DIFF
--- a/src/DiscordBot.Bot/Pages/Admin/Performance/Alerts.cshtml
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/Alerts.cshtml
@@ -183,6 +183,7 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/microsoft-signalr/8.0.0/signalr.min.js"></script>
     <script src="~/js/dashboard-hub.js"></script>
+    <script src="~/js/performance/tabs/alerts.js"></script>
     <script src="~/js/performance/alerts-realtime.js"></script>
     <script>
         // Chart.js default dark theme settings


### PR DESCRIPTION
## Summary

- Added missing `<script src="~/js/performance/tabs/alerts.js"></script>` to the standalone Alerts page (`Alerts.cshtml`)
- Placed before `alerts-realtime.js` to match dependency order

The standalone Alerts Configuration page (`/Admin/Performance/Alerts`) was non-functional because the `alerts.js` module was never loaded. The Overview page (`Index.cshtml`) included it correctly, but the standalone page was missed when JS was extracted into external modules.

Closes #1773

## Test plan

- [ ] Navigate to `/Admin/Performance/Alerts` — Alert Frequency chart should render
- [ ] Change threshold inputs and enabled toggles — change tracking should activate
- [ ] Click Save button — should function correctly
- [ ] Verify behavior matches the Alerts tab on `/Admin/Performance` (Overview page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)