### PR TITLE
feat: server-side pagination and lazy loading for soundboard portal

### DIFF
--- a/src/DiscordBot.Bot/Controllers/PortalSoundboardController.cs
+++ b/src/DiscordBot.Bot/Controllers/PortalSoundboardController.cs
@@ -77,20 +77,32 @@ public class PortalSoundboardController : ControllerBase
     }
 
     /// <summary>
-    /// Gets all sounds for the specified guild with play counts.
-    /// Sounds are returned in alphabetical order by name.
-    /// Optionally filters by category ID. Use categoryId=0 for uncategorized sounds.
+    /// Gets a page of sounds for the specified guild.
+    /// Supports search, sort, and category filtering.
     /// </summary>
     /// <param name="guildId">The guild's Discord snowflake ID.</param>
-    /// <param name="categoryId">Optional category ID to filter by. Use 0 for uncategorized sounds only.</param>
+    /// <param name="page">1-based page number (default 1).</param>
+    /// <param name="pageSize">Sounds per page (default 40, max 100).</param>
+    /// <param name="search">Optional search term (case-insensitive name match).</param>
+    /// <param name="sort">Sort order: name-asc (default), name-desc, newest, oldest, most-played.</param>
+    /// <param name="categoryId">Optional category filter. Use 0 for uncategorized sounds only.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>List of sounds with play counts.</returns>
+    /// <returns>Paginated list of sounds with metadata.</returns>
     [HttpGet("sounds")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> GetSounds(ulong guildId, [FromQuery] int? categoryId, CancellationToken cancellationToken)
+    public async Task<IActionResult> GetSounds(
+        ulong guildId,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 40,
+        [FromQuery] string? search = null,
+        [FromQuery] string? sort = null,
+        [FromQuery] int? categoryId = null,
+        CancellationToken cancellationToken = default)
     {
-        _logger.LogInformation("Get sounds request for guild {GuildId}, categoryId={CategoryId}", guildId, categoryId);
+        _logger.LogInformation(
+            "Get sounds request for guild {GuildId}, page={Page}, pageSize={PageSize}, search={Search}, sort={Sort}, categoryId={CategoryId}",
+            guildId, page, pageSize, search, sort, categoryId);
 
         // Check if audio is globally enabled at the bot level
         if (!await IsAudioGloballyEnabledAsync())
@@ -121,28 +133,16 @@ public class PortalSoundboardController : ControllerBase
             });
         }
 
-        var sounds = await _soundService.GetAllByGuildAsync(guildId, cancellationToken);
+        // Clamp pageSize to valid range
+        pageSize = Math.Clamp(pageSize, 1, 100);
+        page = Math.Max(1, page);
 
-        // Apply category filter if specified
-        IEnumerable<Sound> filteredSounds = sounds;
-        if (categoryId.HasValue)
-        {
-            if (categoryId.Value == 0)
-            {
-                // Filter to uncategorized sounds only
-                filteredSounds = sounds.Where(s => s.CategoryId == null);
-            }
-            else
-            {
-                filteredSounds = sounds.Where(s => s.CategoryId == categoryId.Value);
-            }
-        }
-
-        var soundList = filteredSounds.ToList();
+        var (sounds, totalCount) = await _soundService.GetByGuildPagedAsync(
+            guildId, page, pageSize, search, sort, categoryId, cancellationToken);
 
         var response = new
         {
-            sounds = soundList.Select(s => new
+            sounds = sounds.Select(s => new
             {
                 id = s.Id.ToString(),
                 name = s.Name,
@@ -153,10 +153,15 @@ public class PortalSoundboardController : ControllerBase
                 categoryId = s.CategoryId,
                 categoryName = s.Category?.Name
             }).ToList(),
-            totalCount = soundList.Count
+            totalCount,
+            page,
+            pageSize,
+            hasMore = (page * pageSize) < totalCount
         };
 
-        _logger.LogInformation("Returning {Count} sounds for guild {GuildId}", soundList.Count, guildId);
+        _logger.LogInformation(
+            "Returning {Count} of {Total} sounds (page {Page}) for guild {GuildId}",
+            sounds.Count, totalCount, page, guildId);
         return Ok(response);
     }
 

--- a/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml
+++ b/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml
@@ -1170,10 +1170,10 @@ else
 
                 <!-- Sound Grid (rendered progressively by portal-soundboard.js) -->
                 <div id="soundGrid" class="sound-grid">
-                    @if (Model.Sounds.Count > 0)
+                    @if (Model.CurrentSoundCount > 0)
                     {
-                        @* Skeleton placeholders shown during initial JS load *@
-                        @for (var i = 0; i < Math.Min(Model.Sounds.Count, 8); i++)
+                        @* Skeleton placeholders shown while JS loads first page from API *@
+                        @for (var i = 0; i < Math.Min(Model.CurrentSoundCount, 8); i++)
                         {
                             <div class="sound-card-skeleton">
                                 <div class="skeleton-circle"></div>
@@ -1185,7 +1185,7 @@ else
                 </div>
 
                 <!-- Empty State -->
-                <div id="emptyState" class="empty-state @(Model.Sounds.Count == 0 ? "" : "hidden")">
+                <div id="emptyState" class="empty-state @(Model.CurrentSoundCount == 0 ? "" : "hidden")">
                     <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                     </svg>
@@ -1230,18 +1230,6 @@ else
          data-current-sound-count="@Model.CurrentSoundCount"
          data-max-duration-seconds="@Model.MaxDurationSeconds"
          style="display:none;"></div>
-
-    <!-- Sound data for progressive rendering -->
-    <script id="soundboard-data" type="application/json">@Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.Sounds.Select(s => new {
-        id = s.Id.ToString(),
-        name = s.Name,
-        playCount = s.PlayCount,
-        durationSeconds = s.DurationSeconds,
-        uploadedById = s.UploadedById ?? "",
-        uploadedAt = s.UploadedAt?.ToString("o") ?? "",
-        categoryId = s.CategoryId?.ToString() ?? "",
-        categoryName = s.CategoryName ?? ""
-    })))</script>
 
     <script>
         // Pass guild ID to JavaScript as a string (critical for Discord snowflake IDs)

--- a/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml.cs
+++ b/src/DiscordBot.Bot/Pages/Portal/Soundboard/Index.cshtml.cs
@@ -139,24 +139,9 @@ public class IndexModel : PortalPageModelBase
             var userIdClaim = User.FindFirst("discord:user_id")?.Value;
             CurrentUserId = userIdClaim;
 
-            // User is authorized - load full soundboard
-            var sounds = await _soundService.GetAllByGuildAsync(guildId, cancellationToken);
-
-            // Get audio settings for limits
+            // Load settings and sound count — sounds themselves are loaded client-side via API pagination
             var settings = await _audioSettingsRepository.GetOrCreateAsync(guildId, cancellationToken);
-
-            // Map sounds to portal view models
-            var soundViewModels = sounds
-                .Select(s => new PortalSoundViewModel
-                {
-                    Id = s.Id,
-                    Name = s.Name,
-                    PlayCount = s.PlayCount,
-                    DurationSeconds = s.DurationSeconds,
-                    UploadedById = s.UploadedById?.ToString(),
-                    UploadedAt = s.UploadedAt
-                })
-                .ToList();
+            var soundCount = await _soundService.GetSoundCountAsync(guildId, cancellationToken);
 
             // Build voice channel panel data
             var connectedChannelId = _audioService.GetConnectedChannelId(guildId);
@@ -198,15 +183,13 @@ public class IndexModel : PortalPageModelBase
             };
 
             // Set remaining view properties
-            Sounds = soundViewModels;
             MaxSounds = settings.MaxSoundsPerGuild;
-            CurrentSoundCount = sounds.Count;
+            CurrentSoundCount = soundCount;
             SupportedFormats = "MP3, WAV, OGG";
             MaxFileSizeMB = (int)(settings.MaxFileSizeBytes / (1024.0 * 1024.0));
             MaxDurationSeconds = settings.MaxDurationSeconds;
 
-            _logger.LogDebug("Loaded {Count} sounds for guild {GuildId} in portal view",
-                sounds.Count, guildId);
+            _logger.LogDebug("Loading soundboard portal for guild {GuildId} ({Count} sounds total)", guildId, soundCount);
 
             return Page();
         }

--- a/src/DiscordBot.Bot/Services/SoundService.cs
+++ b/src/DiscordBot.Bot/Services/SoundService.cs
@@ -75,6 +75,39 @@ public class SoundService : ISoundService
     }
 
     /// <inheritdoc/>
+    public async Task<(IReadOnlyList<Sound> Sounds, int TotalCount)> GetByGuildPagedAsync(
+        ulong guildId,
+        int page,
+        int pageSize,
+        string? search = null,
+        string? sortBy = null,
+        int? categoryId = null,
+        CancellationToken ct = default)
+    {
+        return await ServiceActivityHelper.ExecuteAsync<(IReadOnlyList<Sound>, int)>(
+            "sound", "get_by_guild_paged",
+            async activity =>
+            {
+                var skip = (page - 1) * pageSize;
+
+                _logger.LogDebug(
+                    "Getting paged sounds for guild {GuildId}: page={Page}, pageSize={PageSize}, search={Search}, sort={Sort}",
+                    guildId, page, pageSize, search, sortBy);
+
+                var (sounds, totalCount) = await _soundRepository.GetByGuildIdPagedAsync(
+                    guildId, skip, pageSize, search, sortBy, categoryId, ct);
+
+                _logger.LogInformation(
+                    "Retrieved {Count} of {Total} sounds (page {Page}) for guild {GuildId}",
+                    sounds.Count, totalCount, page, guildId);
+
+                BotActivitySource.SetRecordsReturned(activity, sounds.Count);
+                return (sounds, totalCount);
+            },
+            guildId: guildId);
+    }
+
+    /// <inheritdoc/>
     public async Task<Sound?> GetByNameAsync(string name, ulong guildId, CancellationToken ct = default)
     {
         return await ServiceActivityHelper.ExecuteAsync<Sound?>(

--- a/src/DiscordBot.Bot/wwwroot/js/portal-soundboard.js
+++ b/src/DiscordBot.Bot/wwwroot/js/portal-soundboard.js
@@ -20,7 +20,14 @@
         play: (guildId, soundId) => `/api/portal/soundboard/${guildId}/play/${soundId}`,
         delete: (guildId, soundId) => `/api/portal/soundboard/${guildId}/sounds/${soundId}`,
         upload: (guildId) => `/api/portal/soundboard/${guildId}/sounds`,
-        audio: (guildId, soundId) => `/api/portal/soundboard/${guildId}/sounds/${soundId}/audio`
+        audio: (guildId, soundId) => `/api/portal/soundboard/${guildId}/sounds/${soundId}/audio`,
+        sounds: (guildId, page, pageSize, search, sort, categoryId) => {
+            let url = `/api/portal/soundboard/${guildId}/sounds?page=${page}&pageSize=${pageSize}`;
+            if (sort) url += `&sort=${encodeURIComponent(sort)}`;
+            if (search) url += `&search=${encodeURIComponent(search)}`;
+            if (categoryId !== undefined && categoryId !== null && categoryId !== '') url += `&categoryId=${categoryId}`;
+            return url;
+        }
     };
 
     // ========================================
@@ -44,6 +51,12 @@
     let currentSoundCount = 0;
     let maxDurationSeconds = 0;
     const recentlyAddedSoundIds = new Set();
+
+    // Pagination state
+    let totalSoundCount = 0;           // Total count from last API response
+    let currentPage = 0;               // Last fully-fetched page number
+    let isLoadingPage = false;         // Guard against concurrent page fetches
+    let hasMorePages = false;          // Whether more pages are available from API
 
     // VirtualSoundGrid instance
     let virtualGrid = null;
@@ -76,8 +89,14 @@
         _setupObserver() {
             this.observer = new IntersectionObserver((entries) => {
                 for (const entry of entries) {
-                    if (entry.isIntersecting && this.renderedCount < this.filteredSounds.length) {
-                        this.loadMore();
+                    if (entry.isIntersecting) {
+                        if (this.renderedCount < this.filteredSounds.length) {
+                            // More to render from already-fetched sounds
+                            this.loadMore();
+                        } else if (hasMorePages && !isLoadingPage) {
+                            // Fetch next page from API
+                            loadNextSoundsPage();
+                        }
                     }
                 }
             }, {
@@ -89,11 +108,18 @@
         }
 
         /**
-         * Set the full sound array (from page data or API).
+         * Set or append the sound array.
          * @param {Array} sounds - Array of sound objects
+         * @param {boolean} append - If true, append to existing; if false, replace and clear DOM
          */
-        setSounds(sounds) {
-            this.allSounds = sounds.slice();
+        setSounds(sounds, append = false) {
+            if (append) {
+                this.allSounds = this.allSounds.concat(sounds);
+            } else {
+                this.allSounds = sounds.slice();
+                this.renderedCount = 0;
+                this.container.innerHTML = '';
+            }
             this.filteredSounds = this.allSounds.slice();
         }
 
@@ -443,31 +469,18 @@
             sortSelect.value = currentSort;
         }
 
-        // Parse initial sounds data from the page
-        const soundsDataEl = document.getElementById('soundboard-data');
-        let initialSounds = [];
-        if (soundsDataEl) {
-            try {
-                initialSounds = JSON.parse(soundsDataEl.textContent);
-            } catch (e) {
-                // Failed to parse initial sounds
-            }
-        }
-
-        // Initialize virtual grid
+        // Initialize virtual grid (will be populated via API)
         const gridContainer = document.getElementById('soundGrid');
         if (gridContainer) {
             virtualGrid = new VirtualSoundGrid(gridContainer, {
                 batchSize: CONFIG.BATCH_SIZE
             });
-            virtualGrid.setSounds(initialSounds);
         }
 
-        // Load favorites first, then render (favorites affect sort order)
+        // Load favorites, then fetch first page from API
         loadFavorites().then(() => {
-            if (virtualGrid) {
-                virtualGrid.sort(currentSort);
-            }
+            return loadSoundsPage(1, true);
+        }).then(() => {
             setupEventHandlers();
             initializeFullscreen();
             initSignalR();
@@ -487,6 +500,61 @@
         } catch (error) {
             console.warn('Failed to load favorites from server:', error);
         }
+    }
+
+    // ========================================
+    // API-Driven Sound Pagination
+    // ========================================
+
+    /**
+     * Fetch a page of sounds from the API and update the virtual grid.
+     * @param {number} page - 1-based page number
+     * @param {boolean} reset - If true, replace existing sounds (new search/sort); if false, append
+     */
+    async function loadSoundsPage(page, reset = false) {
+        if (isLoadingPage) return;
+        isLoadingPage = true;
+
+        try {
+            const searchTerm = document.getElementById('searchInput')?.value || '';
+            const url = API.sounds(guildId, page, CONFIG.BATCH_SIZE, searchTerm || null, currentSort, null);
+            const response = await fetch(url);
+            if (!response.ok) return;
+
+            const data = await response.json();
+            totalSoundCount = data.totalCount;
+            hasMorePages = data.hasMore;
+            currentPage = data.page;
+
+            if (virtualGrid) {
+                virtualGrid.setSounds(data.sounds, !reset);
+                if (reset) {
+                    virtualGrid.sort(currentSort);
+                } else {
+                    virtualGrid.loadMore();
+                }
+                applyFavoriteState();
+                applyPlayingState();
+            }
+        } catch (error) {
+            // Silently fail — grid stays empty or shows partial results
+        } finally {
+            isLoadingPage = false;
+            // Retry if the sentinel is still in view (catches drops from fast scrolling)
+            if (hasMorePages && virtualGrid) {
+                const rect = virtualGrid.sentinel.getBoundingClientRect();
+                if (rect.top <= window.innerHeight + 200) {
+                    loadNextSoundsPage();
+                }
+            }
+        }
+    }
+
+    /**
+     * Fetch the next page (called by VirtualSoundGrid when user scrolls to bottom with more pages).
+     */
+    function loadNextSoundsPage() {
+        loadSoundsPage(currentPage + 1, false);
     }
 
     function applyFavoriteState() {
@@ -775,9 +843,12 @@
             sortSelect.addEventListener('change', function() {
                 currentSort = this.value;
                 localStorage.setItem('portal:soundboard:sort:' + guildId, currentSort);
-                if (virtualGrid) {
-                    virtualGrid.sort(currentSort);
-                }
+                // Reset pagination and fetch from API with new sort order
+                currentPage = 0;
+                loadSoundsPage(1, true).then(() => {
+                    applyFavoriteState();
+                    applyPlayingState();
+                });
             });
         }
 
@@ -863,12 +934,12 @@
     // Search Functionality
     // ========================================
     function filterSounds() {
-        const searchTerm = document.getElementById('searchInput')?.value || '';
-        if (virtualGrid) {
-            virtualGrid.filter(searchTerm);
+        // Reset pagination and fetch from API with current search term
+        currentPage = 0;
+        loadSoundsPage(1, true).then(() => {
             applyFavoriteState();
             applyPlayingState();
-        }
+        });
     }
 
     // ========================================

--- a/src/DiscordBot.Core/Interfaces/ISoundRepository.cs
+++ b/src/DiscordBot.Core/Interfaces/ISoundRepository.cs
@@ -18,6 +18,26 @@ public interface ISoundRepository : IRepository<Sound>
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Gets a page of sounds for a specific guild with optional search and sort.
+    /// </summary>
+    /// <param name="guildId">Discord guild ID.</param>
+    /// <param name="skip">Number of records to skip.</param>
+    /// <param name="take">Number of records to take.</param>
+    /// <param name="search">Optional case-insensitive name filter.</param>
+    /// <param name="sortBy">Sort key: "name-asc" (default), "name-desc", "newest", "oldest", "most-played".</param>
+    /// <param name="categoryId">Optional category filter. 0 = uncategorized only.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A page of sounds and the total matching count.</returns>
+    Task<(IReadOnlyList<Sound> Sounds, int TotalCount)> GetByGuildIdPagedAsync(
+        ulong guildId,
+        int skip,
+        int take,
+        string? search = null,
+        string? sortBy = null,
+        int? categoryId = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets a sound by its ID, verifying it belongs to the specified guild.
     /// </summary>
     /// <param name="id">Sound ID.</param>

--- a/src/DiscordBot.Core/Interfaces/ISoundService.cs
+++ b/src/DiscordBot.Core/Interfaces/ISoundService.cs
@@ -26,6 +26,26 @@ public interface ISoundService
     Task<IReadOnlyList<Sound>> GetAllByGuildAsync(ulong guildId, CancellationToken ct = default);
 
     /// <summary>
+    /// Gets a page of sounds for a guild with optional search, sort, and category filter.
+    /// </summary>
+    /// <param name="guildId">Discord guild ID.</param>
+    /// <param name="page">1-based page number.</param>
+    /// <param name="pageSize">Number of sounds per page.</param>
+    /// <param name="search">Optional case-insensitive name filter.</param>
+    /// <param name="sortBy">Sort key: "name-asc" (default), "name-desc", "newest", "oldest", "most-played".</param>
+    /// <param name="categoryId">Optional category filter. 0 = uncategorized only.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A page of sounds and total matching count.</returns>
+    Task<(IReadOnlyList<Sound> Sounds, int TotalCount)> GetByGuildPagedAsync(
+        ulong guildId,
+        int page,
+        int pageSize,
+        string? search = null,
+        string? sortBy = null,
+        int? categoryId = null,
+        CancellationToken ct = default);
+
+    /// <summary>
     /// Gets a sound by its name within a guild.
     /// Name lookup is case-insensitive.
     /// </summary>

--- a/src/DiscordBot.Infrastructure/Data/Repositories/SoundRepository.cs
+++ b/src/DiscordBot.Infrastructure/Data/Repositories/SoundRepository.cs
@@ -38,6 +38,62 @@ public class SoundRepository : Repository<Sound>, ISoundRepository
         return sounds;
     }
 
+    public async Task<(IReadOnlyList<Sound> Sounds, int TotalCount)> GetByGuildIdPagedAsync(
+        ulong guildId,
+        int skip,
+        int take,
+        string? search = null,
+        string? sortBy = null,
+        int? categoryId = null,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug(
+            "Retrieving page of sounds for guild {GuildId}: skip={Skip}, take={Take}, search={Search}, sort={Sort}, categoryId={CategoryId}",
+            guildId, skip, take, search, sortBy, categoryId);
+
+        IQueryable<Sound> query = DbSet
+            .AsNoTracking()
+            .Where(s => s.GuildId == guildId)
+            .Include(s => s.Category)
+            .AsQueryable();
+
+        // Apply category filter
+        if (categoryId.HasValue)
+        {
+            query = categoryId.Value == 0
+                ? query.Where(s => s.CategoryId == null)
+                : query.Where(s => s.CategoryId == categoryId.Value);
+        }
+
+        // Apply search filter
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            var searchLower = search.ToLower();
+            query = query.Where(s => s.Name.ToLower().Contains(searchLower));
+        }
+
+        // Get total count before pagination
+        var totalCount = await query.CountAsync(cancellationToken);
+
+        // Apply sort
+        query = (sortBy ?? "name-asc") switch
+        {
+            "name-desc" => query.OrderByDescending(s => s.Name),
+            "newest" => query.OrderByDescending(s => s.UploadedAt).ThenBy(s => s.Name),
+            "oldest" => query.OrderBy(s => s.UploadedAt).ThenBy(s => s.Name),
+            "most-played" => query.OrderByDescending(s => s.PlayCount).ThenBy(s => s.Name),
+            _ => query.OrderBy(s => s.Name)
+        };
+
+        var sounds = await query
+            .Skip(skip)
+            .Take(take)
+            .ToListAsync(cancellationToken);
+
+        _logger.LogDebug("Found {Count} of {TotalCount} sounds for guild {GuildId}", sounds.Count, totalCount, guildId);
+        return (sounds, totalCount);
+    }
+
     public async Task<Sound?> GetByIdAndGuildAsync(
         Guid id,
         ulong guildId,


### PR DESCRIPTION
## Summary

- Replaces the all-at-once sound loading approach with API-driven lazy loading — the page model now loads only the sound count, and the JS fetches pages on demand
- Adds `GetByGuildIdPagedAsync` to the repository and service layers (skip/take, search, sort, category filter)
- Updates `GET /api/portal/soundboard/{guildId}/sounds` to accept `page`, `pageSize`, `search`, `sort`, `categoryId`; returns `totalCount`, `page`, `pageSize`, `hasMore`
- Removes the inline `<script id="soundboard-data">` JSON embed from the page
- Rewrites JS init to fetch page 1 from API; `VirtualSoundGrid` appends subsequent pages on scroll without clearing the DOM; search/sort now issue fresh API requests with debounce

## Test plan

- [ ] Soundboard loads on page open (skeleton cards → real cards from API)
- [ ] Scrolling to the bottom loads the next page of sounds and appends cards without flicker
- [ ] Fast scroll (multiple pages) doesn't get stuck — retry logic fires after load completes
- [ ] Search term triggers a server-side filtered fetch (debounced); results replace existing cards
- [ ] Sort change fetches page 1 with new sort order
- [ ] Upload via SignalR (`SoundUploaded`) still adds the new card without full reload
- [ ] Delete still removes the card immediately
- [ ] Favorites toggle still works and re-sorts correctly
- [ ] Empty guild shows "No sounds found" empty state correctly
- [ ] Guild with exactly 0, 1, 40, 41, 80 sounds all render without errors

Closes #1796

🤖 Generated with [Claude Code](https://claude.com/claude-code)