### PR TITLE
feat: specific error messages for audio failures

### DIFF
--- a/src/DiscordBot.Bot/Controllers/PortalSoundboardController.cs
+++ b/src/DiscordBot.Bot/Controllers/PortalSoundboardController.cs
@@ -92,7 +92,8 @@ public class PortalSoundboardController : ControllerBase
                 Message = "Audio features disabled",
                 Detail = "Audio features have been disabled by an administrator.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "audio_disabled"
             });
         }
 
@@ -106,7 +107,8 @@ public class PortalSoundboardController : ControllerBase
                 Message = "Audio is not enabled for this guild",
                 Detail = "Enable audio in the guild settings before using soundboard features.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "audio_not_enabled"
             });
         }
 
@@ -154,7 +156,8 @@ public class PortalSoundboardController : ControllerBase
                 Message = "No file provided",
                 Detail = "Please select an audio file to upload.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "no_file"
             });
         }
 
@@ -167,7 +170,8 @@ public class PortalSoundboardController : ControllerBase
                 Message = "Sound name is required",
                 Detail = "Please provide a name for the sound.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "no_name"
             });
         }
 
@@ -188,7 +192,8 @@ public class PortalSoundboardController : ControllerBase
                 Message = "Upload failed",
                 Detail = result.ErrorMessage ?? "Unknown error occurred during upload.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "upload_failed"
             });
         }
 
@@ -262,7 +267,8 @@ public class PortalSoundboardController : ControllerBase
                 Message = result.Success ? "Playing sound" : "Failed to play sound",
                 Detail = result.ErrorMessage ?? "Unknown error occurred during playback.",
                 StatusCode = statusCode,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = statusCode == StatusCodes.Status404NotFound ? "sound_not_found" : "play_failed"
             });
         }
 
@@ -290,7 +296,8 @@ public class PortalSoundboardController : ControllerBase
                 Message = "Guild not found",
                 Detail = "The requested guild was not found or the bot is not a member.",
                 StatusCode = StatusCodes.Status404NotFound,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "guild_not_found"
             });
         }
 
@@ -334,7 +341,8 @@ public class PortalSoundboardController : ControllerBase
                 Message = "Audio features disabled",
                 Detail = "Audio features have been disabled by an administrator.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "audio_disabled"
             });
         }
 
@@ -348,7 +356,8 @@ public class PortalSoundboardController : ControllerBase
                 Message = "Audio is not enabled for this guild",
                 Detail = "Enable audio in the guild settings before using voice features.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "audio_not_enabled"
             });
         }
 
@@ -361,7 +370,8 @@ public class PortalSoundboardController : ControllerBase
                 Message = "Failed to join voice channel",
                 Detail = "The guild or voice channel was not found, or the bot lacks permission to join.",
                 StatusCode = StatusCodes.Status404NotFound,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "channel_not_found"
             });
         }
 
@@ -390,7 +400,8 @@ public class PortalSoundboardController : ControllerBase
                 Message = "Not connected to voice",
                 Detail = "The bot is not currently connected to a voice channel in this guild.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "not_connected"
             });
         }
 
@@ -406,7 +417,8 @@ public class PortalSoundboardController : ControllerBase
                 Message = "Failed to leave voice channel",
                 Detail = "An error occurred while disconnecting from the voice channel.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "leave_failed"
             });
         }
 
@@ -435,7 +447,8 @@ public class PortalSoundboardController : ControllerBase
                 Message = "Not connected to voice",
                 Detail = "The bot is not currently connected to a voice channel in this guild.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "not_connected"
             });
         }
 

--- a/src/DiscordBot.Bot/Controllers/PortalTtsController.cs
+++ b/src/DiscordBot.Bot/Controllers/PortalTtsController.cs
@@ -178,7 +178,8 @@ public class PortalTtsController : ControllerBase
                 Message = "Audio features disabled",
                 Detail = "Audio features have been disabled by an administrator.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "audio_disabled"
             });
         }
 
@@ -192,7 +193,8 @@ public class PortalTtsController : ControllerBase
                 Message = "TTS is not enabled for this guild",
                 Detail = "Contact a server administrator to enable TTS in guild settings.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "tts_not_enabled"
             });
         }
 
@@ -205,7 +207,8 @@ public class PortalTtsController : ControllerBase
                 Message = "Not connected to voice channel",
                 Detail = "The bot must be connected to a voice channel before sending TTS messages.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "not_connected"
             });
         }
 
@@ -218,7 +221,8 @@ public class PortalTtsController : ControllerBase
                 Message = "Message cannot be empty",
                 Detail = "Please provide a message to synthesize.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "empty_message"
             });
         }
 
@@ -232,7 +236,8 @@ public class PortalTtsController : ControllerBase
                 Message = "Message too long",
                 Detail = $"Message length ({request.Message.Length}) exceeds the maximum allowed ({settings.MaxMessageLength}).",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "message_too_long"
             });
         }
 
@@ -263,7 +268,8 @@ public class PortalTtsController : ControllerBase
                 Message = "Rate limit exceeded",
                 Detail = $"You have exceeded the rate limit of {settings.RateLimitPerMinute} messages per minute. Please wait before sending more messages.",
                 StatusCode = StatusCodes.Status429TooManyRequests,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "rate_limited"
             });
         }
 
@@ -329,7 +335,8 @@ public class PortalTtsController : ControllerBase
                 Message = "TTS service not available",
                 Detail = "The text-to-speech service is not properly configured.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "tts_not_configured"
             });
         }
         catch (SsmlValidationException ex)
@@ -340,7 +347,8 @@ public class PortalTtsController : ControllerBase
                 Message = "SSML validation failed",
                 Detail = string.Join("; ", ex.Errors),
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "ssml_validation_failed"
             });
         }
         catch (ArgumentException ex)
@@ -351,7 +359,8 @@ public class PortalTtsController : ControllerBase
                 Message = "Invalid TTS request",
                 Detail = ex.Message,
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "invalid_request"
             });
         }
 
@@ -392,7 +401,8 @@ public class PortalTtsController : ControllerBase
                 Message = "Failed to play TTS",
                 Detail = playbackResult.ErrorMessage ?? "An error occurred while streaming audio to Discord.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "play_failed"
             });
         }
 
@@ -421,7 +431,8 @@ public class PortalTtsController : ControllerBase
                 Message = "Guild not found",
                 Detail = "The requested guild was not found or the bot is not a member.",
                 StatusCode = StatusCodes.Status404NotFound,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "guild_not_found"
             });
         }
 
@@ -465,7 +476,8 @@ public class PortalTtsController : ControllerBase
                 Message = "Audio features disabled",
                 Detail = "Audio features have been disabled by an administrator.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "audio_disabled"
             });
         }
 
@@ -479,7 +491,8 @@ public class PortalTtsController : ControllerBase
                 Message = "TTS is not enabled for this guild",
                 Detail = "Contact a server administrator to enable TTS in guild settings.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "tts_not_enabled"
             });
         }
 
@@ -492,7 +505,8 @@ public class PortalTtsController : ControllerBase
                 Message = "Failed to join voice channel",
                 Detail = "The guild or voice channel was not found, or the bot lacks permission to join.",
                 StatusCode = StatusCodes.Status404NotFound,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "channel_not_found"
             });
         }
 
@@ -521,7 +535,8 @@ public class PortalTtsController : ControllerBase
                 Message = "Not connected to voice",
                 Detail = "The bot is not currently connected to a voice channel in this guild.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "not_connected"
             });
         }
 
@@ -541,7 +556,8 @@ public class PortalTtsController : ControllerBase
                 Message = "Failed to leave voice channel",
                 Detail = "An error occurred while disconnecting from the voice channel.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "leave_failed"
             });
         }
 
@@ -570,7 +586,8 @@ public class PortalTtsController : ControllerBase
                 Message = "Not connected to voice",
                 Detail = "The bot is not currently connected to a voice channel in this guild.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "not_connected"
             });
         }
 
@@ -618,7 +635,8 @@ public class PortalTtsController : ControllerBase
                 Message = "SSML cannot be empty",
                 Detail = "Please provide SSML markup to validate.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "ssml_empty"
             });
         }
 
@@ -672,7 +690,8 @@ public class PortalTtsController : ControllerBase
                 Message = "SSML cannot be empty",
                 Detail = "Please provide SSML markup to synthesize.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "ssml_empty"
             });
         }
 
@@ -688,7 +707,8 @@ public class PortalTtsController : ControllerBase
                 Message = "SSML is not enabled for this guild",
                 Detail = "Contact a server administrator to enable SSML features in guild TTS settings.",
                 StatusCode = StatusCodes.Status403Forbidden,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "ssml_not_enabled"
             });
         }
 
@@ -701,7 +721,8 @@ public class PortalTtsController : ControllerBase
                 Message = "Audio features disabled",
                 Detail = "Audio features have been disabled by an administrator.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "audio_disabled"
             });
         }
 
@@ -726,7 +747,8 @@ public class PortalTtsController : ControllerBase
                 Message = "SSML validation failed",
                 Detail = $"Validation errors: {string.Join("; ", validationResult.Errors)}",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "ssml_validation_failed"
             });
         }
 
@@ -741,7 +763,8 @@ public class PortalTtsController : ControllerBase
                 Message = "SSML complexity exceeds limit",
                 Detail = $"The SSML complexity ({complexity}) exceeds the guild limit ({settings.MaxSsmlComplexity}). Simplify the markup or contact an administrator to increase the limit.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "ssml_complexity_exceeded"
             });
         }
 
@@ -759,7 +782,8 @@ public class PortalTtsController : ControllerBase
                 Message = "TTS service not available",
                 Detail = "The text-to-speech service is not properly configured.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "tts_not_configured"
             });
         }
         catch (SsmlValidationException ex)
@@ -770,7 +794,8 @@ public class PortalTtsController : ControllerBase
                 Message = "SSML validation failed",
                 Detail = string.Join("; ", ex.Errors),
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "ssml_validation_failed"
             });
         }
         catch (ArgumentException ex)
@@ -781,7 +806,8 @@ public class PortalTtsController : ControllerBase
                 Message = "Invalid SSML",
                 Detail = ex.Message,
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "invalid_request"
             });
         }
 
@@ -802,7 +828,8 @@ public class PortalTtsController : ControllerBase
                         Message = "Not connected to voice channel",
                         Detail = "The bot must be connected to a voice channel to play SSML audio.",
                         StatusCode = StatusCodes.Status400BadRequest,
-                        TraceId = HttpContext.GetCorrelationId()
+                        TraceId = HttpContext.GetCorrelationId(),
+                        ErrorCode = "not_connected"
                     });
                 }
 
@@ -857,7 +884,8 @@ public class PortalTtsController : ControllerBase
                         Message = "Failed to play SSML audio",
                         Detail = playbackResult.ErrorMessage ?? "An error occurred while streaming audio to Discord.",
                         StatusCode = StatusCodes.Status400BadRequest,
-                        TraceId = HttpContext.GetCorrelationId()
+                        TraceId = HttpContext.GetCorrelationId(),
+                        ErrorCode = "play_failed"
                     });
                 }
 
@@ -910,7 +938,8 @@ public class PortalTtsController : ControllerBase
                 Message = "No segments provided",
                 Detail = "Please provide at least one SSML segment to build.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "invalid_request"
             });
         }
 
@@ -1042,7 +1071,8 @@ public class PortalTtsController : ControllerBase
                 Message = "Failed to build SSML",
                 Detail = ex.Message,
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "invalid_request"
             });
         }
     }

--- a/src/DiscordBot.Bot/Controllers/PortalVoxController.cs
+++ b/src/DiscordBot.Bot/Controllers/PortalVoxController.cs
@@ -102,7 +102,8 @@ public class PortalVoxController : ControllerBase
                 Message = "Guild not found",
                 Detail = "The requested guild was not found or the bot is not a member.",
                 StatusCode = StatusCodes.Status404NotFound,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "guild_not_found"
             });
         }
 
@@ -115,7 +116,8 @@ public class PortalVoxController : ControllerBase
                 Message = "Invalid group name",
                 Detail = $"The group '{group}' is not valid. Valid groups are: vox, fvox, hgrunt.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "invalid_group"
             });
         }
 
@@ -175,7 +177,8 @@ public class PortalVoxController : ControllerBase
                 Message = "Guild not found",
                 Detail = "The requested guild was not found or the bot is not a member.",
                 StatusCode = StatusCodes.Status404NotFound,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "guild_not_found"
             });
         }
 
@@ -195,7 +198,8 @@ public class PortalVoxController : ControllerBase
                 Message = "Invalid group name",
                 Detail = $"The group '{group}' is not valid. Valid groups are: vox, fvox, hgrunt.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "invalid_group"
             });
         }
 
@@ -250,7 +254,8 @@ public class PortalVoxController : ControllerBase
                 Message = "Audio features disabled",
                 Detail = "Audio features have been disabled by an administrator.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "audio_disabled"
             });
         }
 
@@ -264,7 +269,8 @@ public class PortalVoxController : ControllerBase
                 Message = "Audio is not enabled for this guild",
                 Detail = "Enable audio in the guild settings before using VOX features.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "audio_not_enabled"
             });
         }
 
@@ -278,7 +284,8 @@ public class PortalVoxController : ControllerBase
                 Message = "Guild not found",
                 Detail = "The requested guild was not found or the bot is not a member.",
                 StatusCode = StatusCodes.Status404NotFound,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "guild_not_found"
             });
         }
 
@@ -291,7 +298,8 @@ public class PortalVoxController : ControllerBase
                 Message = "Not connected to voice channel",
                 Detail = "The bot must be connected to a voice channel before playing VOX announcements.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "not_connected"
             });
         }
 
@@ -326,7 +334,8 @@ public class PortalVoxController : ControllerBase
                 Message = "Invalid word gap",
                 Detail = $"Word gap must be between {MinWordGapMs} and {MaxWordGapMs} milliseconds.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "invalid_word_gap"
             });
         }
 
@@ -342,7 +351,8 @@ public class PortalVoxController : ControllerBase
                 Message = "No matching clips found",
                 Detail = $"None of the words in the message have matching VOX clips. Unmatched words: {string.Join(", ", unmatchedWords)}",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "no_matching_clips"
             });
         }
 
@@ -379,7 +389,8 @@ public class PortalVoxController : ControllerBase
                 Message = "VOX playback failed",
                 Detail = ex.Message,
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "vox_validation_failed"
             });
         }
 
@@ -391,7 +402,8 @@ public class PortalVoxController : ControllerBase
                 Message = "Failed to play VOX message",
                 Detail = result.ErrorMessage ?? "An error occurred during playback.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "play_failed"
             });
         }
 
@@ -434,7 +446,8 @@ public class PortalVoxController : ControllerBase
                 Message = "Guild not found",
                 Detail = "The requested guild was not found or the bot is not a member.",
                 StatusCode = StatusCodes.Status404NotFound,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "guild_not_found"
             });
         }
 
@@ -447,7 +460,8 @@ public class PortalVoxController : ControllerBase
                 Message = "Not connected to voice channel",
                 Detail = "The bot is not currently connected to a voice channel in this guild.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "not_connected"
             });
         }
 
@@ -474,7 +488,8 @@ public class PortalVoxController : ControllerBase
                 Message = "Message cannot be empty",
                 Detail = "Please provide a message to convert to VOX speech.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "empty_message"
             });
         }
 
@@ -486,7 +501,8 @@ public class PortalVoxController : ControllerBase
                 Message = "Message too long",
                 Detail = $"Message length ({message.Length}) exceeds the maximum allowed ({MaxMessageLength}).",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "message_too_long"
             });
         }
 
@@ -499,7 +515,8 @@ public class PortalVoxController : ControllerBase
                 Message = "Too many words",
                 Detail = $"Message contains {words.Length} words, exceeding the maximum of {MaxWordCount}.",
                 StatusCode = StatusCodes.Status400BadRequest,
-                TraceId = HttpContext.GetCorrelationId()
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "too_many_words"
             });
         }
 

--- a/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml
@@ -1382,7 +1382,7 @@ else
             .then(async response => {
                 if (!response.ok) {
                     const errorData = await response.json().catch(() => ({}));
-                    if (errorData.message === 'Not connected to voice channel') {
+                    if (errorData.errorCode === 'not_connected') {
                         PortalToast.warning('Please join a voice channel first!');
                         return Promise.reject('not_connected');
                     }

--- a/src/DiscordBot.Bot/Pages/Portal/VOX/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Portal/VOX/Index.cshtml
@@ -844,7 +844,10 @@
         async function loadClipsForGroup(group) {
             try {
                 const response = await fetch(`/api/portal/vox/${window.guildId}/clips?group=${group}`);
-                if (!response.ok) throw new Error('Failed to load clips');
+                if (!response.ok) {
+                    const error = await response.json().catch(() => ({}));
+                    throw new Error(error.message || 'Failed to load clips');
+                }
 
                 const data = await response.json();
                 voxState.clipCache[group] = data.clips || [];
@@ -852,9 +855,13 @@
                 renderClipGrid();
                 updateTokenPreview();
             } catch (error) {
-                // Show error state in clip grid
+                // Show specific error message in clip grid
                 if (voxEls.clipGrid) {
-                    voxEls.clipGrid.innerHTML = '<div class="vox-token-empty">Failed to load clips</div>';
+                    const msg = document.createElement('div');
+                    msg.className = 'vox-token-empty';
+                    msg.textContent = error.message || 'Failed to load clips';
+                    voxEls.clipGrid.innerHTML = '';
+                    voxEls.clipGrid.appendChild(msg);
                 }
             }
         }
@@ -1085,27 +1092,28 @@
                 });
 
                 if (!response.ok) {
-                    const error = await response.json();
+                    const error = await response.json().catch(() => ({}));
                     throw new Error(error.message || 'Failed to play VOX message');
                 }
 
                 // Success - clear the message input
                 voxEls.messageInput.value = '';
                 updateTokenPreview();
+                voxEls.playBtnText.textContent = 'Play VOX Announcement';
             } catch (error) {
-                // Display error inline instead of alert
+                // Display specific error message inline
                 if (voxEls.playBtnText) {
-                    voxEls.playBtnText.textContent = 'Error: ' + (error.message || 'Failed to play').substring(0, 50);
+                    const errMsg = (error.message || 'Failed to play').substring(0, 100);
+                    voxEls.playBtnText.textContent = 'Error: ' + errMsg;
                     setTimeout(() => {
                         if (voxEls.playBtnText) {
                             voxEls.playBtnText.textContent = 'Play VOX Announcement';
                         }
-                    }, 3000);
+                    }, 4000);
                 }
             } finally {
                 voxState.isLoading = false;
                 voxEls.playBtn.classList.remove('loading');
-                voxEls.playBtnText.textContent = 'Play VOX Announcement';
                 updateTokenPreview();
             }
         }

--- a/src/DiscordBot.Bot/wwwroot/js/portal-tts.js
+++ b/src/DiscordBot.Bot/wwwroot/js/portal-tts.js
@@ -257,7 +257,7 @@
             });
 
             if (response.status === 429) {
-                const data = await response.json();
+                const data = await response.json().catch(() => ({}));
                 showToast('warning', data.message || 'Rate limit exceeded. Please wait.');
                 return;
             }

--- a/src/DiscordBot.Core/DTOs/ApiErrorDto.cs
+++ b/src/DiscordBot.Core/DTOs/ApiErrorDto.cs
@@ -24,4 +24,9 @@ public class ApiErrorDto
     /// Gets or sets the trace ID for correlation.
     /// </summary>
     public string? TraceId { get; set; }
+
+    /// <summary>
+    /// Gets or sets a machine-readable error code for programmatic handling.
+    /// </summary>
+    public string? ErrorCode { get; set; }
 }


### PR DESCRIPTION
## Summary
- Added `ErrorCode` property to `ApiErrorDto` for machine-readable error identification
- Populated error codes across all portal audio controllers (Soundboard: 13, VOX: 17, TTS: 30 instances)
- Fixed VOX play error visibility bug where `finally` block immediately overwrote error messages
- Added `.catch(() => ({}))` JSON parse fallbacks to prevent unhandled rejections on non-JSON responses
- VOX clip loading now displays specific API error messages instead of generic "Failed to load clips"
- Soundboard play uses `errorCode` for voice channel detection instead of fragile string matching
- Increased VOX button error message truncation from 50 to 100 chars

## Changes
- **Backend**: `ApiErrorDto.ErrorCode` added and populated with snake_case codes across `PortalSoundboardController`, `PortalVoxController`, `PortalTtsController`
- **Frontend (VOX)**: Fixed error display bug, added JSON parse safety, show specific errors in clip grid and play button
- **Frontend (TTS)**: Added JSON parse safety on 429 handler
- **Frontend (Soundboard)**: Use `errorCode` instead of message string matching for voice channel check

Closes #1765

## Test plan
- [ ] Upload a file over the size limit — verify specific size error message appears in toast
- [ ] Attempt VOX play when not in a voice channel — verify specific message appears
- [ ] Attempt soundboard play when not in voice channel — verify warning toast appears
- [ ] Attempt TTS send with empty message — verify specific validation error in toast
- [ ] Simulate a 429 response — verify rate limit message appears
- [ ] Verify VOX play error message stays visible for 4 seconds before resetting

🤖 Generated with [Claude Code](https://claude.com/claude-code)