### PR TITLE
fix: execute alerts DB queries sequentially to avoid DbContext thread-safety issues

### DIFF
--- a/src/DiscordBot.Bot/Controllers/PerformanceTabsController.cs
+++ b/src/DiscordBot.Bot/Controllers/PerformanceTabsController.cs
@@ -477,31 +477,24 @@ public class PerformanceTabsController : Controller
 
     private async Task<AlertsPageViewModel> BuildAlertsViewModelAsync(CancellationToken cancellationToken)
     {
-        var activeIncidentsTask = _alertService.GetActiveIncidentsAsync(cancellationToken);
-        var alertConfigsTask = _alertService.GetAllConfigsAsync(cancellationToken);
-        var recentIncidentsTask = _alertService.GetIncidentHistoryAsync(
+        // Execute sequentially — DbContext is not thread-safe
+        var activeIncidents = await _alertService.GetActiveIncidentsAsync(cancellationToken);
+        var alertConfigs = await _alertService.GetAllConfigsAsync(cancellationToken);
+        var recentIncidents = await _alertService.GetIncidentHistoryAsync(
             new IncidentQueryDto { PageNumber = 1, PageSize = 10 },
             cancellationToken);
-        var autoRecoveryEventsTask = _alertService.GetAutoRecoveryEventsAsync(10, cancellationToken);
-        var alertFrequencyTask = _alertService.GetAlertFrequencyDataAsync(30, cancellationToken);
-        var summaryTask = _alertService.GetActiveAlertSummaryAsync(cancellationToken);
-
-        await Task.WhenAll(
-            activeIncidentsTask,
-            alertConfigsTask,
-            recentIncidentsTask,
-            autoRecoveryEventsTask,
-            alertFrequencyTask,
-            summaryTask);
+        var autoRecoveryEvents = await _alertService.GetAutoRecoveryEventsAsync(10, cancellationToken);
+        var alertFrequency = await _alertService.GetAlertFrequencyDataAsync(30, cancellationToken);
+        var alertSummary = await _alertService.GetActiveAlertSummaryAsync(cancellationToken);
 
         return new AlertsPageViewModel
         {
-            ActiveIncidents = activeIncidentsTask.Result,
-            AlertConfigs = alertConfigsTask.Result,
-            RecentIncidents = recentIncidentsTask.Result.Items,
-            AutoRecoveryEvents = autoRecoveryEventsTask.Result,
-            AlertFrequencyData = alertFrequencyTask.Result,
-            AlertSummary = summaryTask.Result
+            ActiveIncidents = activeIncidents,
+            AlertConfigs = alertConfigs,
+            RecentIncidents = recentIncidents.Items,
+            AutoRecoveryEvents = autoRecoveryEvents,
+            AlertFrequencyData = alertFrequency,
+            AlertSummary = alertSummary
         };
     }
 

--- a/src/DiscordBot.Bot/Pages/Admin/Performance/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Admin/Performance/Index.cshtml.cs
@@ -580,30 +580,23 @@ public class IndexModel : PageModel
             var authResult = await _authorizationService.AuthorizeAsync(User, "RequireAdmin");
             var canEdit = authResult.Succeeded;
 
-            var activeIncidentsTask = _alertService.GetActiveIncidentsAsync();
-            var alertConfigsTask = _alertService.GetAllConfigsAsync();
-            var recentIncidentsTask = _alertService.GetIncidentHistoryAsync(
+            // Execute sequentially — DbContext is not thread-safe
+            var activeIncidents = await _alertService.GetActiveIncidentsAsync();
+            var alertConfigs = await _alertService.GetAllConfigsAsync();
+            var recentIncidents = await _alertService.GetIncidentHistoryAsync(
                 new IncidentQueryDto { PageNumber = 1, PageSize = 10 });
-            var autoRecoveryEventsTask = _alertService.GetAutoRecoveryEventsAsync(10);
-            var alertFrequencyTask = _alertService.GetAlertFrequencyDataAsync(30);
-            var summaryTask = _alertService.GetActiveAlertSummaryAsync();
-
-            await Task.WhenAll(
-                activeIncidentsTask,
-                alertConfigsTask,
-                recentIncidentsTask,
-                autoRecoveryEventsTask,
-                alertFrequencyTask,
-                summaryTask);
+            var autoRecoveryEvents = await _alertService.GetAutoRecoveryEventsAsync(10);
+            var alertFrequency = await _alertService.GetAlertFrequencyDataAsync(30);
+            var alertSummary = await _alertService.GetActiveAlertSummaryAsync();
 
             return new AlertsPageViewModel
             {
-                ActiveIncidents = activeIncidentsTask.Result,
-                AlertConfigs = alertConfigsTask.Result,
-                RecentIncidents = recentIncidentsTask.Result.Items,
-                AutoRecoveryEvents = autoRecoveryEventsTask.Result,
-                AlertFrequencyData = alertFrequencyTask.Result,
-                AlertSummary = summaryTask.Result,
+                ActiveIncidents = activeIncidents,
+                AlertConfigs = alertConfigs,
+                RecentIncidents = recentIncidents.Items,
+                AutoRecoveryEvents = autoRecoveryEvents,
+                AlertFrequencyData = alertFrequency,
+                AlertSummary = alertSummary,
                 CanEdit = canEdit
             };
         }


### PR DESCRIPTION
## Summary
- Fixed two code paths (`PerformanceTabsController.BuildAlertsViewModelAsync` and `Index.cshtml.cs.BuildAlertsPageViewModelAsync`) that ran 6 alert service DB queries in parallel via `Task.WhenAll` using a shared scoped `DbContext`
- `DbContext` is not thread-safe — parallel access caused intermittent `InvalidOperationException`, which was silently caught and returned an empty `AlertsPageViewModel`, making the Alerts page appear unpopulated
- The standalone `Alerts.cshtml.cs` page model was already fixed (sequential execution), but these two other code paths were missed

## Test plan
- [ ] Navigate to `/Admin/Performance` and click the Alerts tab — verify alert configs, incidents, and chart populate correctly
- [ ] Navigate to `/Admin/Performance/Alerts` (standalone page) — verify it still works as before
- [ ] Verify no errors in logs related to DbContext concurrent access

🤖 Generated with [Claude Code](https://claude.com/claude-code)