### PR TITLE
docs: weekly review — 2026-03-31 to 2026-04-06

### DIFF
--- a/CLAUDE-REFERENCE.md
+++ b/CLAUDE-REFERENCE.md
@@ -2,7 +2,7 @@
 
 Auto-generated lookup tables for Discord bot management system. Regenerate with `/update-instructions tables`.
 
-**Last updated:** 2026-03-22
+**Last updated:** 2026-04-06
 
 ## Configuration Options
 
@@ -23,6 +23,7 @@ The application uses `IOptions<T>` pattern for strongly-typed configuration. All
 | `BotConfiguration` | `Discord` | Discord bot settings (token, test guild, rate limits, owner IDs) |
 | `CachingOptions` | `Caching` | In-memory cache durations for guild, user, and search data |
 | `DatabaseSettings` | `Database` | Query performance logging (slow query threshold, parameter logging) |
+| `DmAssistantOptions` | `DmAssistant` | DM-based AI assistant (owner-only): model, conversation history, cost tracking, code execution |
 | *(string key)* | `Database:Provider` | Database provider selection: `Sqlite`, `PostgreSql`, or omit for auto-detection from connection string |
 | `DiscordOAuthOptions` | `Discord:OAuth` | OAuth client credentials (use user secrets) |
 | `GuildMembershipCacheOptions` | `GuildMembershipCache` | Guild membership database cache duration |
@@ -30,8 +31,10 @@ The application uses `IOptions<T>` pattern for strongly-typed configuration. All
 | `IdentityConfigOptions` | `Identity` | ASP.NET Identity settings (passwords, lockout, cookies, default admin) |
 | `LogSanitizationOptions` | `LogSanitization` | Log sanitization patterns and sensitive key redaction |
 | `MessageLogRetentionOptions` | `MessageLogRetention` | Message log cleanup policies |
+| `FeatureRequestsOptions` | `FeatureRequests` | Feature request command settings (description limits, conversation timeout, AI model, doc gen, injection patterns) |
 | `MogwaiOptions` | `Mogwai` | Claude Code CLI integration for coding tasks via owner DM (disabled by default; used only by the Mogwai Docker instance) |
 | `ModerationOptions` | `Moderation` | Moderation system settings (temp bans, purge limits, case history) |
+| `NotXOptions` | `NotX` | X/Twitter link preview settings (HTTP timeout, max response size, user agent) |
 | `NotificationOptions` | `Notification` | Admin notification event filters and deduplication |
 | `NotificationRetentionOptions` | `NotificationRetention` | Notification cleanup by status (dismissed, read, unread retention) |
 | `ObservabilityOptions` | `Observability` | External observability tool URLs (Kibana, Seq) |
@@ -86,6 +89,9 @@ The application uses `IOptions<T>` pattern for strongly-typed configuration. All
 | Moderation Settings | `/Guilds/{guildId:long}/ModerationSettings` | Guild auto-moderation config |
 | Flagged Events | `/Guilds/{guildId:long}/FlaggedEvents` | Auto-moderation flagged events |
 | Flagged Event Details | `/Guilds/{guildId:long}/FlaggedEvents/{id:guid}` | Single flagged event |
+| Feature Requests | `/Guilds/{guildId:long}/FeatureRequests` | Guild feature request submissions |
+| Feature Request Details | `/Guilds/{guildId:long}/FeatureRequests/{id:guid}` | Single feature request with admin actions |
+| Audio Moderation Log | `/Guilds/{guildId:long}/AudioModerationLog` | Audio playback event log (soundboard, TTS, VOX) |
 | Soundboard | `/Guilds/Soundboard/{guildId:long}` | Guild soundboard management |
 | Rat Watch | `/Guilds/RatWatch/{guildId:long}` | Rat Watch management |
 | Rat Watch Analytics | `/Guilds/RatWatch/Analytics/{guildId:long}` | Rat Watch analytics and metrics |
@@ -169,6 +175,15 @@ REST API for Portal functionality. All endpoints require `[Authorize(Policy = "P
 | `/api/portal/tts/voices/{voiceName}/capabilities` | GET | Get voice capabilities |
 | `/api/portal/tts/presets` | GET | Get SSML style presets |
 
+### User Preferences (`UserPreferencesController.cs`)
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/portal/preferences/{guildId}` | GET | Get all preferences for current user in guild |
+| `/api/portal/preferences/{guildId}/{key}` | GET | Get single preference by key |
+| `/api/portal/preferences/{guildId}/{key}` | PUT | Set preference value |
+| `/api/portal/preferences/{guildId}/{key}` | DELETE | Delete preference |
+
 ## Discord Command Modules
 
 Using Discord.NET 3.19.0-beta.1 - slash commands only, registered via `InteractionHandler`.
@@ -196,8 +211,11 @@ Using Discord.NET 3.19.0-beta.1 - slash commands only, registered via `Interacti
 | `ModTagModule` | `/modtag add/remove/list/create/delete` |
 | `WatchlistModule` | `/watchlist add/remove/list` |
 | `InvestigateModule` | `/investigate` |
+| `NotXCommandModule` | `/notx enable`, `/notx disable`, `/notx status`, `/notx sensitive-only`, `/notx channel set`, `/notx channel clear`, `/notx monitor add`, `/notx monitor remove`, `/notx monitor clear` |
+| `NotXContextMenuModule` | `Fetch Tweet` (message context menu) |
+| `FeatureRequestModule` | `/feature-request` |
 
-**Component-only modules** (handle button/select interactions, no slash commands): `AdminComponentModule`, `RatWatchComponentModule`, `ScheduleComponentModule`, `ModerationHistoryComponentModule`, `FlaggedEventComponentModule`
+**Component-only modules** (handle button/select interactions, no slash commands): `AdminComponentModule`, `RatWatchComponentModule`, `ScheduleComponentModule`, `ModerationHistoryComponentModule`, `FlaggedEventComponentModule`, `FeatureRequestComponentModule`
 
 ### Interactive Components Pattern
 
@@ -237,6 +255,7 @@ Build and serve locally: `.\build-docs.ps1 -Serve` (http://localhost:8080)
 | [background-services.md](docs/articles/background-services.md) | Background hosted services, retention, aggregation |
 | [bot-performance-dashboard.md](docs/articles/bot-performance-dashboard.md) | Performance monitoring dashboard |
 | [bot-verification.md](docs/articles/bot-verification.md) | Bot verification as OAuth alternative |
+| [configuration-guide.md](docs/articles/configuration-guide.md) | Application configuration reference |
 | [command-configuration.md](docs/articles/command-configuration.md) | Command module enable/disable |
 | [commands-page-design.md](docs/articles/commands-page-design.md) | Commands page design spec |
 | [commands-page.md](docs/articles/commands-page.md) | Commands page feature |
@@ -244,6 +263,7 @@ Build and serve locally: `.\build-docs.ps1 -Serve` (http://localhost:8080)
 | [consent-privacy.md](docs/articles/consent-privacy.md) | GDPR-compliant consent and privacy management |
 | [database-schema.md](docs/articles/database-schema.md) | Entity relationships and schema |
 | [design-system.md](docs/articles/design-system.md) | UI tokens, color palette, theming |
+| [docker-deployment.md](docs/articles/docker-deployment.md) | Docker deployment guide (includes Mogwai container) |
 | [discord-bot-setup.md](docs/articles/discord-bot-setup.md) | Discord Developer Portal setup |
 | [elastic-apm.md](docs/articles/elastic-apm.md) | Elastic APM distributed tracing |
 | [elastic-stack-setup.md](docs/articles/elastic-stack-setup.md) | Local Elastic Stack setup |
@@ -268,6 +288,8 @@ Build and serve locally: `.\build-docs.ps1 -Serve` (http://localhost:8080)
 | [nav-tabs-design-spec.md](docs/articles/nav-tabs-design-spec.md) | Navigation Tabs design specification |
 | [nav-tabs-migration.md](docs/articles/nav-tabs-migration.md) | Navigation Tabs migration guide |
 | [nav-tabs-spec.md](docs/articles/nav-tabs-spec.md) | Navigation component unification spec |
+| [not-x/](docs/articles/not-x/) | Not-X feature: X/Twitter link preview embeds (spec, BRD, PRD, user stories, test constraints, feature reference) |
+| [feature-request-command/](docs/articles/feature-request-command/) | Feature request command: AI-powered submission with DM conversation and doc gen (BRD, PRD, user stories, architecture, reference) |
 | [notification-system.md](docs/articles/notification-system.md) | Real-time notifications with SignalR |
 | [permissions.md](docs/articles/permissions.md) | Precondition attribute system |
 | [rat-watch.md](docs/articles/rat-watch.md) | Rat Watch accountability feature |
@@ -354,6 +376,9 @@ Build and serve locally: `.\build-docs.ps1 -Serve` (http://localhost:8080)
 | [docs/index.md](docs/index.md) | Documentation index/welcome page |
 | [docs/agents/assistant-agent.md](docs/agents/assistant-agent.md) | AI assistant agent prompt |
 | [docs/agents/assistant-agent-evil.md](docs/agents/assistant-agent-evil.md) | Evil AI assistant agent (easter egg) |
+| [docs/agents/dm-owner-agent.md](docs/agents/dm-owner-agent.md) | DM assistant owner agent prompt |
+| [docs/TEST_COVERAGE_GAPS.md](docs/TEST_COVERAGE_GAPS.md) | Test coverage gap analysis and recommended minimum cases |
+| [docs/articles/user-profile-extraction/](docs/articles/user-profile-extraction/) | User profile extraction proposal (BRD, PRD, user stories, reference) |
 | [docs/changelogs/CHANGELOG-v0.5.0.md](docs/changelogs/CHANGELOG-v0.5.0.md) | v0.5.0 changelog |
 | [docs/changelogs/CHANGELOG-v0.5.1.md](docs/changelogs/CHANGELOG-v0.5.1.md) | v0.5.1 changelog |
 | [docs/lessons-learned/](docs/lessons-learned/) | 8 post-implementation lessons learned docs |

--- a/docs/architecture/feature-map.md
+++ b/docs/architecture/feature-map.md
@@ -311,7 +311,7 @@ Automatic or manual preview embeds for X/Twitter links, using the fxtwitter API 
 
 | Aspect | Components |
 |--------|------------|
-| **Discord Commands** | `/notx enable`, `/notx disable`, `/notx status`, `/notx sensitive-only`, `/notx output set`, `/notx output clear`, `/notx monitor add`, `/notx monitor remove`, `/notx monitor clear` (NotXCommandModule); `Fetch Tweet` context menu (NotXContextMenuModule) |
+| **Discord Commands** | `/notx enable`, `/notx disable`, `/notx status`, `/notx sensitive-only`, `/notx channel set`, `/notx channel clear`, `/notx monitor add`, `/notx monitor remove`, `/notx monitor clear` (NotXCommandModule); `Fetch Tweet` context menu (NotXContextMenuModule) |
 | **Handlers** | `NotXMessageHandler` (auto-detects tweet URLs in messages) |
 | **Services** | `INotXService`, `FxTwitterClient`, `NotXEmbedBuilder`, `TweetUrlExtractor` |
 | **Database Entities** | `NotXGuildSettings` |

--- a/docs/architecture/service-catalog.md
+++ b/docs/architecture/service-catalog.md
@@ -145,7 +145,7 @@ Services for AI-powered feature request submission with multi-step DM conversati
 | `IInputValidationService` | Core Interfaces | Input validation contract for feature request text |
 | `InputValidationService` | Bot/Services/FeatureRequests | Validates description length and content constraints |
 | `PromptInjectionFilter` | Bot/Services/FeatureRequests | Regex-based prompt injection detection using configurable patterns from `FeatureRequestsOptions` |
-| `FeatureRequestToolProvider` | Infrastructure/Services/LLM/Providers | `IToolProvider` implementation exposing feature-request tools to the AI agent |
+| `FeatureRequestToolProvider` | Infrastructure/Services/FeatureRequests | `IDmToolProvider` implementation exposing feature-request tools to the AI agent |
 | `FeatureRequestDmHandler` | Bot/Handlers | Handles DM messages during active feature request conversations |
 
 ---

--- a/docs/articles/feature-request-command/Architecture.md
+++ b/docs/articles/feature-request-command/Architecture.md
@@ -303,7 +303,7 @@ The `<user_request>` block is populated only with sanitized, validated, length-c
 
 | Risk | Likelihood | Impact | Mitigation |
 |---|---|---|---|
-| `claude` CLI not available on server | Medium | Doc gen broken | Configurable binary path; graceful `DocGenFailed` status; admin retry |
+| `claude` CLI not available on host | Medium | Doc gen broken | Configurable binary path; graceful `DocGenFailed` status; admin retry |
 | Prompt injection bypasses filter | Low | Malicious repo changes | Restricted subprocess permissions; XML data delimiters; `--print` mode only creates files in docs/ |
 | DM conversation abandoned at scale | Medium | Stale state memory | `InteractionStateCleanupService` (already exists) handles TTL expiry |
 | Slug collision for similar requests | Low | Doc gen error | Collision detection with numeric suffix (`poll-command-2`) |

--- a/docs/articles/feature-request-command/README.md
+++ b/docs/articles/feature-request-command/README.md
@@ -33,12 +33,12 @@ Documentation for the `/feature-request` Discord slash command — a feature tha
 
 | Document | Status |
 |---|---|
-| BRD | Draft |
-| PRD | Draft |
-| User Stories | Draft |
-| Architecture | Draft |
-| Reference | Draft |
-| Implementation | Not started |
+| BRD | Complete |
+| PRD | Complete |
+| User Stories | Complete |
+| Architecture | Complete |
+| Reference | Complete |
+| Implementation | Complete |
 
 ---
 

--- a/docs/articles/feature-request-command/Reference.md
+++ b/docs/articles/feature-request-command/Reference.md
@@ -221,6 +221,8 @@ All settings under `FeatureRequests:` in `appsettings.json` / environment variab
 | `DocGen:BaseBranch` | string | `main` | Branch to create feature branches from |
 | `DocGen:BranchPrefix` | string | `feature-proposal/` | Prefix for generated branches |
 | `DocGen:DocsBasePath` | string | `docs/feature-proposals/` | Repo-relative path for generated docs |
+| `RequirementsGatheringModel` | string | `claude-sonnet-4-20250514` | AI model used for the DM requirements gathering conversation |
+| `MaxConversationTurns` | int | `10` | Maximum user messages before the DM conversation is auto-concluded |
 | `InjectionPatterns` | string[] | (see below) | Phrases triggering injection filter |
 
 Default `InjectionPatterns`:

--- a/docs/articles/not-x/feature-reference.md
+++ b/docs/articles/not-x/feature-reference.md
@@ -46,13 +46,14 @@ src/DiscordBot.Bot/
 │   └── NotXMessageHandler.cs         MessageReceived event hook
 ├── Services/
 │   └── NotXService.cs                orchestration; implements INotXService
-└── Extensions/
-    └── NotXExtensions.cs             AddNotX() DI registration
-
-src/DiscordBot.Infrastructure/
-├── Services/
-│   └── Http/
-│       └── FxTwitterClient.cs        HTTP client; implements IFxTwitterClient
+├── Extensions/
+│   └── NotXServiceExtensions.cs      AddNotX() DI registration
+└── Services/
+    └── NotX/
+        ├── FxTwitterClient.cs        HTTP client; implements IFxTwitterClient
+        ├── NotXEmbedBuilder.cs       Builds Discord embeds from tweet data
+        ├── NotXService.cs            Orchestration; implements INotXService
+        └── TweetUrlExtractor.cs      Static; shared by handler and command module
 ├── Data/
 │   ├── Repositories/
 │   │   └── NotXGuildSettingsRepository.cs
@@ -70,12 +71,7 @@ src/DiscordBot.Core/
     └── FxTweetResult.cs              (record types: FxTweetResult, FxTweetAuthor, FxTweetMedia, etc.)
 ```
 
-Internal helper (not an interface-backed service):
-
-```
-src/DiscordBot.Bot/Utilities/
-└── TweetUrlExtractor.cs              static; shared by handler and command module
-```
+**Note:** `TweetUrlExtractor` is a static helper (not interface-backed) located alongside the other Not-X services in `Bot/Services/NotX/`.
 
 ---
 

--- a/docs/articles/not-x/feature-reference.md
+++ b/docs/articles/not-x/feature-reference.md
@@ -206,7 +206,7 @@ Named client:   "FxTwitter"
 Base address:   https://api.fxtwitter.com/
 Timeout:        5 seconds (configurable via NotXOptions)
 Max response:   256 KB (enforced before deserialization)
-User-Agent:     discordbot/1.0
+User-Agent:     DiscordBot/1.0 (+not-x)
 ```
 
 ---
@@ -395,7 +395,7 @@ The bot never posts an error message to any guild channel. All errors are intern
 |-----|------|---------|-------------|
 | `RequestTimeoutSeconds` | `int` | `5` | HTTP timeout for fxtwitter API calls |
 | `MaxResponseBytes` | `int` | `262144` | Maximum response body size (bytes) before rejection |
-| `UserAgent` | `string` | `discordbot/1.0` | User-Agent header sent to fxtwitter |
+| `UserAgent` | `string` | `DiscordBot/1.0 (+not-x)` | User-Agent header sent to fxtwitter |
 
 Options class: `NotXOptions` (bound from `IOptions<NotXOptions>`).
 

--- a/docs/articles/not-x/spec.md
+++ b/docs/articles/not-x/spec.md
@@ -2,7 +2,7 @@
 
 **Version:** 1.1
 **Date:** 2026-04-01
-**Status:** Proposal
+**Status:** Implemented
 **Target Framework:** .NET 8, Discord.Net
 
 ---
@@ -466,7 +466,7 @@ Corresponding options class: `NotXOptions`.
 ## Dependency Injection
 
 ```csharp
-// NotXExtensions.cs
+// NotXServiceExtensions.cs
 public static IServiceCollection AddNotX(
     this IServiceCollection services,
     IConfiguration configuration)
@@ -479,11 +479,10 @@ public static IServiceCollection AddNotX(
         client.BaseAddress = new Uri("https://api.fxtwitter.com/");
         client.Timeout = TimeSpan.FromSeconds(5);
         client.DefaultRequestHeaders.UserAgent
-            .ParseAdd("discordbot/1.0");
+            .ParseAdd("DiscordBot/1.0 (+not-x)");
     });
 
     services.AddScoped<INotXGuildSettingsRepository, NotXGuildSettingsRepository>();
-    services.AddScoped<INotXGuildSettingsService, NotXGuildSettingsService>();
     services.AddScoped<IFxTwitterClient, FxTwitterClient>();
     services.AddScoped<INotXService, NotXService>();
 


### PR DESCRIPTION
## Summary

Weekly documentation review covering 22 commits from 2026-03-31 to 2026-04-06. Four major features landed this week (Not-X, Feature Requests, Mogwai, Audio Portal batch) — all had extensive docs already contributed. This PR fixes accuracy issues, stale references, and updates lookup tables.

### Fixes applied

- **feature-request-command/README.md** — Status table: "Draft"/"Not started" → "Complete" (implementation merged in `43c8e6f`)
- **feature-request-command/Reference.md** — Added missing `RequirementsGatheringModel` and `MaxConversationTurns` config options
- **feature-request-command/Architecture.md** — "server" → "host" in risk table (project convention)
- **feature-map.md** — Not-X commands: `/notx output set/clear` → `/notx channel set/clear` (matches source)
- **not-x/feature-reference.md** — Fixed UserAgent default (`DiscordBot/1.0 (+not-x)`), corrected component paths for `FxTwitterClient` and `TweetUrlExtractor`
- **not-x/spec.md** — Status "Proposal" → "Implemented"; fixed DI file name, UserAgent, removed non-existent `NotXGuildSettingsService`
- **service-catalog.md** — `FeatureRequestToolProvider` location and interface corrected
- **CLAUDE-REFERENCE.md** — Added `NotXOptions`, `FeatureRequestsOptions`, `DmAssistantOptions` configs; `NotXCommandModule`, `FeatureRequestModule` commands; Feature Requests + Audio Moderation Log page routes; UserPreferences API endpoints; new article index entries

### No changes needed for
- `docs/articles/mogwai.md` — accurate and complete
- `docs/articles/docker-deployment.md` — already covers Mogwai
- `docs/TEST_COVERAGE_GAPS.md` — accurate baseline

## Test plan
- [ ] Verify all internal doc cross-references resolve correctly
- [ ] Spot-check command names against source (`NotXCommandModule.cs`, `FeatureRequestModule.cs`)
- [ ] Confirm CLAUDE-REFERENCE.md tables are alphabetically ordered

https://claude.ai/code/session_01QPfywEdA1ENa6P4VZci3tG