### PR TITLE
docs: weekly review — Mar 26 – Apr 2, 2026

### DIFF
--- a/docs/architecture/feature-map.md
+++ b/docs/architecture/feature-map.md
@@ -8,9 +8,9 @@ This document maps all major features to their supporting components: Discord co
 
 ## Table of Contents
 
-1. [Audio Features](#audio-features) - Soundboard, VOX, TTS
+1. [Audio Features](#audio-features) - Soundboard, VOX, TTS, Audio Moderation Log, User Preferences
 2. [Moderation Features](#moderation-features) - Warnings, bans, notes, watchlist
-3. [Community Features](#community-features) - Reminders, Rat Watch, Scheduled Messages
+3. [Community Features](#community-features) - Reminders, Rat Watch, Scheduled Messages, Not-X, Feature Requests
 4. [Administrative Features](#administrative-features) - Guild management, settings, monitoring, verification
 5. [System Features](#system-features) - Authentication, logging, notifications, activity tracking, DM assistant
 
@@ -27,7 +27,7 @@ The soundboard system allows guild members to play pre-uploaded audio files in v
 | **Discord Commands** | `/play`, `/sounds`, `/stop` (SoundboardModule) |
 | **Services** | `IAudioService`, `IPlaybackService`, `ISoundService`, `ISoundboardOrchestrationService`, `IGuildAudioSettingsService`, `IAudioNotifier` |
 | **UI Pages** | Portal: Soundboard player page; Admin: Sounds management (`SoundsController`) |
-| **Database Entities** | `Sound`, `SoundPlayLog`, `GuildAudioSettings` |
+| **Database Entities** | `Sound`, `SoundPlayLog`, `GuildAudioSettings`, `AudioPlaybackLog` |
 | **Storage** | Audio files on disk (configurable path) |
 | **Key Features** | Queue management, audio filtering (distortion, echo, pitch shift), silent playback mode, auto-leave voice channels |
 | **Rate Limiting** | 5 commands per 10 seconds |
@@ -90,6 +90,43 @@ Converts text messages to speech using Azure Cognitive Services and plays them i
 | **Rate Limiting** | 5 commands per 10 seconds |
 
 **Preconditions**: `[RequireGuildActive]`, `[RequireTtsEnabled]`, `[RequireVoiceChannel]`
+
+---
+
+### Audio Moderation Log
+
+Unified playback log tracking all audio feature usage (soundboard, TTS, VOX) for moderation and auditing. Admin UI page with filtering by user, feature type, and date range.
+
+| Aspect | Components |
+|--------|------------|
+| **Services** | `IAudioModerationLogService`, `IAudioPlaybackLogRepository` |
+| **UI Pages** | Admin: Audio moderation log (`/guilds/{guildId}/audio-moderation-log`) |
+| **Database Entities** | `AudioPlaybackLog` |
+| **Enums** | `AudioFeatureType` (Soundboard, Tts, Vox) |
+| **Key Features** | Fire-and-forget logging via `IBackgroundTaskRunner`, content name truncation (200 chars), per-guild/per-user filtering |
+
+**Architecture Flow**:
+```
+Audio command (Soundboard/TTS/VOX) →
+  Orchestration service calls IAudioModerationLogService.LogPlayback() →
+  BackgroundTaskRunner (fire-and-forget) →
+  IAudioPlaybackLogRepository.AddAsync() →
+  Admin UI queries AudioPlaybackLog table
+```
+
+---
+
+### User Preferences
+
+Per-user, per-guild preference storage with REST API and client-side localStorage cache. Supports arbitrary key-value preferences (e.g., selected TTS voice, playback mode).
+
+| Aspect | Components |
+|--------|------------|
+| **Controllers** | `UserPreferencesController` (`api/portal/preferences/{guildId}`) |
+| **Client JS** | `user-preferences.js` |
+| **Database Entities** | `UserPreference` |
+| **Key Features** | GET/PUT/DELETE per key, localStorage sync, 100-char key limit, 2000-char value limit, guild-scoped |
+| **Authorization** | `PortalGuildMember` policy |
 
 ---
 
@@ -265,6 +302,68 @@ Admin-configurable recurring messages sent to specified channels. Supports cron 
 **Supported Frequencies**: Daily, Weekly, Monthly, Custom (cron expression)
 
 **Preconditions**: `[RequireAdmin]`, `[RequireGuildActive]`
+
+---
+
+### Not-X (Twitter/X Link Previews)
+
+Automatic or manual preview embeds for X/Twitter links, using the fxtwitter API to fetch tweet data. Supports sensitive-only filtering, channel routing, and per-guild configuration.
+
+| Aspect | Components |
+|--------|------------|
+| **Discord Commands** | `/notx enable`, `/notx disable`, `/notx status`, `/notx sensitive-only`, `/notx output set`, `/notx output clear`, `/notx monitor add`, `/notx monitor remove`, `/notx monitor clear` (NotXCommandModule); `Fetch Tweet` context menu (NotXContextMenuModule) |
+| **Handlers** | `NotXMessageHandler` (auto-detects tweet URLs in messages) |
+| **Services** | `INotXService`, `FxTwitterClient`, `NotXEmbedBuilder`, `TweetUrlExtractor` |
+| **Database Entities** | `NotXGuildSettings` |
+| **Configuration** | `NotXOptions` (`NotX` section) |
+| **External Services** | fxtwitter API (tweet metadata and media) |
+| **Key Features** | Auto-detect tweet URLs, sensitive-only mode, output channel routing, monitored channel filtering, context menu manual fetch, guild-level kill-switch |
+| **Rate Limiting** | 5 commands per 60 seconds |
+
+**Architecture Flow**:
+```
+Tweet URL posted (or context menu) →
+  NotXMessageHandler / NotXContextMenuModule →
+  TweetUrlExtractor (parse URL) →
+  NotXService (settings gate check) →
+  FxTwitterClient (fetch tweet data) →
+  NotXEmbedBuilder (build Discord embed) →
+  Post embed to output channel
+```
+
+**Preconditions**: `[RequireGuildActive]`, `[RequireUserPermission(ManageGuild)]` (config commands)
+
+---
+
+### Feature Requests
+
+AI-powered feature request submission with optional multi-step DM conversation for requirements gathering. Includes prompt injection detection and configurable conversation flow.
+
+| Aspect | Components |
+|--------|------------|
+| **Discord Commands** | `/feature-request` (FeatureRequestModule, FeatureRequestComponentModule) |
+| **Handlers** | `FeatureRequestDmHandler` (multi-step DM conversation) |
+| **Services** | `IFeatureRequestService`, `FeatureRequestConversationService`, `InputValidationService`, `PromptInjectionFilter`, `FeatureRequestToolProvider` |
+| **Database Entities** | `FeatureRequest`, `FeatureRequestRejection` |
+| **Configuration** | `FeatureRequestsOptions` (`FeatureRequests` section) |
+| **Key Features** | Direct submit for detailed requests (100+ chars), multi-step DM conversation for brief requests, AI requirements gathering, prompt injection filtering, configurable conversation timeout and turn limits, doc generation integration |
+| **Rate Limiting** | 3 per hour |
+
+**Architecture Flow**:
+```
+User invokes /feature-request →
+  FeatureRequestModule (validate input) →
+  Short description? → Button: "Refine in DM" or "Submit as-is"
+    → DM path: FeatureRequestDmHandler →
+      FeatureRequestConversationService (AI conversation) →
+      PromptInjectionFilter (safety check) →
+      Consolidated summary generated
+    → Direct path: Submit immediately
+  → FeatureRequestService.SubmitAsync() →
+  FeatureRequest entity persisted
+```
+
+**Preconditions**: `[RequireGuildActive]`
 
 ---
 
@@ -535,7 +634,7 @@ Application settings management with environment-based configuration.
 |--------|------------|
 | **Configuration** | `appsettings.json`, `appsettings.{Environment}.json`, User Secrets |
 | **Options Pattern** | `IOptions<T>` dependency injection |
-| **Configuration Classes** | `BotConfiguration`, `VoxOptions`, `ReminderOptions`, `DiscordOAuthSettings` |
+| **Configuration Classes** | `BotConfiguration`, `VoxOptions`, `ReminderOptions`, `DiscordOAuthSettings`, `NotXOptions`, `FeatureRequestsOptions`, `MogwaiOptions`, `DmAssistantOptions` |
 | **Key Features** | Environment-specific settings, feature flags, service configuration |
 
 ---
@@ -556,9 +655,9 @@ Application settings management with environment-based configuration.
 │ • Soundboard    │  │ • Actions        │  │ • Reminders           │
 │ • VOX/FVOX      │  │ • Notes          │  │ • Rat Watch           │
 │ • TTS           │  │ • Tags           │  │ • Scheduled Messages  │
-└─────────────────┘  │ • Watchlist      │  └───────────────────────┘
-                     │ • History        │
-                     │ • Investigation  │
+│ • Moderation Log│  │ • Watchlist      │  │ • Not-X               │
+│ • User Prefs    │  │ • History        │  │ • Feature Requests    │
+└─────────────────┘  │ • Investigation  │  └───────────────────────┘
                      │ • Logging        │
                      └──────────────────┘
 

--- a/docs/architecture/service-catalog.md
+++ b/docs/architecture/service-catalog.md
@@ -2,8 +2,8 @@
 
 Quick reference catalog of all services in the Discord bot system. Organized by domain area for easy discovery and understanding of service relationships.
 
-**Last Updated**: March 2026
-**Codebase Version**: v1.1.0
+**Last Updated**: April 2026
+**Codebase Version**: v1.5.1-dev
 
 ---
 
@@ -13,6 +13,9 @@ Quick reference catalog of all services in the Discord bot system. Organized by 
 - [Soundboard & Audio Playback](#soundboard--audio-playback)
 - [VOX System](#vox-system)
 - [Text-to-Speech Services](#text-to-speech-services)
+- [Audio Moderation & User Preferences](#audio-moderation--user-preferences)
+- [Not-X (Tweet Previews)](#not-x-tweet-previews)
+- [Feature Requests](#feature-requests)
 - [Discord Integration Services](#discord-integration-services)
 - [User & Guild Management](#user--guild-management)
 - [Moderation & Enforcement](#moderation--enforcement)
@@ -97,6 +100,53 @@ Services for Azure Cognitive Services TTS and SSML generation.
 | `StylePresetProvider` | Bot/Services | Singleton implementation with 12 built-in presets across 4 categories; supports lookup by ID or category |
 | `ISsmlBuilder` | Core Interfaces | SSML markup generation for advanced TTS features |
 | `ISsmlValidator` | Core Interfaces | SSML markup validation |
+
+---
+
+## Audio Moderation & User Preferences
+
+Services for cross-feature audio playback logging and per-user preference storage.
+
+| Service | Location | Purpose |
+|---------|----------|---------|
+| `IAudioModerationLogService` | Core Interfaces | Fire-and-forget audio playback event logging |
+| `AudioModerationLogService` | Bot/Services | Logs playback events via `IBackgroundTaskRunner`; truncates content names to 200 chars |
+| `IAudioPlaybackLogRepository` | Core Interfaces | Data access for `AudioPlaybackLog` entities |
+| `AudioPlaybackLogRepository` | Infrastructure/Data/Repositories | EF Core repository for audio playback log persistence |
+| `UserPreferencesController` | Bot/Controllers | REST API (`api/portal/preferences/{guildId}`) for per-user, per-guild preference CRUD |
+
+---
+
+## Not-X (Tweet Previews)
+
+Services for automatic and manual X/Twitter link preview embeds via the fxtwitter API.
+
+| Service | Location | Purpose |
+|---------|----------|---------|
+| `INotXService` | Core Interfaces | Orchestrates tweet processing: settings gate, fetch, embed, post |
+| `NotXService` | Bot/Services/NotX | Implements tweet processing pipeline with guild settings checks |
+| `IFxTwitterClient` | Core Interfaces | HTTP client contract for fxtwitter API calls |
+| `FxTwitterClient` | Bot/Services/NotX | Fetches tweet metadata and media from fxtwitter API with configurable timeout and response size limits |
+| `NotXEmbedBuilder` | Bot/Services/NotX | Static helper building Discord embeds from tweet data |
+| `TweetUrlExtractor` | Bot/Services/NotX | Static helper parsing X/Twitter URLs from message content |
+| `NotXMessageHandler` | Bot/Handlers | Auto-detects tweet URLs in incoming messages and routes to `INotXService` |
+
+---
+
+## Feature Requests
+
+Services for AI-powered feature request submission with multi-step DM conversation and safety filtering.
+
+| Service | Location | Purpose |
+|---------|----------|---------|
+| `IFeatureRequestService` | Core Interfaces | Feature request CRUD, status updates, doc-gen result tracking |
+| `FeatureRequestService` | Infrastructure/Services | EF Core implementation of feature request persistence |
+| `FeatureRequestConversationService` | Bot/Services/FeatureRequests | Multi-turn DM conversation orchestrator for AI requirements gathering |
+| `IInputValidationService` | Core Interfaces | Input validation contract for feature request text |
+| `InputValidationService` | Bot/Services/FeatureRequests | Validates description length and content constraints |
+| `PromptInjectionFilter` | Bot/Services/FeatureRequests | Regex-based prompt injection detection using configurable patterns from `FeatureRequestsOptions` |
+| `FeatureRequestToolProvider` | Infrastructure/Services/LLM/Providers | `IToolProvider` implementation exposing feature-request tools to the AI agent |
+| `FeatureRequestDmHandler` | Bot/Handlers | Handles DM messages during active feature request conversations |
 
 ---
 

--- a/docs/features/mogwai-claude-code-integration.md
+++ b/docs/features/mogwai-claude-code-integration.md
@@ -1,5 +1,7 @@
 # Mogwai: Claude Code CLI Integration via DM Assistant
 
+> **Note:** This is the original design spec. For the user-facing feature guide, see [docs/articles/mogwai.md](../articles/mogwai.md).
+
 ## Overview
 
 Mogwai is a third Discord bot instance running in Docker on a local PC that invokes Claude Code CLI through Discord DMs. It provides an OpenClaw/Claude Code Channels-like experience integrated into the existing bot infrastructure.


### PR DESCRIPTION
## Summary

- **Updated `feature-map.md`** — Added Not-X, Feature Requests, Audio Moderation Log, and User Preferences sections; updated Soundboard entities; added `MogwaiOptions`, `DmAssistantOptions`, `NotXOptions`, `FeatureRequestsOptions` to config classes list; updated feature dependency graph
- **Updated `service-catalog.md`** — Added 3 new sections (Audio Moderation & User Preferences, Not-X, Feature Requests) with 20 new service entries; updated version v1.1.0 → v1.5.1-dev and date to April 2026
- **Updated `mogwai-claude-code-integration.md`** — Added cross-reference to canonical `docs/articles/mogwai.md`

## Test plan

- [ ] Verify all internal markdown links resolve correctly
- [ ] Confirm TOC anchors match section headings in both architecture docs
- [ ] Spot-check service locations against actual file paths in `src/`

https://claude.ai/code/session_011aqbdAgfrfdVSKDGxJkV8v