### PR TITLE
feat: client-side upload validation for soundboard

### DIFF
--- a/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml
@@ -1416,9 +1416,11 @@ else
         // ========================================
         let selectedFile = null;
         let isUploading = false;
+        let uploadMessageSource = null; // tracks which validation set the current message
         const maxSizeBytes = @Model.MaxFileSizeMB * 1024 * 1024;
         const maxSounds = @Model.MaxSounds;
         const currentSoundCount = @Model.CurrentSoundCount;
+        const maxDurationSeconds = @Model.MaxDurationSeconds;
 
         function handleFileSelect(event) {
             const files = event.target.files;
@@ -1474,6 +1476,28 @@ else
                 return;
             }
 
+            // Check audio duration
+            const audio = new Audio();
+            const objectUrl = URL.createObjectURL(file);
+            audio.src = objectUrl;
+            audio.onloadedmetadata = function() {
+                URL.revokeObjectURL(objectUrl);
+                if (!isFinite(audio.duration) || audio.duration > maxDurationSeconds) {
+                    showUploadMessage('error', !isFinite(audio.duration)
+                        ? 'Could not determine audio duration. Please try a different file.'
+                        : `Audio too long (${Math.round(audio.duration)}s). Maximum duration is ${maxDurationSeconds} seconds.`);
+                    return;
+                }
+                // Duration is valid, proceed to show upload form
+                showFileReady(file);
+            };
+            audio.onerror = function() {
+                URL.revokeObjectURL(objectUrl);
+                showUploadMessage('error', 'Could not read audio file. The file may be corrupted.');
+            };
+        }
+
+        function showFileReady(file) {
             // Store selected file
             selectedFile = file;
 
@@ -1518,6 +1542,20 @@ else
         function updateUploadButton() {
             const btn = document.getElementById('uploadBtn');
             const name = document.getElementById('soundNameInput').value.trim();
+
+            // Check for duplicate name
+            if (name) {
+                const existingNames = Array.from(document.querySelectorAll('.sound-card[data-sound-name]'))
+                    .map(card => card.getAttribute('data-sound-name').toLowerCase());
+                if (existingNames.includes(name.toLowerCase())) {
+                    btn.disabled = true;
+                    showUploadMessage('error', `A sound named "${name}" already exists. Please choose a different name.`, 'duplicate');
+                    return;
+                } else if (uploadMessageSource === 'duplicate') {
+                    hideUploadMessage();
+                }
+            }
+
             btn.disabled = !selectedFile || !name || isUploading;
         }
 
@@ -1527,11 +1565,12 @@ else
             return (bytes / (1024 * 1024)).toFixed(2) + ' MB';
         }
 
-        function showUploadMessage(type, message) {
+        function showUploadMessage(type, message, source) {
             const container = document.getElementById('uploadMessage');
             const icon = document.getElementById('uploadMessageIcon');
             const text = document.getElementById('uploadMessageText');
 
+            uploadMessageSource = source || null;
             container.classList.remove('hidden', 'success', 'error');
             container.classList.add(type);
 
@@ -1545,6 +1584,7 @@ else
         }
 
         function hideUploadMessage() {
+            uploadMessageSource = null;
             document.getElementById('uploadMessage').classList.add('hidden');
         }
 
@@ -1554,6 +1594,14 @@ else
             const name = document.getElementById('soundNameInput').value.trim();
             if (!name) {
                 showUploadMessage('error', 'Please enter a name for the sound.');
+                return;
+            }
+
+            // Check for duplicate name
+            const existingNames = Array.from(document.querySelectorAll('.sound-card[data-sound-name]'))
+                .map(card => card.getAttribute('data-sound-name').toLowerCase());
+            if (existingNames.includes(name.toLowerCase())) {
+                showUploadMessage('error', `A sound named "${name}" already exists. Please choose a different name.`);
                 return;
             }
 


### PR DESCRIPTION
## Summary
- Adds client-side **audio duration validation** using the HTML5 Audio API (`URL.createObjectURL` + `onloadedmetadata`) — blocks files exceeding the configured max duration before upload starts
- Adds client-side **duplicate sound name check** against existing sounds in the DOM, with real-time feedback as the user types in the name input
- Handles edge cases: `Infinity` duration (streaming/malformed files), corrupted audio files (`onerror`), and uses a `source`-tracking pattern for reliable error message clearing
- Server-side validation remains unchanged as the authoritative source of truth

Closes #1770

## Test plan
- [ ] Select a file over the max file size — verify immediate error, no upload request sent
- [ ] Select an audio file over 30s — verify duration error after metadata loads, no upload request sent
- [ ] Enter a name that matches an existing sound — verify duplicate name error appears inline and upload button is disabled
- [ ] Change the name to something unique — verify the duplicate error clears and upload button re-enables
- [ ] Upload a valid file with a unique name — verify it proceeds normally
- [ ] Try a corrupted/non-audio file with an audio extension — verify error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)