### PR TITLE
Phase 0: Test baseline audit and coverage for refactoring

### DIFF
--- a/tests/DiscordBot.Tests/Bot/Pages/Guilds/Analytics/IndexModelTests.cs
+++ b/tests/DiscordBot.Tests/Bot/Pages/Guilds/Analytics/IndexModelTests.cs
@@ -1,0 +1,264 @@
+using Discord.WebSocket;
+using DiscordBot.Bot.Pages.Guilds.Analytics;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Entities;
+using DiscordBot.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace DiscordBot.Tests.Bot.Pages.Guilds.Analytics;
+
+/// <summary>
+/// Unit tests for the <see cref="IndexModel"/> Razor Page (Guilds/Analytics).
+/// Covers GET handler behaviour, layout view model population, and not-found handling.
+/// Note: <see cref="DiscordSocketClient"/> is used by the page to resolve channel names.
+/// When the mock returns null for GetGuild (default), the page falls back to "Unknown Channel".
+/// </summary>
+public class IndexModelTests
+{
+    private readonly Mock<IServerAnalyticsService> _mockAnalyticsService;
+    private readonly Mock<IGuildService> _mockGuildService;
+    private readonly Mock<IMessageLogRepository> _mockMessageLogRepository;
+    private readonly Mock<DiscordSocketClient> _mockDiscordClient;
+    private readonly Mock<ILogger<IndexModel>> _mockLogger;
+    private readonly IndexModel _indexModel;
+
+    public IndexModelTests()
+    {
+        _mockAnalyticsService = new Mock<IServerAnalyticsService>();
+        _mockGuildService = new Mock<IGuildService>();
+        _mockMessageLogRepository = new Mock<IMessageLogRepository>();
+        _mockDiscordClient = new Mock<DiscordSocketClient>(new DiscordSocketConfig());
+        _mockLogger = new Mock<ILogger<IndexModel>>();
+
+        // Default happy-path setup — return empty analytics data
+        _mockAnalyticsService
+            .Setup(s => s.GetSummaryAsync(It.IsAny<ulong>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ServerAnalyticsSummaryDto());
+
+        _mockAnalyticsService
+            .Setup(s => s.GetActivityTimeSeriesAsync(It.IsAny<ulong>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<ActivityTimeSeriesDto>());
+
+        _mockAnalyticsService
+            .Setup(s => s.GetActivityHeatmapAsync(It.IsAny<ulong>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<ServerActivityHeatmapDto>());
+
+        _mockAnalyticsService
+            .Setup(s => s.GetTopContributorsAsync(It.IsAny<ulong>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<TopContributorDto>());
+
+        // Message log repository returns empty collection (used when fetching top channels)
+        _mockMessageLogRepository
+            .Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<MessageLog>());
+
+        _indexModel = new IndexModel(
+            _mockAnalyticsService.Object,
+            _mockGuildService.Object,
+            _mockMessageLogRepository.Object,
+            _mockDiscordClient.Object,
+            _mockLogger.Object);
+
+        // Wire up a minimal PageContext so RazorPage helper methods work
+        var httpContext = new DefaultHttpContext();
+        var modelState = new ModelStateDictionary();
+        var actionContext = new ActionContext(httpContext, new RouteData(), new PageActionDescriptor(), modelState);
+        _indexModel.PageContext = new PageContext(actionContext);
+
+        // TempData is required by the catch block in OnGetAsync when analytics loading fails
+        _indexModel.TempData = new TempDataDictionary(httpContext, Mock.Of<ITempDataProvider>());
+    }
+
+    // -----------------------------------------------------------------
+    // OnGetAsync — happy path
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task OnGetAsync_WithValidGuildId_ReturnsPageResult()
+    {
+        // Arrange
+        const ulong guildId = 111222333UL;
+        _mockGuildService
+            .Setup(s => s.GetGuildByIdAsync(guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateGuildDto(guildId, "Test Guild"));
+
+        // Act
+        var result = await _indexModel.OnGetAsync(guildId, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<PageResult>("a found guild should return a PageResult");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_WithValidGuildId_PopulatesBreadcrumb()
+    {
+        // Arrange
+        const ulong guildId = 111222333UL;
+        _mockGuildService
+            .Setup(s => s.GetGuildByIdAsync(guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateGuildDto(guildId, "Test Guild"));
+
+        // Act
+        await _indexModel.OnGetAsync(guildId, CancellationToken.None);
+
+        // Assert
+        _indexModel.Breadcrumb.Should().NotBeNull("Breadcrumb must be set for the guild layout");
+        _indexModel.Breadcrumb.Items.Should().NotBeEmpty("Breadcrumb must contain navigation items");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_WithValidGuildId_PopulatesHeader()
+    {
+        // Arrange
+        const ulong guildId = 111222333UL;
+        _mockGuildService
+            .Setup(s => s.GetGuildByIdAsync(guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateGuildDto(guildId, "Test Guild"));
+
+        // Act
+        await _indexModel.OnGetAsync(guildId, CancellationToken.None);
+
+        // Assert
+        _indexModel.Header.Should().NotBeNull("Header must be set for the guild layout");
+        _indexModel.Header.GuildId.Should().Be(guildId, "Header must reference the correct guild");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_WithValidGuildId_PopulatesNavigation()
+    {
+        // Arrange
+        const ulong guildId = 111222333UL;
+        _mockGuildService
+            .Setup(s => s.GetGuildByIdAsync(guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateGuildDto(guildId, "Test Guild"));
+
+        // Act
+        await _indexModel.OnGetAsync(guildId, CancellationToken.None);
+
+        // Assert
+        _indexModel.Navigation.Should().NotBeNull("Navigation must be set for the guild layout");
+        _indexModel.Navigation.GuildId.Should().Be(guildId, "Navigation must reference the correct guild");
+        _indexModel.Navigation.Tabs.Should().NotBeEmpty("Navigation must include tab definitions");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_WithValidGuildId_PopulatesViewModel()
+    {
+        // Arrange
+        const ulong guildId = 111222333UL;
+        _mockGuildService
+            .Setup(s => s.GetGuildByIdAsync(guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateGuildDto(guildId, "Analytics Guild"));
+
+        // Act
+        await _indexModel.OnGetAsync(guildId, CancellationToken.None);
+
+        // Assert
+        _indexModel.ViewModel.Should().NotBeNull("ViewModel must be populated after OnGetAsync");
+        _indexModel.ViewModel.GuildId.Should().Be(guildId, "ViewModel must reference the correct guild");
+    }
+
+    // -----------------------------------------------------------------
+    // OnGetAsync — not-found path
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task OnGetAsync_WithUnknownGuildId_ReturnsNotFound()
+    {
+        // Arrange
+        const ulong unknownGuildId = 999999999UL;
+        _mockGuildService
+            .Setup(s => s.GetGuildByIdAsync(unknownGuildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GuildDto?)null);
+
+        // Act
+        var result = await _indexModel.OnGetAsync(unknownGuildId, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<NotFoundResult>("a missing guild should return NotFound");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_WithUnknownGuildId_DoesNotCallAnalyticsService()
+    {
+        // Arrange
+        const ulong unknownGuildId = 999999999UL;
+        _mockGuildService
+            .Setup(s => s.GetGuildByIdAsync(unknownGuildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GuildDto?)null);
+
+        // Act
+        await _indexModel.OnGetAsync(unknownGuildId, CancellationToken.None);
+
+        // Assert
+        _mockAnalyticsService.Verify(
+            s => s.GetSummaryAsync(It.IsAny<ulong>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "analytics service must not be called when guild is not found");
+    }
+
+    // -----------------------------------------------------------------
+    // OnGetAsync — service interaction
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task OnGetAsync_WithValidGuildId_FetchesAnalyticsSummary()
+    {
+        // Arrange
+        const ulong guildId = 111222333UL;
+        _mockGuildService
+            .Setup(s => s.GetGuildByIdAsync(guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateGuildDto(guildId, "Test Guild"));
+
+        // Act
+        await _indexModel.OnGetAsync(guildId, CancellationToken.None);
+
+        // Assert
+        _mockAnalyticsService.Verify(
+            s => s.GetSummaryAsync(guildId, It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Once,
+            "analytics summary must be fetched once for the guild");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_WhenAnalyticsServiceThrows_StillReturnsPageResult()
+    {
+        // Arrange
+        const ulong guildId = 111222333UL;
+        _mockGuildService
+            .Setup(s => s.GetGuildByIdAsync(guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateGuildDto(guildId, "Test Guild"));
+
+        _mockAnalyticsService
+            .Setup(s => s.GetSummaryAsync(It.IsAny<ulong>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Analytics unavailable"));
+
+        // Act
+        // The page catches all exceptions in OnGetAsync and returns Page() with empty data
+        var result = await _indexModel.OnGetAsync(guildId, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<PageResult>("the page should handle analytics exceptions gracefully and still return PageResult");
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    private static GuildDto CreateGuildDto(ulong id, string name) => new()
+    {
+        Id = id,
+        Name = name,
+        IsActive = true,
+        JoinedAt = DateTime.UtcNow.AddMonths(-6),
+        IconUrl = null
+    };
+}

--- a/tests/DiscordBot.Tests/Bot/Pages/Guilds/DetailsModelSyncTests.cs
+++ b/tests/DiscordBot.Tests/Bot/Pages/Guilds/DetailsModelSyncTests.cs
@@ -33,6 +33,7 @@ public class DetailsModelSyncTests
     private readonly Mock<ISoundRepository> _mockSoundRepository;
     private readonly Mock<ITtsMessageRepository> _mockTtsMessageRepository;
     private readonly Mock<IAssistantGuildSettingsService> _mockAssistantGuildSettingsService;
+    private readonly Mock<IGuildMembershipService> _mockGuildMembershipService;
     private readonly Mock<ILogger<DetailsModel>> _mockLogger;
     private readonly DetailsModel _detailsModel;
 
@@ -49,6 +50,7 @@ public class DetailsModelSyncTests
         _mockSoundRepository = new Mock<ISoundRepository>();
         _mockTtsMessageRepository = new Mock<ITtsMessageRepository>();
         _mockAssistantGuildSettingsService = new Mock<IAssistantGuildSettingsService>();
+        _mockGuildMembershipService = new Mock<IGuildMembershipService>();
         _mockLogger = new Mock<ILogger<DetailsModel>>();
 
         // Setup default scheduled message service behavior
@@ -82,6 +84,7 @@ public class DetailsModelSyncTests
             _mockSoundRepository.Object,
             _mockTtsMessageRepository.Object,
             _mockAssistantGuildSettingsService.Object,
+            _mockGuildMembershipService.Object,
             assistantOptions,
             _mockLogger.Object);
 

--- a/tests/DiscordBot.Tests/Bot/Pages/Guilds/DetailsModelTests.cs
+++ b/tests/DiscordBot.Tests/Bot/Pages/Guilds/DetailsModelTests.cs
@@ -32,6 +32,7 @@ public class DetailsModelTests
     private readonly Mock<ISoundRepository> _mockSoundRepository;
     private readonly Mock<ITtsMessageRepository> _mockTtsMessageRepository;
     private readonly Mock<IAssistantGuildSettingsService> _mockAssistantGuildSettingsService;
+    private readonly Mock<IGuildMembershipService> _mockGuildMembershipService;
     private readonly Mock<ILogger<DetailsModel>> _mockLogger;
     private readonly DetailsModel _detailsModel;
 
@@ -48,6 +49,7 @@ public class DetailsModelTests
         _mockSoundRepository = new Mock<ISoundRepository>();
         _mockTtsMessageRepository = new Mock<ITtsMessageRepository>();
         _mockAssistantGuildSettingsService = new Mock<IAssistantGuildSettingsService>();
+        _mockGuildMembershipService = new Mock<IGuildMembershipService>();
         _mockLogger = new Mock<ILogger<DetailsModel>>();
 
         // Setup default scheduled message service behavior
@@ -81,6 +83,7 @@ public class DetailsModelTests
             _mockSoundRepository.Object,
             _mockTtsMessageRepository.Object,
             _mockAssistantGuildSettingsService.Object,
+            _mockGuildMembershipService.Object,
             assistantOptions,
             _mockLogger.Object);
 
@@ -648,6 +651,7 @@ public class DetailsModelTests
             _mockSoundRepository.Object,
             _mockTtsMessageRepository.Object,
             _mockAssistantGuildSettingsService.Object,
+            _mockGuildMembershipService.Object,
             assistantOptions,
             _mockLogger.Object);
 

--- a/tests/DiscordBot.Tests/Bot/Pages/Guilds/RatWatch/IndexModelTests.cs
+++ b/tests/DiscordBot.Tests/Bot/Pages/Guilds/RatWatch/IndexModelTests.cs
@@ -1,0 +1,250 @@
+using DiscordBot.Bot.Pages.Guilds.RatWatch;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Entities;
+using DiscordBot.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace DiscordBot.Tests.Bot.Pages.Guilds.RatWatch;
+
+/// <summary>
+/// Unit tests for the <see cref="IndexModel"/> Razor Page (Guilds/RatWatch).
+/// Covers GET handler behaviour, layout view model population, and not-found handling.
+/// </summary>
+public class IndexModelTests
+{
+    private readonly Mock<IRatWatchService> _mockRatWatchService;
+    private readonly Mock<IGuildService> _mockGuildService;
+    private readonly Mock<IRatWatchRepository> _mockRatWatchRepository;
+    private readonly Mock<ILogger<IndexModel>> _mockLogger;
+    private readonly IndexModel _indexModel;
+
+    public IndexModelTests()
+    {
+        _mockRatWatchService = new Mock<IRatWatchService>();
+        _mockGuildService = new Mock<IGuildService>();
+        _mockRatWatchRepository = new Mock<IRatWatchRepository>();
+        _mockLogger = new Mock<ILogger<IndexModel>>();
+
+        // Default happy-path setup
+        _mockRatWatchService
+            .Setup(s => s.GetGuildSettingsAsync(It.IsAny<ulong>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GuildRatWatchSettings { IsEnabled = true, Timezone = "UTC" });
+
+        _mockRatWatchService
+            .Setup(s => s.GetByGuildAsync(It.IsAny<ulong>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Enumerable.Empty<RatWatchDto>(), 0));
+
+        _mockRatWatchService
+            .Setup(s => s.GetLeaderboardAsync(It.IsAny<ulong>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<RatLeaderboardEntryDto>());
+
+        _mockRatWatchRepository
+            .Setup(r => r.GetAnalyticsSummaryAsync(
+                It.IsAny<ulong?>(),
+                It.IsAny<DateTime?>(),
+                It.IsAny<DateTime?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RatWatchAnalyticsSummaryDto());
+
+        _indexModel = new IndexModel(
+            _mockRatWatchService.Object,
+            _mockGuildService.Object,
+            _mockRatWatchRepository.Object,
+            _mockLogger.Object);
+
+        // Wire up a minimal PageContext so RazorPage helper methods work
+        var httpContext = new DefaultHttpContext();
+        var modelState = new ModelStateDictionary();
+        var actionContext = new ActionContext(httpContext, new RouteData(), new PageActionDescriptor(), modelState);
+        _indexModel.PageContext = new PageContext(actionContext);
+    }
+
+    // -----------------------------------------------------------------
+    // OnGetAsync — happy path
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task OnGetAsync_WithValidGuildId_ReturnsPageResult()
+    {
+        // Arrange
+        const ulong guildId = 111222333UL;
+        _mockGuildService
+            .Setup(s => s.GetGuildByIdAsync(guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateGuildDto(guildId, "Test Guild"));
+
+        // Act
+        var result = await _indexModel.OnGetAsync(guildId, cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<PageResult>("a found guild should return a PageResult");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_WithValidGuildId_PopulatesBreadcrumb()
+    {
+        // Arrange
+        const ulong guildId = 111222333UL;
+        _mockGuildService
+            .Setup(s => s.GetGuildByIdAsync(guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateGuildDto(guildId, "Test Guild"));
+
+        // Act
+        await _indexModel.OnGetAsync(guildId, cancellationToken: CancellationToken.None);
+
+        // Assert
+        _indexModel.Breadcrumb.Should().NotBeNull("Breadcrumb must be set for the guild layout");
+        _indexModel.Breadcrumb.Items.Should().NotBeEmpty("Breadcrumb must contain navigation items");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_WithValidGuildId_PopulatesHeader()
+    {
+        // Arrange
+        const ulong guildId = 111222333UL;
+        _mockGuildService
+            .Setup(s => s.GetGuildByIdAsync(guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateGuildDto(guildId, "Test Guild"));
+
+        // Act
+        await _indexModel.OnGetAsync(guildId, cancellationToken: CancellationToken.None);
+
+        // Assert
+        _indexModel.Header.Should().NotBeNull("Header must be set for the guild layout");
+        _indexModel.Header.GuildId.Should().Be(guildId, "Header must reference the correct guild");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_WithValidGuildId_PopulatesNavigation()
+    {
+        // Arrange
+        const ulong guildId = 111222333UL;
+        _mockGuildService
+            .Setup(s => s.GetGuildByIdAsync(guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateGuildDto(guildId, "Test Guild"));
+
+        // Act
+        await _indexModel.OnGetAsync(guildId, cancellationToken: CancellationToken.None);
+
+        // Assert
+        _indexModel.Navigation.Should().NotBeNull("Navigation must be set for the guild layout");
+        _indexModel.Navigation.GuildId.Should().Be(guildId, "Navigation must reference the correct guild");
+        _indexModel.Navigation.Tabs.Should().NotBeEmpty("Navigation must include tab definitions");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_WithValidGuildId_PopulatesViewModel()
+    {
+        // Arrange
+        const ulong guildId = 111222333UL;
+        _mockGuildService
+            .Setup(s => s.GetGuildByIdAsync(guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateGuildDto(guildId, "Rat Watch Guild"));
+
+        // Act
+        await _indexModel.OnGetAsync(guildId, cancellationToken: CancellationToken.None);
+
+        // Assert
+        _indexModel.ViewModel.Should().NotBeNull("ViewModel must be populated after OnGetAsync");
+    }
+
+    // -----------------------------------------------------------------
+    // OnGetAsync — not-found path
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task OnGetAsync_WithUnknownGuildId_ReturnsNotFound()
+    {
+        // Arrange
+        const ulong unknownGuildId = 999999999UL;
+        _mockGuildService
+            .Setup(s => s.GetGuildByIdAsync(unknownGuildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GuildDto?)null);
+
+        // Act
+        var result = await _indexModel.OnGetAsync(unknownGuildId, cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<NotFoundResult>("a missing guild should return NotFound");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_WithUnknownGuildId_DoesNotCallRatWatchService()
+    {
+        // Arrange
+        const ulong unknownGuildId = 999999999UL;
+        _mockGuildService
+            .Setup(s => s.GetGuildByIdAsync(unknownGuildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GuildDto?)null);
+
+        // Act
+        await _indexModel.OnGetAsync(unknownGuildId, cancellationToken: CancellationToken.None);
+
+        // Assert
+        _mockRatWatchService.Verify(
+            s => s.GetGuildSettingsAsync(It.IsAny<ulong>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "rat watch service must not be called when guild is not found");
+    }
+
+    // -----------------------------------------------------------------
+    // OnGetAsync — service interaction
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task OnGetAsync_WithValidGuildId_FetchesRatWatchSettings()
+    {
+        // Arrange
+        const ulong guildId = 111222333UL;
+        _mockGuildService
+            .Setup(s => s.GetGuildByIdAsync(guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateGuildDto(guildId, "Test Guild"));
+
+        // Act
+        await _indexModel.OnGetAsync(guildId, cancellationToken: CancellationToken.None);
+
+        // Assert
+        _mockRatWatchService.Verify(
+            s => s.GetGuildSettingsAsync(guildId, It.IsAny<CancellationToken>()),
+            Times.Once,
+            "rat watch settings must be fetched once for the guild");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_WithValidGuildId_FetchesAnalyticsSummary()
+    {
+        // Arrange
+        const ulong guildId = 111222333UL;
+        _mockGuildService
+            .Setup(s => s.GetGuildByIdAsync(guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateGuildDto(guildId, "Test Guild"));
+
+        // Act
+        await _indexModel.OnGetAsync(guildId, cancellationToken: CancellationToken.None);
+
+        // Assert
+        _mockRatWatchRepository.Verify(
+            r => r.GetAnalyticsSummaryAsync(guildId, null, null, It.IsAny<CancellationToken>()),
+            Times.Once,
+            "analytics summary must be fetched for the guild");
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    private static GuildDto CreateGuildDto(ulong id, string name) => new()
+    {
+        Id = id,
+        Name = name,
+        IsActive = true,
+        JoinedAt = DateTime.UtcNow.AddMonths(-6),
+        IconUrl = null
+    };
+}

--- a/tests/DiscordBot.Tests/Bot/Pages/Guilds/Reminders/IndexModelTests.cs
+++ b/tests/DiscordBot.Tests/Bot/Pages/Guilds/Reminders/IndexModelTests.cs
@@ -1,0 +1,258 @@
+using Discord.WebSocket;
+using DiscordBot.Bot.Pages.Guilds.Reminders;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Entities;
+using DiscordBot.Core.Enums;
+using DiscordBot.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace DiscordBot.Tests.Bot.Pages.Guilds.Reminders;
+
+/// <summary>
+/// Unit tests for the <see cref="IndexModel"/> Razor Page (Guilds/Reminders).
+/// Covers GET handler behaviour, layout view model population, and not-found handling.
+/// </summary>
+public class IndexModelTests
+{
+    private readonly Mock<IReminderRepository> _mockReminderRepository;
+    private readonly Mock<IGuildService> _mockGuildService;
+    private readonly Mock<DiscordSocketClient> _mockDiscordClient;
+    private readonly Mock<ILogger<IndexModel>> _mockLogger;
+    private readonly IndexModel _indexModel;
+
+    public IndexModelTests()
+    {
+        _mockReminderRepository = new Mock<IReminderRepository>();
+        _mockGuildService = new Mock<IGuildService>();
+        _mockDiscordClient = new Mock<DiscordSocketClient>(new DiscordSocketConfig());
+        _mockLogger = new Mock<ILogger<IndexModel>>();
+
+        // Default happy-path setup — empty reminder list
+        _mockReminderRepository
+            .Setup(r => r.GetByGuildAsync(
+                It.IsAny<ulong>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<ReminderStatus?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Enumerable.Empty<Reminder>(), 0));
+
+        _mockReminderRepository
+            .Setup(r => r.GetGuildStatsAsync(It.IsAny<ulong>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((0, 0, 0, 0));
+
+        // DiscordSocketClient.GetGuild returns null by default (no setup needed; mock returns null)
+
+        _indexModel = new IndexModel(
+            _mockReminderRepository.Object,
+            _mockGuildService.Object,
+            _mockDiscordClient.Object,
+            _mockLogger.Object);
+
+        // Wire up a minimal PageContext so RazorPage helper methods work
+        var httpContext = new DefaultHttpContext();
+        var modelState = new ModelStateDictionary();
+        var actionContext = new ActionContext(httpContext, new RouteData(), new PageActionDescriptor(), modelState);
+        _indexModel.PageContext = new PageContext(actionContext);
+    }
+
+    // -----------------------------------------------------------------
+    // OnGetAsync — happy path
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task OnGetAsync_WithValidGuildId_ReturnsPageResult()
+    {
+        // Arrange
+        const long guildId = 111222333L;
+        _mockGuildService
+            .Setup(s => s.GetGuildByIdAsync((ulong)guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateGuildDto((ulong)guildId, "Test Guild"));
+
+        // Act
+        var result = await _indexModel.OnGetAsync(guildId, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<PageResult>("a found guild should return a PageResult");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_WithValidGuildId_PopulatesBreadcrumb()
+    {
+        // Arrange
+        const long guildId = 111222333L;
+        _mockGuildService
+            .Setup(s => s.GetGuildByIdAsync((ulong)guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateGuildDto((ulong)guildId, "Test Guild"));
+
+        // Act
+        await _indexModel.OnGetAsync(guildId, CancellationToken.None);
+
+        // Assert
+        _indexModel.Breadcrumb.Should().NotBeNull("Breadcrumb must be set for the guild layout");
+        _indexModel.Breadcrumb.Items.Should().NotBeEmpty("Breadcrumb must contain navigation items");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_WithValidGuildId_PopulatesHeader()
+    {
+        // Arrange
+        const long guildId = 111222333L;
+        _mockGuildService
+            .Setup(s => s.GetGuildByIdAsync((ulong)guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateGuildDto((ulong)guildId, "Test Guild"));
+
+        // Act
+        await _indexModel.OnGetAsync(guildId, CancellationToken.None);
+
+        // Assert
+        _indexModel.Header.Should().NotBeNull("Header must be set for the guild layout");
+        _indexModel.Header.GuildId.Should().Be((ulong)guildId, "Header must reference the correct guild");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_WithValidGuildId_PopulatesNavigation()
+    {
+        // Arrange
+        const long guildId = 111222333L;
+        _mockGuildService
+            .Setup(s => s.GetGuildByIdAsync((ulong)guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateGuildDto((ulong)guildId, "Test Guild"));
+
+        // Act
+        await _indexModel.OnGetAsync(guildId, CancellationToken.None);
+
+        // Assert
+        _indexModel.Navigation.Should().NotBeNull("Navigation must be set for the guild layout");
+        _indexModel.Navigation.GuildId.Should().Be((ulong)guildId, "Navigation must reference the correct guild");
+        _indexModel.Navigation.Tabs.Should().NotBeEmpty("Navigation must include tab definitions");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_WithValidGuildId_PopulatesViewModel()
+    {
+        // Arrange
+        const long guildId = 111222333L;
+        _mockGuildService
+            .Setup(s => s.GetGuildByIdAsync((ulong)guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateGuildDto((ulong)guildId, "Reminder Guild"));
+
+        // Act
+        await _indexModel.OnGetAsync(guildId, CancellationToken.None);
+
+        // Assert
+        _indexModel.ViewModel.Should().NotBeNull("ViewModel must be populated after OnGetAsync");
+        _indexModel.ViewModel.GuildId.Should().Be((ulong)guildId, "ViewModel must reference the correct guild");
+    }
+
+    // -----------------------------------------------------------------
+    // OnGetAsync — not-found path
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task OnGetAsync_WithUnknownGuildId_ReturnsNotFound()
+    {
+        // Arrange
+        const long unknownGuildId = 999999999L;
+        _mockGuildService
+            .Setup(s => s.GetGuildByIdAsync((ulong)unknownGuildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GuildDto?)null);
+
+        // Act
+        var result = await _indexModel.OnGetAsync(unknownGuildId, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<NotFoundResult>("a missing guild should return NotFound");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_WithUnknownGuildId_DoesNotQueryReminderRepository()
+    {
+        // Arrange
+        const long unknownGuildId = 999999999L;
+        _mockGuildService
+            .Setup(s => s.GetGuildByIdAsync((ulong)unknownGuildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GuildDto?)null);
+
+        // Act
+        await _indexModel.OnGetAsync(unknownGuildId, CancellationToken.None);
+
+        // Assert
+        _mockReminderRepository.Verify(
+            r => r.GetByGuildAsync(
+                It.IsAny<ulong>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<ReminderStatus?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never,
+            "reminder repository must not be queried when guild is not found");
+    }
+
+    // -----------------------------------------------------------------
+    // OnGetAsync — service interaction
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task OnGetAsync_WithValidGuildId_FetchesGuildStats()
+    {
+        // Arrange
+        const long guildId = 111222333L;
+        _mockGuildService
+            .Setup(s => s.GetGuildByIdAsync((ulong)guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateGuildDto((ulong)guildId, "Test Guild"));
+
+        // Act
+        await _indexModel.OnGetAsync(guildId, CancellationToken.None);
+
+        // Assert
+        _mockReminderRepository.Verify(
+            r => r.GetGuildStatsAsync((ulong)guildId, It.IsAny<CancellationToken>()),
+            Times.Once,
+            "guild stats must be fetched once for the reminders page");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_WithValidGuildId_FetchesReminders()
+    {
+        // Arrange
+        const long guildId = 111222333L;
+        _mockGuildService
+            .Setup(s => s.GetGuildByIdAsync((ulong)guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateGuildDto((ulong)guildId, "Test Guild"));
+
+        // Act
+        await _indexModel.OnGetAsync(guildId, CancellationToken.None);
+
+        // Assert
+        _mockReminderRepository.Verify(
+            r => r.GetByGuildAsync(
+                (ulong)guildId,
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<ReminderStatus?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "reminders must be fetched once for the guild");
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    private static GuildDto CreateGuildDto(ulong id, string name) => new()
+    {
+        Id = id,
+        Name = name,
+        IsActive = true,
+        JoinedAt = DateTime.UtcNow.AddMonths(-6),
+        IconUrl = null
+    };
+}

--- a/tests/DiscordBot.Tests/Controllers/CommandLogsControllerTests.cs
+++ b/tests/DiscordBot.Tests/Controllers/CommandLogsControllerTests.cs
@@ -1,0 +1,641 @@
+using DiscordBot.Bot.Controllers;
+using DiscordBot.Bot.Middleware;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace DiscordBot.Tests.Controllers;
+
+/// <summary>
+/// Unit tests for <see cref="CommandLogsController"/>.
+/// Tests cover all endpoints: GetLogs, GetCommandStats, GetAnalytics,
+/// GetUsageOverTime, GetSuccessRate, and GetPerformance.
+/// </summary>
+[Trait("Category", "Unit")]
+public class CommandLogsControllerTests
+{
+    private readonly Mock<ICommandLogService> _mockCommandLogService;
+    private readonly Mock<ICommandAnalyticsService> _mockAnalyticsService;
+    private readonly Mock<ILogger<CommandLogsController>> _mockLogger;
+    private readonly CommandLogsController _controller;
+
+    public CommandLogsControllerTests()
+    {
+        _mockCommandLogService = new Mock<ICommandLogService>();
+        _mockAnalyticsService = new Mock<ICommandAnalyticsService>();
+        _mockLogger = new Mock<ILogger<CommandLogsController>>();
+
+        _controller = new CommandLogsController(
+            _mockCommandLogService.Object,
+            _mockAnalyticsService.Object,
+            _mockLogger.Object);
+
+        // Setup HttpContext for TraceIdentifier and correlation ID
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+        _controller.HttpContext.Items[CorrelationIdMiddleware.ItemKey] = "test-correlation-id";
+    }
+
+    #region GetLogs Tests
+
+    [Fact]
+    public async Task GetLogs_ShouldReturnOkWithPaginatedResults_WhenLogsExist()
+    {
+        // Arrange
+        var paginatedResponse = new PaginatedResponseDto<CommandLogDto>
+        {
+            Items = new List<CommandLogDto>
+            {
+                CreateTestCommandLogDto(commandName: "ping"),
+                CreateTestCommandLogDto(commandName: "status")
+            }.AsReadOnly(),
+            Page = 1,
+            PageSize = 50,
+            TotalCount = 2
+        };
+
+        _mockCommandLogService
+            .Setup(s => s.GetLogsAsync(It.IsAny<CommandLogQueryDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(paginatedResponse);
+
+        // Act
+        var result = await _controller.GetLogs(cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<OkObjectResult>();
+
+        var okResult = result.Result as OkObjectResult;
+        var response = okResult!.Value as PaginatedResponseDto<CommandLogDto>;
+
+        response.Should().NotBeNull();
+        response!.Items.Should().HaveCount(2);
+        response.Page.Should().Be(1);
+        response.PageSize.Should().Be(50);
+        response.TotalCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetLogs_ShouldReturnOkWithEmptyList_WhenNoLogsExist()
+    {
+        // Arrange
+        var paginatedResponse = new PaginatedResponseDto<CommandLogDto>
+        {
+            Items = new List<CommandLogDto>().AsReadOnly(),
+            Page = 1,
+            PageSize = 50,
+            TotalCount = 0
+        };
+
+        _mockCommandLogService
+            .Setup(s => s.GetLogsAsync(It.IsAny<CommandLogQueryDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(paginatedResponse);
+
+        // Act
+        var result = await _controller.GetLogs(cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<OkObjectResult>();
+
+        var okResult = result.Result as OkObjectResult;
+        var response = okResult!.Value as PaginatedResponseDto<CommandLogDto>;
+
+        response.Should().NotBeNull();
+        response!.Items.Should().BeEmpty();
+        response.TotalCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetLogs_ShouldReturnBadRequest_WhenStartDateIsAfterEndDate()
+    {
+        // Arrange
+        var startDate = DateTime.UtcNow;
+        var endDate = DateTime.UtcNow.AddDays(-1); // end before start
+
+        // Act
+        var result = await _controller.GetLogs(
+            startDate: startDate,
+            endDate: endDate,
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+
+        var badRequestResult = result.Result as BadRequestObjectResult;
+        var apiError = badRequestResult!.Value as ApiErrorDto;
+
+        apiError.Should().NotBeNull();
+        apiError!.Message.Should().Be("Invalid date range");
+        apiError.Detail.Should().Be("Start date cannot be after end date.");
+        apiError.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+
+        _mockCommandLogService.Verify(
+            s => s.GetLogsAsync(It.IsAny<CommandLogQueryDto>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "service should not be called when date range is invalid");
+    }
+
+    [Fact]
+    public async Task GetLogs_ShouldIncludeCorrelationId_InBadRequestErrorResponse()
+    {
+        // Arrange
+        const string expectedCorrelationId = "my-correlation-id";
+        _controller.HttpContext.Items[CorrelationIdMiddleware.ItemKey] = expectedCorrelationId;
+
+        var startDate = DateTime.UtcNow;
+        var endDate = DateTime.UtcNow.AddDays(-1);
+
+        // Act
+        var result = await _controller.GetLogs(
+            startDate: startDate,
+            endDate: endDate,
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        var badRequestResult = result.Result as BadRequestObjectResult;
+        var apiError = badRequestResult!.Value as ApiErrorDto;
+
+        apiError!.TraceId.Should().Be(expectedCorrelationId);
+    }
+
+    [Fact]
+    public async Task GetLogs_ShouldAllowValidDateRange()
+    {
+        // Arrange
+        var startDate = DateTime.UtcNow.AddDays(-7);
+        var endDate = DateTime.UtcNow;
+        var paginatedResponse = new PaginatedResponseDto<CommandLogDto>
+        {
+            Items = new List<CommandLogDto>().AsReadOnly(),
+            Page = 1,
+            PageSize = 50,
+            TotalCount = 0
+        };
+
+        _mockCommandLogService
+            .Setup(s => s.GetLogsAsync(It.IsAny<CommandLogQueryDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(paginatedResponse);
+
+        // Act
+        var result = await _controller.GetLogs(
+            startDate: startDate,
+            endDate: endDate,
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<OkObjectResult>();
+
+        _mockCommandLogService.Verify(
+            s => s.GetLogsAsync(It.IsAny<CommandLogQueryDto>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetLogs_ShouldPassFilters_ToService()
+    {
+        // Arrange
+        const ulong guildId = 123456789UL;
+        const ulong userId = 987654321UL;
+        const string commandName = "ping";
+        const bool successOnly = true;
+        const int page = 2;
+        const int pageSize = 25;
+
+        var paginatedResponse = new PaginatedResponseDto<CommandLogDto>
+        {
+            Items = new List<CommandLogDto>().AsReadOnly(),
+            Page = page,
+            PageSize = pageSize,
+            TotalCount = 0
+        };
+
+        _mockCommandLogService
+            .Setup(s => s.GetLogsAsync(It.IsAny<CommandLogQueryDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(paginatedResponse);
+
+        // Act
+        await _controller.GetLogs(
+            guildId: guildId,
+            userId: userId,
+            commandName: commandName,
+            successOnly: successOnly,
+            page: page,
+            pageSize: pageSize,
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        _mockCommandLogService.Verify(
+            s => s.GetLogsAsync(
+                It.Is<CommandLogQueryDto>(q =>
+                    q.GuildId == guildId &&
+                    q.UserId == userId &&
+                    q.CommandName == commandName &&
+                    q.SuccessOnly == successOnly &&
+                    q.Page == page &&
+                    q.PageSize == pageSize),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetLogs_ShouldAllowEqualStartAndEndDates()
+    {
+        // Arrange
+        var date = DateTime.UtcNow.Date;
+        var paginatedResponse = new PaginatedResponseDto<CommandLogDto>
+        {
+            Items = new List<CommandLogDto>().AsReadOnly(),
+            Page = 1,
+            PageSize = 50,
+            TotalCount = 0
+        };
+
+        _mockCommandLogService
+            .Setup(s => s.GetLogsAsync(It.IsAny<CommandLogQueryDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(paginatedResponse);
+
+        // Act
+        var result = await _controller.GetLogs(
+            startDate: date,
+            endDate: date,
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<OkObjectResult>();
+    }
+
+    #endregion
+
+    #region GetCommandStats Tests
+
+    [Fact]
+    public async Task GetCommandStats_ShouldReturnOkWithStatsDictionary()
+    {
+        // Arrange
+        var expectedStats = new Dictionary<string, int>
+        {
+            { "ping", 150 },
+            { "status", 75 },
+            { "play", 300 }
+        };
+
+        _mockCommandLogService
+            .Setup(s => s.GetCommandStatsAsync(It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedStats);
+
+        // Act
+        var result = await _controller.GetCommandStats(cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<OkObjectResult>();
+
+        var okResult = result.Result as OkObjectResult;
+        var stats = okResult!.Value as IDictionary<string, int>;
+
+        stats.Should().NotBeNull();
+        stats.Should().HaveCount(3);
+        stats!["ping"].Should().Be(150);
+        stats["status"].Should().Be(75);
+        stats["play"].Should().Be(300);
+    }
+
+    [Fact]
+    public async Task GetCommandStats_ShouldReturnEmptyDictionary_WhenNoCommandsExecuted()
+    {
+        // Arrange
+        _mockCommandLogService
+            .Setup(s => s.GetCommandStatsAsync(It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, int>());
+
+        // Act
+        var result = await _controller.GetCommandStats(cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<OkObjectResult>();
+
+        var okResult = result.Result as OkObjectResult;
+        var stats = okResult!.Value as IDictionary<string, int>;
+
+        stats.Should().NotBeNull();
+        stats.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetCommandStats_ShouldPassSinceParameter_ToService()
+    {
+        // Arrange
+        var since = DateTime.UtcNow.AddDays(-30);
+
+        _mockCommandLogService
+            .Setup(s => s.GetCommandStatsAsync(since, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, int>());
+
+        // Act
+        await _controller.GetCommandStats(since: since, cancellationToken: CancellationToken.None);
+
+        // Assert
+        _mockCommandLogService.Verify(
+            s => s.GetCommandStatsAsync(since, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    #endregion
+
+    #region GetAnalytics Tests
+
+    [Fact]
+    public async Task GetAnalytics_ShouldReturnOkWithAnalyticsData()
+    {
+        // Arrange
+        var analytics = new CommandAnalyticsDto
+        {
+            TotalCommands = 500,
+            SuccessRate = 95.5m,
+            AvgResponseTimeMs = 120.0,
+            UniqueCommands = 15
+        };
+
+        _mockAnalyticsService
+            .Setup(s => s.GetAnalyticsAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<ulong?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(analytics);
+
+        // Act
+        var result = await _controller.GetAnalytics(cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<OkObjectResult>();
+
+        var okResult = result.Result as OkObjectResult;
+        var returnedAnalytics = okResult!.Value as CommandAnalyticsDto;
+
+        returnedAnalytics.Should().NotBeNull();
+        returnedAnalytics!.TotalCommands.Should().Be(500);
+        returnedAnalytics.SuccessRate.Should().Be(95.5m);
+    }
+
+    [Fact]
+    public async Task GetAnalytics_ShouldUseDefaultDateRange_WhenNotProvided()
+    {
+        // Arrange
+        var analytics = new CommandAnalyticsDto { TotalCommands = 0 };
+
+        _mockAnalyticsService
+            .Setup(s => s.GetAnalyticsAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<ulong?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(analytics);
+
+        // Act
+        await _controller.GetAnalytics(cancellationToken: CancellationToken.None);
+
+        // Assert — defaults to last 30 days; verify dates are in the expected range
+        _mockAnalyticsService.Verify(
+            s => s.GetAnalyticsAsync(
+                It.Is<DateTime>(d => d > DateTime.UtcNow.AddDays(-31) && d < DateTime.UtcNow.AddDays(-29)),
+                It.Is<DateTime>(d => d > DateTime.UtcNow.AddMinutes(-1) && d <= DateTime.UtcNow.AddMinutes(1)),
+                null,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAnalytics_ShouldPassGuildId_ToService()
+    {
+        // Arrange
+        const ulong guildId = 123456789UL;
+        var analytics = new CommandAnalyticsDto { TotalCommands = 0 };
+
+        _mockAnalyticsService
+            .Setup(s => s.GetAnalyticsAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                guildId,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(analytics);
+
+        // Act
+        await _controller.GetAnalytics(guildId: guildId, cancellationToken: CancellationToken.None);
+
+        // Assert
+        _mockAnalyticsService.Verify(
+            s => s.GetAnalyticsAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                guildId,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    #endregion
+
+    #region GetUsageOverTime Tests
+
+    [Fact]
+    public async Task GetUsageOverTime_ShouldReturnOkWithDataPoints()
+    {
+        // Arrange
+        var start = DateTime.UtcNow.AddDays(-7);
+        var end = DateTime.UtcNow;
+
+        var usageData = new List<UsageOverTimeDto>
+        {
+            new() { Date = start, Count = 10 },
+            new() { Date = start.AddDays(1), Count = 15 },
+            new() { Date = start.AddDays(2), Count = 8 }
+        }.AsReadOnly();
+
+        _mockAnalyticsService
+            .Setup(s => s.GetUsageOverTimeAsync(start, end, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(usageData);
+
+        // Act
+        var result = await _controller.GetUsageOverTime(start, end, cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<OkObjectResult>();
+
+        var okResult = result.Result as OkObjectResult;
+        var data = okResult!.Value as IEnumerable<UsageOverTimeDto>;
+
+        data.Should().NotBeNull();
+        data.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task GetUsageOverTime_ShouldPassGuildId_ToService()
+    {
+        // Arrange
+        var start = DateTime.UtcNow.AddDays(-7);
+        var end = DateTime.UtcNow;
+        const ulong guildId = 123456789UL;
+
+        _mockAnalyticsService
+            .Setup(s => s.GetUsageOverTimeAsync(start, end, guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<UsageOverTimeDto>().AsReadOnly());
+
+        // Act
+        await _controller.GetUsageOverTime(start, end, guildId: guildId, cancellationToken: CancellationToken.None);
+
+        // Assert
+        _mockAnalyticsService.Verify(
+            s => s.GetUsageOverTimeAsync(start, end, guildId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    #endregion
+
+    #region GetSuccessRate Tests
+
+    [Fact]
+    public async Task GetSuccessRate_ShouldReturnOkWithSuccessRateData()
+    {
+        // Arrange
+        var successRateData = new CommandSuccessRateDto
+        {
+            SuccessCount = 480,
+            FailureCount = 20
+        };
+
+        _mockAnalyticsService
+            .Setup(s => s.GetSuccessRateAsync(It.IsAny<DateTime?>(), It.IsAny<ulong?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(successRateData);
+
+        // Act
+        var result = await _controller.GetSuccessRate(cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<OkObjectResult>();
+
+        var okResult = result.Result as OkObjectResult;
+        var returnedData = okResult!.Value as CommandSuccessRateDto;
+
+        returnedData.Should().NotBeNull();
+        returnedData!.SuccessCount.Should().Be(480);
+        returnedData.FailureCount.Should().Be(20);
+        returnedData.TotalCount.Should().Be(500);
+        returnedData.SuccessRate.Should().Be(96m);
+    }
+
+    [Fact]
+    public async Task GetSuccessRate_ShouldPassFilters_ToService()
+    {
+        // Arrange
+        var since = DateTime.UtcNow.AddDays(-14);
+        const ulong guildId = 123456789UL;
+
+        _mockAnalyticsService
+            .Setup(s => s.GetSuccessRateAsync(since, guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CommandSuccessRateDto { SuccessCount = 0, FailureCount = 0 });
+
+        // Act
+        await _controller.GetSuccessRate(since: since, guildId: guildId, cancellationToken: CancellationToken.None);
+
+        // Assert
+        _mockAnalyticsService.Verify(
+            s => s.GetSuccessRateAsync(since, guildId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    #endregion
+
+    #region GetPerformance Tests
+
+    [Fact]
+    public async Task GetPerformance_ShouldReturnOkWithPerformanceMetrics()
+    {
+        // Arrange
+        var performanceData = new List<CommandPerformanceDto>
+        {
+            new() { CommandName = "play", AvgResponseTimeMs = 250.0, MinResponseTimeMs = 100, MaxResponseTimeMs = 500, ExecutionCount = 200 },
+            new() { CommandName = "ping", AvgResponseTimeMs = 50.0, MinResponseTimeMs = 10, MaxResponseTimeMs = 150, ExecutionCount = 500 }
+        }.AsReadOnly();
+
+        _mockAnalyticsService
+            .Setup(s => s.GetCommandPerformanceAsync(
+                It.IsAny<DateTime?>(),
+                It.IsAny<ulong?>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(performanceData);
+
+        // Act
+        var result = await _controller.GetPerformance(cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<OkObjectResult>();
+
+        var okResult = result.Result as OkObjectResult;
+        var data = okResult!.Value as IEnumerable<CommandPerformanceDto>;
+
+        data.Should().NotBeNull();
+        data.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task GetPerformance_ShouldPassLimitParameter_ToService()
+    {
+        // Arrange
+        const int limit = 5;
+
+        _mockAnalyticsService
+            .Setup(s => s.GetCommandPerformanceAsync(
+                It.IsAny<DateTime?>(),
+                It.IsAny<ulong?>(),
+                limit,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CommandPerformanceDto>().AsReadOnly());
+
+        // Act
+        await _controller.GetPerformance(limit: limit, cancellationToken: CancellationToken.None);
+
+        // Assert
+        _mockAnalyticsService.Verify(
+            s => s.GetCommandPerformanceAsync(
+                It.IsAny<DateTime?>(),
+                It.IsAny<ulong?>(),
+                limit,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    /// <summary>
+    /// Creates a test command log DTO with default values.
+    /// </summary>
+    private static CommandLogDto CreateTestCommandLogDto(
+        string commandName = "ping",
+        bool success = true,
+        ulong? guildId = null,
+        ulong userId = 123456789UL)
+    {
+        return new CommandLogDto
+        {
+            Id = Guid.NewGuid(),
+            CommandName = commandName,
+            UserId = userId,
+            Username = "TestUser",
+            GuildId = guildId,
+            GuildName = guildId.HasValue ? "Test Guild" : null,
+            ExecutedAt = DateTime.UtcNow,
+            ResponseTimeMs = 100,
+            Success = success,
+            ErrorMessage = success ? null : "Test error"
+        };
+    }
+
+    #endregion
+}

--- a/tests/DiscordBot.Tests/Controllers/ModerationCasesControllerTests.cs
+++ b/tests/DiscordBot.Tests/Controllers/ModerationCasesControllerTests.cs
@@ -1,0 +1,763 @@
+using DiscordBot.Bot.Controllers;
+using DiscordBot.Bot.Middleware;
+using DiscordBot.Core.DTOs;
+using DiscordBot.Core.Enums;
+using DiscordBot.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace DiscordBot.Tests.Controllers;
+
+/// <summary>
+/// Unit tests for <see cref="ModerationCasesController"/>.
+/// Tests cover all endpoints: GetCases, GetCaseById, GetCaseByNumber,
+/// CreateCase, and UpdateCaseReason.
+/// </summary>
+[Trait("Category", "Unit")]
+public class ModerationCasesControllerTests
+{
+    private readonly Mock<IModerationService> _mockModerationService;
+    private readonly Mock<ILogger<ModerationCasesController>> _mockLogger;
+    private readonly ModerationCasesController _controller;
+    private const ulong TestGuildId = 111222333UL;
+
+    public ModerationCasesControllerTests()
+    {
+        _mockModerationService = new Mock<IModerationService>();
+        _mockLogger = new Mock<ILogger<ModerationCasesController>>();
+
+        _controller = new ModerationCasesController(
+            _mockModerationService.Object,
+            _mockLogger.Object);
+
+        // Setup HttpContext for TraceIdentifier and correlation ID
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+        _controller.HttpContext.Items[CorrelationIdMiddleware.ItemKey] = "test-correlation-id";
+    }
+
+    #region GetCases Tests
+
+    [Fact]
+    public async Task GetCases_ShouldReturnOkWithPaginatedResults_WhenCasesExist()
+    {
+        // Arrange
+        var cases = new List<ModerationCaseDto>
+        {
+            CreateTestModerationCaseDto(guildId: TestGuildId, caseNumber: 1),
+            CreateTestModerationCaseDto(guildId: TestGuildId, caseNumber: 2),
+            CreateTestModerationCaseDto(guildId: TestGuildId, caseNumber: 3)
+        };
+
+        _mockModerationService
+            .Setup(s => s.GetCasesAsync(It.IsAny<ModerationCaseQueryDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((cases, cases.Count));
+
+        // Act
+        var result = await _controller.GetCases(TestGuildId, cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<OkObjectResult>();
+
+        var okResult = result.Result as OkObjectResult;
+        var response = okResult!.Value as PaginatedResponseDto<ModerationCaseDto>;
+
+        response.Should().NotBeNull();
+        response!.Items.Should().HaveCount(3);
+        response.Page.Should().Be(1);
+        response.PageSize.Should().Be(20);
+        response.TotalCount.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task GetCases_ShouldReturnOkWithEmptyList_WhenNoCasesExist()
+    {
+        // Arrange
+        _mockModerationService
+            .Setup(s => s.GetCasesAsync(It.IsAny<ModerationCaseQueryDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Enumerable.Empty<ModerationCaseDto>(), 0));
+
+        // Act
+        var result = await _controller.GetCases(TestGuildId, cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<OkObjectResult>();
+
+        var okResult = result.Result as OkObjectResult;
+        var response = okResult!.Value as PaginatedResponseDto<ModerationCaseDto>;
+
+        response.Should().NotBeNull();
+        response!.Items.Should().BeEmpty();
+        response.TotalCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetCases_ShouldReturnBadRequest_WhenPageNumberIsLessThanOne()
+    {
+        // Arrange
+        const int invalidPage = 0;
+
+        // Act
+        var result = await _controller.GetCases(TestGuildId, page: invalidPage, cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+
+        var badRequestResult = result.Result as BadRequestObjectResult;
+        var apiError = badRequestResult!.Value as ApiErrorDto;
+
+        apiError.Should().NotBeNull();
+        apiError!.Message.Should().Be("Invalid page number");
+        apiError.Detail.Should().Be("Page number must be greater than or equal to 1.");
+        apiError.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+
+        _mockModerationService.Verify(
+            s => s.GetCasesAsync(It.IsAny<ModerationCaseQueryDto>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "service should not be called when page number is invalid");
+    }
+
+    [Fact]
+    public async Task GetCases_ShouldReturnBadRequest_WhenPageNumberIsNegative()
+    {
+        // Arrange
+        const int invalidPage = -5;
+
+        // Act
+        var result = await _controller.GetCases(TestGuildId, page: invalidPage, cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+
+        var badRequestResult = result.Result as BadRequestObjectResult;
+        var apiError = badRequestResult!.Value as ApiErrorDto;
+
+        apiError.Should().NotBeNull();
+        apiError!.Message.Should().Be("Invalid page number");
+        apiError.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task GetCases_ShouldReturnBadRequest_WhenPageSizeIsLessThanOne()
+    {
+        // Arrange
+        const int invalidPageSize = 0;
+
+        // Act
+        var result = await _controller.GetCases(TestGuildId, pageSize: invalidPageSize, cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+
+        var badRequestResult = result.Result as BadRequestObjectResult;
+        var apiError = badRequestResult!.Value as ApiErrorDto;
+
+        apiError.Should().NotBeNull();
+        apiError!.Message.Should().Be("Invalid page size");
+        apiError.Detail.Should().Be("Page size must be between 1 and 100.");
+        apiError.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+
+        _mockModerationService.Verify(
+            s => s.GetCasesAsync(It.IsAny<ModerationCaseQueryDto>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "service should not be called when page size is invalid");
+    }
+
+    [Fact]
+    public async Task GetCases_ShouldReturnBadRequest_WhenPageSizeExceedsMaximum()
+    {
+        // Arrange
+        const int invalidPageSize = 101;
+
+        // Act
+        var result = await _controller.GetCases(TestGuildId, pageSize: invalidPageSize, cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+
+        var badRequestResult = result.Result as BadRequestObjectResult;
+        var apiError = badRequestResult!.Value as ApiErrorDto;
+
+        apiError.Should().NotBeNull();
+        apiError!.Message.Should().Be("Invalid page size");
+        apiError.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task GetCases_ShouldIncludeCorrelationId_InBadRequestErrorResponse()
+    {
+        // Arrange
+        const string expectedCorrelationId = "cases-correlation-id";
+        _controller.HttpContext.Items[CorrelationIdMiddleware.ItemKey] = expectedCorrelationId;
+
+        // Act
+        var result = await _controller.GetCases(TestGuildId, page: 0, cancellationToken: CancellationToken.None);
+
+        // Assert
+        var badRequestResult = result.Result as BadRequestObjectResult;
+        var apiError = badRequestResult!.Value as ApiErrorDto;
+
+        apiError!.TraceId.Should().Be(expectedCorrelationId);
+    }
+
+    [Fact]
+    public async Task GetCases_ShouldPassFilters_ToService()
+    {
+        // Arrange
+        var type = CaseType.Ban;
+        const ulong targetUserId = 555666777UL;
+        const ulong moderatorUserId = 888999000UL;
+        const int page = 2;
+        const int pageSize = 10;
+
+        _mockModerationService
+            .Setup(s => s.GetCasesAsync(It.IsAny<ModerationCaseQueryDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Enumerable.Empty<ModerationCaseDto>(), 0));
+
+        // Act
+        await _controller.GetCases(
+            TestGuildId,
+            type: type,
+            targetUserId: targetUserId,
+            moderatorUserId: moderatorUserId,
+            page: page,
+            pageSize: pageSize,
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        _mockModerationService.Verify(
+            s => s.GetCasesAsync(
+                It.Is<ModerationCaseQueryDto>(q =>
+                    q.GuildId == TestGuildId &&
+                    q.Type == type &&
+                    q.TargetUserId == targetUserId &&
+                    q.ModeratorUserId == moderatorUserId &&
+                    q.Page == page &&
+                    q.PageSize == pageSize),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetCases_ShouldAllowMaximumPageSize()
+    {
+        // Arrange
+        const int maxPageSize = 100;
+
+        _mockModerationService
+            .Setup(s => s.GetCasesAsync(It.IsAny<ModerationCaseQueryDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Enumerable.Empty<ModerationCaseDto>(), 0));
+
+        // Act
+        var result = await _controller.GetCases(TestGuildId, pageSize: maxPageSize, cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<OkObjectResult>();
+    }
+
+    #endregion
+
+    #region GetCaseById Tests
+
+    [Fact]
+    public async Task GetCaseById_ShouldReturnOkWithCase_WhenCaseExists()
+    {
+        // Arrange
+        var caseId = Guid.NewGuid();
+        var moderationCase = CreateTestModerationCaseDto(id: caseId, guildId: TestGuildId, caseNumber: 5);
+
+        _mockModerationService
+            .Setup(s => s.GetCaseAsync(caseId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(moderationCase);
+
+        // Act
+        var result = await _controller.GetCaseById(TestGuildId, caseId, CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<OkObjectResult>();
+
+        var okResult = result.Result as OkObjectResult;
+        var returnedCase = okResult!.Value as ModerationCaseDto;
+
+        returnedCase.Should().NotBeNull();
+        returnedCase!.Id.Should().Be(caseId);
+        returnedCase.GuildId.Should().Be(TestGuildId);
+        returnedCase.CaseNumber.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task GetCaseById_ShouldReturnNotFound_WhenCaseDoesNotExist()
+    {
+        // Arrange
+        var caseId = Guid.NewGuid();
+
+        _mockModerationService
+            .Setup(s => s.GetCaseAsync(caseId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ModerationCaseDto?)null);
+
+        // Act
+        var result = await _controller.GetCaseById(TestGuildId, caseId, CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<NotFoundObjectResult>();
+
+        var notFoundResult = result.Result as NotFoundObjectResult;
+        var apiError = notFoundResult!.Value as ApiErrorDto;
+
+        apiError.Should().NotBeNull();
+        apiError!.Message.Should().Be("Moderation case not found");
+        apiError.Detail.Should().Contain(caseId.ToString());
+        apiError.Detail.Should().Contain(TestGuildId.ToString());
+        apiError.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Fact]
+    public async Task GetCaseById_ShouldReturnNotFound_WhenCaseBelongsToDifferentGuild()
+    {
+        // Arrange
+        var caseId = Guid.NewGuid();
+        const ulong differentGuildId = 999888777UL;
+
+        // Case exists but belongs to a different guild
+        var moderationCase = CreateTestModerationCaseDto(id: caseId, guildId: differentGuildId, caseNumber: 1);
+
+        _mockModerationService
+            .Setup(s => s.GetCaseAsync(caseId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(moderationCase);
+
+        // Act — request case for TestGuildId but case belongs to differentGuildId
+        var result = await _controller.GetCaseById(TestGuildId, caseId, CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<NotFoundObjectResult>();
+
+        var notFoundResult = result.Result as NotFoundObjectResult;
+        var apiError = notFoundResult!.Value as ApiErrorDto;
+
+        apiError.Should().NotBeNull();
+        apiError!.Message.Should().Be("Moderation case not found");
+        apiError.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Fact]
+    public async Task GetCaseById_ShouldIncludeCorrelationId_InNotFoundErrorResponse()
+    {
+        // Arrange
+        const string expectedCorrelationId = "case-not-found-correlation";
+        _controller.HttpContext.Items[CorrelationIdMiddleware.ItemKey] = expectedCorrelationId;
+
+        var caseId = Guid.NewGuid();
+
+        _mockModerationService
+            .Setup(s => s.GetCaseAsync(caseId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ModerationCaseDto?)null);
+
+        // Act
+        var result = await _controller.GetCaseById(TestGuildId, caseId, CancellationToken.None);
+
+        // Assert
+        var notFoundResult = result.Result as NotFoundObjectResult;
+        var apiError = notFoundResult!.Value as ApiErrorDto;
+
+        apiError!.TraceId.Should().Be(expectedCorrelationId);
+    }
+
+    #endregion
+
+    #region GetCaseByNumber Tests
+
+    [Fact]
+    public async Task GetCaseByNumber_ShouldReturnOkWithCase_WhenCaseExists()
+    {
+        // Arrange
+        const long caseNumber = 42L;
+        var moderationCase = CreateTestModerationCaseDto(guildId: TestGuildId, caseNumber: (int)caseNumber);
+
+        _mockModerationService
+            .Setup(s => s.GetCaseByNumberAsync(TestGuildId, caseNumber, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(moderationCase);
+
+        // Act
+        var result = await _controller.GetCaseByNumber(TestGuildId, caseNumber, CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<OkObjectResult>();
+
+        var okResult = result.Result as OkObjectResult;
+        var returnedCase = okResult!.Value as ModerationCaseDto;
+
+        returnedCase.Should().NotBeNull();
+        returnedCase!.CaseNumber.Should().Be((int)caseNumber);
+        returnedCase.GuildId.Should().Be(TestGuildId);
+    }
+
+    [Fact]
+    public async Task GetCaseByNumber_ShouldReturnNotFound_WhenCaseDoesNotExist()
+    {
+        // Arrange
+        const long caseNumber = 99999L;
+
+        _mockModerationService
+            .Setup(s => s.GetCaseByNumberAsync(TestGuildId, caseNumber, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ModerationCaseDto?)null);
+
+        // Act
+        var result = await _controller.GetCaseByNumber(TestGuildId, caseNumber, CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<NotFoundObjectResult>();
+
+        var notFoundResult = result.Result as NotFoundObjectResult;
+        var apiError = notFoundResult!.Value as ApiErrorDto;
+
+        apiError.Should().NotBeNull();
+        apiError!.Message.Should().Be("Moderation case not found");
+        apiError.Detail.Should().Contain(caseNumber.ToString());
+        apiError.Detail.Should().Contain(TestGuildId.ToString());
+        apiError.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    #endregion
+
+    #region CreateCase Tests
+
+    [Fact]
+    public async Task CreateCase_ShouldReturnCreatedWithCase_WhenRequestIsValid()
+    {
+        // Arrange
+        var request = new ModerationCaseCreateDto
+        {
+            TargetUserId = 555666777UL,
+            ModeratorUserId = 888999000UL,
+            Type = CaseType.Warn,
+            Reason = "Spamming in #general"
+        };
+
+        var createdCase = CreateTestModerationCaseDto(guildId: TestGuildId, caseNumber: 10);
+
+        _mockModerationService
+            .Setup(s => s.CreateCaseAsync(It.IsAny<ModerationCaseCreateDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(createdCase);
+
+        // Act
+        var result = await _controller.CreateCase(TestGuildId, request, CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<CreatedAtActionResult>();
+
+        var createdResult = result.Result as CreatedAtActionResult;
+        var returnedCase = createdResult!.Value as ModerationCaseDto;
+
+        returnedCase.Should().NotBeNull();
+        returnedCase!.GuildId.Should().Be(TestGuildId);
+        returnedCase.CaseNumber.Should().Be(10);
+    }
+
+    [Fact]
+    public async Task CreateCase_ShouldReturnBadRequest_WhenRequestIsNull()
+    {
+        // Act
+        var result = await _controller.CreateCase(TestGuildId, null!, CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+
+        var badRequestResult = result.Result as BadRequestObjectResult;
+        var apiError = badRequestResult!.Value as ApiErrorDto;
+
+        apiError.Should().NotBeNull();
+        apiError!.Message.Should().Be("Invalid request");
+        apiError.Detail.Should().Contain("null");
+        apiError.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+
+        _mockModerationService.Verify(
+            s => s.CreateCaseAsync(It.IsAny<ModerationCaseCreateDto>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "service should not be called when request is null");
+    }
+
+    [Fact]
+    public async Task CreateCase_ShouldReturnBadRequest_WhenServiceThrowsArgumentException()
+    {
+        // Arrange
+        var request = new ModerationCaseCreateDto
+        {
+            TargetUserId = 0UL, // invalid: zero user ID
+            ModeratorUserId = 888999000UL,
+            Type = CaseType.Ban
+        };
+
+        _mockModerationService
+            .Setup(s => s.CreateCaseAsync(It.IsAny<ModerationCaseCreateDto>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ArgumentException("Target user ID must be a valid Discord snowflake."));
+
+        // Act
+        var result = await _controller.CreateCase(TestGuildId, request, CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+
+        var badRequestResult = result.Result as BadRequestObjectResult;
+        var apiError = badRequestResult!.Value as ApiErrorDto;
+
+        apiError.Should().NotBeNull();
+        apiError!.Message.Should().Be("Invalid request");
+        apiError.Detail.Should().Contain("Target user ID must be a valid Discord snowflake.");
+        apiError.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task CreateCase_ShouldOverrideRequestGuildId_WithRouteGuildId()
+    {
+        // Arrange — request has a different GuildId, should be overridden by route
+        const ulong differentGuildId = 999888777UL;
+        var request = new ModerationCaseCreateDto
+        {
+            GuildId = differentGuildId,
+            TargetUserId = 555666777UL,
+            ModeratorUserId = 888999000UL,
+            Type = CaseType.Kick,
+            Reason = "Disruptive behavior"
+        };
+
+        var createdCase = CreateTestModerationCaseDto(guildId: TestGuildId, caseNumber: 1);
+
+        _mockModerationService
+            .Setup(s => s.CreateCaseAsync(It.IsAny<ModerationCaseCreateDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(createdCase);
+
+        // Act
+        await _controller.CreateCase(TestGuildId, request, CancellationToken.None);
+
+        // Assert — GuildId should be overridden by the route value
+        _mockModerationService.Verify(
+            s => s.CreateCaseAsync(
+                It.Is<ModerationCaseCreateDto>(dto => dto.GuildId == TestGuildId),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateCase_ShouldReturnCreatedAtAction_WithCorrectLocation()
+    {
+        // Arrange
+        var caseId = Guid.NewGuid();
+        var request = new ModerationCaseCreateDto
+        {
+            TargetUserId = 555666777UL,
+            ModeratorUserId = 888999000UL,
+            Type = CaseType.Warn,
+            Reason = "Test reason"
+        };
+
+        var createdCase = CreateTestModerationCaseDto(id: caseId, guildId: TestGuildId, caseNumber: 15);
+
+        _mockModerationService
+            .Setup(s => s.CreateCaseAsync(It.IsAny<ModerationCaseCreateDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(createdCase);
+
+        // Act
+        var result = await _controller.CreateCase(TestGuildId, request, CancellationToken.None);
+
+        // Assert
+        var createdResult = result.Result as CreatedAtActionResult;
+        createdResult.Should().NotBeNull();
+        createdResult!.ActionName.Should().Be(nameof(ModerationCasesController.GetCaseById));
+
+        var routeValues = createdResult.RouteValues;
+        routeValues.Should().NotBeNull();
+        routeValues!["guildId"].Should().Be(TestGuildId);
+        routeValues["caseId"].Should().Be(caseId);
+    }
+
+    #endregion
+
+    #region UpdateCaseReason Tests
+
+    [Fact]
+    public async Task UpdateCaseReason_ShouldReturnOkWithUpdatedCase_WhenCaseExists()
+    {
+        // Arrange
+        const long caseNumber = 5L;
+        var request = new CaseReasonUpdateDto
+        {
+            Reason = "Updated reason: repeat offender",
+            ModeratorId = 888999000UL
+        };
+
+        var updatedCase = CreateTestModerationCaseDto(guildId: TestGuildId, caseNumber: (int)caseNumber);
+
+        _mockModerationService
+            .Setup(s => s.UpdateCaseReasonAsync(
+                TestGuildId, caseNumber, request.Reason, request.ModeratorId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(updatedCase);
+
+        // Act
+        var result = await _controller.UpdateCaseReason(TestGuildId, caseNumber, request, CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<OkObjectResult>();
+
+        var okResult = result.Result as OkObjectResult;
+        var returnedCase = okResult!.Value as ModerationCaseDto;
+
+        returnedCase.Should().NotBeNull();
+        returnedCase!.CaseNumber.Should().Be((int)caseNumber);
+    }
+
+    [Fact]
+    public async Task UpdateCaseReason_ShouldReturnNotFound_WhenCaseDoesNotExist()
+    {
+        // Arrange
+        const long caseNumber = 99999L;
+        var request = new CaseReasonUpdateDto
+        {
+            Reason = "Updated reason",
+            ModeratorId = 888999000UL
+        };
+
+        _mockModerationService
+            .Setup(s => s.UpdateCaseReasonAsync(
+                TestGuildId, caseNumber, request.Reason, request.ModeratorId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ModerationCaseDto?)null);
+
+        // Act
+        var result = await _controller.UpdateCaseReason(TestGuildId, caseNumber, request, CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<NotFoundObjectResult>();
+
+        var notFoundResult = result.Result as NotFoundObjectResult;
+        var apiError = notFoundResult!.Value as ApiErrorDto;
+
+        apiError.Should().NotBeNull();
+        apiError!.Message.Should().Be("Moderation case not found");
+        apiError.Detail.Should().Contain(caseNumber.ToString());
+        apiError.Detail.Should().Contain(TestGuildId.ToString());
+        apiError.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Fact]
+    public async Task UpdateCaseReason_ShouldReturnBadRequest_WhenReasonIsEmpty()
+    {
+        // Arrange
+        const long caseNumber = 5L;
+        var request = new CaseReasonUpdateDto
+        {
+            Reason = string.Empty, // invalid: empty reason
+            ModeratorId = 888999000UL
+        };
+
+        // Act
+        var result = await _controller.UpdateCaseReason(TestGuildId, caseNumber, request, CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+
+        var badRequestResult = result.Result as BadRequestObjectResult;
+        var apiError = badRequestResult!.Value as ApiErrorDto;
+
+        apiError.Should().NotBeNull();
+        apiError!.Message.Should().Be("Invalid request");
+        apiError.Detail.Should().Contain("Reason is required");
+        apiError.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+
+        _mockModerationService.Verify(
+            s => s.UpdateCaseReasonAsync(
+                It.IsAny<ulong>(), It.IsAny<long>(), It.IsAny<string>(), It.IsAny<ulong>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "service should not be called when reason is empty");
+    }
+
+    [Fact]
+    public async Task UpdateCaseReason_ShouldReturnBadRequest_WhenReasonIsWhitespace()
+    {
+        // Arrange
+        const long caseNumber = 5L;
+        var request = new CaseReasonUpdateDto
+        {
+            Reason = "   ", // invalid: whitespace only
+            ModeratorId = 888999000UL
+        };
+
+        // Act
+        var result = await _controller.UpdateCaseReason(TestGuildId, caseNumber, request, CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+
+        var badRequestResult = result.Result as BadRequestObjectResult;
+        var apiError = badRequestResult!.Value as ApiErrorDto;
+
+        apiError.Should().NotBeNull();
+        apiError!.Message.Should().Be("Invalid request");
+        apiError.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task UpdateCaseReason_ShouldPassAllParameters_ToService()
+    {
+        // Arrange
+        const long caseNumber = 7L;
+        const ulong moderatorId = 777888999UL;
+        const string reason = "Banned for repeated violations";
+
+        var request = new CaseReasonUpdateDto
+        {
+            Reason = reason,
+            ModeratorId = moderatorId
+        };
+
+        var updatedCase = CreateTestModerationCaseDto(guildId: TestGuildId, caseNumber: (int)caseNumber);
+
+        _mockModerationService
+            .Setup(s => s.UpdateCaseReasonAsync(
+                TestGuildId, caseNumber, reason, moderatorId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(updatedCase);
+
+        // Act
+        await _controller.UpdateCaseReason(TestGuildId, caseNumber, request, CancellationToken.None);
+
+        // Assert
+        _mockModerationService.Verify(
+            s => s.UpdateCaseReasonAsync(TestGuildId, caseNumber, reason, moderatorId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    /// <summary>
+    /// Creates a test moderation case DTO with default values.
+    /// </summary>
+    private static ModerationCaseDto CreateTestModerationCaseDto(
+        Guid? id = null,
+        ulong guildId = TestGuildId,
+        int caseNumber = 1,
+        CaseType type = CaseType.Warn,
+        ulong targetUserId = 555666777UL,
+        ulong moderatorUserId = 888999000UL)
+    {
+        return new ModerationCaseDto
+        {
+            Id = id ?? Guid.NewGuid(),
+            CaseNumber = caseNumber,
+            GuildId = guildId,
+            TargetUserId = targetUserId,
+            TargetUsername = "TargetUser",
+            ModeratorUserId = moderatorUserId,
+            ModeratorUsername = "ModeratorUser",
+            Type = type,
+            Reason = "Test moderation reason",
+            CreatedAt = DateTime.UtcNow
+        };
+    }
+
+    #endregion
+}

--- a/tests/DiscordBot.Tests/Controllers/PortalTtsControllerTests.cs
+++ b/tests/DiscordBot.Tests/Controllers/PortalTtsControllerTests.cs
@@ -36,6 +36,7 @@ public class PortalTtsControllerTests
     private readonly Mock<IStylePresetProvider> _mockStylePresetProvider;
     private readonly Mock<ISsmlValidator> _mockSsmlValidator;
     private readonly Mock<ISsmlBuilder> _mockSsmlBuilder;
+    private readonly Mock<IUserTtsPresetRepository> _mockUserTtsPresetRepository;
     private readonly Mock<ILogger<PortalTtsController>> _mockLogger;
     private readonly PortalTtsController _controller;
 
@@ -53,6 +54,7 @@ public class PortalTtsControllerTests
         _mockStylePresetProvider = new Mock<IStylePresetProvider>();
         _mockSsmlValidator = new Mock<ISsmlValidator>();
         _mockSsmlBuilder = new Mock<ISsmlBuilder>();
+        _mockUserTtsPresetRepository = new Mock<IUserTtsPresetRepository>();
         _mockLogger = new Mock<ILogger<PortalTtsController>>();
 
         // Setup bot-level audio enabled by default
@@ -79,6 +81,7 @@ public class PortalTtsControllerTests
             _mockStylePresetProvider.Object,
             _mockSsmlValidator.Object,
             _mockSsmlBuilder.Object,
+            _mockUserTtsPresetRepository.Object,
             _mockLogger.Object);
 
         // Setup HttpContext and User claims

--- a/tests/DiscordBot.Tests/DiscordBot.Tests.csproj
+++ b/tests/DiscordBot.Tests/DiscordBot.Tests.csproj
@@ -12,8 +12,8 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="FluentAssertions" Version="8.8.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.23" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.23" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.*" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />

--- a/tests/DiscordBot.Tests/Integration/PortalTtsIntegrationTests.cs
+++ b/tests/DiscordBot.Tests/Integration/PortalTtsIntegrationTests.cs
@@ -45,6 +45,7 @@ public class PortalTtsIntegrationTests : IDisposable
     private readonly Mock<IStylePresetProvider> _mockStylePresetProvider;
     private readonly Mock<ISsmlValidator> _mockSsmlValidator;
     private readonly Mock<ISsmlBuilder> _mockSsmlBuilder;
+    private readonly Mock<IUserTtsPresetRepository> _mockUserTtsPresetRepository;
     private readonly Mock<ILogger<PortalTtsController>> _mockLogger;
     private readonly AzureSpeechOptions _azureSpeechOptions;
 
@@ -66,6 +67,7 @@ public class PortalTtsIntegrationTests : IDisposable
         _mockStylePresetProvider = new Mock<IStylePresetProvider>();
         _mockSsmlValidator = new Mock<ISsmlValidator>();
         _mockSsmlBuilder = new Mock<ISsmlBuilder>();
+        _mockUserTtsPresetRepository = new Mock<IUserTtsPresetRepository>();
         _mockLogger = new Mock<ILogger<PortalTtsController>>();
 
         // Setup bot-level audio enabled by default
@@ -95,6 +97,7 @@ public class PortalTtsIntegrationTests : IDisposable
             _mockStylePresetProvider.Object,
             _mockSsmlValidator.Object,
             _mockSsmlBuilder.Object,
+            _mockUserTtsPresetRepository.Object,
             _mockLogger.Object);
 
         // Setup HttpContext with Discord claims (simulating OAuth authentication)

--- a/tests/DiscordBot.Tests/Services/BotServiceTests.cs
+++ b/tests/DiscordBot.Tests/Services/BotServiceTests.cs
@@ -3,7 +3,9 @@ using Discord.WebSocket;
 using DiscordBot.Bot.Services;
 using DiscordBot.Core.DTOs;
 using DiscordBot.Core.Interfaces;
+using DiscordBot.Infrastructure.Configuration;
 using FluentAssertions;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -23,6 +25,8 @@ public class BotServiceTests
     private readonly Mock<IDashboardUpdateService> _mockDashboardUpdateService;
     private readonly Mock<ILogger<BotService>> _mockLogger;
     private readonly Mock<IOptions<BotConfiguration>> _mockConfig;
+    private readonly Mock<IOptions<DatabaseSettings>> _mockDbSettings;
+    private readonly Mock<IConfiguration> _mockConfiguration;
 
     public BotServiceTests()
     {
@@ -37,6 +41,10 @@ public class BotServiceTests
             DefaultRateLimitInvokes = 3,
             DefaultRateLimitPeriodSeconds = 60.0
         });
+        _mockDbSettings = new Mock<IOptions<DatabaseSettings>>();
+        _mockDbSettings.Setup(d => d.Value).Returns(new DatabaseSettings());
+        _mockConfiguration = new Mock<IConfiguration>();
+        _mockConfiguration.Setup(c => c.GetSection(It.IsAny<string>())).Returns(new Mock<IConfigurationSection>().Object);
     }
 
     /// <summary>
@@ -121,7 +129,7 @@ public class BotServiceTests
     {
         // Arrange
         var client = new DiscordSocketClient();
-        var service = new BotService(client, _mockLifetime.Object, _mockDashboardUpdateService.Object, _mockLogger.Object, _mockConfig.Object);
+        var service = new BotService(client, _mockLifetime.Object, _mockDashboardUpdateService.Object, _mockLogger.Object, _mockConfig.Object, _mockDbSettings.Object, _mockConfiguration.Object);
 
         // Act
         await service.ShutdownAsync();
@@ -141,7 +149,7 @@ public class BotServiceTests
     {
         // Arrange
         var client = new DiscordSocketClient();
-        var service = new BotService(client, _mockLifetime.Object, _mockDashboardUpdateService.Object, _mockLogger.Object, _mockConfig.Object);
+        var service = new BotService(client, _mockLifetime.Object, _mockDashboardUpdateService.Object, _mockLogger.Object, _mockConfig.Object, _mockDbSettings.Object, _mockConfiguration.Object);
 
         // Act
         await service.ShutdownAsync();
@@ -166,7 +174,7 @@ public class BotServiceTests
     {
         // Arrange
         var client = new DiscordSocketClient();
-        var service = new BotService(client, _mockLifetime.Object, _mockDashboardUpdateService.Object, _mockLogger.Object, _mockConfig.Object);
+        var service = new BotService(client, _mockLifetime.Object, _mockDashboardUpdateService.Object, _mockLogger.Object, _mockConfig.Object, _mockDbSettings.Object, _mockConfiguration.Object);
         var cancellationTokenSource = new CancellationTokenSource();
 
         // Act
@@ -187,7 +195,7 @@ public class BotServiceTests
     {
         // Arrange
         var client = new DiscordSocketClient();
-        var service = new BotService(client, _mockLifetime.Object, _mockDashboardUpdateService.Object, _mockLogger.Object, _mockConfig.Object);
+        var service = new BotService(client, _mockLifetime.Object, _mockDashboardUpdateService.Object, _mockLogger.Object, _mockConfig.Object, _mockDbSettings.Object, _mockConfiguration.Object);
 
         // Act
         // Note: RestartAsync now performs a soft restart (disconnect/reconnect)
@@ -221,7 +229,7 @@ public class BotServiceTests
     {
         // Arrange
         var client = new DiscordSocketClient();
-        var service = new BotService(client, _mockLifetime.Object, _mockDashboardUpdateService.Object, _mockLogger.Object, _mockConfig.Object);
+        var service = new BotService(client, _mockLifetime.Object, _mockDashboardUpdateService.Object, _mockLogger.Object, _mockConfig.Object, _mockDbSettings.Object, _mockConfiguration.Object);
 
         // Act
         var config = service.GetConfiguration();

--- a/tests/DiscordBot.Tests/Services/BusinessMetricsUpdateServiceTests.cs
+++ b/tests/DiscordBot.Tests/Services/BusinessMetricsUpdateServiceTests.cs
@@ -24,6 +24,7 @@ public class BusinessMetricsUpdateServiceTests : IDisposable
     private readonly Mock<ICommandLogRepository> _mockCommandLogRepository;
     private readonly Mock<IGuildRepository> _mockGuildRepository;
     private readonly Mock<IOptions<BackgroundServicesOptions>> _mockBgOptions;
+    private readonly Mock<IApiRequestTracker> _mockApiRequestTracker;
     private readonly Mock<ILogger<BusinessMetricsUpdateService>> _mockLogger;
     private readonly BusinessMetrics _businessMetrics;
     private readonly SloMetrics _sloMetrics;
@@ -37,6 +38,7 @@ public class BusinessMetricsUpdateServiceTests : IDisposable
         _mockCommandLogRepository = new Mock<ICommandLogRepository>();
         _mockGuildRepository = new Mock<IGuildRepository>();
         _mockBgOptions = new Mock<IOptions<BackgroundServicesOptions>>();
+        _mockApiRequestTracker = new Mock<IApiRequestTracker>();
         _mockLogger = new Mock<ILogger<BusinessMetricsUpdateService>>();
 
         // Setup service scope factory
@@ -65,6 +67,7 @@ public class BusinessMetricsUpdateServiceTests : IDisposable
             _businessMetrics,
             _sloMetrics,
             _mockBgOptions.Object,
+            _mockApiRequestTracker.Object,
             _mockLogger.Object);
     }
 
@@ -78,6 +81,7 @@ public class BusinessMetricsUpdateServiceTests : IDisposable
             _businessMetrics,
             _sloMetrics,
             _mockBgOptions.Object,
+            _mockApiRequestTracker.Object,
             _mockLogger.Object);
 
         // Assert


### PR DESCRIPTION
## Summary

- Fix 6 test files with stale constructor signatures (PortalTtsController, BotService, BusinessMetricsUpdateService, DetailsModel)
- Align EF Core test package versions (`8.0.23` → `8.*`) to match Infrastructure project
- Add smoke tests for 3 guild pages: RatWatch/Index, Reminders/Index, Analytics/Index
- Add error-response tests for 2 controllers: CommandLogsController (18 tests), ModerationCasesController (26 tests)

**Baseline: 3,477 tests** (3,417 passed, 41 pre-existing failures, 19 skipped)

## Test plan

- [x] All 71 new tests pass
- [x] No regressions — pre-existing failure count unchanged at 41
- [ ] Verify CI passes

Closes #1855, Closes #1856, Closes #1857

🤖 Generated with [Claude Code](https://claude.com/claude-code)