### PR TITLE
fix: wait for UDP voice connection before returning from JoinChannelAsync

### DIFF
--- a/src/DiscordBot.Bot/Services/AudioService.cs
+++ b/src/DiscordBot.Bot/Services/AudioService.cs
@@ -95,6 +95,45 @@ public class AudioService : IAudioService
             // Connect to voice channel
             var audioClient = await voiceChannel.ConnectAsync();
 
+            // Wait for UDP voice connection to be fully established before returning.
+            // ConnectAsync() returns once the gateway handshake completes, but audio data
+            // written before the UDP connection is ready gets buffered and plays delayed.
+            if (audioClient.ConnectionState != Discord.ConnectionState.Connected)
+            {
+                var udpReady = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                Task OnConnected()
+                {
+                    udpReady.TrySetResult(true);
+                    return Task.CompletedTask;
+                }
+
+                audioClient.Connected += OnConnected;
+                try
+                {
+                    // Re-check after subscribing to avoid a race where Connected fired between
+                    // the ConnectionState check above and attaching the event handler.
+                    if (audioClient.ConnectionState == Discord.ConnectionState.Connected)
+                    {
+                        udpReady.TrySetResult(true);
+                    }
+
+                    using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                    timeoutCts.CancelAfter(TimeSpan.FromSeconds(5));
+
+                    await udpReady.Task.WaitAsync(timeoutCts.Token);
+                    _logger.LogDebug("UDP voice connection ready for guild {GuildId}", guildId);
+                }
+                catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+                {
+                    _logger.LogWarning("Timed out waiting for UDP voice connection in guild {GuildId}; proceeding anyway", guildId);
+                }
+                finally
+                {
+                    audioClient.Connected -= OnConnected;
+                }
+            }
+
             // Store connection info
             var now = DateTime.UtcNow;
             var connectionInfo = new VoiceConnectionInfo(audioClient, voiceChannelId, now, now);


### PR DESCRIPTION
## Summary

- After `ConnectAsync()` returns, the Discord gateway handshake is complete but the UDP voice transport may not be ready to transmit audio yet
- PCM data written before UDP is ready gets buffered internally by Discord.Net and plays with a delay (the root cause of #1918)
- Subscribes to `IAudioClient.Connected` event (with a double-check after subscribing to close the race) and awaits it before storing the connection and returning
- A 5-second timeout guards against hanging if the UDP connection never becomes ready; on timeout a warning is logged and the method proceeds rather than throwing

## Test plan

- [ ] Join bot to a voice channel via the portal dropdown
- [ ] Immediately click soundboard clips — verify audio plays promptly (no multi-second delay)
- [ ] Verify TTS and VOX playback are unaffected for an already-connected bot
- [ ] Verify bot join does not hang indefinitely (e.g., in a network-impaired environment the 5-second timeout fires and a warning is logged)

Closes #1918

🤖 Generated with [Claude Code](https://claude.com/claude-code)