### PR TITLE
fix: make error toasts persist until manually dismissed

### DIFF
--- a/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml
@@ -934,7 +934,11 @@ else
                 this.container = document.getElementById('portalToastContainer');
             },
 
-            show(type, message, duration = 5000) {
+            show(type, message, duration) {
+                // Default durations by type: success=3s, info/warning=5s, error=no auto-dismiss
+                if (duration === undefined) {
+                    duration = type === 'error' ? 0 : type === 'success' ? 3000 : 5000;
+                }
                 if (!this.container) this.init();
 
                 const toast = document.createElement('div');

--- a/src/DiscordBot.Bot/Pages/Shared/_ToastContainer.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/_ToastContainer.cshtml
@@ -4,7 +4,7 @@
 
     Usage from JavaScript:
         ToastManager.show('success', 'Your changes have been saved.');
-        ToastManager.show('error', 'Something went wrong.', { title: 'Error', duration: 10000 });
+        ToastManager.show('error', 'Something went wrong.', { title: 'Error' });
         ToastManager.show('warning', 'Rate limit approaching.');
         ToastManager.show('info', 'New features available.');
 *@
@@ -46,8 +46,7 @@
             {
                 <text>
                 ToastManager.show('error', @Html.Raw(Json.Serialize(toastError)), {
-                    title: @Html.Raw(Json.Serialize(toastErrorTitle)),
-                    duration: 10000
+                    title: @Html.Raw(Json.Serialize(toastErrorTitle))
                 });
                 </text>
             }

--- a/src/DiscordBot.Bot/wwwroot/js/command-error-handler.js
+++ b/src/DiscordBot.Bot/wwwroot/js/command-error-handler.js
@@ -223,9 +223,9 @@
    * @param {string} message - Error message to display
    * @param {Object} [options={}] - Toast options
    * @param {string} [options.title='Error'] - Toast title
-   * @param {number} [options.duration=5000] - Display duration in milliseconds
+   * @param {number} [options.duration] - Display duration in ms (defaults to no auto-dismiss for errors)
    * @example
-   * CommandErrorHandler.showErrorToast('Failed to load data', { duration: 3000 });
+   * CommandErrorHandler.showErrorToast('Failed to load data');
    */
   function showErrorToast(message, options = {}) {
     if (!checkToastManager()) {
@@ -235,8 +235,7 @@
     }
 
     const defaultOptions = {
-      title: 'Error',
-      duration: 5000
+      title: 'Error'
     };
 
     const toastOptions = { ...defaultOptions, ...options };

--- a/src/DiscordBot.Bot/wwwroot/js/dashboard-realtime.js
+++ b/src/DiscordBot.Bot/wwwroot/js/dashboard-realtime.js
@@ -198,8 +198,7 @@ const DashboardRealtime = (function() {
                     // Skip initial connection toast
                 } else {
                     ToastManager.show(config.type, config.message, {
-                        title: config.title,
-                        duration: state === 'connected' ? 3000 : 5000
+                        title: config.title
                     });
                 }
             }

--- a/src/DiscordBot.Bot/wwwroot/js/portal-tts.js
+++ b/src/DiscordBot.Bot/wwwroot/js/portal-tts.js
@@ -394,8 +394,11 @@
 
         container.appendChild(toast);
 
-        // Auto dismiss after 5 seconds
-        setTimeout(() => dismissToast(toast), 5000);
+        // Error toasts persist until manually dismissed; success=3s, info/warning=5s
+        if (type !== 'error') {
+            const delay = type === 'success' ? 3000 : 5000;
+            setTimeout(() => dismissToast(toast), delay);
+        }
     }
 
     function dismissToast(toast) {

--- a/src/DiscordBot.Bot/wwwroot/js/quick-actions.js
+++ b/src/DiscordBot.Bot/wwwroot/js/quick-actions.js
@@ -290,10 +290,15 @@
       info: '<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>'
     };
 
+    const isError = variant === 'error';
+
     toast.className = `flex items-center gap-3 px-4 py-3 rounded-lg shadow-lg transform transition-all duration-300 ${variantClasses[variant] || variantClasses.info}`;
     toast.innerHTML = `
       ${icons[variant] || icons.info}
-      <span class="text-sm font-medium">${message}</span>
+      <span class="text-sm font-medium flex-1">${message}</span>
+      ${isError ? `<button class="toast-dismiss-btn ml-2 opacity-80 hover:opacity-100 transition-opacity" aria-label="Dismiss notification">
+        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
+      </button>` : ''}
     `;
 
     // Start offscreen
@@ -310,14 +315,25 @@
       });
     });
 
-    // Remove after 3 seconds
-    setTimeout(() => {
-      toast.style.transform = 'translateX(100%)';
-      toast.style.opacity = '0';
+    // Error toasts persist until manually dismissed
+    if (isError) {
+      const dismissBtn = toast.querySelector('.toast-dismiss-btn');
+      dismissBtn.addEventListener('click', () => {
+        toast.style.transform = 'translateX(100%)';
+        toast.style.opacity = '0';
+        setTimeout(() => toast.remove(), 300);
+      });
+    } else {
+      // Success/info/warning: auto-dismiss (success=3s, info=5s, warning=5s)
+      const delay = variant === 'success' ? 3000 : 5000;
       setTimeout(() => {
-        toast.remove();
-      }, 300);
-    }, 3000);
+        toast.style.transform = 'translateX(100%)';
+        toast.style.opacity = '0';
+        setTimeout(() => {
+          toast.remove();
+        }, 300);
+      }, delay);
+    }
   }
 
   // ============================================

--- a/src/DiscordBot.Bot/wwwroot/js/toast.js
+++ b/src/DiscordBot.Bot/wwwroot/js/toast.js
@@ -31,7 +31,7 @@ const ToastManager = {
    * @param {string} message - The message to display
    * @param {object} options - Optional configuration
    * @param {string} options.title - Optional title
-   * @param {number} options.duration - Auto-dismiss duration in ms (default: 5000)
+   * @param {number} options.duration - Auto-dismiss duration in ms (default: 3000 for success, 5000 for info/warning, 0/no auto-dismiss for error)
    * @param {object} options.action - Optional action button { label: string, onClick: function }
    */
   show(type, message, options = {}) {
@@ -39,9 +39,11 @@ const ToastManager = {
       this.init();
     }
 
+    // Default durations by type: success=3s, info=5s, error=no auto-dismiss
+    const defaultDuration = type === 'error' ? 0 : type === 'success' ? 3000 : 5000;
     const {
       title = null,
-      duration = 5000,
+      duration = defaultDuration,
       action = null
     } = options;
 
@@ -98,6 +100,8 @@ const ToastManager = {
     toast.setAttribute('role', 'alert');
     toast.setAttribute('aria-live', 'polite');
 
+    const autoDismiss = duration > 0;
+
     // Build content HTML
     let contentHTML = '';
     if (title) {
@@ -134,7 +138,7 @@ const ToastManager = {
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
         </svg>
       </button>
-      <div class="toast-progress animating" style="animation-duration: ${duration}ms;"></div>
+      ${autoDismiss ? `<div class="toast-progress animating" style="animation-duration: ${duration}ms;"></div>` : ''}
     `;
 
     // Store timer reference
@@ -145,35 +149,37 @@ const ToastManager = {
       startTime: Date.now()
     };
 
-    // Set up auto-dismiss
-    toastData.timeoutId = setTimeout(() => {
-      this.dismissToast(toastData);
-    }, duration);
-
-    // Pause on hover
-    toast.addEventListener('mouseenter', () => {
-      const elapsed = Date.now() - toastData.startTime;
-      toastData.remainingTime = Math.max(0, toastData.remainingTime - elapsed);
-
-      clearTimeout(toastData.timeoutId);
-
-      const progressBar = toast.querySelector('.toast-progress');
-      if (progressBar) {
-        progressBar.classList.add('paused');
-      }
-    });
-
-    toast.addEventListener('mouseleave', () => {
-      toastData.startTime = Date.now();
+    // Set up auto-dismiss (only for non-persistent toasts)
+    if (autoDismiss) {
       toastData.timeoutId = setTimeout(() => {
         this.dismissToast(toastData);
-      }, toastData.remainingTime);
+      }, duration);
 
-      const progressBar = toast.querySelector('.toast-progress');
-      if (progressBar) {
-        progressBar.classList.remove('paused');
-      }
-    });
+      // Pause on hover
+      toast.addEventListener('mouseenter', () => {
+        const elapsed = Date.now() - toastData.startTime;
+        toastData.remainingTime = Math.max(0, toastData.remainingTime - elapsed);
+
+        clearTimeout(toastData.timeoutId);
+
+        const progressBar = toast.querySelector('.toast-progress');
+        if (progressBar) {
+          progressBar.classList.add('paused');
+        }
+      });
+
+      toast.addEventListener('mouseleave', () => {
+        toastData.startTime = Date.now();
+        toastData.timeoutId = setTimeout(() => {
+          this.dismissToast(toastData);
+        }, toastData.remainingTime);
+
+        const progressBar = toast.querySelector('.toast-progress');
+        if (progressBar) {
+          progressBar.classList.remove('paused');
+        }
+      });
+    }
 
     // Close button handler
     const closeBtn = toast.querySelector('.toast-close');


### PR DESCRIPTION
## Summary
- Error toasts no longer auto-dismiss — they persist until the user clicks the close (x) button
- Success toasts auto-dismiss after 3 seconds
- Info/warning toasts auto-dismiss after 5 seconds
- Applied consistently across all 4 toast implementations: `ToastManager` (dashboard), `quick-actions.js` (settings/moderation), `portal-tts.js` (TTS portal), and inline `PortalToast` (Soundboard portal)
- Removed explicit duration overrides on error toasts in `dashboard-realtime.js`, `command-error-handler.js`, and `_ToastContainer.cshtml` so they pick up the new type-based defaults
- Error toasts in `ToastManager` skip the progress bar and hover-pause listeners (not needed when persistent)

## Test plan
- [ ] Trigger a success toast — verify it disappears after ~3s
- [ ] Trigger an info toast — verify it disappears after ~5s
- [ ] Trigger an error toast — verify it stays visible until the close button is clicked
- [ ] Test on Soundboard, TTS, and dashboard pages
- [ ] Verify the dashboard "Disconnected" error toast persists until dismissed

Closes #1771

🤖 Generated with [Claude Code](https://claude.com/claude-code)