### PR TITLE
feat: show requesting user's display name in Now Playing

### DIFF
--- a/docs/articles/signalr-realtime.md
+++ b/docs/articles/signalr-realtime.md
@@ -1442,6 +1442,7 @@ DashboardHub.on('PlaybackStarted', (data) => {
 - `soundId` (Guid): The sound ID
 - `name` (string): The sound name
 - `durationSeconds` (double): Duration in seconds
+- `requestedByDisplayName` (string?): Display name of the user who requested playback (null if unknown)
 - `timestamp` (DateTime): UTC timestamp
 
 ---

--- a/src/DiscordBot.Bot/Interfaces/IPlaybackService.cs
+++ b/src/DiscordBot.Bot/Interfaces/IPlaybackService.cs
@@ -29,7 +29,7 @@ public interface IPlaybackService
     /// </remarks>
     /// <exception cref="InvalidOperationException">Thrown if no audio client is available for the guild.</exception>
     /// <exception cref="FileNotFoundException">Thrown if the sound file does not exist.</exception>
-    Task PlayAsync(ulong guildId, Sound sound, bool queueEnabled, AudioFilter filter = AudioFilter.None, CancellationToken cancellationToken = default);
+    Task PlayAsync(ulong guildId, Sound sound, bool queueEnabled, AudioFilter filter = AudioFilter.None, string? requestedByDisplayName = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Stops the currently playing sound in the specified guild and clears the queue.

--- a/src/DiscordBot.Bot/Pages/Shared/Components/_VoiceChannelPanel.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/Components/_VoiceChannelPanel.cshtml
@@ -219,6 +219,7 @@
                    title="@(Model.NowPlaying?.Name ?? "Nothing playing")">
                     @(Model.NowPlaying?.Name ?? "Nothing playing")
                 </p>
+                <p id="now-playing-requested-by" class="text-xs text-text-tertiary hidden"></p>
                 @if (Model.ShowProgress)
                 {
                     <div class="mt-1.5">

--- a/src/DiscordBot.Bot/Services/AudioNotifier.cs
+++ b/src/DiscordBot.Bot/Services/AudioNotifier.cs
@@ -122,6 +122,7 @@ public class AudioNotifier : IAudioNotifier
         Guid soundId,
         string name,
         double durationSeconds,
+        string? requestedByDisplayName = null,
         CancellationToken cancellationToken = default)
     {
         var groupName = DashboardHub.GetGuildAudioGroupName(guildId);
@@ -131,15 +132,17 @@ public class AudioNotifier : IAudioNotifier
             SoundId = soundId,
             Name = name,
             DurationSeconds = durationSeconds,
+            RequestedByDisplayName = requestedByDisplayName,
             Timestamp = DateTime.UtcNow
         };
 
         _logger.LogDebug(
-            "Broadcasting PlaybackStarted: GuildId={GuildId}, SoundId={SoundId}, Name={Name}, Duration={DurationSeconds}s",
+            "Broadcasting PlaybackStarted: GuildId={GuildId}, SoundId={SoundId}, Name={Name}, Duration={DurationSeconds}s, RequestedBy={RequestedBy}",
             guildId,
             soundId,
             name,
-            durationSeconds);
+            durationSeconds,
+            requestedByDisplayName);
 
         await _hubContext.Clients.Group(groupName).SendAsync(
             Events.PlaybackStarted,

--- a/src/DiscordBot.Bot/Services/PlaybackService.cs
+++ b/src/DiscordBot.Bot/Services/PlaybackService.cs
@@ -64,7 +64,7 @@ public class PlaybackService : IPlaybackService
     }
 
     /// <inheritdoc/>
-    public async Task PlayAsync(ulong guildId, Sound sound, bool queueEnabled, AudioFilter filter = AudioFilter.None, CancellationToken cancellationToken = default)
+    public async Task PlayAsync(ulong guildId, Sound sound, bool queueEnabled, AudioFilter filter = AudioFilter.None, string? requestedByDisplayName = null, CancellationToken cancellationToken = default)
     {
         using var scope = BotActivitySource.StartServiceActivityWithApm(
             "playback",
@@ -117,7 +117,7 @@ public class PlaybackService : IPlaybackService
                 if (queueEnabled)
                 {
                     // Queue mode: Add to queue
-                    state.Queue.Enqueue(new QueuedSound(sound, filter));
+                    state.Queue.Enqueue(new QueuedSound(sound, filter, requestedByDisplayName));
                     _logger.LogDebug("Added sound {SoundName} to queue (position {QueuePosition}) in guild {GuildId} with filter {Filter}",
                         sound.Name, state.Queue.Count, guildId, filter);
 
@@ -135,7 +135,7 @@ public class PlaybackService : IPlaybackService
                         state.Queue.Clear();
                     }
 
-                    state.Queue.Enqueue(new QueuedSound(sound, filter));
+                    state.Queue.Enqueue(new QueuedSound(sound, filter, requestedByDisplayName));
 
                     // Broadcast queue update
                     BroadcastQueueUpdate(guildId, state);
@@ -359,6 +359,7 @@ public class PlaybackService : IPlaybackService
                         // Queue empty, stop playback loop
                         state.IsPlaying = false;
                         state.CurrentSound = null;
+                        state.CurrentRequestedByDisplayName = null;
                         state.CancellationTokenSource?.Dispose();
                         state.CancellationTokenSource = null;
                         _logger.LogDebug("Playback queue empty, stopping playback loop for guild {GuildId}", guildId);
@@ -369,6 +370,7 @@ public class PlaybackService : IPlaybackService
                     queuedSound = state.Queue.Dequeue();
                     state.IsPlaying = true;
                     state.CurrentSound = queuedSound.Sound;
+                    state.CurrentRequestedByDisplayName = queuedSound.RequestedByDisplayName;
                     state.CancellationTokenSource?.Dispose();
                     state.CancellationTokenSource = new CancellationTokenSource();
 
@@ -388,7 +390,7 @@ public class PlaybackService : IPlaybackService
                 // Play the sound
                 try
                 {
-                    await PlaySoundAsync(guildId, queuedSound.Sound, queuedSound.Filter, state.CancellationTokenSource.Token);
+                    await PlaySoundAsync(guildId, queuedSound.Sound, queuedSound.Filter, queuedSound.RequestedByDisplayName, state.CancellationTokenSource.Token);
                 }
                 catch (OperationCanceledException)
                 {
@@ -437,7 +439,7 @@ public class PlaybackService : IPlaybackService
     /// <param name="sound">The sound to play.</param>
     /// <param name="filter">The audio filter to apply.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    private async Task PlaySoundAsync(ulong guildId, Sound sound, AudioFilter filter, CancellationToken cancellationToken)
+    private async Task PlaySoundAsync(ulong guildId, Sound sound, AudioFilter filter, string? requestedByDisplayName, CancellationToken cancellationToken)
     {
         using var scope = BotActivitySource.StartServiceActivityWithApm(
             "playback",
@@ -480,7 +482,7 @@ public class PlaybackService : IPlaybackService
             _audioService.UpdateLastActivity(guildId);
 
             // Broadcast PlaybackStarted event
-            _ = _audioNotifier.NotifyPlaybackStartedAsync(guildId, sound.Id, sound.Name, durationSeconds, cancellationToken);
+            _ = _audioNotifier.NotifyPlaybackStartedAsync(guildId, sound.Id, sound.Name, durationSeconds, requestedByDisplayName, cancellationToken);
 
             // Determine FFmpeg executable path - handle null or empty string
             // If not configured, look for ffmpeg in the application's base directory first, then fall back to PATH
@@ -914,7 +916,7 @@ public class PlaybackService : IPlaybackService
     /// <summary>
     /// Represents a queued sound with its optional audio filter.
     /// </summary>
-    private record QueuedSound(Sound Sound, AudioFilter Filter);
+    private record QueuedSound(Sound Sound, AudioFilter Filter, string? RequestedByDisplayName = null);
 
     /// <summary>
     /// Represents the playback state for a guild.
@@ -941,5 +943,10 @@ public class PlaybackService : IPlaybackService
         /// The currently playing sound (used for notifications).
         /// </summary>
         public Sound? CurrentSound { get; set; }
+
+        /// <summary>
+        /// The display name of the user who requested the currently playing sound.
+        /// </summary>
+        public string? CurrentRequestedByDisplayName { get; set; }
     }
 }

--- a/src/DiscordBot.Bot/Services/SoundboardOrchestrationService.cs
+++ b/src/DiscordBot.Bot/Services/SoundboardOrchestrationService.cs
@@ -1,3 +1,4 @@
+using Discord.WebSocket;
 using DiscordBot.Bot.Interfaces;
 using DiscordBot.Bot.Tracing;
 using DiscordBot.Core.DTOs.Soundboard;
@@ -20,6 +21,7 @@ public class SoundboardOrchestrationService : ISoundboardOrchestrationService
     private readonly IGuildAudioSettingsService _audioSettingsService;
     private readonly ISettingsService _settingsService;
     private readonly IAudioNotifier _audioNotifier;
+    private readonly DiscordSocketClient _discordClient;
     private readonly ILogger<SoundboardOrchestrationService> _logger;
 
     /// <summary>
@@ -32,6 +34,7 @@ public class SoundboardOrchestrationService : ISoundboardOrchestrationService
     /// <param name="audioSettingsService">The audio settings service.</param>
     /// <param name="settingsService">The bot-level settings service.</param>
     /// <param name="audioNotifier">The audio notifier for real-time updates.</param>
+    /// <param name="discordClient">The Discord socket client for resolving user display names.</param>
     /// <param name="logger">The logger.</param>
     public SoundboardOrchestrationService(
         ISoundService soundService,
@@ -41,6 +44,7 @@ public class SoundboardOrchestrationService : ISoundboardOrchestrationService
         IGuildAudioSettingsService audioSettingsService,
         ISettingsService settingsService,
         IAudioNotifier audioNotifier,
+        DiscordSocketClient discordClient,
         ILogger<SoundboardOrchestrationService> logger)
     {
         _soundService = soundService;
@@ -50,6 +54,7 @@ public class SoundboardOrchestrationService : ISoundboardOrchestrationService
         _audioSettingsService = audioSettingsService;
         _settingsService = settingsService;
         _audioNotifier = audioNotifier;
+        _discordClient = discordClient;
         _logger = logger;
     }
 
@@ -308,6 +313,19 @@ public class SoundboardOrchestrationService : ISoundboardOrchestrationService
                 };
             }
 
+            // Resolve the requesting user's display name
+            string? requestedByDisplayName = null;
+            try
+            {
+                var guild = _discordClient.GetGuild(guildId);
+                var guildUser = guild?.GetUser(userId);
+                requestedByDisplayName = guildUser?.DisplayName ?? _discordClient.GetUser(userId)?.Username;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Could not resolve display name for user {UserId} in guild {GuildId}", userId, guildId);
+            }
+
             // Determine if sound will be queued based on current playback state
             var wasPlaying = _playbackService.IsPlaying(guildId);
             var queueLengthBefore = _playbackService.GetQueueLength(guildId);
@@ -315,7 +333,7 @@ public class SoundboardOrchestrationService : ISoundboardOrchestrationService
             int? queuePosition = willBeQueued ? queueLengthBefore + 1 : null;
 
             // Play the sound
-            await _playbackService.PlayAsync(guildId, sound, queueEnabled, filter, cancellationToken);
+            await _playbackService.PlayAsync(guildId, sound, queueEnabled, filter, requestedByDisplayName, cancellationToken);
             _logger.LogInformation("Successfully started playback of sound {SoundName} ({SoundId}) in guild {GuildId}",
                 sound.Name, sound.Id, guildId);
 

--- a/src/DiscordBot.Bot/wwwroot/js/voice-channel-panel.js
+++ b/src/DiscordBot.Bot/wwwroot/js/voice-channel-panel.js
@@ -19,6 +19,7 @@ const VoiceChannelPanel = (function() {
     let channelMemberCount = null;
     let nowPlayingSection = null;
     let nowPlayingName = null;
+    let nowPlayingRequestedBy = null;
     let nowPlayingProgress = null;
     let nowPlayingPosition = null;
     let nowPlayingDuration = null;
@@ -60,6 +61,7 @@ const VoiceChannelPanel = (function() {
         channelMemberCount = document.getElementById('channel-member-count');
         nowPlayingSection = document.getElementById('now-playing-section');
         nowPlayingName = document.getElementById('now-playing-name');
+        nowPlayingRequestedBy = document.getElementById('now-playing-requested-by');
         nowPlayingProgress = document.getElementById('now-playing-progress');
         nowPlayingPosition = document.getElementById('now-playing-position');
         nowPlayingDuration = document.getElementById('now-playing-duration');
@@ -384,7 +386,8 @@ const VoiceChannelPanel = (function() {
             id: data.soundId,
             name: data.name,
             durationSeconds: data.durationSeconds,
-            positionSeconds: 0
+            positionSeconds: 0,
+            requestedByDisplayName: data.requestedByDisplayName
         });
     }
 
@@ -479,6 +482,16 @@ const VoiceChannelPanel = (function() {
             if (nowPlayingName) {
                 nowPlayingName.textContent = nowPlaying.name;
                 nowPlayingName.title = nowPlaying.name;
+            }
+
+            if (nowPlayingRequestedBy) {
+                if (nowPlaying.requestedByDisplayName) {
+                    nowPlayingRequestedBy.textContent = 'Requested by ' + nowPlaying.requestedByDisplayName;
+                    nowPlayingRequestedBy.classList.remove('hidden');
+                } else {
+                    nowPlayingRequestedBy.textContent = '';
+                    nowPlayingRequestedBy.classList.add('hidden');
+                }
             }
 
             updatePlaybackProgress(nowPlaying.positionSeconds || 0, nowPlaying.durationSeconds || 0);

--- a/src/DiscordBot.Core/DTOs/AudioEventDtos.cs
+++ b/src/DiscordBot.Core/DTOs/AudioEventDtos.cs
@@ -117,6 +117,12 @@ public class PlaybackStartedDto
     public double DurationSeconds { get; set; }
 
     /// <summary>
+    /// Gets or sets the display name of the user who requested playback.
+    /// Null if the requester is unknown.
+    /// </summary>
+    public string? RequestedByDisplayName { get; set; }
+
+    /// <summary>
     /// Gets or sets the timestamp when playback started.
     /// </summary>
     public DateTime Timestamp { get; set; } = DateTime.UtcNow;

--- a/src/DiscordBot.Core/Interfaces/IAudioNotifier.cs
+++ b/src/DiscordBot.Core/Interfaces/IAudioNotifier.cs
@@ -43,6 +43,7 @@ public interface IAudioNotifier
     /// <param name="soundId">The sound ID.</param>
     /// <param name="name">The sound name.</param>
     /// <param name="durationSeconds">The sound duration in seconds.</param>
+    /// <param name="requestedByDisplayName">The display name of the user who requested playback, or null if unknown.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     Task NotifyPlaybackStartedAsync(
@@ -50,6 +51,7 @@ public interface IAudioNotifier
         Guid soundId,
         string name,
         double durationSeconds,
+        string? requestedByDisplayName = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Add `RequestedByDisplayName` field to `PlaybackStartedDto` and thread it through the full playback pipeline (orchestration service -> playback service -> audio notifier -> SignalR -> JS)
- Resolve the display name from the Discord guild member (nickname with username fallback) in `SoundboardOrchestrationService` before queueing playback
- Display "Requested by {name}" beneath the track name in the VoiceChannelPanel; line is omitted when the requester is unknown (null/empty)
- Update SignalR docs to document the new `requestedByDisplayName` property

Closes #1767

## Changed Files
- **`AudioEventDtos.cs`** — Added `RequestedByDisplayName` to `PlaybackStartedDto`
- **`IAudioNotifier.cs` / `AudioNotifier.cs`** — Added optional `requestedByDisplayName` parameter
- **`IPlaybackService.cs` / `PlaybackService.cs`** — Threaded display name through `QueuedSound`, `PlaybackState`, and `PlaySoundAsync`
- **`SoundboardOrchestrationService.cs`** — Injected `DiscordSocketClient`, resolves guild display name with username fallback
- **`_VoiceChannelPanel.cshtml`** — Added `now-playing-requested-by` element
- **`voice-channel-panel.js`** — Updated `handlePlaybackStarted` and `updateNowPlaying` to display requester name
- **`signalr-realtime.md`** — Documented new DTO field

## Test plan
- [ ] Play a soundboard sound, verify "Requested by [your name]" appears beneath the track name in Now Playing
- [ ] Verify the "Requested by" line disappears when playback finishes
- [ ] Verify the line is omitted (not blank) when requester name is unavailable
- [ ] Verify no JS console errors on the soundboard page

🤖 Generated with [Claude Code](https://claude.com/claude-code)