### PR TITLE
fix: wire TTS playback to Now Playing UI via SignalR events

### DIFF
--- a/src/DiscordBot.Bot/Pages/Shared/Components/_VoiceChannelPanel.cshtml
+++ b/src/DiscordBot.Bot/Pages/Shared/Components/_VoiceChannelPanel.cshtml
@@ -209,7 +209,7 @@
             </button>
         </div>
         <div class="flex items-center gap-3">
-            <div class="w-10 h-10 bg-accent-blue/20 rounded-lg flex items-center justify-center text-accent-blue flex-shrink-0">
+            <div class="w-10 h-10 bg-accent-blue/20 rounded-lg flex items-center justify-center text-accent-blue flex-shrink-0 now-playing-icon">
                 <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
                     <path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z"/>
                 </svg>

--- a/src/DiscordBot.Bot/Services/AudioNotifier.cs
+++ b/src/DiscordBot.Bot/Services/AudioNotifier.cs
@@ -123,6 +123,7 @@ public class AudioNotifier : IAudioNotifier
         string name,
         double durationSeconds,
         string? requestedByDisplayName = null,
+        string? source = null,
         CancellationToken cancellationToken = default)
     {
         var groupName = DashboardHub.GetGuildAudioGroupName(guildId);
@@ -133,6 +134,7 @@ public class AudioNotifier : IAudioNotifier
             Name = name,
             DurationSeconds = durationSeconds,
             RequestedByDisplayName = requestedByDisplayName,
+            Source = source,
             Timestamp = DateTime.UtcNow
         };
 

--- a/src/DiscordBot.Bot/Services/PlaybackService.cs
+++ b/src/DiscordBot.Bot/Services/PlaybackService.cs
@@ -495,7 +495,7 @@ public class PlaybackService : IPlaybackService
             _audioService.UpdateLastActivity(guildId);
 
             // Broadcast PlaybackStarted event
-            _ = _audioNotifier.NotifyPlaybackStartedAsync(guildId, sound.Id, sound.Name, durationSeconds, requestedByDisplayName, cancellationToken);
+            _ = _audioNotifier.NotifyPlaybackStartedAsync(guildId, sound.Id, sound.Name, durationSeconds, requestedByDisplayName, cancellationToken: cancellationToken);
 
             // Determine FFmpeg executable path - handle null or empty string
             // If not configured, look for ffmpeg in the application's base directory first, then fall back to PATH

--- a/src/DiscordBot.Bot/Services/Tts/TtsPlaybackService.cs
+++ b/src/DiscordBot.Bot/Services/Tts/TtsPlaybackService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using DiscordBot.Bot.Interfaces;
 using DiscordBot.Bot.Tracing;
 using DiscordBot.Core.DTOs.Tts;
@@ -13,6 +14,7 @@ namespace DiscordBot.Bot.Services.Tts;
 public class TtsPlaybackService : ITtsPlaybackService
 {
     private readonly IAudioService _audioService;
+    private readonly IAudioNotifier _audioNotifier;
     private readonly ITtsHistoryService _ttsHistoryService;
     private readonly ILogger<TtsPlaybackService> _logger;
 
@@ -20,14 +22,17 @@ public class TtsPlaybackService : ITtsPlaybackService
     /// Initializes a new instance of the <see cref="TtsPlaybackService"/> class.
     /// </summary>
     /// <param name="audioService">The audio service for voice connections.</param>
+    /// <param name="audioNotifier">The audio notifier for Now Playing UI updates.</param>
     /// <param name="ttsHistoryService">The TTS history service for logging messages.</param>
     /// <param name="logger">The logger.</param>
     public TtsPlaybackService(
         IAudioService audioService,
+        IAudioNotifier audioNotifier,
         ITtsHistoryService ttsHistoryService,
         ILogger<TtsPlaybackService> logger)
     {
         _audioService = audioService;
+        _audioNotifier = audioNotifier;
         _ttsHistoryService = ttsHistoryService;
         _logger = logger;
     }
@@ -71,6 +76,15 @@ public class TtsPlaybackService : ITtsPlaybackService
             };
         }
 
+        // Generate playback ID and display name for Now Playing UI
+        var playbackId = Guid.NewGuid();
+        var displayName = message.Length > 60 ? message[..57] + "..." : message;
+
+        // Notify Now Playing UI (use CancellationToken.None — this is a UI side-effect, not part of the cancellable operation)
+        _ = _audioNotifier.NotifyPlaybackStartedAsync(
+            guildId, playbackId, displayName, durationSeconds,
+            requestedByDisplayName: username, source: "TTS", cancellationToken: CancellationToken.None);
+
         // Stream the audio to Discord
         try
         {
@@ -83,6 +97,8 @@ public class TtsPlaybackService : ITtsPlaybackService
             try
             {
                 var bytesWritten = 0L;
+                var totalBytes = audioStream.Length;
+                var lastProgressTime = Stopwatch.GetTimestamp();
                 var buffer = new byte[3840]; // 20ms at 48kHz stereo 16-bit
                 int bytesRead;
 
@@ -90,9 +106,21 @@ public class TtsPlaybackService : ITtsPlaybackService
                 {
                     await pcmStream.WriteAsync(buffer, 0, bytesRead, cancellationToken);
                     bytesWritten += bytesRead;
+
+                    // Send progress updates every ~1 second
+                    var now = Stopwatch.GetTimestamp();
+                    if (Stopwatch.GetElapsedTime(lastProgressTime, now).TotalSeconds >= 1.0)
+                    {
+                        var positionSeconds = (double)bytesWritten / totalBytes * durationSeconds;
+                        _ = _audioNotifier.NotifyPlaybackProgressAsync(guildId, playbackId, positionSeconds, durationSeconds, cancellationToken);
+                        lastProgressTime = now;
+                    }
                 }
 
                 await pcmStream.FlushAsync(cancellationToken);
+
+                // Notify playback finished
+                _ = _audioNotifier.NotifyPlaybackFinishedAsync(guildId, playbackId, wasCancelled: false, CancellationToken.None);
 
                 // Record streaming metrics
                 BotActivitySource.RecordAudioStreamMetrics(
@@ -110,11 +138,13 @@ public class TtsPlaybackService : ITtsPlaybackService
             }
             catch (OperationCanceledException)
             {
+                _ = _audioNotifier.NotifyPlaybackFinishedAsync(guildId, playbackId, wasCancelled: true, CancellationToken.None);
                 _logger.LogInformation("TTS audio streaming cancelled for guild {GuildId}", guildId);
                 throw; // Let the caller decide how to handle cancellation
             }
             catch (Exception ex)
             {
+                _ = _audioNotifier.NotifyPlaybackFinishedAsync(guildId, playbackId, wasCancelled: false, CancellationToken.None);
                 _logger.LogError(ex, "Failed to stream TTS audio for guild {GuildId}", guildId);
                 streamScope.RecordException(ex);
                 throw;
@@ -126,7 +156,6 @@ public class TtsPlaybackService : ITtsPlaybackService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to stream TTS audio for guild {GuildId}", guildId);
             playScope.RecordException(ex);
             return new TtsPlaybackResult
             {

--- a/src/DiscordBot.Bot/wwwroot/js/voice-channel-panel.js
+++ b/src/DiscordBot.Bot/wwwroot/js/voice-channel-panel.js
@@ -396,7 +396,8 @@ const VoiceChannelPanel = (function() {
             name: data.name,
             durationSeconds: data.durationSeconds,
             positionSeconds: 0,
-            requestedByDisplayName: data.requestedByDisplayName
+            requestedByDisplayName: data.requestedByDisplayName,
+            source: data.source || 'Soundboard'
         });
     }
 
@@ -491,6 +492,18 @@ const VoiceChannelPanel = (function() {
             if (nowPlayingName) {
                 nowPlayingName.textContent = nowPlaying.name;
                 nowPlayingName.title = nowPlaying.name;
+            }
+
+            // Update source icon
+            var iconContainer = nowPlayingSection.querySelector('.now-playing-icon');
+            if (iconContainer) {
+                if (nowPlaying.source === 'TTS') {
+                    iconContainer.innerHTML = '<svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2z"/></svg>';
+                    iconContainer.className = 'w-10 h-10 bg-purple-500/20 rounded-lg flex items-center justify-center text-purple-400 flex-shrink-0 now-playing-icon';
+                } else {
+                    iconContainer.innerHTML = '<svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z"/></svg>';
+                    iconContainer.className = 'w-10 h-10 bg-accent-blue/20 rounded-lg flex items-center justify-center text-accent-blue flex-shrink-0 now-playing-icon';
+                }
             }
 
             if (nowPlayingRequestedBy) {

--- a/src/DiscordBot.Core/DTOs/AudioEventDtos.cs
+++ b/src/DiscordBot.Core/DTOs/AudioEventDtos.cs
@@ -123,6 +123,12 @@ public class PlaybackStartedDto
     public string? RequestedByDisplayName { get; set; }
 
     /// <summary>
+    /// Gets or sets the playback source type (e.g., "Soundboard", "TTS").
+    /// Null defaults to "Soundboard" for backwards compatibility.
+    /// </summary>
+    public string? Source { get; set; }
+
+    /// <summary>
     /// Gets or sets the timestamp when playback started.
     /// </summary>
     public DateTime Timestamp { get; set; } = DateTime.UtcNow;

--- a/src/DiscordBot.Core/Interfaces/IAudioNotifier.cs
+++ b/src/DiscordBot.Core/Interfaces/IAudioNotifier.cs
@@ -44,6 +44,7 @@ public interface IAudioNotifier
     /// <param name="name">The sound name.</param>
     /// <param name="durationSeconds">The sound duration in seconds.</param>
     /// <param name="requestedByDisplayName">The display name of the user who requested playback, or null if unknown.</param>
+    /// <param name="source">The playback source type (e.g., "Soundboard", "TTS"). Null defaults to "Soundboard".</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     Task NotifyPlaybackStartedAsync(
@@ -52,6 +53,7 @@ public interface IAudioNotifier
         string name,
         double durationSeconds,
         string? requestedByDisplayName = null,
+        string? source = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>


### PR DESCRIPTION
## Summary

- Injected `IAudioNotifier` into `TtsPlaybackService` to broadcast `PlaybackStarted`, `PlaybackProgress`, and `PlaybackFinished` SignalR events during TTS playback
- Added `Source` field to `PlaybackStartedDto` to distinguish TTS from Soundboard playback
- Updated `voice-channel-panel.js` to swap icon/color scheme based on source (purple speech bubble for TTS, blue music note for Soundboard)
- Added `now-playing-icon` CSS class to the CSHTML template for JS targeting

Closes #1838

## Test plan

- [ ] Play a TTS message and verify the Now Playing section appears with purple speech-bubble icon, truncated message text, requester name, and progress bar
- [ ] Play a soundboard sound and verify Now Playing still shows blue music note icon (no regression)
- [ ] Verify Now Playing clears when TTS playback completes
- [ ] Verify Now Playing clears when TTS playback is cancelled/stopped
- [ ] Verify progress bar updates during TTS streaming
- [ ] Test with a long TTS message (>60 chars) and verify truncation with ellipsis

🤖 Generated with [Claude Code](https://claude.com/claude-code)