### PR TITLE
fix: correct claim name in soundboard favorites endpoints

### DIFF
--- a/src/DiscordBot.Bot/Controllers/PortalSoundboardController.cs
+++ b/src/DiscordBot.Bot/Controllers/PortalSoundboardController.cs
@@ -237,7 +237,7 @@ public class PortalSoundboardController : ControllerBase
         var queueEnabled = audioSettings?.QueueEnabled ?? false;
 
         // Get user ID from claims (default to 0 if not found, which indicates portal/API play)
-        var userIdClaim = User.FindFirst("discord_id")?.Value;
+        var userIdClaim = User.FindFirst("discord:user_id")?.Value;
         var userId = userIdClaim != null && ulong.TryParse(userIdClaim, out var parsed) ? parsed : 0UL;
 
         // Enrich APM transaction for Kibana visibility
@@ -518,7 +518,7 @@ public class PortalSoundboardController : ControllerBase
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> GetFavorites(ulong guildId, CancellationToken cancellationToken)
     {
-        var userIdClaim = User.FindFirst("discord_id")?.Value;
+        var userIdClaim = User.FindFirst("discord:user_id")?.Value;
         if (userIdClaim == null || !ulong.TryParse(userIdClaim, out var userId))
             return Unauthorized();
 
@@ -543,7 +543,7 @@ public class PortalSoundboardController : ControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> AddFavorite(ulong guildId, Guid soundId, CancellationToken cancellationToken)
     {
-        var userIdClaim = User.FindFirst("discord_id")?.Value;
+        var userIdClaim = User.FindFirst("discord:user_id")?.Value;
         if (userIdClaim == null || !ulong.TryParse(userIdClaim, out var userId))
             return Unauthorized();
 
@@ -593,7 +593,7 @@ public class PortalSoundboardController : ControllerBase
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> RemoveFavorite(ulong guildId, Guid soundId, CancellationToken cancellationToken)
     {
-        var userIdClaim = User.FindFirst("discord_id")?.Value;
+        var userIdClaim = User.FindFirst("discord:user_id")?.Value;
         if (userIdClaim == null || !ulong.TryParse(userIdClaim, out var userId))
             return Unauthorized();
 


### PR DESCRIPTION
## Summary

- Fixed claim name mismatch in `PortalSoundboardController.cs` — `"discord_id"` → `"discord:user_id"` (4 occurrences)
- The controller looked up a claim that doesn't exist, causing all favorites endpoints (`GET`, `POST`, `DELETE`) and the play endpoint's user ID lookup to always fail with 401

## Details

`DiscordClaimsTransformation.cs` registers the Discord user ID under the claim type `"discord:user_id"`, but `PortalSoundboardController` was looking for `"discord_id"`. The mismatch meant `FindFirst()` always returned `null`, triggering the `Unauthorized()` fallback.

Verified no other controllers use the incorrect claim name.

Closes #1828

## Test plan

- [ ] Log in to portal and navigate to a guild's soundboard page
- [ ] Click the favorite (heart) button on a sound — should return 201, not 401
- [ ] Verify favorites list loads on page refresh
- [ ] Remove a favorite — should return 200, not 401
- [ ] Play a sound — user ID should be correctly resolved (non-zero) in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)