### PR TITLE
feat: show sound duration on soundboard cards

### DIFF
--- a/src/DiscordBot.Bot/Controllers/PortalSoundboardController.cs
+++ b/src/DiscordBot.Bot/Controllers/PortalSoundboardController.cs
@@ -118,7 +118,8 @@ public class PortalSoundboardController : ControllerBase
             {
                 id = s.Id.ToString(),
                 name = s.Name,
-                playCount = s.PlayCount
+                playCount = s.PlayCount,
+                durationSeconds = s.DurationSeconds
             }).ToList(),
             totalCount = sounds.Count
         };
@@ -199,7 +200,8 @@ public class PortalSoundboardController : ControllerBase
             {
                 id = result.Sound!.Id.ToString(),
                 name = result.Sound.Name,
-                playCount = result.Sound.PlayCount
+                playCount = result.Sound.PlayCount,
+                durationSeconds = result.Sound.DurationSeconds
             });
     }
 

--- a/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml
@@ -1,6 +1,15 @@
 @page "{guildId:long}"
 @model DiscordBot.Bot.Pages.Portal.Soundboard.IndexModel
 @using DiscordBot.Bot.ViewModels.Portal
+@functions {
+    static string FormatDuration(double seconds)
+    {
+        var totalSeconds = (int)seconds;
+        return totalSeconds < 60
+            ? $"{totalSeconds}s"
+            : $"{totalSeconds / 60}:{totalSeconds % 60:D2}";
+    }
+}
 @{
     ViewData["Title"] = Model.IsAuthenticated ? "Soundboard" : "Verify Your Membership";
 }
@@ -636,6 +645,11 @@
         color: var(--color-text-secondary);
     }
 
+    .sound-duration {
+        font-size: 0.75rem;
+        color: var(--color-text-secondary);
+    }
+
     /* Empty State */
     .empty-state {
         text-align: center;
@@ -875,6 +889,10 @@ else
                             </div>
                             <div class="sound-name">@sound.Name</div>
                             <div class="sound-plays">@sound.PlayCount plays</div>
+                            @if (sound.DurationSeconds > 0)
+                            {
+                                <div class="sound-duration">@FormatDuration(sound.DurationSeconds)</div>
+                            }
                         </div>
                     }
                 </div>
@@ -1626,6 +1644,12 @@ else
             xhr.send(formData);
         }
 
+        function formatDuration(seconds) {
+            seconds = Math.floor(seconds);
+            if (seconds < 60) return seconds + 's';
+            return Math.floor(seconds / 60) + ':' + String(seconds % 60).padStart(2, '0');
+        }
+
         function addSoundToGrid(sound) {
             const grid = document.getElementById('soundGrid');
             const emptyState = document.getElementById('emptyState');
@@ -1655,6 +1679,7 @@ else
                 </div>
                 <div class="sound-name">${sound.name}</div>
                 <div class="sound-plays">0 plays</div>
+                ${sound.durationSeconds > 0 ? `<div class="sound-duration">${formatDuration(sound.durationSeconds)}</div>` : ''}
             `;
 
             // Add event listeners

--- a/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml.cs
@@ -141,7 +141,8 @@ public class IndexModel : PortalPageModelBase
                 {
                     Id = s.Id,
                     Name = s.Name,
-                    PlayCount = s.PlayCount
+                    PlayCount = s.PlayCount,
+                    DurationSeconds = s.DurationSeconds
                 })
                 .ToList();
 

--- a/src/DiscordBot.Bot/ViewModels/Portal/PortalSoundViewModel.cs
+++ b/src/DiscordBot.Bot/ViewModels/Portal/PortalSoundViewModel.cs
@@ -20,4 +20,9 @@ public record PortalSoundViewModel
     /// Gets the number of times this sound has been played.
     /// </summary>
     public int PlayCount { get; init; }
+
+    /// <summary>
+    /// Gets the audio duration in seconds.
+    /// </summary>
+    public double DurationSeconds { get; init; }
 }


### PR DESCRIPTION
## Summary
- Display sound duration on each soundboard card in the portal grid
- Format: "Xs" for clips under 60s, "M:SS" for 60s+ (e.g., "7s", "1:05")
- Cards with null/zero duration show nothing
- Added `durationSeconds` to both GetSounds and Upload API responses
- Duration rendering in both server-rendered Razor and client-side JS (addSoundToGrid)

Closes #1764

## Test plan
- [ ] Load soundboard, verify cards display durations in correct format
- [ ] Verify format switches from "Xs" to "M:SS" at the 60s boundary
- [ ] Verify cards with null/zero duration show no duration text
- [ ] Upload a new sound and verify duration appears on the new card without refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)