### PR TITLE
Mogwai: Claude Code CLI Integration via DM Assistant

### DIFF
--- a/.env.mogwai.example
+++ b/.env.mogwai.example
@@ -1,0 +1,34 @@
+# Mogwai Bot Instance — Docker Environment Configuration
+#
+# Usage:
+#   1. Copy this file to .env.mogwai:  cp .env.mogwai.example .env.mogwai
+#   2. Replace placeholder values with your actual secrets
+#   3. Start with:  docker compose -f docker-compose.mogwai.yml up -d
+#
+# IMPORTANT: Never commit .env.mogwai with real secrets to version control!
+
+# =============================================================================
+# REQUIRED SETTINGS
+# =============================================================================
+
+# Discord Bot Token (separate bot application for Mogwai)
+# Get this from: https://discord.com/developers/applications > Your App > Bot > Token
+Discord__Token=YOUR_MOGWAI_BOT_TOKEN_HERE
+
+# Anthropic API Key (powers the DM assistant's Haiku model)
+Anthropic__ApiKey=YOUR_ANTHROPIC_API_KEY_HERE
+
+# Anthropic API Key for Claude Code CLI (used by the claude CLI process)
+# Typically the same key as above
+ANTHROPIC_API_KEY=YOUR_ANTHROPIC_API_KEY_HERE
+
+# =============================================================================
+# OPTIONAL SETTINGS
+# =============================================================================
+
+# Discord Test Guild ID
+# Set this for instant command registration (otherwise global commands take up to 1 hour)
+# Discord__TestGuildId=123456789012345678
+
+# Database provider selection (defaults to Sqlite)
+# Database__Provider=Sqlite

--- a/CLAUDE-REFERENCE.md
+++ b/CLAUDE-REFERENCE.md
@@ -30,6 +30,7 @@ The application uses `IOptions<T>` pattern for strongly-typed configuration. All
 | `IdentityConfigOptions` | `Identity` | ASP.NET Identity settings (passwords, lockout, cookies, default admin) |
 | `LogSanitizationOptions` | `LogSanitization` | Log sanitization patterns and sensitive key redaction |
 | `MessageLogRetentionOptions` | `MessageLogRetention` | Message log cleanup policies |
+| `MogwaiOptions` | `Mogwai` | Claude Code CLI integration for coding tasks via owner DM (disabled by default; used only by the Mogwai Docker instance) |
 | `ModerationOptions` | `Moderation` | Moderation system settings (temp bans, purge limits, case history) |
 | `NotificationOptions` | `Notification` | Admin notification event filters and deduplication |
 | `NotificationRetentionOptions` | `NotificationRetention` | Notification cleanup by status (dismissed, read, unread retention) |
@@ -260,6 +261,7 @@ Build and serve locally: `.\build-docs.ps1 -Serve` (http://localhost:8080)
 | [login-page-design-spec.md](docs/articles/login-page-design-spec.md) | Login page design |
 | [loki-production-setup.md](docs/articles/loki-production-setup.md) | Loki production setup |
 | [member-directory.md](docs/articles/member-directory.md) | Member Directory feature |
+| [mogwai.md](docs/articles/mogwai.md) | Mogwai — Claude Code CLI integration via DM (owner-only) |
 | [message-logging.md](docs/articles/message-logging.md) | Message logging system |
 | [metrics.md](docs/articles/metrics.md) | OpenTelemetry metrics collection |
 | [nav-tabs-component.md](docs/articles/nav-tabs-component.md) | Navigation Tabs component guide |

--- a/Dockerfile.mogwai
+++ b/Dockerfile.mogwai
@@ -1,0 +1,122 @@
+# =============================================================================
+# Build Stage
+# =============================================================================
+# Noble (Ubuntu 24.04) is required because libdave.so (Discord DAVE E2EE
+# protocol) needs GLIBC 2.38 / GLIBCXX 3.4.32. Debian Bookworm (the default
+# 8.0 tag) ships older versions, and Alpine uses musl instead of glibc, so
+# neither can load the prebuilt libdave binary.
+FROM mcr.microsoft.com/dotnet/sdk:8.0-noble AS build
+
+WORKDIR /src
+
+# Install Node.js 20.x (required for Tailwind CSS compilation)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        gnupg \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy solution and project files for layer-cached restore
+COPY DiscordBot.sln ./
+COPY Directory.Build.props ./
+COPY src/DiscordBot.Core/DiscordBot.Core.csproj src/DiscordBot.Core/
+COPY src/DiscordBot.Infrastructure/DiscordBot.Infrastructure.csproj src/DiscordBot.Infrastructure/
+COPY src/DiscordBot.Bot/DiscordBot.Bot.csproj src/DiscordBot.Bot/
+
+# Local NuGet feed for forked Discord.Net packages (DAVE multi-party voice fix)
+COPY nuget.config ./
+COPY local-packages/ local-packages/
+
+RUN dotnet restore src/DiscordBot.Bot/DiscordBot.Bot.csproj
+
+# Install npm dependencies (cached separately from source changes)
+COPY src/DiscordBot.Bot/package.json src/DiscordBot.Bot/package-lock.json src/DiscordBot.Bot/
+RUN cd src/DiscordBot.Bot && npm ci
+
+# Download libdave native library for Discord DAVE E2EE protocol (cached separately from source changes)
+RUN curl -fsSL -o /tmp/libdave.zip \
+        https://github.com/discord/libdave/releases/download/v1.1.1/cpp/libdave-Linux-X64-boringssl.zip \
+    && apt-get update && apt-get install -y --no-install-recommends unzip \
+    && unzip /tmp/libdave.zip -d /tmp/libdave \
+    && rm /tmp/libdave.zip
+
+# Copy remaining source code
+COPY src/ src/
+
+# Build Tailwind CSS (npm packages already installed above)
+WORKDIR /src/src/DiscordBot.Bot
+RUN npm run build:css
+
+# Publish the application
+WORKDIR /src
+RUN dotnet publish src/DiscordBot.Bot/DiscordBot.Bot.csproj \
+        -c Release \
+        -o /app/publish \
+        --no-restore
+
+# =============================================================================
+# Runtime Stage — Mogwai (extends base with Claude Code + Playwright)
+# =============================================================================
+# See build stage comment for why Noble is required (libdave glibc dependency).
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-noble AS runtime
+
+# Install runtime dependencies (audio libs + curl for health checks)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl \
+        ffmpeg \
+        python3 \
+        libsodium23 \
+        libopus0 \
+        git \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -s /usr/lib/x86_64-linux-gnu/libopus.so.0 /usr/lib/x86_64-linux-gnu/libopus.so \
+    && ln -s /usr/lib/x86_64-linux-gnu/libsodium.so.23 /usr/lib/x86_64-linux-gnu/libsodium.so
+
+# Install Node.js 22 LTS (required for Claude Code CLI)
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Claude Code CLI
+RUN npm install -g @anthropic-ai/claude-code
+
+# Install Playwright + Chromium for web content rendering
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+RUN npx playwright install --with-deps chromium
+
+# Copy libdave native library for Discord DAVE E2EE protocol
+COPY --from=build /tmp/libdave/lib/libdave.so /usr/lib/x86_64-linux-gnu/libdave.so
+
+# Create non-root user
+RUN useradd --create-home --shell /bin/bash appuser
+
+WORKDIR /app
+
+# Copy published output
+COPY --from=build /app/publish ./
+
+# Copy AI assistant runtime docs (prompt templates + documentation tool articles)
+COPY docs/agents/ ./docs/agents/
+COPY docs/articles/ ./docs/articles/
+
+# Create data directory for SQLite database volume mount (not used when running PostgreSQL)
+RUN mkdir -p /app/data && chown -R appuser:appuser /app
+
+# Create workspace directory for Claude Code git worktree isolation
+RUN mkdir -p /workspace && chown -R appuser:appuser /workspace
+
+# Create .claude directory for Claude Code session storage
+RUN mkdir -p /home/appuser/.claude && chown -R appuser:appuser /home/appuser/.claude
+
+USER appuser
+
+ENV ASPNETCORE_URLS=http://+:5000
+
+EXPOSE 5000
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD curl -sf http://localhost:5000/health || exit 1
+
+ENTRYPOINT ["dotnet", "DiscordBot.Bot.dll"]

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ A Discord bot built with .NET 8 and Discord.NET that provides a foundation for m
 ### Bot Features
 - **Rat Watch** - Accountability system for tracking commitments with community voting and leaderboards ([docs](docs/articles/rat-watch.md))
 - **AI Assistant** - Claude-powered conversational assistant with tool usage, conversation history, and cost tracking ([docs](docs/articles/ai-assistant.md))
+- **Mogwai** - Claude Code CLI integration for coding tasks via DM — delegates to Claude Code running in Docker for file editing, debugging, and project analysis. Owner-only, runs as a separate bot instance ([docs](docs/articles/mogwai.md))
 - **Auto-Moderation** - Configurable content filtering with spam detection, flagged event management, and automated actions
 - **Scheduled Messages** - Automated announcements with flexible scheduling (one-time, recurring, cron expressions) ([docs](docs/articles/scheduled-messages.md))
 - **Welcome System** - Configurable welcome messages and automatic role assignment for new members ([docs](docs/articles/welcome-system.md))
@@ -208,6 +209,14 @@ docker compose up -d
 ```
 
 The admin UI will be available at `http://localhost:5000`. Optional profiles add PostgreSQL (`--profile postgres`) and Seq log viewer (`--profile seq`).
+
+**Mogwai (Claude Code bot):** Uses a separate compose file and a larger Docker image (~1.5–2 GB):
+
+```bash
+cp .env.mogwai.example .env.mogwai
+# Edit .env.mogwai — set Discord__Token (separate bot token), Anthropic__ApiKey, ANTHROPIC_API_KEY
+docker compose -f docker-compose.mogwai.yml up -d
+```
 
 See [Docker Deployment Guide](docs/articles/docker-deployment.md) for the full reference including database options, volume mounts, audio support, updating, and troubleshooting.
 
@@ -553,6 +562,21 @@ dotnet user-secrets set "Anthropic:DefaultModel" "claude-sonnet-4-20250514"  # O
 - Requires user consent: `/consent grant type:assistant`
 - See [ai-assistant.md](docs/articles/ai-assistant.md)
 
+#### Mogwai (Claude Code CLI via DM)
+```env
+# In .env.mogwai (Docker only — never use with the main bot)
+Discord__Token=your-mogwai-bot-token
+Anthropic__ApiKey=your-anthropic-api-key
+ANTHROPIC_API_KEY=your-anthropic-api-key
+```
+
+**Configuration:** `appsettings.json` → `Mogwai` section (set via Docker environment overrides)
+- `Mogwai__Enabled=true` — master toggle (disabled by default)
+- `Mogwai__WorkingDirectory=/workspace` — project directory inside container
+- `Mogwai__SkipPermissions=true` — enables `--dangerously-skip-permissions` (safe inside Docker)
+- `DmAssistant__Model=claude-haiku-4-5-20251001` — Haiku for fast/cheap triage
+- See [mogwai.md](docs/articles/mogwai.md)
+
 #### Text-to-Speech (Azure Cognitive Services)
 ```bash
 dotnet user-secrets set "AzureSpeech:SubscriptionKey" "your-azure-speech-key"
@@ -819,6 +843,7 @@ This project is for educational and development purposes.
 - [Interactive Components](docs/articles/interactive-components.md) - Button/component patterns
 
 ### Features
+- [Mogwai](docs/articles/mogwai.md) - Claude Code CLI integration for owner DM coding tasks
 - [Rat Watch](docs/articles/rat-watch.md) - Accountability system with voting and leaderboards
 - [Reminder System](docs/articles/reminder-system.md) - Personal reminders with natural language time parsing
 - [Utility Commands](docs/articles/utility-commands.md) - User/server/role information commands

--- a/docker-compose.mogwai.yml
+++ b/docker-compose.mogwai.yml
@@ -1,0 +1,31 @@
+# Mogwai Bot Instance — Docker Compose
+#
+# Standalone compose file for the Mogwai bot (Claude Code integration).
+#
+# Usage:
+#   1. Copy .env.mogwai.example to .env.mogwai and fill in secrets
+#   2. Run: docker compose -f docker-compose.mogwai.yml up -d
+
+services:
+  mogwai:
+    build:
+      context: .
+      dockerfile: Dockerfile.mogwai
+    container_name: mogwai
+    env_file: .env.mogwai
+    environment:
+      Mogwai__Enabled: "true"
+      Mogwai__WorkingDirectory: /workspace
+      Mogwai__SkipPermissions: "true"
+      DmAssistant__Enabled: "true"
+      DmAssistant__Model: "claude-haiku-4-5-20251001"
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+    volumes:
+      - mogwai-data:/app/data
+      - ./:/workspace:rw
+    ports:
+      - "7310:5000"
+    restart: unless-stopped
+
+volumes:
+  mogwai-data:

--- a/docs/agents/dm-owner-agent.md
+++ b/docs/agents/dm-owner-agent.md
@@ -46,6 +46,11 @@ Save and retrieve personal notes across conversations. Use `save_note` when the 
 - `get_command_details` — Gets detailed information about a specific slash command including parameters, permissions, and examples.
 - `list_features` — Lists all bot features with descriptions and availability. Use when the owner asks what the bot can do.
 
+### Claude Code (Mogwai)
+- `run_claude_code` — Delegates a coding task to Claude Code CLI running inside the container. Use for: code changes, bug fixes, file creation/editing, git operations, project analysis, debugging, or any task requiring filesystem access. Pass a clear, detailed prompt describing what to do. Supports session continuity — follow-up messages automatically resume the previous session.
+  - Parameters: `prompt` (required), `continue_session` (optional, default true), `working_directory` (optional)
+- `get_claude_code_status` — Check if a Claude Code session exists and its cumulative cost. No parameters.
+
 ## Tool Usage Guidelines
 
 - **Guild context**: Many tools require a guild context. If the owner hasn't set one and asks a guild-specific question, use `list_guilds` to show options, then `set_active_guild`. Always confirm which guild you're querying in your response.
@@ -53,6 +58,13 @@ Save and retrieve personal notes across conversations. Use `save_note` when the 
 - **Memory**: When the owner says "remember this" or similar, save a note. When answering questions, check if you have relevant saved notes.
 - **Documentation**: When the owner asks about a feature, use `get_feature_documentation` first — it provides comprehensive guides. Only fall back to `search_commands` when looking for a specific command name.
 - **Efficiency**: Don't call tools unnecessarily. If you already have the information in context, use it directly.
+- **Claude Code vs answering directly**:
+  - Simple questions, conversation, bot management, moderation lookups → answer directly (faster and cheaper)
+  - Code changes, file editing, debugging, project analysis, git operations → delegate to `run_claude_code`
+  - Multi-file refactoring, complex bug fixes, writing new features → definitely delegate to `run_claude_code`
+  - If unsure whether a task needs code access → answer directly first; the owner can ask you to use Claude Code if needed
+  - Always check `get_claude_code_status` before running expensive tasks if concerned about cumulative cost
+  - When delegating, write a detailed prompt — Claude Code works best with specific, actionable instructions
 
 ## Guidelines
 
@@ -66,11 +78,12 @@ Save and retrieve personal notes across conversations. Use `save_note` when the 
 
 ## Response Length
 
-Your responses are sent as Discord messages, which have a 2000-character limit. Responses exceeding this are truncated, losing content mid-sentence. To avoid this:
+Your responses are sent as Discord messages. Short responses (≤2000 chars) are sent as a single message. Longer responses are automatically split into multiple messages or uploaded as a file attachment, so you don't need to worry about truncation. That said, prefer concise responses:
 
 - **Summarize tool results** — never paste raw tool output verbatim. Extract the key points relevant to the question.
 - **Documentation tools return full articles** — read them internally, then answer the owner's specific question in your own words. A 2-3 paragraph summary with the most relevant details is ideal.
 - **Analytics and moderation data** — highlight the important numbers and patterns, don't dump raw JSON.
+- **Claude Code results** — summarize what was done, what changed, and any issues. Don't echo the full CLI output unless the owner asks for it.
 - **If more detail is needed**, tell the owner you have more and offer to elaborate on specific parts.
 
 ## Format

--- a/docs/architecture/feature-map.md
+++ b/docs/architecture/feature-map.md
@@ -12,7 +12,7 @@ This document maps all major features to their supporting components: Discord co
 2. [Moderation Features](#moderation-features) - Warnings, bans, notes, watchlist
 3. [Community Features](#community-features) - Reminders, Rat Watch, Scheduled Messages
 4. [Administrative Features](#administrative-features) - Guild management, settings, monitoring, verification
-5. [System Features](#system-features) - Authentication, logging, notifications, activity tracking
+5. [System Features](#system-features) - Authentication, logging, notifications, activity tracking, DM assistant
 
 ---
 
@@ -478,6 +478,40 @@ Structured logging with Serilog and optional Seq/Elasticsearch aggregation.
 | **Tracing** | Jaeger/OpenTelemetry (optional) |
 | **Key Services** | `ILogger<T>` dependency injection throughout |
 | **Key Features** | Structured logging, correlation IDs, performance profiling, log aggregation |
+
+---
+
+### DM Assistant & Mogwai
+
+Owner-only DM assistant with multi-turn conversation history and optional Claude Code CLI delegation (Mogwai).
+
+| Aspect | Components |
+|--------|------------|
+| **Discord Entry Point** | `DmAssistantMessageHandler` — handles incoming DM messages, routes to `IDmAssistantService` |
+| **Services** | `IDmAssistantService`, `IAgentRunner`, `ILlmClient` (AnthropicLlmClient), `IToolRegistry` |
+| **Tool Providers** | `ClaudeCodeToolProvider` (Mogwai only — `IDmToolProvider`) |
+| **Database Entities** | `DmConversationMessage`, `DmAssistantInteractionLog`, `DmAssistantUsageMetrics` |
+| **Configuration** | `DmAssistantOptions` (`DmAssistant` section), `MogwaiOptions` (`Mogwai` section) |
+| **Docker** | `Dockerfile.mogwai`, `docker-compose.mogwai.yml`, `.env.mogwai` |
+| **Agent Prompt** | `docs/agents/dm-owner-agent.md` |
+| **Key Features** | Owner-only access (Discord API check), sliding-window conversation history, response chunking (split / `.md` attachment), Claude Code subprocess spawning, per-user session continuity, concurrency guard |
+| **Access Control** | Owner identified via `GetApplicationInfoAsync()`. Non-owners receive placeholder response. |
+| **Mogwai toggle** | `Mogwai__Enabled=false` by default — zero impact on all other bot instances when unset |
+
+**Architecture Flow (Mogwai path)**:
+```
+Owner DMs Mogwai bot →
+  DmAssistantMessageHandler →
+  DmAssistantService (history load + LLM call) →
+  AgentRunner (agentic loop) →
+  Haiku decides: answer directly OR call run_claude_code tool →
+  ClaudeCodeToolProvider.ExecuteAsync() →
+  claude CLI subprocess (--output-format json) →
+  JSON response parsed, session ID stored →
+  Response chunked and sent via DmAssistantMessageHandler
+```
+
+**Preconditions**: Owner check via Discord API. `DmAssistant__Enabled=true` and `Mogwai__Enabled=true` required in configuration.
 
 ---
 

--- a/docs/architecture/service-catalog.md
+++ b/docs/architecture/service-catalog.md
@@ -342,6 +342,7 @@ Services for AI-powered chat, tool execution, and LLM integration.
 | `RatWatchToolProvider` | Bot/Services/LLM | RatWatch-specific tool provider for assistant |
 | `RatWatchTools` | Infrastructure/Services/LLM | Tool implementations for RatWatch queries |
 | `UserGuildInfoToolProvider` | Bot/Services/LLM | Tool provider exposing get_user_profile, get_guild_info, and get_user_roles tools; resolves data from Discord client and database |
+| `ClaudeCodeToolProvider` | Infrastructure/Services/LLM/Providers | DM tool provider for Mogwai — spawns the `claude` CLI as a subprocess, tracks per-user session IDs in memory, enforces concurrency guard; registers `run_claude_code` and `get_claude_code_status` tools |
 
 ---
 

--- a/docs/articles/docker-deployment.md
+++ b/docs/articles/docker-deployment.md
@@ -114,6 +114,53 @@ Seq UI is available at `http://localhost:5341`.
 docker compose --profile postgres --profile seq up -d
 ```
 
+### Mogwai — Claude Code Bot
+
+Mogwai uses a **separate compose file** (`docker-compose.mogwai.yml`) and a separate Dockerfile (`Dockerfile.mogwai`) because it includes Node.js, Claude Code CLI, and Playwright/Chromium — adding ~1.5–2 GB to the image size. The main bot image stays lean.
+
+```bash
+# Build and start Mogwai
+docker compose -f docker-compose.mogwai.yml build
+docker compose -f docker-compose.mogwai.yml up -d
+```
+
+**Required `.env.mogwai` variables:**
+
+| Variable | Description |
+|----------|-------------|
+| `Discord__Token` | A **separate** Discord bot token for Mogwai (must not share with the main bot) |
+| `Anthropic__ApiKey` | Anthropic API key for the .NET DM assistant (Haiku model) |
+| `ANTHROPIC_API_KEY` | Same key, exposed to the `claude` CLI process inside the container |
+
+Both `Anthropic__ApiKey` and `ANTHROPIC_API_KEY` are required. The .NET runtime reads the double-underscore form; the `claude` binary reads the conventional environment variable name.
+
+**Volume mounts:**
+
+| Volume | Container Path | Purpose |
+|--------|---------------|---------|
+| `mogwai-data` | `/app/data` | SQLite database and conversation history |
+| `./` (host repo root) | `/workspace` | Project directory exposed to Claude Code (read-write) |
+
+The `/workspace` mount gives Claude Code access to your project files. Restrict to `:ro` if you want read-only access.
+
+**Key environment overrides set in the compose file:**
+
+```yaml
+environment:
+  Mogwai__Enabled: "true"
+  Mogwai__WorkingDirectory: /workspace
+  Mogwai__SkipPermissions: "true"
+  DmAssistant__Enabled: "true"
+  DmAssistant__Model: "claude-haiku-4-5-20251001"
+  ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+```
+
+`Mogwai__Enabled` defaults to `false` in `appsettings.json`. The compose file overrides it to `true`, which means running the image without the compose file (or without the environment variable) starts a normal bot instance with no Claude Code tools registered.
+
+See [Mogwai feature guide](mogwai.md) for full configuration details.
+
+---
+
 ## Configuration Reference
 
 Configure the bot by editing `.env`. See `.env.example` for all available settings.
@@ -344,6 +391,35 @@ The container runs as non-root user `appuser`. Ensure mounted directories are re
 # Fix sounds directory permissions
 chmod -R o+r ./sounds/
 ```
+
+### Mogwai container won't start
+
+**Image build fails (Playwright/Chromium):**
+
+`npx playwright install --with-deps chromium` requires internet access at build time. Ensure the build host can reach `registry.npmjs.org` and Playwright's CDN:
+
+```bash
+docker compose -f docker-compose.mogwai.yml build --no-cache
+```
+
+**`claude: command not found` at runtime:**
+
+The npm global install failed silently. Rebuild the image and check npm output:
+
+```bash
+docker compose -f docker-compose.mogwai.yml build --no-cache 2>&1 | grep -i npm
+docker compose -f docker-compose.mogwai.yml exec mogwai claude --version
+```
+
+**DM assistant not responding after start:**
+
+1. Confirm `Discord__Token` in `.env.mogwai` is a different token from the main bot. Two processes sharing a token will fight for the connection.
+2. Confirm `DmAssistant__Enabled=true` is in the compose environment section.
+3. Check logs: `docker compose -f docker-compose.mogwai.yml logs mogwai`
+
+**`ANTHROPIC_API_KEY` errors from the `claude` CLI:**
+
+Both `Anthropic__ApiKey` (for .NET) and `ANTHROPIC_API_KEY` (for the `claude` process) must be set in `.env.mogwai`. If only one is set, one of the two will fail.
 
 ### Container health check failing
 

--- a/docs/articles/mogwai.md
+++ b/docs/articles/mogwai.md
@@ -1,0 +1,298 @@
+---
+uid: mogwai
+title: Mogwai — Claude Code CLI Integration
+description: Owner-only DM assistant that delegates coding tasks to Claude Code CLI running in Docker
+---
+
+# Mogwai — Claude Code CLI Integration
+
+Mogwai is a separate bot instance that runs in Docker and extends the DM assistant with Claude Code CLI capabilities. The bot owner can DM it with coding tasks — file editing, debugging, project analysis — and Haiku decides whether to answer directly or delegate to Claude Code.
+
+## Overview
+
+- **Owner-only access** — Only the Discord application owner can use the assistant. All other DMs receive a placeholder response.
+- **Haiku as triage** — `claude-haiku` handles the conversation loop. Simple questions are answered directly. Coding tasks are delegated via the `run_claude_code` tool.
+- **Claude Code as a tool** — `ClaudeCodeToolProvider` implements `IDmToolProvider` and registers `run_claude_code` and `get_claude_code_status` as tools into the existing `IAgentRunner` / `IToolRegistry` pipeline. No new handlers or services.
+- **Docker as sandbox** — The container provides OS-level isolation. `--dangerously-skip-permissions` is safe to enable inside the container because the container itself limits the blast radius.
+- **Session continuity** — Claude Code session IDs are tracked per-user in memory. Follow-up messages automatically resume the previous session via `--resume`.
+- **Response chunking** — Long responses (from Claude Code output) are split on newline boundaries into ≤2000-character chunks, or uploaded as a `.md` file attachment when they exceed 8000 characters.
+
+---
+
+## Prerequisites
+
+### Host Machine
+
+| Requirement | Notes |
+|-------------|-------|
+| Docker Engine 24.0+ | Required to build and run `Dockerfile.mogwai` |
+| Separate Discord bot token | Mogwai runs as its own bot application — it must not share a token with the main bot |
+| `ANTHROPIC_API_KEY` | Required for both Haiku (DM assistant) and Claude Code CLI inside the container |
+
+### Claude Code CLI (inside container)
+
+The `Dockerfile.mogwai` installs all CLI dependencies. You do not need to install anything on the host beyond Docker.
+
+**What the image installs on top of the base bot image:**
+- Node.js 22 LTS
+- `@anthropic-ai/claude-code` (npm global install)
+- Playwright + Chromium (for web browsing tasks)
+- `git` (for worktree isolation within the container)
+
+> **Image size**: Expect ~1.5–2 GB due to Chromium and Node.js dependencies.
+
+---
+
+## Configuration
+
+### `Mogwai` appsettings Section
+
+```json
+{
+  "Mogwai": {
+    "Enabled": false,
+    "ClaudeCliPath": "claude",
+    "WorkingDirectory": ".",
+    "AllowedTools": "Bash,Read,Glob,Grep,Write,Edit",
+    "MaxBudgetUsd": 5.00,
+    "MaxTurns": 10,
+    "TimeoutSeconds": 300,
+    "MaxOutputLength": 50000,
+    "UseBareMode": true
+  }
+}
+```
+
+### Property Reference
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `Enabled` | bool | `false` | Master toggle. When `false`, `ClaudeCodeToolProvider` registers no tools. Zero impact on other bot instances. |
+| `ClaudeCliPath` | string | `"claude"` | Path to the `claude` binary. Use the default when the binary is on `PATH` (as it will be inside the container). |
+| `WorkingDirectory` | string | `"."` | Working directory passed to Claude Code. In Docker, set to `/workspace` to give access to the mounted project. |
+| `AllowedTools` | string | `"Bash,Read,Glob,Grep,Write,Edit"` | Comma-separated tool whitelist passed as `--allowedTools` to the CLI. |
+| `MaxBudgetUsd` | decimal | `5.00` | Per-invocation spend cap passed as `--max-budget-usd`. |
+| `MaxTurns` | int | `10` | Maximum agentic turns per invocation passed as `--max-turns`. |
+| `TimeoutSeconds` | int | `300` | Wall-clock timeout before the process is killed (5 minutes). |
+| `MaxOutputLength` | int | `50000` | Output characters beyond this limit are truncated before returning to Haiku. |
+| `AppendSystemPrompt` | string? | `null` | Optional extra instructions passed as `--append-system-prompt`. |
+| `UseBareMode` | bool | `true` | Passes `--bare` to skip hooks, skills, and MCP configuration. |
+| `SkipPermissions` | bool | `false` | Passes `--dangerously-skip-permissions`. Set to `true` in `docker-compose.mogwai.yml` via environment override. |
+
+### Environment Variable Override
+
+All `appsettings.json` values can be overridden with environment variables using `__` as the separator:
+
+```env
+Mogwai__Enabled=true
+Mogwai__WorkingDirectory=/workspace
+Mogwai__SkipPermissions=true
+```
+
+---
+
+## Architecture
+
+### ClaudeCodeToolProvider
+
+`ClaudeCodeToolProvider` implements `IDmToolProvider` and is registered into the DI container as a scoped `IDmToolProvider`. The existing `IToolRegistry` picks it up automatically — no changes to `AgentRunner` or `DmAssistantService`.
+
+**Tool: `run_claude_code`**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `prompt` | string | Yes | The task or question for Claude Code |
+| `continue_session` | bool | No (default: `true`) | Resume the user's previous Claude Code session |
+| `working_directory` | string | No | Override the default working directory for this invocation |
+
+**Tool: `get_claude_code_status`**
+
+No parameters. Returns the current session state, last known cost, and whether a session is active for the calling user.
+
+### Process Spawning
+
+`ClaudeCodeToolProvider` builds and executes:
+
+```
+claude -p "{prompt}" \
+  --output-format json \
+  --allowedTools "Bash,Read,Glob,Grep,Write,Edit" \
+  --max-budget-usd 5.00 \
+  --max-turns 10 \
+  --bare \
+  [--resume {sessionId}] \
+  [--append-system-prompt "..."] \
+  [--dangerously-skip-permissions]
+```
+
+The process output is JSON: `{ result, session_id, duration_ms, total_cost_usd, is_error }`.
+
+### Session Tracking
+
+Session IDs are stored in a `ConcurrentDictionary<ulong, ClaudeCodeSession>` (userId to session). Sessions are **in-memory only** — they do not survive a container restart. This is intentional; no database entities or migrations are required.
+
+A second `ConcurrentDictionary<ulong, bool>` prevents concurrent invocations per user. If a user sends a second message while Claude Code is still running, the provider returns an error response immediately.
+
+### Response Chunking
+
+`DmAssistantMessageHandler` applies the following chunking strategy before sending:
+
+| Response length | Behavior |
+|-----------------|----------|
+| ≤ 2000 characters | Single Discord message (existing behavior) |
+| 2001–8000 characters | Split on newline boundaries into ≤ 2000-character chunks, sent sequentially |
+| > 8000 characters | Uploaded as a `.md` file attachment via `SendFileAsync` |
+
+---
+
+## Docker Setup
+
+Mogwai uses a **separate Dockerfile and compose file** so that the main bot images remain lean (~500 MB vs ~2 GB).
+
+### Building and Running
+
+```bash
+# Build the Mogwai image
+docker compose -f docker-compose.mogwai.yml build
+
+# Start Mogwai
+docker compose -f docker-compose.mogwai.yml up -d
+
+# View logs
+docker compose -f docker-compose.mogwai.yml logs -f mogwai
+```
+
+### `.env.mogwai`
+
+Create a `.env.mogwai` file (never commit this) with the Mogwai-specific bot token and API key:
+
+```env
+Discord__Token=your-mogwai-bot-token-here
+Anthropic__ApiKey=your-anthropic-api-key-here
+ANTHROPIC_API_KEY=your-anthropic-api-key-here
+```
+
+> Both `Anthropic__ApiKey` (used by the .NET DM assistant) and `ANTHROPIC_API_KEY` (used by the `claude` CLI process inside the container) are required.
+
+### `docker-compose.mogwai.yml` Overview
+
+```yaml
+services:
+  mogwai:
+    build:
+      context: .
+      dockerfile: Dockerfile.mogwai
+    env_file: .env.mogwai
+    environment:
+      Mogwai__Enabled: "true"
+      Mogwai__WorkingDirectory: /workspace
+      Mogwai__SkipPermissions: "true"
+      DmAssistant__Enabled: "true"
+      DmAssistant__Model: "claude-haiku-4-5-20251001"
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+    volumes:
+      - mogwai-data:/app/data
+      - ./:/workspace:rw
+    ports:
+      - "7310:5000"
+    restart: unless-stopped
+```
+
+### Volume Mounts
+
+| Volume | Container Path | Purpose |
+|--------|---------------|---------|
+| `mogwai-data` | `/app/data` | SQLite database and DM conversation history |
+| `./` (host repo root) | `/workspace` | Project directory exposed to Claude Code |
+
+The `/workspace` mount is **read-write** by default so Claude Code can edit files. Restrict to `:ro` if you only want read access.
+
+---
+
+## Security
+
+### Owner-Only Access
+
+Mogwai inherits the DM assistant's owner check (`GetApplicationInfoAsync()`). The bot owner is identified via the Discord API — no configuration-based user ID is needed. Non-owner DMs receive a placeholder response.
+
+### Container Sandbox
+
+`--dangerously-skip-permissions` is enabled inside the container via the `Mogwai__SkipPermissions=true` environment variable. This is safe because:
+
+- The container has no access to the host filesystem beyond the explicit `/workspace` mount.
+- The mounted directory is the project repository that you are explicitly granting access to.
+- Container network is isolated from host services unless ports are explicitly mapped.
+
+### API Key Handling
+
+- `Anthropic__ApiKey` is injected via `.env.mogwai` and is never committed to version control.
+- The `claude` CLI reads `ANTHROPIC_API_KEY` from the process environment — no browser-based authentication is needed inside the container.
+
+---
+
+## Troubleshooting
+
+### `claude: command not found` inside container
+
+The `claude` CLI failed to install during the image build. Rebuild the image and check for npm errors:
+
+```bash
+docker compose -f docker-compose.mogwai.yml build --no-cache
+docker compose -f docker-compose.mogwai.yml logs mogwai | grep -i npm
+```
+
+Verify the binary exists after a successful build:
+
+```bash
+docker compose -f docker-compose.mogwai.yml exec mogwai claude --version
+```
+
+### Claude Code invocation times out
+
+The default timeout is 300 seconds. For tasks that need longer, increase `Mogwai__TimeoutSeconds` in `docker-compose.mogwai.yml`. Check `MaxTurns` as well — a high turn count with complex tasks can exceed the timeout.
+
+### `ANTHROPIC_API_KEY` not found
+
+Both the .NET process and the `claude` CLI need the API key. Confirm your `.env.mogwai` contains both variables:
+
+```env
+Anthropic__ApiKey=sk-ant-...
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+If they differ, the CLI will fail even if the .NET DM assistant is working.
+
+### Container starts but DM assistant is not responding
+
+1. Verify `DmAssistant__Enabled=true` is set in the compose file environment.
+2. Confirm `Discord__Token` in `.env.mogwai` is a **different token** from the main bot. Sharing a token between two bot processes will cause one to be kicked offline.
+3. Check logs: `docker compose -f docker-compose.mogwai.yml logs mogwai`
+
+### Container won't start (image build fails)
+
+Playwright/Chromium installation can fail if the base image is missing system packages. The `Dockerfile.mogwai` runs `npx playwright install --with-deps chromium` which handles dependencies, but this requires internet access at build time. Ensure the build machine can reach `registry.npmjs.org` and Playwright's CDN.
+
+---
+
+## Verification Checklist
+
+1. `docker compose -f docker-compose.mogwai.yml build` completes without errors
+2. `docker compose -f docker-compose.mogwai.yml up -d` starts the container
+3. `docker exec mogwai claude --version` returns a version string
+4. `docker exec mogwai npx playwright --version` returns a version string
+5. DM the Mogwai bot with a simple question — Haiku answers directly (no Claude Code invocation)
+6. DM the Mogwai bot with a coding task — Haiku delegates to `run_claude_code`
+7. JSON output from the CLI is parsed and the response is chunked/sent correctly
+8. Send a follow-up coding message — `--resume` uses the stored session ID
+9. Confirm timeout kills the process after the configured seconds
+10. Send two rapid messages — confirm the second is rejected with a concurrency error
+
+---
+
+## Related Documentation
+
+- [AI Assistant](ai-assistant.md) — Guild-based AI assistant (different feature)
+- [DM Assistant Requirements](../requirements/dm-assistant-requirements.md) — DM assistant foundation
+- [Docker Deployment Guide](docker-deployment.md) — Main bot Docker setup
+- [Agent Prompt](../../docs/agents/dm-owner-agent.md) — Owner DM assistant system prompt
+- [Service Catalog](../architecture/service-catalog.md) — `ClaudeCodeToolProvider` entry

--- a/docs/features/mogwai-claude-code-integration.md
+++ b/docs/features/mogwai-claude-code-integration.md
@@ -1,0 +1,175 @@
+# Mogwai: Claude Code CLI Integration via DM Assistant
+
+## Overview
+
+Mogwai is a third Discord bot instance running in Docker on a local PC that invokes Claude Code CLI through Discord DMs. It provides an OpenClaw/Claude Code Channels-like experience integrated into the existing bot infrastructure.
+
+**Architecture**: Claude Code as a DM Tool Provider — not a separate service. The existing DM assistant with Haiku as its model sees a `run_claude_code` tool and decides when to delegate. No separate routing layer, no new handler, no new service. The AgentRunner's agentic loop handles it naturally.
+
+**Docker as sandbox** — Mogwai runs in a custom Docker image (`Dockerfile.mogwai`) that extends the base bot image with Node.js, `claude` CLI, and Playwright + Chromium. Claude Code runs with `--dangerously-skip-permissions` since the container itself is the sandbox.
+
+## Why This Works
+
+- Haiku is fast/cheap for triage — it answers simple questions directly, delegates coding to the tool
+- The system prompt instructs Haiku on when to use Claude Code
+- Follows the exact `CodeExecutionToolProvider` pattern (process spawn, timeout, kill tree)
+- Zero changes to AgentRunner, ToolRegistry, or DmAssistantService
+- Container provides OS-level sandboxing — no host filesystem access beyond mounted volumes
+
+## New Files
+
+### 1. `src/DiscordBot.Core/Configuration/MogwaiOptions.cs`
+
+Configuration class, section name `"Mogwai"`:
+
+| Property | Type | Default | Purpose |
+|----------|------|---------|---------|
+| `Enabled` | bool | false | Master toggle — no tools registered when false |
+| `ClaudeCliPath` | string | `"claude"` | Path to `claude` binary |
+| `WorkingDirectory` | string | `"."` | Working directory for Claude Code sessions |
+| `AllowedTools` | string | `"Bash,Read,Glob,Grep,Write,Edit"` | `--allowedTools` whitelist |
+| `MaxBudgetUsd` | decimal | `5.00` | `--max-budget-usd` per invocation |
+| `MaxTurns` | int | `10` | `--max-turns` per invocation |
+| `TimeoutSeconds` | int | `300` | Process timeout (5 min) |
+| `MaxOutputLength` | int | `50000` | Truncate CLI output beyond this |
+| `AppendSystemPrompt` | string? | null | `--append-system-prompt` extra instructions |
+| `UseBareMode` | bool | true | `--bare` flag (skip hooks/skills/MCP) |
+| `SkipPermissions` | bool | false | `--dangerously-skip-permissions` (safe inside Docker) |
+
+### 2. `src/DiscordBot.Infrastructure/Services/LLM/Implementations/ClaudeCodeTools.cs`
+
+Static tool definitions (follows `CodeExecutionTools` pattern):
+
+**Tool: `run_claude_code`**
+- `prompt` (string, required) — the task/question for Claude Code
+- `continue_session` (bool, optional, default true) — resume previous session
+- `working_directory` (string, optional) — override default working dir
+
+**Tool: `get_claude_code_status`**
+- No parameters — returns session state, last cost, whether a session is active
+
+### 3. `src/DiscordBot.Infrastructure/Services/LLM/Providers/ClaudeCodeToolProvider.cs`
+
+Core implementation, implements `IDmToolProvider`:
+
+- **Process spawning**: Builds `claude -p "{prompt}" --output-format json --allowedTools "..." --max-budget-usd N --max-turns N [--bare] [--resume sessionId] [--append-system-prompt "..."]`
+- **Session tracking**: `ConcurrentDictionary<ulong, ClaudeCodeSession>` (userId → {sessionId, cumulativeCost, lastUsed}). In-memory only — sessions are ephemeral.
+- **Concurrency guard**: `ConcurrentDictionary<ulong, bool>` tracks in-progress executions. Returns error if user tries concurrent invocations.
+- **Output parsing**: Deserializes JSON response `{ result, session_id, duration_ms, total_cost_usd, is_error }`
+- **Timeout**: Same linked CancellationTokenSource + KillProcessTree pattern as CodeExecutionToolProvider
+- **CLI not found**: Catches Win32Exception, returns helpful error
+
+## Modified Files
+
+### 4. `src/DiscordBot.Bot/Extensions/DmAssistantServiceExtensions.cs`
+
+- Add `services.Configure<MogwaiOptions>(configuration.GetSection("Mogwai"));`
+- Add `services.AddScoped<IDmToolProvider, ClaudeCodeToolProvider>();`
+
+### 5. `src/DiscordBot.Bot/Handlers/DmAssistantMessageHandler.cs`
+
+Replace single `SendMessageAsync(response.Response)` with chunked sending:
+- ≤2000 chars: single message (current behavior)
+- ≤8000 chars: split on newline boundaries into ≤2000 char chunks, send sequentially
+- \>8000 chars: upload as `.md` file attachment via `SendFileAsync`
+
+Extract to private helper `SendResponseAsync(IMessageChannel channel, string response)`.
+
+### 6. `src/DiscordBot.Core/Configuration/DmAssistantOptions.cs`
+
+- Increase `MaxResponseLength` default from 1800 to 50000 since the handler now handles Discord's limit via chunking.
+
+### 7. `docs/agents/dm-owner-agent.md`
+
+Add Claude Code tool section documenting `run_claude_code` and `get_claude_code_status` tools, including guidance on when to use Claude Code vs answering directly.
+
+### 8. `src/DiscordBot.Bot/appsettings.json`
+
+Add Mogwai section (disabled by default):
+```json
+"Mogwai": {
+  "Enabled": false,
+  "ClaudeCliPath": "claude",
+  "WorkingDirectory": ".",
+  "AllowedTools": "Bash,Read,Glob,Grep,Write,Edit",
+  "MaxBudgetUsd": 5.00,
+  "MaxTurns": 10,
+  "TimeoutSeconds": 300,
+  "MaxOutputLength": 50000,
+  "UseBareMode": true
+}
+```
+
+## Docker Files
+
+### 9. `Dockerfile.mogwai`
+
+Separate Dockerfile extending the bot with Mogwai dependencies. Reuses the same build stage as the main Dockerfile, adds to the runtime stage:
+
+- Node.js 22 LTS (for claude CLI)
+- Claude Code CLI (`npm install -g @anthropic-ai/claude-code`)
+- Playwright + Chromium (`npx playwright install --with-deps chromium`)
+- git (for worktree isolation within container)
+- All existing runtime deps (ffmpeg, python3, libsodium, libopus)
+
+Image will be ~1.5-2GB. `ANTHROPIC_API_KEY` passed via env var (no browser auth needed).
+
+### 10. `docker-compose.mogwai.yml`
+
+Standalone compose file for Mogwai:
+
+```yaml
+services:
+  mogwai:
+    build:
+      context: .
+      dockerfile: Dockerfile.mogwai
+    env_file: .env.mogwai
+    environment:
+      Mogwai__Enabled: "true"
+      Mogwai__WorkingDirectory: /workspace
+      Mogwai__SkipPermissions: "true"
+      DmAssistant__Enabled: "true"
+      DmAssistant__Model: "claude-haiku-4-5-20251001"
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+    volumes:
+      - mogwai-data:/app/data
+      - ./:/workspace:rw
+    ports:
+      - "7310:5000"
+    restart: unless-stopped
+```
+
+## Implementation Phases
+
+1. **Phase 1 — Configuration & Tool Definitions**: `MogwaiOptions.cs` + `ClaudeCodeTools.cs` + appsettings (no behavior change)
+2. **Phase 2 — Tool Provider & DI**: `ClaudeCodeToolProvider.cs` + DI registration
+3. **Phase 3 — Response Chunking**: DmAssistantMessageHandler chunking + MaxResponseLength adjustment
+4. **Phase 4 — System Prompt**: Update `dm-owner-agent.md` with Claude Code tool guidance
+5. **Phase 5 — Docker**: `Dockerfile.mogwai` + `docker-compose.mogwai.yml`
+
+## Key Design Decisions
+
+- **No new DB entities/migrations** — session IDs are in-memory, ephemeral
+- **No new handler** — reuses existing DmAssistantMessageHandler
+- **No new service** — reuses existing DmAssistantService + AgentRunner
+- **Haiku model** — configured via existing `DmAssistantOptions.Model`
+- **Disabled by default** — `MogwaiOptions.Enabled = false` means zero impact on other bot instances
+- **Concurrency guard** — prevents overlapping Claude Code invocations per user
+- **Separate Dockerfile** — keeps other bot images lean (~500MB vs ~2GB)
+- **Docker = sandbox** — `--dangerously-skip-permissions` is safe; container limits blast radius
+- **API key auth** — no browser needed inside container
+
+## Verification
+
+1. Build: `docker compose -f docker-compose.mogwai.yml build`
+2. Run: `docker compose -f docker-compose.mogwai.yml up -d`
+3. Verify `claude --version` works inside container
+4. Verify Playwright: `docker exec mogwai npx playwright --version`
+5. DM with simple question → Haiku answers directly (no Claude Code)
+6. DM coding task → Haiku delegates to `run_claude_code` tool
+7. Verify JSON output parsed, response chunked/sent correctly
+8. Follow-up coding message → verify `--resume` uses stored session ID
+9. Verify timeout kills process after configured seconds
+10. Verify budget limit passed through to CLI
+11. Test concurrent message rejection

--- a/docs/requirements/dm-assistant-requirements.md
+++ b/docs/requirements/dm-assistant-requirements.md
@@ -1,7 +1,8 @@
 # DM Chat Assistant Requirements
 
-> **Status:** Draft
+> **Status:** Implemented (MVP + Claude Code extension)
 > **Created:** 2026-02-03
+> **Updated:** 2026-03-23
 > **Target Version:** v0.20.0
 
 ## Executive Summary
@@ -99,17 +100,17 @@ Maintain a sliding-window conversation history per user, stored in the database.
 | Feature | Description | Priority |
 |---------|-------------|----------|
 | Non-owner access | Restricted prompts for non-owner users | Medium |
-| MCP/Claude Code tooling | Dev tooling integration via MCP | High |
+| ~~MCP/Claude Code tooling~~ | **Implemented as Mogwai** — see [mogwai.md](../articles/mogwai.md) | Done |
 | Rate limiting | Per-user rate limits for non-owners | Low |
 | Per-user prompts | Customizable prompts per user | Low |
 
 ---
 
-## Out of Scope
+## Out of Scope (MVP)
 
 - **Rate limiting** — Deferred until non-owner access is implemented
 - **Production-to-dev communication** — Separate tooling phase
-- **Tool use** — Start with pure conversation, add tools later
+- **Tool use** — Deferred from MVP; implemented as part of Mogwai (see [mogwai.md](../articles/mogwai.md))
 
 ---
 
@@ -119,12 +120,13 @@ Maintain a sliding-window conversation history per user, stored in the database.
 
 | Component | Approach |
 |-----------|----------|
-| Service | New `IDmAssistantService` (separate from guild assistant) |
-| Handler | DM message handler in bot event handlers |
-| LLM | Reuse existing `ILlmClient` / `AnthropicLlmClient` |
-| Prompts | New prompt file(s) in `docs/agents/` |
-| Config | New `DmAssistant` section in appsettings |
-| Storage | New entities for DM interaction logs/metrics |
+| Service | `IDmAssistantService` / `DmAssistantService` (separate from guild assistant) |
+| Handler | `DmAssistantMessageHandler` — responds to Discord DM events; handles response chunking (split ≤2000-char chunks or `.md` file attachment for long responses) |
+| LLM | Reuses existing `ILlmClient` / `AnthropicLlmClient` |
+| Tool integration | `ClaudeCodeToolProvider` implements `IDmToolProvider`; registered as scoped DI — no changes to `AgentRunner` or `ToolRegistry` |
+| Prompts | `docs/agents/dm-owner-agent.md` — includes guidance on when to use Claude Code vs answer directly |
+| Config | `DmAssistant` section (base DM assistant) + `Mogwai` section (Claude Code extension) in appsettings |
+| Storage | `DmConversationMessage`, `DmAssistantInteractionLog`, `DmAssistantUsageMetrics` entities; Claude Code session IDs are in-memory only (no DB entities) |
 
 ### Service Interface
 
@@ -260,3 +262,4 @@ Daily aggregated metrics, similar structure to `AssistantUsageMetrics` but for D
 |------|---------|---------|
 | 2026-02-03 | 0.1 | Initial draft from requirements gathering |
 | 2026-03-05 | 0.2 | Added conversation history (sliding window) to MVP scope |
+| 2026-03-23 | 0.3 | Updated status to Implemented; reflected Mogwai Claude Code extension (ClaudeCodeToolProvider, response chunking, MogwaiOptions); marked MCP/Claude Code future feature as Done |

--- a/src/DiscordBot.Bot/Extensions/DmAssistantServiceExtensions.cs
+++ b/src/DiscordBot.Bot/Extensions/DmAssistantServiceExtensions.cs
@@ -29,6 +29,8 @@ public static class DmAssistantServiceExtensions
         // Register configuration
         services.Configure<DmAssistantOptions>(
             configuration.GetSection(DmAssistantOptions.SectionName));
+        services.Configure<MogwaiOptions>(
+            configuration.GetSection(MogwaiOptions.SectionName));
 
         // Register repositories (always needed for admin/cleanup)
         services.AddScoped<IDmConversationMessageRepository, DmConversationMessageRepository>();
@@ -50,6 +52,7 @@ public static class DmAssistantServiceExtensions
         services.AddScoped<DocumentationToolProvider>();
         services.AddScoped<IDmToolProvider, DmDocumentationToolProvider>();
         services.AddScoped<IDmToolProvider, CodeExecutionToolProvider>();
+        services.AddScoped<IDmToolProvider, ClaudeCodeToolProvider>();
         services.AddHttpClient("DmAssistantWebFetch", client =>
         {
             client.Timeout = TimeSpan.FromSeconds(10);

--- a/src/DiscordBot.Bot/Handlers/DmAssistantMessageHandler.cs
+++ b/src/DiscordBot.Bot/Handlers/DmAssistantMessageHandler.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Discord;
 using Discord.WebSocket;
 using DiscordBot.Bot.Tracing;
@@ -90,7 +91,7 @@ public class DmAssistantMessageHandler
 
             if (response.Success && !string.IsNullOrWhiteSpace(response.Response))
             {
-                await message.Channel.SendMessageAsync(response.Response);
+                await SendResponseAsync(message.Channel, response.Response);
 
                 _logger.LogInformation(
                     "Sent DM assistant response to user {UserId}",
@@ -129,6 +130,80 @@ public class DmAssistantMessageHandler
         finally
         {
             typingState?.Dispose();
+        }
+    }
+
+    private const int DiscordMaxMessageLength = 2000;
+    private const int FileAttachmentThreshold = 8000;
+
+    /// <summary>
+    /// Sends a response to the channel, handling Discord's 2000-char message limit
+    /// by chunking into multiple messages or uploading as a file attachment.
+    /// </summary>
+    private static async Task SendResponseAsync(IMessageChannel channel, string response)
+    {
+        if (string.IsNullOrWhiteSpace(response))
+            return;
+
+        if (response.Length <= DiscordMaxMessageLength)
+        {
+            await channel.SendMessageAsync(response);
+            return;
+        }
+
+        if (response.Length > FileAttachmentThreshold)
+        {
+            await channel.SendMessageAsync("Here's the full response:");
+
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(response));
+            await channel.SendFileAsync(stream, "response.md", text: null);
+            return;
+        }
+
+        // Split on newline boundaries into <=2000 char chunks
+        var lines = response.Split('\n');
+        var chunk = new StringBuilder();
+
+        foreach (var line in lines)
+        {
+            // If a single line exceeds the limit, hard-split it
+            if (line.Length > DiscordMaxMessageLength)
+            {
+                // Flush any accumulated content first
+                if (chunk.Length > 0)
+                {
+                    await channel.SendMessageAsync(chunk.ToString());
+                    chunk.Clear();
+                }
+
+                // Hard-split the long line at max-length boundaries
+                for (var i = 0; i < line.Length; i += DiscordMaxMessageLength)
+                {
+                    var length = Math.Min(DiscordMaxMessageLength, line.Length - i);
+                    await channel.SendMessageAsync(line.Substring(i, length));
+                }
+
+                continue;
+            }
+
+            // Check if adding this line (with newline separator) would exceed the limit
+            var addition = chunk.Length == 0 ? line.Length : line.Length + 1;
+            if (chunk.Length + addition > DiscordMaxMessageLength)
+            {
+                await channel.SendMessageAsync(chunk.ToString());
+                chunk.Clear();
+            }
+
+            if (chunk.Length > 0)
+                chunk.Append('\n');
+
+            chunk.Append(line);
+        }
+
+        // Send any remaining content
+        if (chunk.Length > 0)
+        {
+            await channel.SendMessageAsync(chunk.ToString());
         }
     }
 }

--- a/src/DiscordBot.Bot/appsettings.json
+++ b/src/DiscordBot.Bot/appsettings.json
@@ -269,6 +269,17 @@
       }
     ]
   },
+  "Mogwai": {
+    "Enabled": false,
+    "ClaudeCliPath": "claude",
+    "WorkingDirectory": ".",
+    "AllowedTools": "Bash,Read,Glob,Grep,Write,Edit",
+    "MaxBudgetUsd": 5.00,
+    "MaxTurns": 10,
+    "TimeoutSeconds": 300,
+    "MaxOutputLength": 50000,
+    "UseBareMode": true
+  },
   "DmAssistant": {
     "Enabled": false,
     "OwnerSystemPromptPath": "docs/agents/dm-owner-agent.md",

--- a/src/DiscordBot.Core/Configuration/DmAssistantOptions.cs
+++ b/src/DiscordBot.Core/Configuration/DmAssistantOptions.cs
@@ -66,9 +66,10 @@ public class DmAssistantOptions
 
     /// <summary>
     /// Gets or sets the maximum length of Claude's response in characters.
-    /// Default is 1800 (leaves buffer for Discord's 2000 char limit).
+    /// Default is 50000. The DM handler manages Discord's 2000-char message limit
+    /// by chunking long responses or uploading them as file attachments.
     /// </summary>
-    public int MaxResponseLength { get; set; } = 1800;
+    public int MaxResponseLength { get; set; } = 50000;
 
     /// <summary>
     /// Gets or sets the suffix appended when responses are truncated.

--- a/src/DiscordBot.Core/Configuration/MogwaiOptions.cs
+++ b/src/DiscordBot.Core/Configuration/MogwaiOptions.cs
@@ -1,0 +1,87 @@
+namespace DiscordBot.Core.Configuration;
+
+/// <summary>
+/// Configuration options for the Mogwai feature — Claude Code CLI integration for coding tasks.
+/// </summary>
+public class MogwaiOptions
+{
+    public const string SectionName = "Mogwai";
+
+    /// <summary>
+    /// Gets or sets whether the Mogwai feature is enabled.
+    /// Default is false (disabled until explicitly enabled).
+    /// </summary>
+    public bool Enabled { get; set; } = false;
+
+    #region CLI Configuration
+
+    /// <summary>
+    /// Gets or sets the path to the Claude CLI binary.
+    /// Default is "claude".
+    /// </summary>
+    public string ClaudeCliPath { get; set; } = "claude";
+
+    /// <summary>
+    /// Gets or sets the working directory for Claude Code sessions.
+    /// Default is ".".
+    /// </summary>
+    public string WorkingDirectory { get; set; } = ".";
+
+    /// <summary>
+    /// Gets or sets the comma-separated list of allowed tools for --allowedTools.
+    /// Default is "Bash,Read,Glob,Grep,Write,Edit".
+    /// </summary>
+    public string AllowedTools { get; set; } = "Bash,Read,Glob,Grep,Write,Edit";
+
+    #endregion
+
+    #region Limits
+
+    /// <summary>
+    /// Gets or sets the maximum budget in USD per invocation (--max-budget-usd).
+    /// Default is 5.00.
+    /// </summary>
+    public decimal MaxBudgetUsd { get; set; } = 5.00m;
+
+    /// <summary>
+    /// Gets or sets the maximum number of turns per invocation (--max-turns).
+    /// Default is 10.
+    /// </summary>
+    public int MaxTurns { get; set; } = 10;
+
+    /// <summary>
+    /// Gets or sets the process timeout in seconds.
+    /// Default is 300 (5 minutes).
+    /// </summary>
+    public int TimeoutSeconds { get; set; } = 300;
+
+    /// <summary>
+    /// Gets or sets the maximum CLI output length in characters before truncation.
+    /// Default is 50000.
+    /// </summary>
+    public int MaxOutputLength { get; set; } = 50000;
+
+    #endregion
+
+    #region Behavior
+
+    /// <summary>
+    /// Gets or sets an optional system prompt appended via --append-system-prompt.
+    /// Default is null (no extra instructions).
+    /// </summary>
+    public string? AppendSystemPrompt { get; set; } = null;
+
+    /// <summary>
+    /// Gets or sets whether to use the --bare flag for machine-readable output.
+    /// Default is true.
+    /// </summary>
+    public bool UseBareMode { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets whether to use --dangerously-skip-permissions.
+    /// Default is false.
+    /// </summary>
+    public bool SkipPermissions { get; set; } = false;
+
+    #endregion
+}

--- a/src/DiscordBot.Infrastructure/Services/LLM/Implementations/ClaudeCodeTools.cs
+++ b/src/DiscordBot.Infrastructure/Services/LLM/Implementations/ClaudeCodeTools.cs
@@ -1,0 +1,79 @@
+using System.Text.Json;
+using DiscordBot.Core.DTOs.LLM;
+
+namespace DiscordBot.Infrastructure.Services.LLM.Implementations;
+
+/// <summary>
+/// Static tool definitions for Claude Code CLI integration.
+/// </summary>
+public static class ClaudeCodeTools
+{
+    /// <summary>
+    /// Tool name for running a Claude Code session.
+    /// </summary>
+    public const string RunClaudeCode = "run_claude_code";
+
+    /// <summary>
+    /// Tool name for checking Claude Code session status.
+    /// </summary>
+    public const string GetClaudeCodeStatus = "get_claude_code_status";
+
+    /// <summary>
+    /// Gets all Claude Code tool definitions.
+    /// </summary>
+    public static IEnumerable<LlmToolDefinition> GetAllTools()
+    {
+        yield return CreateRunClaudeCodeTool();
+        yield return CreateGetClaudeCodeStatusTool();
+    }
+
+    private static LlmToolDefinition CreateRunClaudeCodeTool()
+    {
+        var schema = JsonDocument.Parse("""
+            {
+                "type": "object",
+                "properties": {
+                    "prompt": {
+                        "type": "string",
+                        "description": "The task or question for Claude Code to work on. Be specific and detailed."
+                    },
+                    "continue_session": {
+                        "type": "boolean",
+                        "description": "Whether to resume the previous Claude Code session for continuity",
+                        "default": true
+                    },
+                    "working_directory": {
+                        "type": "string",
+                        "description": "Override the default working directory for this invocation"
+                    }
+                },
+                "required": ["prompt"]
+            }
+            """);
+
+        return new LlmToolDefinition
+        {
+            Name = RunClaudeCode,
+            Description = "Runs a Claude Code CLI session to perform coding tasks such as reading, writing, and editing files, running commands, and answering questions about the codebase. Use for any task that requires direct interaction with the project repository.",
+            InputSchema = schema.RootElement.Clone()
+        };
+    }
+
+    private static LlmToolDefinition CreateGetClaudeCodeStatusTool()
+    {
+        var schema = JsonDocument.Parse("""
+            {
+                "type": "object",
+                "properties": {},
+                "required": []
+            }
+            """);
+
+        return new LlmToolDefinition
+        {
+            Name = GetClaudeCodeStatus,
+            Description = "Check if a Claude Code session exists and its cumulative cost.",
+            InputSchema = schema.RootElement.Clone()
+        };
+    }
+}

--- a/src/DiscordBot.Infrastructure/Services/LLM/Providers/ClaudeCodeToolProvider.cs
+++ b/src/DiscordBot.Infrastructure/Services/LLM/Providers/ClaudeCodeToolProvider.cs
@@ -1,0 +1,438 @@
+using System.Collections.Concurrent;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using DiscordBot.Core.Configuration;
+using DiscordBot.Core.DTOs.LLM;
+using DiscordBot.Core.Interfaces.LLM;
+using DiscordBot.Infrastructure.Services.LLM.Implementations;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace DiscordBot.Infrastructure.Services.LLM.Providers;
+
+/// <summary>
+/// DM tool provider for running Claude Code CLI sessions.
+/// Spawns a Claude Code process, captures JSON output, and enforces timeout.
+/// Disabled by default via <see cref="MogwaiOptions.Enabled"/>.
+/// </summary>
+public class ClaudeCodeToolProvider : IDmToolProvider
+{
+    private readonly ILogger<ClaudeCodeToolProvider> _logger;
+    private readonly IOptions<MogwaiOptions> _options;
+
+    private static readonly ConcurrentDictionary<ulong, ClaudeCodeSession> _sessions = new();
+    private static readonly ConcurrentDictionary<ulong, bool> _activeExecutions = new();
+
+    /// <inheritdoc />
+    public string Name => "ClaudeCode";
+
+    /// <inheritdoc />
+    public string Description => "Run Claude Code CLI sessions for coding tasks";
+
+    public ClaudeCodeToolProvider(
+        ILogger<ClaudeCodeToolProvider> logger,
+        IOptions<MogwaiOptions> options)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<LlmToolDefinition> GetTools()
+    {
+        if (!_options.Value.Enabled)
+            return Enumerable.Empty<LlmToolDefinition>();
+
+        return ClaudeCodeTools.GetAllTools();
+    }
+
+    /// <inheritdoc />
+    public async Task<ToolExecutionResult> ExecuteToolAsync(
+        string toolName,
+        JsonElement input,
+        ToolContext context,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_options.Value.Enabled)
+        {
+            return ToolExecutionResult.CreateError("Claude Code integration is disabled.");
+        }
+
+        return toolName switch
+        {
+            ClaudeCodeTools.RunClaudeCode => await ExecuteRunClaudeCodeAsync(input, context, cancellationToken),
+            ClaudeCodeTools.GetClaudeCodeStatus => ExecuteGetStatus(context),
+            _ => throw new NotSupportedException($"Tool '{toolName}' is not supported by this provider")
+        };
+    }
+
+    private ToolExecutionResult ExecuteGetStatus(ToolContext context)
+    {
+        var userId = context.UserId;
+        var isActive = _activeExecutions.ContainsKey(userId);
+        var hasSession = _sessions.TryGetValue(userId, out var session);
+
+        var result = new Dictionary<string, object?>
+        {
+            ["has_session"] = hasSession,
+            ["is_running"] = isActive,
+            ["session_id"] = session?.SessionId,
+            ["cumulative_cost_usd"] = session?.CumulativeCost,
+            ["last_used_utc"] = session?.LastUsed.ToString("O")
+        };
+
+        var json = JsonSerializer.Serialize(result);
+        var element = JsonDocument.Parse(json).RootElement.Clone();
+        return ToolExecutionResult.CreateSuccess(element);
+    }
+
+    private async Task<ToolExecutionResult> ExecuteRunClaudeCodeAsync(
+        JsonElement input,
+        ToolContext context,
+        CancellationToken cancellationToken)
+    {
+        var userId = context.UserId;
+
+        // Extract parameters
+        if (!input.TryGetProperty("prompt", out var promptElement))
+        {
+            return ToolExecutionResult.CreateError("Missing required parameter: prompt");
+        }
+
+        var prompt = promptElement.GetString();
+        if (string.IsNullOrWhiteSpace(prompt))
+        {
+            return ToolExecutionResult.CreateError("Parameter prompt cannot be empty");
+        }
+
+        var continueSession = true;
+        if (input.TryGetProperty("continue_session", out var continueElement))
+        {
+            continueSession = continueElement.GetBoolean();
+        }
+
+        string? workingDirectory = null;
+        if (input.TryGetProperty("working_directory", out var wdElement))
+        {
+            workingDirectory = wdElement.GetString();
+        }
+
+        // Concurrency guard
+        if (!_activeExecutions.TryAdd(userId, true))
+        {
+            return ToolExecutionResult.CreateError(
+                "A Claude Code session is already running. Wait for it to complete or check status with get_claude_code_status.");
+        }
+
+        try
+        {
+            return await SpawnClaudeProcessAsync(
+                prompt, continueSession, workingDirectory, userId, cancellationToken);
+        }
+        finally
+        {
+            _activeExecutions.TryRemove(userId, out _);
+        }
+    }
+
+    private async Task<ToolExecutionResult> SpawnClaudeProcessAsync(
+        string prompt,
+        bool continueSession,
+        string? workingDirectory,
+        ulong userId,
+        CancellationToken cancellationToken)
+    {
+        var opts = _options.Value;
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = opts.ClaudeCliPath,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            RedirectStandardInput = true,
+            WorkingDirectory = workingDirectory ?? opts.WorkingDirectory
+        };
+
+        // Build arguments: --print (read prompt from stdin), --output-format json, --verbose
+        psi.ArgumentList.Add("--print");
+        psi.ArgumentList.Add("--output-format");
+        psi.ArgumentList.Add("json");
+        psi.ArgumentList.Add("--verbose");
+
+        // --allowedTools
+        psi.ArgumentList.Add("--allowedTools");
+        psi.ArgumentList.Add(opts.AllowedTools);
+
+        // --max-turns
+        psi.ArgumentList.Add("--max-turns");
+        psi.ArgumentList.Add(opts.MaxTurns.ToString());
+
+        // --bare
+        if (opts.UseBareMode)
+        {
+            psi.ArgumentList.Add("--bare");
+        }
+
+        // --dangerously-skip-permissions
+        if (opts.SkipPermissions)
+        {
+            psi.ArgumentList.Add("--dangerously-skip-permissions");
+        }
+
+        // --append-system-prompt
+        if (!string.IsNullOrEmpty(opts.AppendSystemPrompt))
+        {
+            psi.ArgumentList.Add("--append-system-prompt");
+            psi.ArgumentList.Add(opts.AppendSystemPrompt);
+        }
+
+        // --resume with session ID
+        if (continueSession && _sessions.TryGetValue(userId, out var existingSession))
+        {
+            psi.ArgumentList.Add("--resume");
+            psi.ArgumentList.Add(existingSession.SessionId);
+        }
+
+        using var process = new Process { StartInfo = psi };
+
+        var stdout = new StringBuilder();
+        var stderr = new StringBuilder();
+
+        process.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data != null) stdout.AppendLine(e.Data);
+        };
+        process.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data != null) stderr.AppendLine(e.Data);
+        };
+
+        try
+        {
+            process.Start();
+        }
+        catch (Win32Exception ex)
+        {
+            _logger.LogWarning(ex, "Claude CLI not found at {Path}", opts.ClaudeCliPath);
+            return ToolExecutionResult.CreateError(
+                $"Claude CLI not found at '{opts.ClaudeCliPath}'. Ensure it is installed and in PATH.");
+        }
+
+        // Pipe prompt via stdin
+        await process.StandardInput.WriteAsync(prompt);
+        process.StandardInput.Close();
+
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        // Timeout handling
+        var timeoutMs = opts.TimeoutSeconds * 1000;
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(timeoutMs);
+
+        bool timedOut = false;
+        try
+        {
+            await process.WaitForExitAsync(timeoutCts.Token);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            timedOut = true;
+            KillProcessTree(process);
+        }
+
+        var stdoutStr = stdout.ToString();
+        var stderrStr = stderr.ToString();
+
+        _logger.LogDebug(
+            "Claude Code execution completed. ExitCode={ExitCode}, Stdout={StdoutLen}chars, Stderr={StderrLen}chars, TimedOut={TimedOut}",
+            timedOut ? -1 : process.ExitCode,
+            stdoutStr.Length,
+            stderrStr.Length,
+            timedOut);
+
+        if (timedOut)
+        {
+            return ToolExecutionResult.CreateError(
+                $"Claude Code timed out after {opts.TimeoutSeconds} seconds. The process was killed.");
+        }
+
+        // Non-zero exit code
+        if (process.ExitCode != 0)
+        {
+            var truncatedStderr = TruncateOutput(stderrStr, opts.MaxOutputLength);
+            _logger.LogWarning(
+                "Claude Code exited with non-zero code {ExitCode}. Stderr: {Stderr}",
+                process.ExitCode,
+                truncatedStderr);
+
+            var errorResult = new Dictionary<string, object?>
+            {
+                ["error"] = true,
+                ["exit_code"] = process.ExitCode,
+                ["stderr"] = truncatedStderr
+            };
+            var errorJson = JsonSerializer.Serialize(errorResult);
+            var errorElement = JsonDocument.Parse(errorJson).RootElement.Clone();
+            return ToolExecutionResult.CreateError(errorJson);
+        }
+
+        // Parse JSON output
+        return ParseClaudeOutput(stdoutStr, userId, opts.MaxOutputLength);
+    }
+
+    private ToolExecutionResult ParseClaudeOutput(string rawOutput, ulong userId, int maxOutputLength)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(rawOutput);
+            var root = doc.RootElement;
+
+            string? resultText = null;
+            string? sessionId = null;
+            decimal totalCost = 0;
+            int totalDurationMs = 0;
+
+            // The --output-format json --verbose output is a JSON array of conversation messages
+            if (root.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var message in root.EnumerateArray())
+                {
+                    // Sum cost across all messages
+                    if (message.TryGetProperty("cost_usd", out var costProp))
+                    {
+                        totalCost += costProp.GetDecimal();
+                    }
+
+                    // Sum duration
+                    if (message.TryGetProperty("duration_ms", out var durationProp))
+                    {
+                        totalDurationMs += durationProp.GetInt32();
+                    }
+
+                    // Get session_id if present
+                    if (message.TryGetProperty("session_id", out var sidProp))
+                    {
+                        sessionId = sidProp.GetString();
+                    }
+
+                    // Extract text from the last assistant message
+                    if (message.TryGetProperty("type", out var typeProp) &&
+                        typeProp.GetString() == "assistant" &&
+                        message.TryGetProperty("message", out var msgProp) &&
+                        msgProp.TryGetProperty("content", out var contentProp) &&
+                        contentProp.ValueKind == JsonValueKind.Array)
+                    {
+                        foreach (var block in contentProp.EnumerateArray())
+                        {
+                            if (block.TryGetProperty("type", out var blockType) &&
+                                blockType.GetString() == "text" &&
+                                block.TryGetProperty("text", out var textProp))
+                            {
+                                resultText = textProp.GetString();
+                            }
+                        }
+                    }
+                }
+            }
+            else if (root.ValueKind == JsonValueKind.Object)
+            {
+                // Fallback: single object response
+                if (root.TryGetProperty("result", out var resultProp))
+                {
+                    resultText = resultProp.GetString();
+                }
+
+                if (root.TryGetProperty("session_id", out var sidProp))
+                {
+                    sessionId = sidProp.GetString();
+                }
+
+                if (root.TryGetProperty("total_cost_usd", out var costProp))
+                {
+                    totalCost = costProp.GetDecimal();
+                }
+
+                if (root.TryGetProperty("is_error", out var errorProp) && errorProp.GetBoolean())
+                {
+                    return ToolExecutionResult.CreateError(resultText ?? "Claude Code returned an error.");
+                }
+            }
+
+            // Update session tracking
+            if (!string.IsNullOrEmpty(sessionId))
+            {
+                _sessions.AddOrUpdate(
+                    userId,
+                    _ => new ClaudeCodeSession(sessionId, totalCost, DateTime.UtcNow),
+                    (_, existing) => new ClaudeCodeSession(
+                        sessionId,
+                        existing.CumulativeCost + totalCost,
+                        DateTime.UtcNow));
+            }
+
+            // Truncate result if needed
+            resultText = TruncateOutput(resultText ?? string.Empty, maxOutputLength);
+
+            var result = new Dictionary<string, object?>
+            {
+                ["result"] = resultText,
+                ["session_id"] = sessionId,
+                ["cost_usd"] = totalCost,
+                ["duration_ms"] = totalDurationMs
+            };
+
+            var json = JsonSerializer.Serialize(result);
+            var element = JsonDocument.Parse(json).RootElement.Clone();
+            return ToolExecutionResult.CreateSuccess(element);
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse Claude Code JSON output, returning raw output");
+
+            // Fallback: return raw output as-is
+            var truncated = TruncateOutput(rawOutput, maxOutputLength);
+            var fallback = new Dictionary<string, object?>
+            {
+                ["result"] = truncated,
+                ["parse_error"] = true
+            };
+
+            var json = JsonSerializer.Serialize(fallback);
+            var element = JsonDocument.Parse(json).RootElement.Clone();
+            return ToolExecutionResult.CreateSuccess(element);
+        }
+    }
+
+    private static string TruncateOutput(string output, int maxLength)
+    {
+        if (output.Length <= maxLength)
+            return output;
+
+        return output[..maxLength] + "... (output truncated)";
+    }
+
+    private void KillProcessTree(Process process)
+    {
+        try
+        {
+            process.Kill(entireProcessTree: true);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to kill process tree for PID {Pid}", process.Id);
+        }
+    }
+
+    /// <summary>
+    /// In-memory session state for a Claude Code session.
+    /// </summary>
+    private sealed record ClaudeCodeSession(
+        string SessionId,
+        decimal CumulativeCost,
+        DateTime LastUsed);
+}


### PR DESCRIPTION
## Summary

Adds **Mogwai** — a Claude Code CLI integration that runs as a third bot instance in Docker, allowing the bot owner to delegate coding tasks via DMs. Haiku handles fast triage/routing, and heavy coding tasks are offloaded to `claude --print` spawned as a child process inside the container.

- **Claude Code as a DM tool** — `ClaudeCodeToolProvider` implements `IDmToolProvider`, following the existing `CodeExecutionToolProvider` pattern exactly. Zero changes to AgentRunner, ToolRegistry, or DmAssistantService.
- **Response chunking** — DM handler now splits long responses into ≤2000 char chunks or uploads as `.md` file attachments, removing the 1800 char truncation limit.
- **Docker sandbox** — Separate `Dockerfile.mogwai` extends the base image with Node.js 22, Claude Code CLI, and Playwright+Chromium (~1.5-2GB). `--dangerously-skip-permissions` is safe since the container is the sandbox.
- **Disabled by default** — `MogwaiOptions.Enabled = false` means zero impact on DiskordBott/BlasterBot instances.

### New files
- `MogwaiOptions.cs` — Configuration (CLI path, budget, turns, timeout, allowed tools)
- `ClaudeCodeTools.cs` — Static tool definitions (`run_claude_code`, `get_claude_code_status`)
- `ClaudeCodeToolProvider.cs` — Process spawning, session tracking, concurrency guard, JSON parsing
- `Dockerfile.mogwai` + `docker-compose.mogwai.yml` + `.env.mogwai.example`
- `docs/articles/mogwai.md` — Full feature article
- `docs/features/mogwai-claude-code-integration.md` — Implementation spec

### Modified files
- `DmAssistantServiceExtensions.cs` — DI registration for MogwaiOptions + ClaudeCodeToolProvider
- `DmAssistantMessageHandler.cs` — Response chunking (≤2k single, ≤8k chunked, >8k file attachment)
- `DmAssistantOptions.cs` — MaxResponseLength 1800 → 50000
- `dm-owner-agent.md` — System prompt with Claude Code tool docs + routing guidance
- `appsettings.json` — Mogwai section (disabled by default)
- README, CLAUDE-REFERENCE, architecture docs, deployment guide, requirements

### Key design decisions
- No new DB entities/migrations — sessions are in-memory, ephemeral
- No new handler/service — reuses existing DmAssistantMessageHandler + AgentRunner
- Prompt piped via stdin to avoid shell escaping issues
- `ProcessStartInfo.ArgumentList` for safe argument handling
- Concurrency guard prevents overlapping invocations per user
- Session continuity via `--resume` with tracked session IDs

Closes #1896, closes #1897, closes #1898, closes #1899, closes #1900, closes #1902
Closes #1901

## Test plan

- [ ] `dotnet build` passes with 0 errors
- [ ] `docker compose -f docker-compose.mogwai.yml build` succeeds
- [ ] `docker exec mogwai claude --version` works inside container
- [ ] DM simple question → Haiku answers directly (no Claude Code)
- [ ] DM coding task → Haiku delegates to `run_claude_code`
- [ ] Verify JSON output parsed, response chunked correctly for long responses
- [ ] Follow-up coding message → `--resume` uses stored session ID
- [ ] Verify timeout kills process after configured seconds
- [ ] Verify concurrent message rejection
- [ ] Existing bot instances unaffected (Mogwai disabled by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)