### PR TITLE
docs: weekly review — 2026-04-13 to 2026-04-20

### DIFF
--- a/docs/architecture/patterns.md
+++ b/docs/architecture/patterns.md
@@ -1577,7 +1577,7 @@ IHostedService
 
 `ExecuteAsync` is sealed. The base class:
 
-1. Yields immediately on startup to avoid blocking `IHostedService.StartAsync`.
+1. Dispatches work to the thread pool via `Task.Run()` to avoid blocking `IHostedService.StartAsync`.
 2. Lazily resolves `IBackgroundServiceHealthRegistry` and calls `Register(ServiceName, this)`.
 3. Sets Status to `"Running"` and calls `ExecuteMonitoredAsync(stoppingToken)`.
 4. On `OperationCanceledException`: logs graceful stop (normal shutdown path).

--- a/docs/articles/api-endpoints.md
+++ b/docs/articles/api-endpoints.md
@@ -18,7 +18,7 @@ The REST API provides programmatic access to bot status, guild management, and c
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `/api/health` | GET | Health check with database connectivity |
+| `/health` | GET | Health check with database connectivity |
 | `/metrics` | GET | OpenTelemetry metrics (Prometheus format) |
 | `/api/metrics/health` | GET | Overall bot health status |
 | `/api/metrics/health/latency` | GET | Latency history with statistics |
@@ -122,7 +122,7 @@ The REST API provides programmatic access to bot status, guild management, and c
 
 ## Health Endpoints
 
-### GET /api/health
+### GET /health
 
 Returns the health status of the application including database connectivity.
 
@@ -131,10 +131,20 @@ Returns the health status of the application including database connectivity.
 ```json
 {
   "status": "Healthy",
-  "timestamp": "2024-12-08T15:30:00Z",
-  "version": "1.0.0.0",
+  "timestamp": "2024-12-08T15:30:00.0000000Z",
+  "version": "1.0.0+abc1234",
+  "totalDuration": 42.5,
   "checks": {
-    "Database": "Healthy"
+    "database": {
+      "status": "Healthy",
+      "description": "",
+      "duration": 12.3
+    },
+    "discord": {
+      "status": "Healthy",
+      "description": "",
+      "duration": 30.1
+    }
   }
 }
 ```
@@ -143,14 +153,24 @@ Returns the health status of the application including database connectivity.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `status` | string | Overall status: "Healthy" or "Degraded" |
-| `timestamp` | datetime | UTC timestamp of health check |
-| `version` | string | Application version |
-| `checks` | object | Individual health check results |
+| `status` | string | Overall status: `Healthy`, `Degraded`, or `Unhealthy` |
+| `timestamp` | string | ISO 8601 UTC timestamp of the health check (`DateTime.UtcNow`) |
+| `version` | string | Informational version from the entry assembly (falls back to `"unknown"`) |
+| `totalDuration` | number | Total time to execute all checks, in milliseconds |
+| `checks` | object | Map of check name to check result object (see below) |
+
+**Per-Check Object Fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status` | string | Check status: `Healthy`, `Degraded`, or `Unhealthy` |
+| `description` | string | Optional description (empty string if not set) |
+| `duration` | number | Time to execute this check, in milliseconds |
 
 **Status Values:**
-- `Healthy`: All checks passed
-- `Degraded`: One or more checks failed (still operational)
+- `Healthy`: All checks passed (HTTP 200)
+- `Degraded`: One or more checks degraded but still operational (HTTP 200)
+- `Unhealthy`: One or more checks failed (HTTP 503)
 
 ---
 
@@ -6239,10 +6259,21 @@ Task<bool> CanManageUserAsync(
 
 ```csharp
 {
-  "status": string,           // "Healthy" or "Degraded"
-  "timestamp": DateTime,      // UTC timestamp
-  "version": string,          // Application version
-  "checks": Dictionary<string, string>  // Check name -> status
+  "status": string,           // "Healthy", "Degraded", or "Unhealthy"
+  "timestamp": string,        // ISO 8601 UTC timestamp
+  "version": string,          // Assembly informational version (or "unknown")
+  "totalDuration": double,    // Total check duration in milliseconds
+  "checks": Dictionary<string, HealthCheckEntry>  // Check name -> result
+}
+```
+
+**HealthCheckEntry:**
+
+```csharp
+{
+  "status": string,           // "Healthy", "Degraded", or "Unhealthy"
+  "description": string,      // Description (empty string if not set)
+  "duration": double          // Check duration in milliseconds
 }
 ```
 

--- a/docs/articles/background-services.md
+++ b/docs/articles/background-services.md
@@ -7,7 +7,7 @@
 
 The system uses ASP.NET Core's `IHostedService` and `BackgroundService` patterns for long-running background tasks. All background services are registered in `Program.cs` via domain-specific extension methods in `src/DiscordBot.Bot/Extensions/`.
 
-**Architecture:** Services inherit from `BackgroundService`, execute on separate threads, and report health via `IBackgroundServiceHealthRegistry`.
+**Architecture:** Services extend `MonitoredBackgroundService` (which inherits from `BackgroundService`), execute on the thread pool via `Task.Run()`, and report health via `IBackgroundServiceHealthRegistry`.
 
 ---
 


### PR DESCRIPTION
## Weekly Documentation Review — 2026-04-13 to 2026-04-20

### Commits Reviewed
1 commit

- `2e1d71a` feat: add timestamp and version to health check response (#1924)

### Changes Classified
- **Documentation Required:** 2 (health check response shape, MonitoredBackgroundService threading change)
- **No Documentation Needed:** 1 (test file updates)

### Documentation Actions Taken
- **Updated:** `docs/articles/api-endpoints.md` — Fixed health endpoint path from `/api/health` to `/health`; added missing `totalDuration` field to response example and field table; expanded `checks` from flat strings to per-check objects with `status`/`description`/`duration`; added `Unhealthy` status with HTTP 503; updated `HealthResponseDto` to match actual response shape
- **Updated:** `docs/architecture/patterns.md` — Fixed stale MonitoredBackgroundService lifecycle description: replaced "Yields immediately" with accurate `Task.Run()` description
- **Updated:** `docs/articles/background-services.md` — Updated overview to reference `MonitoredBackgroundService` as the actual base class (not raw `BackgroundService`)

### Documentation Already Updated by Contributors
- `docs/articles/api-endpoints.md` (health section) — `timestamp` and `version` fields were already documented prior to the code change landing (good: docs led implementation)

### No Action Taken
- **Test file changes** (AuditLogQueueProcessorTests, ConnectionStateServiceTests) — No documentation impact
- **Stale `Task.Yield()` references in historical docs** (`docs/lessons-learned/issue-570-performance-alerts.md`, `docs/articles/bot-performance-dashboard.md`) — These are historical documents describing issues at a point in time; adding retroactive update notes would be unusual and low value

### Files Changed
| File | Insertions | Deletions |
|------|-----------|-----------|
| `docs/articles/api-endpoints.md` | +44 | -13 |
| `docs/architecture/patterns.md` | +1 | -1 |
| `docs/articles/background-services.md` | +1 | -1 |
