### PR TITLE
feat: TTS message preview with browser playback

### DIFF
--- a/src/DiscordBot.Bot/Controllers/PortalTtsController.cs
+++ b/src/DiscordBot.Bot/Controllers/PortalTtsController.cs
@@ -280,55 +280,7 @@ public class PortalTtsController : ControllerBase
         Stream audioStream;
         try
         {
-            // If SSML is provided, use SSML synthesis directly
-            if (!string.IsNullOrWhiteSpace(request.Ssml))
-            {
-                _logger.LogDebug("Using SSML synthesis for guild {GuildId}", guildId);
-                audioStream = await _ttsService.SynthesizeSpeechAsync(request.Ssml, null, SynthesisMode.Ssml, cancellationToken);
-            }
-            // If Style is provided, use SSML builder to wrap message with style
-            else if (!string.IsNullOrWhiteSpace(request.Style))
-            {
-                _logger.LogDebug("Using style '{Style}' with intensity {Intensity} for guild {GuildId}",
-                    request.Style, request.StyleIntensity ?? 1.0m, guildId);
-
-                // Build SSML with style using the ISsmlBuilder
-                var styleIntensity = request.StyleIntensity ?? 1.0m;
-                var builder = _ssmlBuilder.Reset()
-                    .BeginDocument("en-US")
-                    .WithVoice(request.Voice)
-                    .WithStyle(request.Style, (double)styleIntensity);
-
-                // Apply prosody adjustments (speed/pitch) if different from defaults
-                if (Math.Abs(request.Speed - 1.0) > 0.01 || Math.Abs(request.Pitch - 1.0) > 0.01)
-                {
-                    builder.WithProsody(rate: request.Speed, pitch: request.Pitch);
-                    builder.AddText(request.Message);
-                    builder.EndProsody();
-                }
-                else
-                {
-                    builder.AddText(request.Message);
-                }
-
-                builder.EndStyle().EndVoice();
-                var ssml = builder.Build();
-
-                _logger.LogDebug("Built SSML with style: {SsmlLength} characters", ssml.Length);
-                audioStream = await _ttsService.SynthesizeSpeechAsync(ssml, null, SynthesisMode.Ssml, cancellationToken);
-            }
-            // Otherwise, use standard TTS synthesis
-            else
-            {
-                _logger.LogDebug("Using standard TTS synthesis for guild {GuildId}", guildId);
-                var options = new TtsOptions
-                {
-                    Voice = request.Voice,
-                    Speed = request.Speed,
-                    Pitch = request.Pitch
-                };
-                audioStream = await _ttsService.SynthesizeSpeechAsync(request.Message, options, cancellationToken);
-            }
+            audioStream = await SynthesizeFromRequestAsync(request, cancellationToken);
         }
         catch (InvalidOperationException ex)
         {
@@ -1180,6 +1132,227 @@ public class PortalTtsController : ControllerBase
         }
 
         return Ok(presets);
+    }
+
+    /// <summary>
+    /// Previews a TTS message by synthesizing speech and returning WAV audio for browser playback.
+    /// Does not require a voice channel connection and does not save to TTS history.
+    /// </summary>
+    /// <param name="guildId">The guild's Discord snowflake ID.</param>
+    /// <param name="request">The TTS request containing message and voice settings.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>WAV audio file for browser playback.</returns>
+    [HttpPost("preview")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> PreviewTts(
+        ulong guildId,
+        [FromBody] SendTtsRequest request,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Preview TTS request for guild {GuildId}, voice {Voice}", guildId, request.Voice);
+
+        // Check if audio is globally enabled at the bot level
+        if (!await IsAudioGloballyEnabledAsync())
+        {
+            _logger.LogWarning("Audio features globally disabled - rejecting PreviewTts for guild {GuildId}", guildId);
+            return BadRequest(new ApiErrorDto
+            {
+                Message = "Audio features disabled",
+                Detail = "Audio features have been disabled by an administrator.",
+                StatusCode = StatusCodes.Status400BadRequest,
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "audio_disabled"
+            });
+        }
+
+        // Check if TTS is enabled for this guild
+        var settings = await _ttsSettingsService.GetOrCreateSettingsAsync(guildId, cancellationToken);
+        if (!settings.TtsEnabled)
+        {
+            _logger.LogWarning("TTS not enabled for guild {GuildId}", guildId);
+            return BadRequest(new ApiErrorDto
+            {
+                Message = "TTS is not enabled for this guild",
+                Detail = "Contact a server administrator to enable TTS in guild settings.",
+                StatusCode = StatusCodes.Status400BadRequest,
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "tts_not_enabled"
+            });
+        }
+
+        // Validate message is not empty
+        if (string.IsNullOrWhiteSpace(request.Message))
+        {
+            _logger.LogWarning("Empty TTS message provided for preview in guild {GuildId}", guildId);
+            return BadRequest(new ApiErrorDto
+            {
+                Message = "Message cannot be empty",
+                Detail = "Please provide a message to preview.",
+                StatusCode = StatusCodes.Status400BadRequest,
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "empty_message"
+            });
+        }
+
+        // Validate message length against guild settings
+        if (request.Message.Length > settings.MaxMessageLength)
+        {
+            _logger.LogWarning("TTS preview message too long for guild {GuildId} (length: {Length}, max: {Max})",
+                guildId, request.Message.Length, settings.MaxMessageLength);
+            return BadRequest(new ApiErrorDto
+            {
+                Message = "Message too long",
+                Detail = $"Message length ({request.Message.Length}) exceeds the maximum allowed ({settings.MaxMessageLength}).",
+                StatusCode = StatusCodes.Status400BadRequest,
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "message_too_long"
+            });
+        }
+
+        // Synthesize speech
+        Stream audioStream;
+        try
+        {
+            audioStream = await SynthesizeFromRequestAsync(request, cancellationToken);
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogError(ex, "TTS service not configured for guild {GuildId}", guildId);
+            return BadRequest(new ApiErrorDto
+            {
+                Message = "TTS service not available",
+                Detail = "The text-to-speech service is not properly configured.",
+                StatusCode = StatusCodes.Status400BadRequest,
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "tts_not_configured"
+            });
+        }
+        catch (SsmlValidationException ex)
+        {
+            _logger.LogWarning(ex, "SSML validation failed for preview in guild {GuildId}", guildId);
+            return BadRequest(new ApiErrorDto
+            {
+                Message = "SSML validation failed",
+                Detail = string.Join("; ", ex.Errors),
+                StatusCode = StatusCodes.Status400BadRequest,
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "ssml_validation_failed"
+            });
+        }
+        catch (ArgumentException ex)
+        {
+            _logger.LogError(ex, "Invalid TTS preview request for guild {GuildId}", guildId);
+            return BadRequest(new ApiErrorDto
+            {
+                Message = "Invalid TTS request",
+                Detail = ex.Message,
+                StatusCode = StatusCodes.Status400BadRequest,
+                TraceId = HttpContext.GetCorrelationId(),
+                ErrorCode = "invalid_request"
+            });
+        }
+
+        // Wrap raw PCM as WAV for browser playback
+        using (audioStream)
+        {
+            var wavStream = WrapPcmAsWav(audioStream);
+            _logger.LogInformation("Successfully generated TTS preview for guild {GuildId}, WAV size: {Size} bytes",
+                guildId, wavStream.Length);
+            return File(wavStream, "audio/wav", "tts-preview.wav");
+        }
+    }
+
+    /// <summary>
+    /// Synthesizes speech from a TTS request, handling SSML, style, and plain text modes.
+    /// </summary>
+    /// <param name="request">The TTS request containing message and voice settings.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A stream containing the synthesized PCM audio.</returns>
+    private async Task<Stream> SynthesizeFromRequestAsync(SendTtsRequest request, CancellationToken cancellationToken)
+    {
+        // If SSML is provided, use SSML synthesis directly
+        if (!string.IsNullOrWhiteSpace(request.Ssml))
+        {
+            _logger.LogDebug("Using SSML synthesis");
+            return await _ttsService.SynthesizeSpeechAsync(request.Ssml, null, SynthesisMode.Ssml, cancellationToken);
+        }
+
+        // If Style is provided, use SSML builder to wrap message with style
+        if (!string.IsNullOrWhiteSpace(request.Style))
+        {
+            _logger.LogDebug("Using style '{Style}' with intensity {Intensity}",
+                request.Style, request.StyleIntensity ?? 1.0m);
+
+            var styleIntensity = request.StyleIntensity ?? 1.0m;
+            var builder = _ssmlBuilder.Reset()
+                .BeginDocument("en-US")
+                .WithVoice(request.Voice)
+                .WithStyle(request.Style, (double)styleIntensity);
+
+            // Apply prosody adjustments (speed/pitch) if different from defaults
+            if (Math.Abs(request.Speed - 1.0) > 0.01 || Math.Abs(request.Pitch - 1.0) > 0.01)
+            {
+                builder.WithProsody(rate: request.Speed, pitch: request.Pitch);
+                builder.AddText(request.Message);
+                builder.EndProsody();
+            }
+            else
+            {
+                builder.AddText(request.Message);
+            }
+
+            builder.EndStyle().EndVoice();
+            var ssml = builder.Build();
+
+            _logger.LogDebug("Built SSML with style: {SsmlLength} characters", ssml.Length);
+            return await _ttsService.SynthesizeSpeechAsync(ssml, null, SynthesisMode.Ssml, cancellationToken);
+        }
+
+        // Otherwise, use standard TTS synthesis
+        _logger.LogDebug("Using standard TTS synthesis");
+        var options = new TtsOptions
+        {
+            Voice = request.Voice,
+            Speed = request.Speed,
+            Pitch = request.Pitch
+        };
+        return await _ttsService.SynthesizeSpeechAsync(request.Message, options, cancellationToken);
+    }
+
+    /// <summary>
+    /// Wraps raw PCM audio data in a WAV container for browser playback.
+    /// </summary>
+    /// <param name="pcmStream">The raw PCM audio stream.</param>
+    /// <param name="sampleRate">Sample rate in Hz (default: 48000).</param>
+    /// <param name="bitsPerSample">Bits per sample (default: 16).</param>
+    /// <param name="channels">Number of audio channels (default: 2 for stereo).</param>
+    /// <returns>A MemoryStream containing valid WAV data.</returns>
+    private static MemoryStream WrapPcmAsWav(Stream pcmStream, int sampleRate = 48000, int bitsPerSample = 16, int channels = 2)
+    {
+        var pcmData = new MemoryStream();
+        pcmStream.CopyTo(pcmData);
+        var dataLength = (int)pcmData.Length;
+
+        var wav = new MemoryStream(44 + dataLength);
+        using var writer = new BinaryWriter(wav, System.Text.Encoding.UTF8, leaveOpen: true);
+        writer.Write(System.Text.Encoding.ASCII.GetBytes("RIFF"));
+        writer.Write(36 + dataLength);
+        writer.Write(System.Text.Encoding.ASCII.GetBytes("WAVE"));
+        writer.Write(System.Text.Encoding.ASCII.GetBytes("fmt "));
+        writer.Write(16);                                           // PCM chunk size
+        writer.Write((short)1);                                     // Audio format (PCM)
+        writer.Write((short)channels);
+        writer.Write(sampleRate);
+        writer.Write(sampleRate * channels * bitsPerSample / 8);    // Byte rate
+        writer.Write((short)(channels * bitsPerSample / 8));        // Block align
+        writer.Write((short)bitsPerSample);
+        writer.Write(System.Text.Encoding.ASCII.GetBytes("data"));
+        writer.Write(dataLength);
+        pcmData.Position = 0;
+        pcmData.CopyTo(wav);
+        wav.Position = 0;
+        return wav;
     }
 
     /// <summary>

--- a/src/DiscordBot.Bot/Pages/Portal/TTS/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Portal/TTS/Index.cshtml
@@ -612,9 +612,15 @@ else
                         </div>
                     </div>
 
-                    <!-- Send Button -->
-                    <div class="form-group">
-                        <button id="sendBtn" class="send-btn" disabled>
+                    <!-- Send and Preview Buttons -->
+                    <div class="form-group" style="display: flex; gap: 0.5rem;">
+                        <button id="previewBtn" class="send-btn" style="flex: 0 0 auto; width: auto; padding: 0.75rem 1rem; background-color: transparent; border: 1px solid var(--color-border-primary); color: var(--color-text-primary);" title="Preview in browser">
+                            <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" style="width: 16px; height: 16px;">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.536 8.464a5 5 0 010 7.072M12 12h.01M18.364 5.636a9 9 0 010 12.728M5.636 18.364a9 9 0 010-12.728M8.464 15.536a5 5 0 010-7.072" />
+                            </svg>
+                            Preview
+                        </button>
+                        <button id="sendBtn" class="send-btn" style="flex: 1;" disabled>
                             <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
                             </svg>

--- a/src/DiscordBot.Bot/wwwroot/js/portal-tts.js
+++ b/src/DiscordBot.Bot/wwwroot/js/portal-tts.js
@@ -21,6 +21,7 @@
     // ========================================
     const API = {
         send: (guildId) => `/api/portal/tts/${guildId}/send`,
+        preview: (guildId) => `/api/portal/tts/${guildId}/preview`,
         voiceCapabilities: (voiceName) => `/api/portal/tts/voices/${voiceName}/capabilities`,
         validateSsml: () => `/api/portal/tts/validate-ssml`,
         buildSsml: () => `/api/portal/tts/build-ssml`
@@ -31,6 +32,7 @@
     // ========================================
     let guildId = null;                    // CRITICAL: Always string, never parse to number
     let isSending = false;                 // Track if a message is currently being sent
+    let isPreviewing = false;              // Track if a preview is currently playing
     let selectedChannel = null;
     let maxMessageLength = 500;            // Dynamic max length from server (default: 500)
 
@@ -97,6 +99,12 @@
         const sendBtn = document.getElementById('sendBtn');
         if (sendBtn) {
             sendBtn.addEventListener('click', sendTtsMessage);
+        }
+
+        // Preview button
+        const previewBtn = document.getElementById('previewBtn');
+        if (previewBtn) {
+            previewBtn.addEventListener('click', previewTtsMessage);
         }
 
         // Clear draft button
@@ -298,6 +306,103 @@
     }
 
     // ========================================
+    // Request Body Builder
+    // ========================================
+
+    /**
+     * Build the common TTS request body from the current form state.
+     * Shared by both send and preview flows.
+     */
+    function buildTtsRequestBody() {
+        const messageInput = document.getElementById('ttsMessage');
+        const message = messageInput?.value?.trim() || '';
+        const voice = window.voiceSelector_getValue ? window.voiceSelector_getValue('portalVoiceSelector') : null;
+        const speed = parseFloat(document.getElementById('speedSlider').value) || CONFIG.SPEED_DEFAULT;
+        const pitch = parseFloat(document.getElementById('pitchSlider').value) || CONFIG.PITCH_DEFAULT;
+
+        return {
+            message,
+            voice,
+            speed,
+            pitch,
+            ...(currentMode === 'standard' && currentStyle ? { style: currentStyle, styleIntensity: currentStyleIntensity } : {}),
+            ...(currentMode === 'pro' && currentSsml ? { ssml: currentSsml } : {})
+        };
+    }
+
+    // ========================================
+    // Preview TTS Message
+    // ========================================
+    async function previewTtsMessage() {
+        const messageInput = document.getElementById('ttsMessage');
+        if (!messageInput) return;
+
+        const message = messageInput.value.trim();
+        if (!message) {
+            showToast('error', 'Please enter a message');
+            return;
+        }
+
+        if (message.length > maxMessageLength) {
+            showToast('error', `Message exceeds maximum length of ${maxMessageLength} characters`);
+            return;
+        }
+
+        const voice = window.voiceSelector_getValue ? window.voiceSelector_getValue('portalVoiceSelector') : null;
+        if (!voice) {
+            showToast('warning', 'Please select a voice first!');
+            return;
+        }
+
+        if (isPreviewing) return;
+        isPreviewing = true;
+
+        const previewBtn = document.getElementById('previewBtn');
+        const originalHtml = previewBtn.innerHTML;
+        previewBtn.disabled = true;
+        previewBtn.innerHTML = `
+            <svg class="inline-block animate-spin" fill="none" viewBox="0 0 24 24" style="width: 16px; height: 16px;">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+            </svg>
+            Loading...
+        `;
+
+        try {
+            const body = buildTtsRequestBody();
+            const response = await fetch(API.preview(guildId), {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body)
+            });
+
+            if (response.status === 429) {
+                const data = await response.json().catch(() => ({}));
+                showToast('warning', data.message || 'Rate limit exceeded. Please wait.');
+                return;
+            }
+
+            if (!response.ok) {
+                const errorData = await response.json().catch(() => ({}));
+                throw new Error(errorData.message || 'Failed to generate preview');
+            }
+
+            const blob = await response.blob();
+            const url = URL.createObjectURL(blob);
+            const audio = new Audio(url);
+            audio.addEventListener('ended', () => URL.revokeObjectURL(url));
+            audio.addEventListener('error', () => URL.revokeObjectURL(url));
+            audio.play();
+        } catch (error) {
+            showToast('error', error.message);
+        } finally {
+            isPreviewing = false;
+            previewBtn.innerHTML = originalHtml;
+            previewBtn.disabled = false;
+        }
+    }
+
+    // ========================================
     // Send TTS Message
     // ========================================
     async function sendTtsMessage() {
@@ -328,8 +433,6 @@
             showToast('warning', 'Please select a voice first!');
             return;
         }
-        const speed = parseFloat(document.getElementById('speedSlider').value) || CONFIG.SPEED_DEFAULT;
-        const pitch = parseFloat(document.getElementById('pitchSlider').value) || CONFIG.PITCH_DEFAULT;
 
         // Mark as sending to prevent duplicate submissions
         isSending = true;
@@ -352,19 +455,13 @@
         `;
 
         try {
+            const body = buildTtsRequestBody();
             const response = await fetch(API.send(guildId), {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json'
                 },
-                body: JSON.stringify({
-                    message,
-                    voice,
-                    speed,
-                    pitch,
-                    ...(currentMode === 'standard' && currentStyle ? { style: currentStyle, styleIntensity: currentStyleIntensity } : {}),
-                    ...(currentMode === 'pro' && currentSsml ? { ssml: currentSsml } : {})
-                })
+                body: JSON.stringify(body)
             });
 
             if (response.status === 429) {


### PR DESCRIPTION
## Summary
- Add `POST /api/portal/tts/{guildId}/preview` endpoint that synthesizes speech and returns WAV audio
- Extract shared `SynthesizeFromRequestAsync` helper to eliminate duplication between Send and Preview
- Add `WrapPcmAsWav` utility to convert raw PCM to browser-playable WAV format
- Add Preview button next to Send on TTS portal — plays audio in browser without voice channel

Closes #1775
Closes #1843, closes #1844

## Test plan
- [ ] Click Preview with plain text — audio plays in browser
- [ ] Click Preview with style selected (Pro mode) — correct style applied
- [ ] Click Preview with custom SSML — SSML is respected
- [ ] Preview works without being connected to a voice channel
- [ ] Send still works identically (no regression)
- [ ] Preview shows loading spinner during synthesis
- [ ] Preview does not save to TTS message history
- [ ] Audio plays in Chrome, Firefox, Safari

🤖 Generated with [Claude Code](https://claude.com/claude-code)