### PR TITLE
fix: reduce SSML preview debounce from 500ms to 250ms

### DIFF
--- a/src/DiscordBot.Bot/wwwroot/js/portal-tts.js
+++ b/src/DiscordBot.Bot/wwwroot/js/portal-tts.js
@@ -75,7 +75,7 @@
                 // Debounced SSML preview for Pro mode
                 if (currentMode === 'pro') {
                     clearTimeout(ssmlDebounceTimer);
-                    ssmlDebounceTimer = setTimeout(buildSsmlFromCurrentState, 500);
+                    ssmlDebounceTimer = setTimeout(buildSsmlFromCurrentState, 250);
                 }
             });
             messageInput.addEventListener('keypress', function(e) {


### PR DESCRIPTION
## Summary
- Reduced the SSML preview debounce delay in TTS Pro mode from 500ms to 250ms for more responsive preview updates during fast typing
- One-line change isolated to the SSML preview debounce timer — no other debounce timers affected

Closes #1772

🤖 Generated with [Claude Code](https://claude.com/claude-code)