### PR TITLE
feat: auto-save TTS drafts to localStorage

### DIFF
--- a/src/DiscordBot.Bot/Pages/Portal/TTS/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Portal/TTS/Index.cshtml
@@ -441,6 +441,17 @@ else
             <div class="tts-panel">
                 <div class="tts-form-wrapper">
 
+                    <!-- Draft Restored Banner -->
+                    <div id="draftRestoredBanner" class="draft-banner hidden" role="status" aria-live="polite">
+                        <div class="draft-banner-content">
+                            <svg class="draft-banner-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                            </svg>
+                            <span class="draft-banner-text">Draft restored — you have unsaved changes</span>
+                        </div>
+                        <button id="clearDraftBtn" class="draft-banner-clear" type="button">Clear draft</button>
+                    </div>
+
                     <!-- Mode Switcher (always visible) -->
                     <div id="portalModeSwitcherContainer" class="form-group">
                         <partial name="../../Shared/Components/_ModeSwitcher" model="Model.ModeSwitcher" />

--- a/src/DiscordBot.Bot/wwwroot/css/portal.css
+++ b/src/DiscordBot.Bot/wwwroot/css/portal.css
@@ -507,6 +507,59 @@ html.portal-page body {
 }
 
 /* -----------------------------------------------
+   Draft Restored Banner
+   ----------------------------------------------- */
+.draft-banner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.375rem;
+    border: 1px solid rgba(59, 130, 246, 0.3);
+    background: rgba(59, 130, 246, 0.08);
+    margin-bottom: 0.75rem;
+}
+
+.draft-banner.hidden {
+    display: none;
+}
+
+.draft-banner-content {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.draft-banner-icon {
+    width: 18px;
+    height: 18px;
+    color: var(--color-accent-blue);
+    flex-shrink: 0;
+}
+
+.draft-banner-text {
+    font-size: 0.8125rem;
+    color: var(--color-text-secondary);
+}
+
+.draft-banner-clear {
+    background: none;
+    border: 1px solid rgba(59, 130, 246, 0.3);
+    border-radius: 0.25rem;
+    padding: 0.25rem 0.625rem;
+    font-size: 0.75rem;
+    color: var(--color-accent-blue);
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background 0.15s ease;
+}
+
+.draft-banner-clear:hover {
+    background: rgba(59, 130, 246, 0.15);
+}
+
+/* -----------------------------------------------
    Toast Styles (Portal-specific)
    ----------------------------------------------- */
 .portal-toast-container {

--- a/src/DiscordBot.Bot/wwwroot/js/portal-tts.js
+++ b/src/DiscordBot.Bot/wwwroot/js/portal-tts.js
@@ -12,7 +12,8 @@
         PITCH_MIN: 0.5,
         PITCH_MAX: 2.0,
         PITCH_DEFAULT: 1.0,
-        STORAGE_KEY_VOICE: 'tts_selected_voice'  // localStorage key for voice persistence
+        STORAGE_KEY_VOICE: 'tts_selected_voice',  // localStorage key for voice persistence
+        DRAFT_DEBOUNCE_MS: 2000                    // 2-second debounce for draft auto-save
     };
 
     // ========================================
@@ -40,6 +41,8 @@
     let currentSsml = '';
     // formattedTextState removed - SSML builder parses visual markers directly from textarea
     let ssmlDebounceTimer = null;
+    let draftDebounceTimer = null;
+    let isInitializing = false;
 
     // ========================================
     // Initialization
@@ -57,9 +60,12 @@
             return;
         }
 
+        isInitializing = true;
         setupEventHandlers();
         loadSavedVoice();
         loadSavedMode();
+        loadDraft();
+        isInitializing = false;
         observeConnectionState();
     }
 
@@ -77,6 +83,7 @@
                     clearTimeout(ssmlDebounceTimer);
                     ssmlDebounceTimer = setTimeout(buildSsmlFromCurrentState, 500);
                 }
+                saveDraftDebounced();
             });
             messageInput.addEventListener('keypress', function(e) {
                 if (e.key === 'Enter' && !e.shiftKey) {
@@ -90,6 +97,19 @@
         const sendBtn = document.getElementById('sendBtn');
         if (sendBtn) {
             sendBtn.addEventListener('click', sendTtsMessage);
+        }
+
+        // Clear draft button
+        const clearDraftBtn = document.getElementById('clearDraftBtn');
+        if (clearDraftBtn) {
+            clearDraftBtn.addEventListener('click', function() {
+                const messageInput = document.getElementById('ttsMessage');
+                if (messageInput) {
+                    messageInput.value = '';
+                    updateCharacterCount();
+                }
+                clearDraft();
+            });
         }
 
         // Note: Voice channel join/leave are handled by voice-channel-panel.js
@@ -151,6 +171,97 @@
         requestAnimationFrame(() => {
             window.portalHandleModeChange(currentMode);
         });
+    }
+
+    // ========================================
+    // Draft Persistence
+    // ========================================
+    function getDraftKey() {
+        return `portal:tts:draft:${guildId}`;
+    }
+
+    function saveDraft() {
+        if (isInitializing) return;
+        try {
+            const messageInput = document.getElementById('ttsMessage');
+            const voice = window.voiceSelector_getValue ? window.voiceSelector_getValue('portalVoiceSelector') : null;
+            const draft = {
+                message: messageInput?.value || '',
+                voice: voice || '',
+                mode: currentMode,
+                timestamp: Date.now()
+            };
+            // Only save if there's actual content
+            if (draft.message || draft.voice) {
+                localStorage.setItem(getDraftKey(), JSON.stringify(draft));
+            }
+        } catch (error) {
+            // Failed to save draft
+        }
+    }
+
+    function saveDraftDebounced() {
+        clearTimeout(draftDebounceTimer);
+        draftDebounceTimer = setTimeout(saveDraft, CONFIG.DRAFT_DEBOUNCE_MS);
+    }
+
+    function loadDraft() {
+        try {
+            const raw = localStorage.getItem(getDraftKey());
+            if (!raw) return;
+
+            const draft = JSON.parse(raw);
+            if (!draft || (!draft.message && !draft.voice)) return;
+
+            // Restore message
+            const messageInput = document.getElementById('ttsMessage');
+            if (messageInput && draft.message) {
+                messageInput.value = draft.message;
+                updateCharacterCount();
+            }
+
+            // Restore voice (if saved and different from current)
+            if (draft.voice && window.voiceSelector_setValue) {
+                window.voiceSelector_setValue('portalVoiceSelector', draft.voice, true);
+            }
+
+            // Restore mode (if saved)
+            if (draft.mode && ['simple', 'standard', 'pro'].includes(draft.mode)) {
+                currentMode = draft.mode;
+                // Re-apply mode UI. Use requestAnimationFrame to ensure DOM is settled.
+                requestAnimationFrame(() => {
+                    window.portalHandleModeChange(currentMode);
+                });
+            }
+
+            // Show draft restored indicator
+            showDraftBanner();
+        } catch (error) {
+            // Failed to load draft
+        }
+    }
+
+    function clearDraft() {
+        try {
+            localStorage.removeItem(getDraftKey());
+        } catch (error) {
+            // Failed to clear draft
+        }
+        hideDraftBanner();
+    }
+
+    function showDraftBanner() {
+        const banner = document.getElementById('draftRestoredBanner');
+        if (banner) {
+            banner.classList.remove('hidden');
+        }
+    }
+
+    function hideDraftBanner() {
+        const banner = document.getElementById('draftRestoredBanner');
+        if (banner) {
+            banner.classList.add('hidden');
+        }
     }
 
     // ========================================
@@ -268,6 +379,7 @@
             }
 
             showToast('success', 'Message sent successfully');
+            clearDraft();
         } catch (error) {
             // Send error occurred
             showToast('error', error.message);
@@ -532,6 +644,10 @@
             ssmlPreview?.classList.remove('hidden');
             buildSsmlFromCurrentState();
         }
+
+        // Save mode change immediately
+        try { localStorage.setItem('tts_mode_preference', mode); } catch(e) {}
+        saveDraft();
     };
 
     /**
@@ -539,6 +655,7 @@
      */
     window.portalHandleVoiceChange = function(voiceValue) {
         saveSelectedVoice(voiceValue);
+        saveDraft();
         if (window.styleSelector_loadStyles) {
             window.styleSelector_loadStyles('portalStyleSelector', voiceValue);
         }
@@ -629,7 +746,8 @@
     // Export public API for testing/debugging
     window.PortalTTS = {
         init: init,
-        showToast: showToast
+        showToast: showToast,
+        clearDraft: clearDraft
     };
 
 })();


### PR DESCRIPTION
## Summary
- Debounce-saves TTS message text to localStorage every 2 seconds as the user types
- Immediately saves voice selection and mode changes to localStorage
- On page load, restores draft (message, voice, mode) and shows a dismissible "Draft restored" banner
- Clears draft on successful TTS send or via explicit "Clear draft" button
- localStorage key namespaced per guild: `portal:tts:draft:{guildId}`

Closes #1768

## Files Changed
- `src/DiscordBot.Bot/wwwroot/js/portal-tts.js` — Draft persistence logic (save/load/clear with debounce), init guard to prevent re-save during load
- `src/DiscordBot.Bot/Pages/Portal/TTS/Index.cshtml` — Draft restored banner HTML with accessibility attributes
- `src/DiscordBot.Bot/wwwroot/css/portal.css` — Draft banner styles (subtle blue info theme)

## Review Notes
- Code review completed: fixed critical bug (draft cleared before send succeeded → moved to after success), fixed voice-only draft silently ignored on restore, removed dead `hasDraft` flag, added `role="status"` for screen readers, added `isInitializing` guard to prevent wasteful re-save during init
- Pre-existing issue noted: `tts_mode_preference` and `tts_selected_voice` keys are not namespaced per guild (out of scope for this PR)

## Test plan
- [ ] Type a TTS message, navigate away, navigate back — verify message text is restored
- [ ] Verify "Draft restored" banner appears after navigation
- [ ] Click "Clear draft" — verify banner disappears and message field clears
- [ ] Submit TTS — verify draft is cleared and banner does not persist
- [ ] Change voice/mode, navigate away, return — verify voice and mode restored
- [ ] Send fails (disconnect from voice) — verify draft is NOT cleared (can refresh to recover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)