### PR TITLE
fix: hide scrollbar and search bar in fullscreen, increase grid density

### DIFF
--- a/src/DiscordBot.Bot/wwwroot/css/portal.css
+++ b/src/DiscordBot.Bot/wwwroot/css/portal.css
@@ -786,6 +786,16 @@ body.portal-fullscreen .sound-grid-wrapper {
 
 body.portal-fullscreen .sound-grid {
     padding: 1rem;
+    scrollbar-width: none;           /* Firefox */
+    -ms-overflow-style: none;        /* IE/Edge */
+}
+
+body.portal-fullscreen .sound-grid::-webkit-scrollbar {
+    display: none;                   /* Chrome/Safari/Edge */
+}
+
+body.portal-fullscreen .search-container {
+    display: none;
 }
 
 /* Override mobile breakpoint scroll behavior when fullscreen is active.
@@ -873,7 +883,7 @@ body:not(.portal-fullscreen) .fullscreen-toolbar {
 
 @media (min-width: 1024px) {
     body.portal-fullscreen .sound-grid {
-        grid-template-columns: repeat(5, 1fr);
+        grid-template-columns: repeat(7, 1fr);
     }
 }
 


### PR DESCRIPTION
## Summary
- **Hide scrollbar** in fullscreen mode on the sound grid using cross-browser CSS (`scrollbar-width: none`, `-ms-overflow-style: none`, `::-webkit-scrollbar { display: none }`) — scrolling still works via mouse wheel/touch
- **Hide main search bar** in fullscreen mode (the floating toolbar already provides its own search input)
- **Increase grid density** from 5 to 7 columns on desktop (≥1024px) in fullscreen mode

Closes #1833

## Test plan
- [ ] Enter fullscreen on the Soundboard page — verify no visible scrollbar on the grid or body
- [ ] Verify scrolling still works via mouse wheel/touch in fullscreen
- [ ] Verify the main search bar row is hidden in fullscreen
- [ ] Verify the floating toolbar search still works
- [ ] Count grid columns on desktop — should be 7 in fullscreen
- [ ] Exit fullscreen — verify scrollbar and search bar return, grid reverts to normal layout
- [ ] Test on Firefox (scrollbar-width) and Chrome/Edge (webkit-scrollbar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)