### PR TITLE
fix: rethrow from inner catch so execution strategy can retry

### DIFF
--- a/src/DiscordBot.Bot/Services/BulkPurgeService.cs
+++ b/src/DiscordBot.Bot/Services/BulkPurgeService.cs
@@ -121,7 +121,7 @@ public class BulkPurgeService : IBulkPurgeService
             var executionStrategy = _dbContext.Database.CreateExecutionStrategy();
             var correlationId = Guid.NewGuid().ToString();
 
-            var (deletedCount, errorResult) = await executionStrategy.ExecuteAsync(async ct =>
+            var deletedCount = await executionStrategy.ExecuteAsync(async ct =>
             {
                 await using var transaction = await _dbContext.Database.BeginTransactionAsync(ct);
 
@@ -138,32 +138,14 @@ public class BulkPurgeService : IBulkPurgeService
 
                     await transaction.CommitAsync(ct);
 
-                    return (deleted, (BulkPurgeResultDto?)null);
+                    return deleted;
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     await transaction.RollbackAsync(ct);
-
-                    _logger.LogError(ex,
-                        "Transaction failed while bulk purging {EntityType}",
-                        criteria.EntityType);
-
-                    // Broadcast failure
-                    await BroadcastProgressAsync(criteria.EntityType, 0, totalCount, true, $"Purge failed: {ex.Message}");
-
-                    activity?.SetTag("purge.success", false);
-                    BotActivitySource.RecordException(activity, ex);
-
-                    return (0, (BulkPurgeResultDto?)BulkPurgeResultDto.Failed(
-                        BulkPurgeResultDto.TransactionFailed,
-                        $"Failed to purge: {ex.Message}"));
+                    throw; // Let execution strategy evaluate for retry
                 }
             }, cancellationToken);
-
-            if (errorResult != null)
-            {
-                return errorResult;
-            }
 
             _logger.LogInformation(
                 "Successfully purged {DeletedCount} {EntityType} records",
@@ -206,14 +188,18 @@ public class BulkPurgeService : IBulkPurgeService
         catch (Exception ex)
         {
             _logger.LogError(ex,
-                "Unexpected error while bulk purging {EntityType}",
+                "Failed while bulk purging {EntityType}",
                 criteria.EntityType);
 
+            // Broadcast failure
+            await BroadcastProgressAsync(criteria.EntityType, 0, totalCount, true, $"Purge failed: {ex.Message}");
+
+            activity?.SetTag("purge.success", false);
             BotActivitySource.RecordException(activity, ex);
 
             return BulkPurgeResultDto.Failed(
-                BulkPurgeResultDto.DatabaseError,
-                "An unexpected error occurred while purging data.");
+                BulkPurgeResultDto.TransactionFailed,
+                $"Failed to purge: {ex.Message}");
         }
     }
 

--- a/src/DiscordBot.Bot/Services/UserPurgeService.cs
+++ b/src/DiscordBot.Bot/Services/UserPurgeService.cs
@@ -93,14 +93,14 @@ public class UserPurgeService : IUserPurgeService
 
             // Use execution strategy to support retrying strategies (e.g. NpgsqlRetryingExecutionStrategy)
             var executionStrategy = _dbContext.Database.CreateExecutionStrategy();
-            var (deletedCounts, correlationId, errorResult) = await executionStrategy.ExecuteAsync(async ct =>
+            var correlationId = Guid.NewGuid().ToString();
+            var deletedCounts = await executionStrategy.ExecuteAsync(async ct =>
             {
                 await using var transaction = await _dbContext.Database.BeginTransactionAsync(ct);
 
                 try
                 {
                     var counts = new Dictionary<string, int>();
-                    var corrId = Guid.NewGuid().ToString();
 
                     // 1. MessageLogs (AuthorId = discordUserId)
                     var messageLogs = await _dbContext.MessageLogs
@@ -235,30 +235,14 @@ public class UserPurgeService : IUserPurgeService
                     // Commit transaction
                     await transaction.CommitAsync(ct);
 
-                    return (counts, corrId, (UserPurgeResultDto?)null);
+                    return counts;
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     await transaction.RollbackAsync(ct);
-
-                    _logger.LogError(ex,
-                        "Transaction failed while purging data for Discord user {DiscordUserId}",
-                        discordUserId);
-
-                    activity?.SetTag("purge.success", false);
-                    BotActivitySource.RecordException(activity, ex);
-
-                    return (new Dictionary<string, int>(), string.Empty,
-                        (UserPurgeResultDto?)UserPurgeResultDto.Failed(
-                            UserPurgeResultDto.TransactionFailed,
-                            "Failed to purge user data: " + ex.Message));
+                    throw; // Let execution strategy evaluate for retry
                 }
             }, cancellationToken);
-
-            if (errorResult != null)
-            {
-                return errorResult;
-            }
 
             _logger.LogInformation(
                 "Successfully purged data for Discord user {DiscordUserId}. Deleted counts: {DeletedCounts}",
@@ -307,14 +291,15 @@ public class UserPurgeService : IUserPurgeService
         catch (Exception ex)
         {
             _logger.LogError(ex,
-                "Unexpected error while purging data for Discord user {DiscordUserId}",
+                "Failed to purge data for Discord user {DiscordUserId}",
                 discordUserId);
 
+            activity?.SetTag("purge.success", false);
             BotActivitySource.RecordException(activity, ex);
 
             return UserPurgeResultDto.Failed(
-                UserPurgeResultDto.DatabaseError,
-                "An unexpected error occurred while purging user data");
+                UserPurgeResultDto.TransactionFailed,
+                "Failed to purge user data: " + ex.Message);
         }
     }
 


### PR DESCRIPTION
Follow-up to #1888 — the inner catch was swallowing exceptions, preventing the execution strategy from retrying transient failures.

Closes #1887