### PR TITLE
fix: send PlaybackFinished event on stop so now-playing UI clears

### DIFF
--- a/src/DiscordBot.Bot/Services/PlaybackService.cs
+++ b/src/DiscordBot.Bot/Services/PlaybackService.cs
@@ -191,6 +191,19 @@ public class PlaybackService : IPlaybackService
                 {
                     _logger.LogInformation("Stopping playback and clearing queue in guild {GuildId}", guildId);
                     state.CancellationTokenSource?.Cancel();
+
+                    // Notify clients that playback has finished so now-playing UI clears.
+                    // Natural completion notifications are handled in PlaySoundAsync;
+                    // StopAsync owns the cancellation-path notification.
+                    if (state.CurrentSound != null)
+                    {
+                        _ = _audioNotifier.NotifyPlaybackFinishedAsync(
+                            guildId, state.CurrentSound.Id, wasCancelled: true, CancellationToken.None);
+                    }
+                    else
+                    {
+                        _logger.LogWarning("StopAsync: IsPlaying=true but CurrentSound is null for guild {GuildId}; PlaybackFinished not sent", guildId);
+                    }
                 }
 
                 state.Queue.Clear();
@@ -525,8 +538,12 @@ public class PlaybackService : IPlaybackService
                 wasCancelled = cancelled;
             }
 
-            // Broadcast PlaybackFinished event
-            _ = _audioNotifier.NotifyPlaybackFinishedAsync(guildId, sound.Id, wasCancelled, CancellationToken.None);
+            // Broadcast PlaybackFinished event for natural completion only.
+            // Cancellation-path notifications are handled by StopAsync to avoid double-fire.
+            if (!wasCancelled)
+            {
+                _ = _audioNotifier.NotifyPlaybackFinishedAsync(guildId, sound.Id, wasCancelled: false, CancellationToken.None);
+            }
 
             if (!success && !wasCancelled)
             {


### PR DESCRIPTION
## Summary

- **Bug:** Clicking Stop in the soundboard portal left the now-playing component frozen because `StopAsync()` never sent a `PlaybackFinished` SignalR event
- **Root cause:** The cancellation path in `StreamFromCacheAsync`/`StreamFromFfmpegAsync` throws `OperationCanceledException`, which bypasses the `NotifyPlaybackFinishedAsync` call in `PlaySoundAsync`
- **Fix:** Added `NotifyPlaybackFinishedAsync` call in `StopAsync()` for the cancellation path, and gated the existing call in `PlaySoundAsync` on `!wasCancelled` to prevent double-fire

Closes #1826

## Test plan

- [ ] Open soundboard portal, play a sound, click Stop — now-playing component should clear
- [ ] Stop via API (`/api/guilds/{guildId}/audio/stop`) — now-playing should also clear
- [ ] Let a sound play to natural completion — now-playing should clear as before (no regression)
- [ ] Play multiple sounds in queue, click Stop — queue and now-playing both clear
- [ ] Rapid double-click Stop — no errors, no duplicate events in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)