### PR TITLE
VOX Accessibility and Responsive Design (WCAG 2.1 AA)

### DIFF
--- a/src/DiscordBot.Bot/Pages/Portal/VOX/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Portal/VOX/Index.cshtml
@@ -342,6 +342,17 @@
             display: flex;
             align-items: center;
             justify-content: space-between;
+            width: 100%;
+            background: none;
+            border: none;
+            padding: 0;
+            font-family: inherit;
+            cursor: pointer;
+        }
+
+        .vox-word-gap-header:focus-visible {
+            outline: 2px solid var(--color-accent-orange);
+            outline-offset: 2px;
         }
 
         .vox-word-gap-label {
@@ -763,15 +774,17 @@
            RESPONSIVE STYLES
            ========================================== */
 
-        @@media (max-width: 1024px) {
+        /* Tablet: 768-1023px */
+        @@media (max-width: 1023px) {
             .vox-clip-grid {
-                grid-template-columns: repeat(auto-fill, minmax(95px, 1fr));
+                grid-template-columns: repeat(4, 1fr);
             }
         }
 
-        @@media (max-width: 768px) {
+        /* Mobile: <768px */
+        @@media (max-width: 767px) {
             .vox-clip-grid {
-                grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
+                grid-template-columns: repeat(3, 1fr);
             }
 
             /* Hide A-Z rail on mobile */
@@ -796,7 +809,13 @@
             .vox-play-btn,
             .vox-az-letter,
             .vox-section-header,
-            .vox-word-gap-preset {
+            .vox-word-gap-preset,
+            .vox-token-preview *,
+            .vox-history-toggle,
+            .vox-history-item,
+            .vox-history-action-btn,
+            .vox-message-input,
+            .vox-clip-search {
                 transition: none;
                 animation: none;
             }
@@ -848,9 +867,13 @@
             justify-content: space-between;
             padding: 0.625rem 0.75rem;
             background-color: var(--color-bg-secondary);
+            border: none;
             border-bottom: 1px solid var(--color-border-primary);
             cursor: pointer;
             user-select: none;
+            width: 100%;
+            font-family: inherit;
+            text-align: left;
         }
 
         .vox-history-header:hover {
@@ -1001,6 +1024,128 @@
             white-space: nowrap;
             border-width: 0;
         }
+
+        /* ==========================================
+           WCAG 2.1 AA COLOR CONTRAST FIXES
+           Scoped to VOX page to avoid affecting shared tokens.
+           Dark theme: bg-primary=#1d2022, bg-secondary=#262a2d, bg-tertiary=#2f3336
+           Original --color-text-tertiary (#7a7876) fails 4.5:1 on most backgrounds.
+           These overrides provide >=4.5:1 contrast ratios.
+           ========================================== */
+
+        /* Accessible secondary text: #b0adab provides ~8.2:1 on bg-primary, ~6.8:1 on bg-secondary */
+        .vox-page .stat-label {
+            color: #b0adab;
+        }
+
+        /* Accessible tertiary text: #9e9b99 provides ~5.6:1 on bg-primary, ~4.7:1 on bg-secondary */
+        .vox-clip-duration {
+            color: #9e9b99;
+        }
+
+        .vox-preview-stats {
+            color: #9e9b99;
+        }
+
+        .vox-autocomplete-duration {
+            color: #9e9b99;
+        }
+
+        .vox-token-gap {
+            color: #9e9b99;
+        }
+
+        .vox-token-empty {
+            color: #9e9b99;
+        }
+
+        .vox-history-meta {
+            color: #9e9b99;
+        }
+
+        .vox-history-empty {
+            color: #9e9b99;
+        }
+
+        .vox-history-action-btn {
+            color: #9e9b99;
+        }
+
+        /* Input placeholder contrast fix: #8a8886 provides ~4.1:1 on bg-primary;
+           use #9e9b99 for better compliance */
+        .vox-message-input::placeholder,
+        .vox-clip-search::placeholder {
+            color: #9e9b99;
+        }
+
+        /* ==========================================
+           ENHANCED FOCUS STYLES (all interactive elements)
+           ========================================== */
+
+        .vox-play-btn:focus-visible {
+            outline: 2px solid var(--color-accent-orange);
+            outline-offset: 2px;
+        }
+
+        .vox-message-input:focus-visible {
+            outline: none;
+            border-color: var(--color-accent-orange);
+            box-shadow: 0 0 0 2px rgba(203, 78, 27, 0.3);
+        }
+
+        .vox-clip-search:focus-visible {
+            outline: none;
+            border-color: var(--color-accent-orange);
+            box-shadow: 0 0 0 2px rgba(203, 78, 27, 0.3);
+        }
+
+        .vox-history-header:focus-visible {
+            outline: 2px solid var(--color-accent-orange);
+            outline-offset: -2px;
+        }
+
+        .vox-history-action-btn:focus-visible {
+            outline: 2px solid var(--color-accent-orange);
+            outline-offset: 1px;
+        }
+
+        .vox-history-message:focus-visible {
+            outline: 2px solid var(--color-accent-orange);
+            outline-offset: 1px;
+        }
+
+        .vox-autocomplete-item:focus-visible {
+            outline: 2px solid var(--color-accent-orange);
+            outline-offset: -2px;
+        }
+
+        /* ==========================================
+           RESPONSIVE: COLLAPSIBLE SETTINGS (tablet + mobile)
+           ========================================== */
+
+        @@media (max-width: 1023px) {
+            /* Settings (word gap) collapsed by default on tablet/mobile */
+            .vox-word-gap-section[aria-expanded="false"] .vox-word-gap-controls {
+                display: none;
+            }
+        }
+
+        /* ==========================================
+           RESPONSIVE: STICKY PLAY (mobile only)
+           ========================================== */
+
+        @@media (max-width: 767px) {
+            /* Sticky play button at bottom of viewport */
+            .vox-play-section {
+                position: sticky;
+                bottom: 0;
+                z-index: 10;
+                background: var(--color-bg-primary);
+                padding: 0.75rem;
+                box-shadow: 0 -2px 8px rgba(0,0,0,0.15);
+                border-radius: 0.375rem 0.375rem 0 0;
+            }
+        }
     </style>
 }
 
@@ -1046,7 +1191,8 @@
             clipGrid: null,
             // A-Z navigation elements
             azRail: null,
-            scrollLetter: null
+            scrollLetter: null,
+            playbackStatus: null
         };
 
         // Debounce utility
@@ -1089,6 +1235,9 @@
             // Initialize word gap slider
             initWordGapSlider();
 
+            // Initialize settings toggle for responsive collapsed state
+            initSettingsToggle();
+
             // Listen for tab switches (nav-tabs.js dispatches 'navtabchange')
             document.addEventListener('navtabchange', (e) => {
                 if (e.detail.containerId === 'voxGroupTabs') {
@@ -1124,7 +1273,10 @@
 
             function syncAllSliders(value) {
                 voxState.wordGapMs = value;
-                sliders.forEach(s => s.value = value);
+                sliders.forEach(s => {
+                    s.value = value;
+                    s.setAttribute('aria-valuenow', value);
+                });
                 valueDisplays.forEach(d => d.textContent = `${value}ms`);
                 updateActivePreset(value);
                 updateTokenPreview();
@@ -1143,6 +1295,40 @@
             });
         }
 
+        function initSettingsToggle() {
+            // On tablet/mobile, collapse settings by default
+            const isMobileOrTablet = window.matchMedia('(max-width: 1023px)').matches;
+
+            document.querySelectorAll('.vox-settings-toggle').forEach(toggle => {
+                const section = toggle.closest('.vox-word-gap-section');
+                if (!section) return;
+
+                if (isMobileOrTablet) {
+                    section.setAttribute('aria-expanded', 'false');
+                    toggle.setAttribute('aria-expanded', 'false');
+                }
+
+                toggle.addEventListener('click', () => {
+                    const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
+                    toggle.setAttribute('aria-expanded', !isExpanded);
+                    section.setAttribute('aria-expanded', !isExpanded);
+                });
+            });
+
+            // Listen for resize to auto-expand on desktop
+            window.matchMedia('(min-width: 1024px)').addEventListener('change', (e) => {
+                if (e.matches) {
+                    document.querySelectorAll('.vox-settings-toggle').forEach(toggle => {
+                        const section = toggle.closest('.vox-word-gap-section');
+                        if (section) {
+                            section.setAttribute('aria-expanded', 'true');
+                            toggle.setAttribute('aria-expanded', 'true');
+                        }
+                    });
+                }
+            });
+        }
+
         function initializeVoxElements(group) {
             const prefix = `vox-${group}`;
             voxEls.messageInput = document.getElementById(`${prefix}-message-input`);
@@ -1158,6 +1344,7 @@
             // A-Z navigation elements
             voxEls.azRail = document.getElementById(`${prefix}-az-rail`);
             voxEls.scrollLetter = document.getElementById(`${prefix}-scroll-letter`);
+            voxEls.playbackStatus = document.getElementById(`${prefix}-playback-status`);
 
             // Attach event listeners
             if (voxEls.messageInput) {
@@ -1430,7 +1617,10 @@
             voxState.isLoading = true;
             voxEls.playBtn.classList.add('loading');
             voxEls.playBtn.disabled = true;
-            voxEls.playBtnText.innerHTML = '<span class="vox-spinner"></span> Playing...';
+            voxEls.playBtnText.innerHTML = '<span class="vox-spinner" aria-hidden="true"></span> Playing...';
+            if (voxEls.playbackStatus) {
+                voxEls.playbackStatus.textContent = 'Playing VOX message...';
+            }
 
             try {
                 const response = await fetch(`/api/portal/vox/${window.guildId}/play`, {
@@ -1452,6 +1642,9 @@
                 voxEls.messageInput.value = '';
                 updateTokenPreview();
                 voxEls.playBtnText.textContent = 'Play VOX Announcement';
+                if (voxEls.playbackStatus) {
+                    voxEls.playbackStatus.textContent = 'VOX message sent successfully.';
+                }
 
                 // Refresh history panel
                 loadVoxHistory();
@@ -1460,6 +1653,9 @@
                 if (voxEls.playBtnText) {
                     const errMsg = (error.message || 'Failed to play').substring(0, 100);
                     voxEls.playBtnText.textContent = 'Error: ' + errMsg;
+                    if (voxEls.playbackStatus) {
+                        voxEls.playbackStatus.textContent = 'Error: ' + errMsg;
+                    }
                     setTimeout(() => {
                         if (voxEls.playBtnText) {
                             voxEls.playBtnText.textContent = 'Play VOX Announcement';
@@ -1800,6 +1996,12 @@
             const isHidden = list.hidden;
             list.hidden = !isHidden;
             toggle.classList.toggle('collapsed', !isHidden);
+
+            // Update aria-expanded on the header button
+            const header = toggle.closest('.vox-history-header');
+            if (header) {
+                header.setAttribute('aria-expanded', isHidden ? 'true' : 'false');
+            }
         }
 
         async function loadVoxHistory() {
@@ -2064,7 +2266,7 @@ else
     }' />
 
     <!-- Main Content -->
-    <main class="main-container">
+    <main class="main-container vox-page">
         <div class="portal-content">
             <!-- LEFT: Sidebar -->
             <div class="sidebar">
@@ -2109,7 +2311,12 @@ else
                 var prefix = $"vox-{group}";
                 var groupName = group == "vox" ? "VOX" : (group == "fvox" ? "FVOX" : "HGrunt");
 
-                <div data-nav-panel-for="voxGroupTabs" data-tab-id="@group" @(isActive ? "" : "hidden")>
+                <div data-nav-panel-for="voxGroupTabs"
+                     data-tab-id="@group"
+                     id="voxGroupTabs-panel-@group"
+                     role="tabpanel"
+                     aria-labelledby="voxGroupTabs-tab-@group"
+                     @(isActive ? "" : "hidden")>
                     <!-- Consolidated Message Composer -->
                     <div class="vox-composer">
                         <!-- Message Input -->
@@ -2120,7 +2327,11 @@ else
                                        class="vox-message-input"
                                        placeholder="Type words to announce..."
                                        autocomplete="off"
+                                       role="combobox"
+                                       aria-autocomplete="list"
+                                       aria-haspopup="listbox"
                                        aria-label="@groupName message"
+                                       aria-describedby="@(prefix)-token-pills"
                                        aria-expanded="false"
                                        aria-controls="@(prefix)-autocomplete" />
 
@@ -2137,21 +2348,23 @@ else
                         </div>
 
                         <!-- Token Preview -->
-                        <div class="vox-token-preview">
+                        <div class="vox-token-preview" aria-live="polite" aria-atomic="true">
                             <div class="vox-token-pills" id="@(prefix)-token-pills">
                                 <span class="vox-token-empty">No words</span>
                             </div>
-                            <div class="vox-preview-stats" id="@(prefix)-preview-stats"></div>
+                            <div class="vox-preview-stats" id="@(prefix)-preview-stats" role="status"></div>
                         </div>
                     </div>
 
                     <!-- Word Gap Slider -->
-                    <div class="vox-word-gap-section">
-                        <div class="vox-word-gap-header">
+                    <div class="vox-word-gap-section" aria-expanded="true">
+                        <button type="button" class="vox-word-gap-header vox-settings-toggle"
+                                aria-expanded="true"
+                                aria-controls="@(prefix)-word-gap-controls">
                             <span class="vox-word-gap-label">Word Gap</span>
                             <span class="vox-word-gap-value" id="@(prefix)-word-gap-value">50ms</span>
-                        </div>
-                        <div class="vox-word-gap-controls">
+                        </button>
+                        <div class="vox-word-gap-controls" id="@(prefix)-word-gap-controls">
                             <input type="range"
                                    id="@(prefix)-word-gap-slider"
                                    class="vox-word-gap-slider"
@@ -2159,7 +2372,10 @@ else
                                    max="200"
                                    step="10"
                                    value="50"
-                                   aria-label="@groupName word gap in milliseconds" />
+                                   aria-label="Word gap in milliseconds"
+                                   aria-valuemin="20"
+                                   aria-valuemax="200"
+                                   aria-valuenow="50" />
                             <div class="vox-word-gap-presets">
                                 <button type="button" class="vox-word-gap-preset" data-gap="20">Fast</button>
                                 <button type="button" class="vox-word-gap-preset active" data-gap="50">Normal</button>
@@ -2174,37 +2390,46 @@ else
                                 class="vox-play-btn"
                                 id="@(prefix)-play-btn"
                                 disabled
-                                aria-label="Play @groupName announcement">
+                                aria-label="Play VOX message">
                             <span id="@(prefix)-play-btn-text">Play @groupName Announcement</span>
                         </button>
+                        <div id="@(prefix)-playback-status" class="sr-only" role="status" aria-live="polite"></div>
                     </div>
 
                     <!-- Favorites & Recent History -->
                     <div class="vox-history-panel" id="@(prefix)-history-panel">
                         <!-- Favorites (always visible) -->
                         <div class="vox-history-section">
-                            <div class="vox-history-header" onclick="toggleHistorySection('@prefix', 'favorites')">
+                            <button type="button"
+                                    class="vox-history-header"
+                                    onclick="toggleHistorySection('@prefix', 'favorites')"
+                                    aria-expanded="true"
+                                    aria-controls="@(prefix)-favorites-list">
                                 <span class="vox-history-title">
                                     Favorites
                                     <span class="vox-history-badge" id="@(prefix)-favorites-count">0</span>
                                 </span>
-                                <span class="vox-history-toggle" id="@(prefix)-favorites-toggle">&#9660;</span>
-                            </div>
-                            <div class="vox-history-list" id="@(prefix)-favorites-list">
+                                <span class="vox-history-toggle" id="@(prefix)-favorites-toggle" aria-hidden="true">&#9660;</span>
+                            </button>
+                            <div class="vox-history-list" id="@(prefix)-favorites-list" role="list">
                                 <div class="vox-history-empty">No favorites yet</div>
                             </div>
                         </div>
 
                         <!-- Recent History (collapsible) -->
                         <div class="vox-history-section">
-                            <div class="vox-history-header" onclick="toggleHistorySection('@prefix', 'recent')">
+                            <button type="button"
+                                    class="vox-history-header"
+                                    onclick="toggleHistorySection('@prefix', 'recent')"
+                                    aria-expanded="false"
+                                    aria-controls="@(prefix)-recent-list">
                                 <span class="vox-history-title">
                                     Recent
                                     <span class="vox-history-badge" id="@(prefix)-recent-count">0</span>
                                 </span>
-                                <span class="vox-history-toggle collapsed" id="@(prefix)-recent-toggle">&#9660;</span>
-                            </div>
-                            <div class="vox-history-list" id="@(prefix)-recent-list" hidden>
+                                <span class="vox-history-toggle collapsed" id="@(prefix)-recent-toggle" aria-hidden="true">&#9660;</span>
+                            </button>
+                            <div class="vox-history-list" id="@(prefix)-recent-list" role="list" hidden>
                                 <div class="vox-history-empty">No recent messages</div>
                             </div>
                         </div>
@@ -2217,7 +2442,8 @@ else
                                    class="vox-clip-search"
                                    id="@(prefix)-clip-search"
                                    placeholder="Search clips..."
-                                   aria-label="Search @groupName clips" />
+                                   aria-label="Search @groupName clips"
+                                   aria-controls="@(prefix)-clip-grid" />
                             <span class="vox-clip-badge" id="@(prefix)-clip-count">0</span>
                         </div>
                         <div class="vox-clip-browser-container">


### PR DESCRIPTION
## Summary

- Add WCAG 2.1 AA compliance to the VOX portal page: keyboard navigation, ARIA attributes, color contrast fixes, responsive breakpoints, reduced motion support, and focus-visible styles
- Responsive layout with 3 breakpoints: desktop (5-6 col grid), tablet (4 col, sidebar stacked, settings collapsed), mobile (3 col, sticky play button)
- All color contrast overrides scoped to `.vox-page` class to avoid affecting shared design tokens on other pages
- History section headers converted from `div` to `button` elements for keyboard accessibility, with `aria-expanded` and `aria-controls`

## Changes

### Keyboard Navigation
- Message input uses `role="combobox"` with `aria-autocomplete="list"` and `aria-haspopup="listbox"`
- Existing autocomplete keyboard nav (Arrow Up/Down, Enter, Escape) preserved with proper `role="option"` and `aria-activedescendant`
- Existing clip grid arrow key navigation preserved with Enter/Space to play

### ARIA Enhancements
- Tab panels: `role="tabpanel"` with `aria-labelledby` linking to corresponding tab
- Token preview container: `aria-live="polite"` for screen reader change announcements
- Word gap slider: `aria-valuemin`, `aria-valuemax`, `aria-valuenow` (synced on change)
- Collapsible sections (history, settings): `aria-expanded` toggled on open/close
- Play button: `aria-label="Play VOX message"` with hidden `role="status"` live region for playback announcements
- Clip search: `aria-controls` pointing to clip grid
- Message input: `aria-describedby` linking to token preview

### Color Contrast (4.5:1+ minimum)
- Tertiary text (`#7a7876` -> `#9e9b99`): ~5.6:1 on bg-primary, ~4.7:1 on bg-secondary
- Stat labels (`#a8a5a3` -> `#b0adab`): ~8.2:1 on bg-primary
- Input placeholder text fixed to `#9e9b99`
- All scoped to VOX page only

### Responsive Layout
- Tablet (768-1023px): sidebar stacks above main, 4-column clip grid, settings collapsed by default
- Mobile (<768px): 3-column grid, sticky play button at bottom, settings collapsed
- Settings auto-expand when resizing back to desktop via `matchMedia` listener

### Reduced Motion
- Extended `prefers-reduced-motion` to cover token preview elements, history toggles, history items, action buttons, inputs

### Focus Styles
- `:focus-visible` on all interactive elements: play button, message input, clip search, history headers, history action buttons, autocomplete items, word gap header

## Test plan

- [ ] Verify keyboard-only navigation flows naturally: sidebar -> tabs -> input -> settings -> play -> history -> search -> grid
- [ ] Verify autocomplete opens with typing, navigates with Arrow keys, selects with Enter, closes with Escape
- [ ] Verify clip grid arrow navigation, Enter/Space plays clip, Escape returns to input
- [ ] Verify screen reader announces token preview changes and playback status
- [ ] Verify color contrast meets 4.5:1 ratio (use browser DevTools accessibility panel)
- [ ] Resize to tablet (768-1023px): sidebar stacks above, 4-col grid, settings collapsed
- [ ] Resize to mobile (<768px): 3-col grid, sticky play button, settings collapsed
- [ ] Resize back to desktop: settings auto-expand
- [ ] Toggle reduced motion in OS settings: verify no animations/transitions
- [ ] Verify all interactive elements show visible focus ring on Tab navigation
- [ ] Verify existing VOX functionality still works: playback, autocomplete, token preview, clip browsing, favorites, history
- [ ] Verify other portal pages (Soundboard, TTS) are unaffected by color changes

Closes #1472

🤖 Generated with [Claude Code](https://claude.com/claude-code)