### PR TITLE
fix: TTS portal false 'draft restored' banner on first load

### DIFF
--- a/src/DiscordBot.Bot/wwwroot/js/portal-tts.js
+++ b/src/DiscordBot.Bot/wwwroot/js/portal-tts.js
@@ -199,8 +199,8 @@
                 mode: currentMode,
                 timestamp: Date.now()
             };
-            // Only save if there's actual content
-            if (draft.message || draft.voice) {
+            // Only save if there's an actual message
+            if (draft.message) {
                 localStorage.setItem(getDraftKey(), JSON.stringify(draft));
             }
         } catch (error) {
@@ -219,11 +219,12 @@
             if (!raw) return;
 
             const draft = JSON.parse(raw);
-            if (!draft || (!draft.message && !draft.voice)) return;
+            // Only restore if there's an actual message
+            if (!draft || !draft.message) return;
 
             // Restore message
             const messageInput = document.getElementById('ttsMessage');
-            if (messageInput && draft.message) {
+            if (messageInput) {
                 messageInput.value = draft.message;
                 updateCharacterCount();
             }


### PR DESCRIPTION
## Summary
- Voice-only selections (no message text) were saved as drafts, causing the "Draft restored — you have unsaved changes" banner to appear on first load with a blank message
- Both `saveDraft()` and `loadDraft()` now require a non-empty `message` field — voice/mode preferences continue to persist independently via their own localStorage keys

Closes #1851

## Test plan
- [ ] Clear localStorage and visit TTS portal — no draft banner should appear
- [ ] Select a voice without typing a message, navigate away and back — no draft banner
- [ ] Type a message, navigate away and back — draft banner appears with message restored
- [ ] Send a message — draft is cleared, no banner on next visit

🤖 Generated with [Claude Code](https://claude.com/claude-code)