### PR TITLE
feat: add word gap slider with named presets to VOX page

### DIFF
--- a/src/DiscordBot.Bot/Pages/Portal/VOX/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Portal/VOX/Index.cshtml
@@ -93,6 +93,7 @@
         /* Prevent composer sections from growing */
         .vox-message-section,
         .vox-token-preview,
+        .vox-word-gap-section,
         .vox-play-section {
             flex-shrink: 0;
         }
@@ -324,6 +325,141 @@
             border-radius: 50%;
             vertical-align: middle;
             animation: spin 0.6s linear infinite;
+        }
+
+        /* Word Gap Slider */
+        .vox-word-gap-section {
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+            padding: 0.75rem 1rem;
+            background-color: var(--color-bg-secondary);
+            border-radius: 0.375rem;
+            border: 1px solid var(--color-border-primary);
+        }
+
+        .vox-word-gap-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+        }
+
+        .vox-word-gap-label {
+            font-size: 0.8rem;
+            font-weight: 600;
+            color: var(--color-text-secondary);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+
+        .vox-word-gap-value {
+            font-size: 0.8rem;
+            font-weight: 600;
+            font-variant-numeric: tabular-nums;
+            color: var(--color-accent-orange);
+            min-width: 45px;
+            text-align: right;
+        }
+
+        .vox-word-gap-controls {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+        }
+
+        .vox-word-gap-slider {
+            flex: 1;
+            appearance: none;
+            -webkit-appearance: none;
+            height: 6px;
+            border-radius: 3px;
+            background: var(--color-bg-tertiary);
+            outline: none;
+            cursor: pointer;
+        }
+
+        .vox-word-gap-slider:focus-visible {
+            outline: 2px solid var(--color-accent-orange);
+            outline-offset: 2px;
+        }
+
+        .vox-word-gap-slider::-webkit-slider-thumb {
+            appearance: none;
+            -webkit-appearance: none;
+            width: 18px;
+            height: 18px;
+            border-radius: 50%;
+            background-color: var(--color-accent-orange);
+            cursor: pointer;
+            transition: var(--transition-fast);
+            box-shadow: var(--shadow-sm);
+        }
+
+        .vox-word-gap-slider::-webkit-slider-thumb:hover {
+            background-color: var(--color-accent-orange-hover);
+            transform: scale(1.1);
+        }
+
+        .vox-word-gap-slider::-webkit-slider-thumb:active {
+            transform: scale(1.2);
+        }
+
+        .vox-word-gap-slider::-moz-range-thumb {
+            width: 18px;
+            height: 18px;
+            border-radius: 50%;
+            background-color: var(--color-accent-orange);
+            border: none;
+            cursor: pointer;
+            transition: var(--transition-fast);
+        }
+
+        .vox-word-gap-slider::-moz-range-thumb:hover {
+            background-color: var(--color-accent-orange-hover);
+            transform: scale(1.1);
+        }
+
+        .vox-word-gap-slider::-moz-range-thumb:active {
+            transform: scale(1.2);
+        }
+
+        .vox-word-gap-slider::-moz-range-track {
+            background: transparent;
+            border: none;
+        }
+
+        .vox-word-gap-presets {
+            display: flex;
+            gap: 0.375rem;
+        }
+
+        .vox-word-gap-preset {
+            padding: 0.2rem 0.6rem;
+            font-size: 0.7rem;
+            font-weight: 500;
+            border: 1px solid var(--color-border-primary);
+            border-radius: 9999px;
+            background-color: transparent;
+            color: var(--color-text-secondary);
+            cursor: pointer;
+            transition: var(--transition-fast);
+            white-space: nowrap;
+        }
+
+        .vox-word-gap-preset:hover {
+            border-color: var(--color-accent-orange);
+            color: var(--color-accent-orange);
+        }
+
+        .vox-word-gap-preset:focus-visible {
+            outline: 2px solid var(--color-accent-orange);
+            outline-offset: 2px;
+        }
+
+        .vox-word-gap-preset.active {
+            background-color: var(--color-accent-orange);
+            border-color: var(--color-accent-orange);
+            color: white;
         }
 
         /* Clip Browser */
@@ -659,9 +795,20 @@
             .vox-autocomplete-item,
             .vox-play-btn,
             .vox-az-letter,
-            .vox-section-header {
+            .vox-section-header,
+            .vox-word-gap-preset {
                 transition: none;
                 animation: none;
+            }
+
+            .vox-word-gap-slider::-webkit-slider-thumb,
+            .vox-word-gap-slider::-moz-range-thumb {
+                transition: none;
+            }
+
+            .vox-word-gap-slider::-webkit-slider-thumb:hover,
+            .vox-word-gap-slider::-moz-range-thumb:hover {
+                transform: none;
             }
 
             .vox-scroll-letter {
@@ -771,6 +918,9 @@
             // Load clips for initial group
             loadClipsForGroup('vox');
 
+            // Initialize word gap slider
+            initWordGapSlider();
+
             // Listen for tab switches (nav-tabs.js dispatches 'navtabchange')
             document.addEventListener('navtabchange', (e) => {
                 if (e.detail.containerId === 'voxGroupTabs') {
@@ -790,6 +940,39 @@
                 }
             });
         });
+
+        function initWordGapSlider() {
+            // Word gap is global across all tab groups, so we sync all sliders
+            const sliders = document.querySelectorAll('.vox-word-gap-slider');
+            const valueDisplays = document.querySelectorAll('.vox-word-gap-value');
+            const presetButtons = document.querySelectorAll('.vox-word-gap-preset');
+
+            function updateActivePreset(value) {
+                presetButtons.forEach(btn => {
+                    btn.classList.toggle('active', parseInt(btn.dataset.gap) === value);
+                });
+            }
+
+            function syncAllSliders(value) {
+                voxState.wordGapMs = value;
+                sliders.forEach(s => s.value = value);
+                valueDisplays.forEach(d => d.textContent = `${value}ms`);
+                updateActivePreset(value);
+                updateTokenPreview();
+            }
+
+            sliders.forEach(slider => {
+                slider.addEventListener('input', (e) => {
+                    syncAllSliders(parseInt(e.target.value));
+                });
+            });
+
+            presetButtons.forEach(btn => {
+                btn.addEventListener('click', () => {
+                    syncAllSliders(parseInt(btn.dataset.gap));
+                });
+            });
+        }
 
         function initializeVoxElements(group) {
             const prefix = `vox-${group}`;
@@ -1632,6 +1815,29 @@ else
                                 <span class="vox-token-empty">No words</span>
                             </div>
                             <div class="vox-preview-stats" id="@(prefix)-preview-stats"></div>
+                        </div>
+                    </div>
+
+                    <!-- Word Gap Slider -->
+                    <div class="vox-word-gap-section">
+                        <div class="vox-word-gap-header">
+                            <span class="vox-word-gap-label">Word Gap</span>
+                            <span class="vox-word-gap-value" id="@(prefix)-word-gap-value">50ms</span>
+                        </div>
+                        <div class="vox-word-gap-controls">
+                            <input type="range"
+                                   id="@(prefix)-word-gap-slider"
+                                   class="vox-word-gap-slider"
+                                   min="20"
+                                   max="200"
+                                   step="10"
+                                   value="50"
+                                   aria-label="@groupName word gap in milliseconds" />
+                            <div class="vox-word-gap-presets">
+                                <button type="button" class="vox-word-gap-preset" data-gap="20">Fast</button>
+                                <button type="button" class="vox-word-gap-preset active" data-gap="50">Normal</button>
+                                <button type="button" class="vox-word-gap-preset" data-gap="150">Dramatic</button>
+                            </div>
                         </div>
                     </div>
 


### PR DESCRIPTION
## Summary
- Added a range input slider (20–200ms, step 10) to the VOX page for controlling the word gap between clips
- Included three named preset buttons: **Fast** (20ms), **Normal** (50ms), **Dramatic** (150ms)
- Slider value syncs across all group tabs (VOX/FVOX/HGrunt) and updates the token preview duration estimate in real-time
- No backend changes needed — the API already accepts `wordGapMs`

Closes #1763

## Test plan
- [ ] Set slider to 150ms, play a VOX message — verify audible pause between words is longer than default
- [ ] Click each preset button and verify slider position and displayed value update correctly
- [ ] Verify value persists within page session across tab switches (VOX → FVOX → back)
- [ ] Verify default is 50ms (Normal preset highlighted) on page load
- [ ] Test keyboard accessibility: Tab to slider, use arrow keys to adjust
- [ ] Verify preset buttons and slider show focus rings on keyboard navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)