### PR TITLE
ci: fix deprecated release actions, docker publish gate, and CI cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      with:
-        fetch-depth: 0  # Full history for better versioning
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v4

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,9 +1,9 @@
 name: Docker Publish
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
   workflow_dispatch:
 
 env:
@@ -14,6 +14,7 @@ jobs:
   docker-build-push:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     permissions:
       contents: read
       packages: write
@@ -50,7 +51,7 @@ jobs:
       uses: docker/build-push-action@v6
       with:
         context: .
-        push: ${{ github.event_name == 'push' }}
+        push: ${{ github.event_name == 'workflow_run' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
@@ -58,7 +59,7 @@ jobs:
         platforms: linux/amd64
 
     - name: Verify pushed image
-      if: github.event_name == 'push'
+      if: github.event_name == 'workflow_run'
       run: |
         echo "### Docker Image Published :whale:" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,18 +90,20 @@ jobs:
         cd ../..
 
     - name: Generate checksums
+      id: checksums
       run: |
         sha256sum discordbot-${{ steps.extract_version.outputs.version }}.zip > checksums.txt
         cat checksums.txt
+        echo "content<<EOF" >> $GITHUB_OUTPUT
+        cat checksums.txt >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
 
     - name: Create GitHub Release
       id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: softprops/action-gh-release@v2
       with:
         tag_name: ${{ steps.extract_version.outputs.tag }}
-        release_name: Release ${{ steps.extract_version.outputs.tag }}
+        name: Release ${{ steps.extract_version.outputs.tag }}
         body: |
           ## Discord Bot Release ${{ steps.extract_version.outputs.version }}
 
@@ -125,30 +127,14 @@ jobs:
 
           **Checksums**
           ```
-          $(cat checksums.txt)
+          ${{ steps.checksums.outputs.content }}
           ```
         draft: false
         prerelease: ${{ contains(steps.extract_version.outputs.version, '-') }}
-
-    - name: Upload release archive
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./discordbot-${{ steps.extract_version.outputs.version }}.zip
-        asset_name: discordbot-${{ steps.extract_version.outputs.version }}.zip
-        asset_content_type: application/zip
-
-    - name: Upload checksums
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./checksums.txt
-        asset_name: checksums.txt
-        asset_content_type: text/plain
+        files: |
+          discordbot-${{ steps.extract_version.outputs.version }}.zip
+          checksums.txt
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
@@ -165,7 +151,7 @@ jobs:
         echo "**Version:** ${{ steps.extract_version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
         echo "**Tag:** ${{ steps.extract_version.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
         echo "**Commit:** ${{ steps.git_info.outputs.commit_sha }}" >> $GITHUB_STEP_SUMMARY
-        echo "**Release URL:** ${{ steps.create_release.outputs.html_url }}" >> $GITHUB_STEP_SUMMARY
+        echo "**Release URL:** ${{ steps.create_release.outputs.url }}" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "**Artifacts:**" >> $GITHUB_STEP_SUMMARY
         echo "- discordbot-${{ steps.extract_version.outputs.version }}.zip" >> $GITHUB_STEP_SUMMARY

--- a/src/DiscordBot.DocGen/DiscordBot.DocGen.csproj
+++ b/src/DiscordBot.DocGen/DiscordBot.DocGen.csproj
@@ -8,12 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.*" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.*" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.*" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.*" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/DiscordBot.Tests/Controllers/PortalTtsControllerTests.cs
+++ b/tests/DiscordBot.Tests/Controllers/PortalTtsControllerTests.cs
@@ -38,6 +38,7 @@ public class PortalTtsControllerTests
     private readonly Mock<ISsmlBuilder> _mockSsmlBuilder;
     private readonly Mock<IUserTtsPresetRepository> _mockUserTtsPresetRepository;
     private readonly Mock<ITtsMessageHistoryRepository> _mockTtsMessageHistoryRepository;
+    private readonly Mock<IAudioModerationLogService> _mockAudioModerationLogService;
     private readonly Mock<ILogger<PortalTtsController>> _mockLogger;
     private readonly PortalTtsController _controller;
 
@@ -57,6 +58,7 @@ public class PortalTtsControllerTests
         _mockSsmlBuilder = new Mock<ISsmlBuilder>();
         _mockUserTtsPresetRepository = new Mock<IUserTtsPresetRepository>();
         _mockTtsMessageHistoryRepository = new Mock<ITtsMessageHistoryRepository>();
+        _mockAudioModerationLogService = new Mock<IAudioModerationLogService>();
         _mockLogger = new Mock<ILogger<PortalTtsController>>();
 
         // Setup bot-level audio enabled by default
@@ -85,6 +87,7 @@ public class PortalTtsControllerTests
             _mockSsmlBuilder.Object,
             _mockUserTtsPresetRepository.Object,
             _mockTtsMessageHistoryRepository.Object,
+            _mockAudioModerationLogService.Object,
             _mockLogger.Object);
 
         // Setup HttpContext and User claims

--- a/tests/DiscordBot.Tests/Integration/PortalTtsIntegrationTests.cs
+++ b/tests/DiscordBot.Tests/Integration/PortalTtsIntegrationTests.cs
@@ -47,6 +47,7 @@ public class PortalTtsIntegrationTests : IDisposable
     private readonly Mock<ISsmlBuilder> _mockSsmlBuilder;
     private readonly Mock<IUserTtsPresetRepository> _mockUserTtsPresetRepository;
     private readonly Mock<ITtsMessageHistoryRepository> _mockTtsMessageHistoryRepository;
+    private readonly Mock<IAudioModerationLogService> _mockAudioModerationLogService;
     private readonly Mock<ILogger<PortalTtsController>> _mockLogger;
     private readonly AzureSpeechOptions _azureSpeechOptions;
 
@@ -70,6 +71,7 @@ public class PortalTtsIntegrationTests : IDisposable
         _mockSsmlBuilder = new Mock<ISsmlBuilder>();
         _mockUserTtsPresetRepository = new Mock<IUserTtsPresetRepository>();
         _mockTtsMessageHistoryRepository = new Mock<ITtsMessageHistoryRepository>();
+        _mockAudioModerationLogService = new Mock<IAudioModerationLogService>();
         _mockLogger = new Mock<ILogger<PortalTtsController>>();
 
         // Setup bot-level audio enabled by default
@@ -101,6 +103,7 @@ public class PortalTtsIntegrationTests : IDisposable
             _mockSsmlBuilder.Object,
             _mockUserTtsPresetRepository.Object,
             _mockTtsMessageHistoryRepository.Object,
+            _mockAudioModerationLogService.Object,
             _mockLogger.Object);
 
         // Setup HttpContext with Discord claims (simulating OAuth authentication)


### PR DESCRIPTION
## Summary
- Replace deprecated `create-release@v1` + `upload-release-asset@v1` with `softprops/action-gh-release@v2`
- Fix checksums not rendering in release body (shell substitution doesn't evaluate inside YAML literal blocks)
- Gate `docker-publish` on `Release` workflow success — prevents Docker image being pushed when tests fail
- Remove unused `fetch-depth: 0` from CI checkout

## Test plan
- [ ] Verify CI passes on this PR
- [ ] On next tag push, confirm Release workflow creates release with correct checksums in body
- [ ] Confirm Docker publish only fires after Release workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)