### PR TITLE
Selective Blazor modernization (islands-first)

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# SessionStart hook — provision the .NET 8 toolchain for Claude Code on the web.
+#
+# Why this is needed:
+#   The remote web environment ships without the .NET SDK, and the official
+#   dotnet-install CDN (builds.dotnet.microsoft.com) is blocked by the egress
+#   policy (HTTP 403). Ubuntu 24.04's own archive, however, ships
+#   `dotnet-sdk-8.0` and is reachable — so we install from there.
+#
+# Behaviour:
+#   - Runs only in the remote (web) environment.
+#   - Idempotent: skips installs that are already present.
+#   - Synchronous: the session waits until the toolchain is ready, so the agent
+#     never races ahead of `dotnet build` / `dotnet test`.
+#   - Verbose tool output goes to a log; only concise status reaches the session.
+set -euo pipefail
+
+# Only provision in the remote web environment (no-op locally).
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+LOG="/tmp/session-start-hook.log"
+: > "$LOG"
+log() { echo "[session-start] $*"; }
+
+export DEBIAN_FRONTEND=noninteractive
+
+# --- .NET 8 SDK (required) -------------------------------------------------
+if command -v dotnet >/dev/null 2>&1; then
+  log "dotnet already present ($(dotnet --version))"
+else
+  log "Installing dotnet-sdk-8.0 from the Ubuntu archive (see $LOG)..."
+  if ! sudo apt-get install -y --no-install-recommends dotnet-sdk-8.0 >>"$LOG" 2>&1; then
+    log "First attempt failed; refreshing package lists and retrying..."
+    sudo apt-get update >>"$LOG" 2>&1
+    sudo apt-get install -y --no-install-recommends dotnet-sdk-8.0 >>"$LOG" 2>&1
+  fi
+  log "Installed dotnet $(dotnet --version)"
+fi
+
+# --- Node.js + Tailwind (best-effort) --------------------------------------
+# Node is only needed to recompile Tailwind CSS. The .csproj skips the Tailwind
+# build when the `SkipTailwind` MSBuild property is set, so if Node is
+# unavailable we persist SkipTailwind=true and C#/Razor builds still work.
+NPM_OK=true
+if ! command -v npm >/dev/null 2>&1; then
+  log "Installing Node.js/npm for Tailwind (best-effort, see $LOG)..."
+  if ! sudo apt-get install -y --no-install-recommends nodejs npm >>"$LOG" 2>&1; then
+    NPM_OK=false
+    log "WARN: Node.js install failed — CSS rebuilds unavailable this session."
+  fi
+fi
+if [ "$NPM_OK" = "true" ] && command -v npm >/dev/null 2>&1; then
+  log "Installing npm packages for Tailwind..."
+  if ! ( cd "$CLAUDE_PROJECT_DIR/src/DiscordBot.Bot" && npm install --no-audit --no-fund >>"$LOG" 2>&1 ); then
+    NPM_OK=false
+    log "WARN: npm install failed — CSS rebuilds unavailable this session."
+  fi
+else
+  NPM_OK=false
+fi
+
+# --- Warm the NuGet cache (snapshotted into the cached container) ----------
+log "Restoring NuGet packages (see $LOG)..."
+dotnet restore "$CLAUDE_PROJECT_DIR/DiscordBot.sln" >>"$LOG" 2>&1
+log "NuGet restore complete."
+
+# --- Persist environment for the session -----------------------------------
+{
+  echo 'export DOTNET_CLI_TELEMETRY_OPTOUT=1'
+  echo 'export DOTNET_NOLOGO=1'
+  # Without Node, tell MSBuild to skip the Tailwind/npm build targets so that
+  # `dotnet build` / `dotnet test` succeed (CSS just isn't regenerated).
+  if [ "$NPM_OK" != "true" ]; then
+    echo 'export SkipTailwind=true'
+  fi
+} >> "$CLAUDE_ENV_FILE"
+
+if [ "$NPM_OK" = "true" ]; then
+  log "Toolchain ready: .NET + Node. Build with: dotnet build"
+else
+  log "Toolchain ready: .NET only. Build with: dotnet build (Tailwind auto-skipped)."
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/architecture/blazor-modernization-handoff.md
+++ b/docs/architecture/blazor-modernization-handoff.md
@@ -1,0 +1,245 @@
+# Blazor Modernization — Agent Handoff
+
+> **Purpose.** Pick up the islands-first Blazor modernization (PR #1927) cleanly.
+> Phase 0 (foundation) is done, verified, and pushed. Slice 1 is the next unit of
+> work. The environment now provisions itself via a SessionStart hook, so you can
+> build and test immediately.
+
+**Branch:** `claude/bot-ui-blazor-plan-slot47`  ·  **PR:** #1927  ·  **Base:** `main`
+
+---
+
+## 1. TL;DR — where things stand
+
+| Commit | What |
+|---|---|
+| `3895d4a` | The plan: `docs/architecture/blazor-modernization-selective-plan.md` |
+| `bdaeb7c` | **Phase 0** — Blazor Server islands foundation (builds clean, 0 errors) |
+| `bf688a8` | SessionStart hook that installs the .NET 8 toolchain on the web |
+
+Nothing is half-finished. Phase 0 is a complete, self-contained increment. The
+**FoundationProbe** island on `/Components` proves circuit + interop + component
+parity end-to-end. Your job is **Slice 1: Moderation Settings** (see §5).
+
+Read these first (already written, don't redo):
+- `docs/architecture/blazor-modernization-selective-plan.md` — the plan, phasing, debounce rules, risks.
+- `docs/architecture/blazor-migration-plan.md` — the *maximalist* north-star (NOT what we're doing now).
+
+---
+
+## 2. Environment — it sets itself up
+
+A SessionStart hook (`.claude/hooks/session-start.sh`, registered in
+`.claude/settings.json`) runs automatically on web sessions and:
+- installs `dotnet-sdk-8.0` from the **Ubuntu archive** (the Microsoft
+  `dotnet-install` CDN, `builds.dotnet.microsoft.com`, is **blocked by egress
+  policy — do not try to use it or route around it**);
+- best-effort installs Node/npm + `npm install` for Tailwind (falls back to
+  `SkipTailwind=true` if Node is missing);
+- warms `dotnet restore`.
+
+If you're in a fresh container and `dotnet` isn't found yet, the hook may still be
+running (synchronous) or you can run it manually:
+```bash
+CLAUDE_CODE_REMOTE=true CLAUDE_PROJECT_DIR="$PWD" CLAUDE_ENV_FILE=/tmp/env.sh \
+  ./.claude/hooks/session-start.sh
+```
+
+### Verified commands (use these to gate every slice)
+
+```bash
+export DOTNET_CLI_TELEMETRY_OPTOUT=1 DOTNET_NOLOGO=1
+
+# Restore (once per session; the hook already does this)
+dotnet restore DiscordBot.sln
+
+# Build — full solution (Node present → Tailwind runs)
+dotnet build DiscordBot.sln -c Debug --no-restore
+
+# Build — Bot only, no Node needed (skips the npm/Tailwind MSBuild targets)
+dotnet build src/DiscordBot.Bot/DiscordBot.Bot.csproj -c Debug --no-restore \
+  -p:SkipTailwind=true -p:CI=true
+
+# Test — scope to one class while iterating
+dotnet test tests/DiscordBot.Tests/DiscordBot.Tests.csproj -c Debug --no-build \
+  --filter "FullyQualifiedName~AuditLogsControllerTests"
+
+# Lint — SDK formatter (CI has no separate linter; analyzers run during build)
+dotnet format DiscordBot.sln --no-restore --include <files...> --verify-no-changes
+```
+
+Baselines on `bf688a8`: solution build **0 errors** (71 pre-existing warnings),
+sample test class **22/22 passing**, `dotnet format` clean on the new files.
+
+---
+
+## 3. What Phase 0 added (inventory)
+
+All new Blazor code lives under `src/DiscordBot.Bot/Blazor/` (a new top-level
+folder — deliberately separate from the existing `Components/` C# folder and the
+`Pages/Shared/Components/` partials).
+
+| File | Role |
+|---|---|
+| `Blazor/_Imports.razor` | Global usings for `.razor` files |
+| `Blazor/Interop/ToastInterop.cs` | Scoped service → existing `toast.js` |
+| `Blazor/Interop/ThemeInterop.cs` | Scoped service → existing `theme.js` |
+| `Blazor/Common/Debouncer.cs` | Server-side trailing-edge debounce (use for filter/search inputs) |
+| `Blazor/Shared/UiButton.razor` | Blazor twin of `_Button.cshtml` (same Tailwind tokens) |
+| `Blazor/Shared/UiToggle.razor` | Blazor twin of `_FormToggle.cshtml` (toggle CSS inlined) |
+| `Blazor/Pages/FoundationProbe.razor` | PoC island; **delete once trusted** |
+| `wwwroot/js/blazor-interop.js` | `window.blazorInterop` shim (see gotcha §6.1) |
+
+Wiring changes:
+- `Extensions/WebServiceExtensions.cs` — `AddServerSideBlazor()`,
+  `AddCascadingAuthenticationState()`, registers `ToastInterop`/`ThemeInterop`.
+- `Program.cs` — `app.MapBlazorHub()` next to `MapHub<DashboardHub>`.
+- `Pages/Components.cshtml` — hosts the probe via `<component … render-mode="ServerPrerendered">`
+  and loads `blazor-interop.js` + `~/_framework/blazor.server.js` in its Scripts section.
+
+---
+
+## 4. How an island is wired (the pattern to repeat)
+
+1. Build the interactive component(s) under `Blazor/Pages/` (no `@page` directive —
+   these are embedded, not routed). Reuse `Blazor/Shared/*` primitives.
+2. Host it in the existing Razor Page's `.cshtml`:
+   ```razor
+   <component type="typeof(DiscordBot.Bot.Blazor.Pages.MyIsland)"
+              render-mode="ServerPrerendered"
+              param-GuildId="@Model.GuildId.ToString()" />   @* IDs as STRINGS — see §6.2 *@
+   ```
+3. In that page's `@section Scripts`, add (once per host page):
+   ```html
+   <script src="~/js/blazor-interop.js" asp-append-version="true"></script>
+   <script src="~/_framework/blazor.server.js"></script>
+   ```
+4. The page keeps its route, layout, breadcrumb, and `[Authorize]` — the island
+   inherits them. Auth inside the island: inject `AuthenticationStateProvider` or
+   use `<AuthorizeView>` (cascading auth state is registered).
+5. Data access: create a DI scope per operation and resolve the **existing**
+   services (see §6.4) — do **not** rewire the global `DbContext`.
+
+---
+
+## 5. Next up — Slice 1: Moderation Settings
+
+**Target:** `/Guilds/{guildId:long}/ModerationSettings`
+**Page:** `Pages/Guilds/ModerationSettings/Index.cshtml(.cs)`
+**JS it replaces:** `wwwroot/js/moderation-settings.js` (540 lines)
+
+Why this is the proof slice: self-contained, guild-scoped, low client-state
+complexity, exercises the tab-form + confirm-modal + guild-auth path that the
+later settings/commands slices all reuse.
+
+### Shape of the page (already mapped)
+- Tabs: **Overview, Spam, Content, Raid, Tags**; Simple/Advanced toggle per tab.
+- Page handlers (reuse these via services, don't reinvent): `OnPostSaveOverviewAsync`,
+  `OnPostSaveSpamAsync`, `OnPostSaveContentAsync`, `OnPostSaveRaidAsync`,
+  `OnPostApplyPresetAsync`, `OnPostCreateTagAsync`, `OnPostDeleteTagAsync`,
+  `OnPostImportTemplatesAsync`.
+- Services injected by the page: `IGuildModerationConfigService` (`GetConfigAsync`,
+  `UpdateConfigAsync`, `ApplyPresetAsync`), `IModTagService` (`GetGuildTagsAsync`,
+  `CreateTagAsync`, `DeleteTagAsync`, `ImportTemplateTagsAsync`),
+  `IGuildService`, `IFlaggedEventService`, `DiscordSocketClient`.
+- DTOs to reuse (do not redefine): `GuildModerationConfigDto`, `OverviewUpdateDto`,
+  `SpamDetectionConfigDto`, `ContentFilterConfigDto`, `RaidProtectionConfigDto`,
+  `ApplyPresetDto`, `ModTagCreateDto`. Auth: `[Authorize(Policy="RequireAdmin")]`
+  + `[Authorize(Policy="GuildAccess")]` (already on the page).
+
+### Recommended build order
+1. Add the reusable kit pieces this slice needs (these were deferred from Phase 0
+   to land with their first consumer): `Blazor/Shared/TabbedFormShell.razor`
+   (tab strip + centralized dirty-flag + unsaved-switch guard + 3-state save
+   button) and `Blazor/Shared/ConfirmModal.razor` (+ `TypedConfirmModal` for the
+   tag-delete confirm). Mirror the markup/classes in `_ConfirmationModal.cshtml`.
+2. Build `Blazor/Pages/ModerationSettingsIsland.razor` composing the shell + one
+   child component per tab. Load config in `OnInitializedAsync` via a scoped
+   service call; save per-tab via the existing `IGuildModerationConfigService`.
+   Debounce nothing here (form saves are explicit), but use the dirty-flag.
+3. Replace the page body in `Index.cshtml` with the `<component>` host; add the two
+   scripts to its Scripts section. Keep the page model's `OnGetAsync` for the
+   guild header/breadcrumb/stats it already computes (the island only owns the
+   interactive settings body).
+4. Parity gate: keep the old JS-driven markup reachable behind a flag/query param
+   until the island matches, then flip the default (plan §9).
+
+### Gate before committing Slice 1
+- `dotnet build DiscordBot.sln -c Debug` → 0 errors.
+- `dotnet format … --verify-no-changes` clean on new files.
+- Manually reason through: auth on the host page, theme, toast on save,
+  reconnect, and that the page still renders its header/stats.
+
+Then continue with the plan's slice order: **2** NotificationBell + BotStatusCard
+(introduces the in-process event bus + notifier dual-publish — see plan §3.2/§5.1),
+**3** Admin Settings, **4** Commands, **5** Member Directory, **6** Soundboard
+grid, **7** Performance live tiles.
+
+---
+
+## 6. Gotchas & constraints (learned the hard way)
+
+**6.1 Toast/theme are not on `window`.** `toast.js`/`theme.js` declare
+`ToastManager`/`ThemeManager` as top-level `const`s, so they're in global lexical
+scope but **not** properties of `window` — `IJSRuntime.InvokeVoidAsync("ToastManager.show")`
+fails. `blazor-interop.js` is the window-attached shim that bridges them; it must
+load **after** toast.js/theme.js (the layout renders those first, so putting it in
+the page's `@section Scripts` is correct). Call toasts only from event handlers /
+`OnAfterRenderAsync`, never during prerender (no JS runtime then).
+
+**6.2 Discord snowflake IDs are strings in JS.** Per `CLAUDE.md`, pass guild/user
+IDs to islands as strings (`param-GuildId="@Model.GuildId.ToString()"`), never as
+`ulong`, to avoid precision loss in the prerender→interactive handoff. Parse back
+to `ulong` inside the component.
+
+**6.3 `blazor.server.js` is loaded per host page, not globally.** Keeps circuits
+off pages without islands. Only add it to pages that host a `<component>`.
+
+**6.4 Don't rewire the global `DbContext`.** Circuits are long-lived, so a
+circuit-scoped `DbContext` would be a bug. The chosen low-blast-radius approach:
+inject `IServiceScopeFactory`, and per operation do
+`using var scope = factory.CreateScope();` then resolve the existing scoped
+service/repository. This reuses all existing business logic and touches no DI
+registration. (The plan mentions `IDbContextFactory` as an alternative — prefer
+the scope-factory route unless a component needs raw `DbContext`.)
+
+**6.5 Nested-route islands need a `<base href>`.** `/Components` is top-level so
+`blazor.server.js` resolves `/_blazor` fine. For islands on nested routes (e.g.
+`/Guilds/123/ModerationSettings`), add `<base href="~/" />` to the layout `<head>`
+**or** configure the hub path explicitly, or the circuit negotiate URL resolves
+wrong. Verify this when you host the first nested-route island (Slice 1).
+
+**6.6 Scoped CSS bundle isn't linked.** The app has no prior `.razor`, so the
+layout doesn't link `DiscordBot.Bot.styles.css`. `UiToggle` therefore **inlines**
+its `<style>` (matching the partial) instead of using `UiToggle.razor.css`. Either
+keep inlining component CSS, or add the bundle `<link>` to the layout if you adopt
+CSS isolation broadly.
+
+**6.7 Tailwind already globs `.razor`** (`tailwind.config.js` content includes
+`./Components/**/*.{razor,cshtml}` and `./Pages/**/*.{razor,cshtml}`). New class
+combos in `.razor` files are picked up on the next CSS rebuild (needs Node).
+
+**6.8 Egress policy.** Microsoft download CDNs are blocked (403). Ubuntu archive,
+npmjs, nuget.org all work through the proxy. Don't retry/route around 403/407 —
+report blocked hosts.
+
+---
+
+## 7. Background research (don't re-run)
+
+Four area maps were produced during planning and are the basis for the plan:
+SignalR/real-time architecture, startup/DI wiring, the rendering/component stack,
+and per-page Blazor-fit profiling. Their conclusions are folded into
+`blazor-modernization-selective-plan.md`. The one SignalR hub is `DashboardHub`
+(`/hubs/dashboard`); 7 notifier services push to it; for islands you'll add an
+in-process `IDashboardEventBus` that those notifiers dual-publish to (Slice 2).
+
+---
+
+## 8. PR etiquette for this branch
+
+- Commit per slice; end commit messages with the established trailers
+  (`Co-Authored-By:` + `Claude-Session:`).
+- Don't merge or change base. The PR (#1927) is open against `main`.
+- The SessionStart hook only applies to sessions on this branch until #1927 merges
+  into `main`.

--- a/docs/architecture/blazor-modernization-selective-plan.md
+++ b/docs/architecture/blazor-modernization-selective-plan.md
@@ -1,0 +1,350 @@
+# Selective Blazor Modernization Plan (Islands-First)
+
+> **Scope note.** This is the *pragmatic, near-term* plan. It deliberately does **not**
+> rewrite the whole portal. It adds Blazor Server **interactive islands** to the existing
+> Razor Pages app to modernize the highest-ROI components and pages, while leaving most of
+> the site — and the entire routing/auth model — exactly as it is today.
+>
+> A separate document, [`blazor-migration-plan.md`](./blazor-migration-plan.md), describes
+> the *maximalist* end-state (full conversion, .NET 9, 51–75 days). Treat that as the
+> long-term north star. **This document is what we actually do first**, and every step here
+> is a valid prefix of that larger plan — nothing here has to be undone to continue.
+
+---
+
+## 1. Why selective, and how this differs from the full-rewrite doc
+
+The portal is a mature ASP.NET Core 8 **Razor Pages + Web API + SignalR** app:
+
+- ~28k lines of vanilla JS across ~55 modules (no HTMX, no Alpine — despite stale docs).
+- 58 shared Razor *partials* + ViewModels acting as the design system.
+- One `DashboardHub` (`/hubs/dashboard`) with rich groups and 7 server-side notifier services
+  already pushing metrics, alerts, notifications, and audio status.
+- Tailwind theme driven by CSS variables; `tailwind.config.js` **already globs `.razor`** files.
+
+The full-rewrite plan is correct as a destination but is a poor *first move*: it forces a
+.NET 9 upgrade (Elastic APM / EF Core 9 risk), converts routing wholesale, and ports all 58
+components before delivering user-visible value. The user's constraint is explicit: **"we
+don't need a full rewrite right now."**
+
+This plan instead picks the few places where Blazor's model (server-held state + diffing over
+SignalR) eliminates the most JS and the most bugs, and ships them as islands.
+
+| Dimension | Full-rewrite doc | **This plan** |
+|---|---|---|
+| Framework | Upgrade to .NET 9 (Phase 0) | **Stay on .NET 8** — no upgrade |
+| Hosting | `MapRazorComponents<App>()` routable app | **Classic Blazor Server islands** embedded in existing Razor Pages |
+| Routing/auth | Replaced by Blazor Router | **Unchanged** — pages stay Razor Pages; islands inherit page auth |
+| Blast radius | Whole `Pages/` tree | **~5 components + 3 pages** initially |
+| Effort to first value | Weeks (Phases 0–2 before any page) | **Days** (one vertical slice) |
+| Reversibility | Large | Each island is independently revertible |
+
+---
+
+## 2. Goals & non-goals
+
+**Goals**
+- Replace the most painful stateful JS (multi-tab forms, dirty-tracking, button state
+  machines, polling) with server-held Blazor state.
+- Convert real-time UI (notification bell, bot status, performance widgets) from
+  client-managed SignalR + DOM patching to push-driven Blazor components.
+- Establish a small, reusable Blazor component kit + interop bridges so future islands are cheap.
+- Use SignalR/server-interactivity where it genuinely helps, and **debounce/throttle** so we
+  don't trade JS bugs for chatty circuits.
+
+**Non-goals (for this increment)**
+- No .NET 9 upgrade. No routing/auth rewrite. No deletion of existing Razor Pages or controllers.
+- No rewrite of audio-scrubbing / low-latency client behavior (TTS sliders, audio preview).
+- No charting-library migration — Chart.js stays, reached via thin interop where needed.
+- No mass port of all 58 partials — we build only the primitives the selected islands need.
+
+---
+
+## 3. Architectural approach: Blazor Server islands on .NET 8
+
+### 3.1 Hosting model
+
+Use the **classic Blazor Server** integration that is fully supported on .NET 8 for embedding
+interactive components into an existing Razor Pages app:
+
+```csharp
+// Extensions/WebServiceExtensions.cs — additive
+services.AddServerSideBlazor();      // circuit + /_blazor hub
+services.AddCascadingAuthenticationState();
+```
+
+```csharp
+// Program.cs — additive, alongside the existing endpoint maps
+app.MapBlazorHub();                  // sits next to MapHub<DashboardHub>("/hubs/dashboard")
+```
+
+```html
+<!-- Pages/Shared/_Layout.cshtml — one script, after the existing bundle -->
+<script src="_framework/blazor.server.js"></script>
+```
+
+Islands are then dropped into any existing `.cshtml` via the **Component Tag Helper**:
+
+```razor
+@* e.g. inside Pages/Guilds/ModerationSettings/Index.cshtml *@
+<component type="typeof(DiscordBot.Bot.Blazor.Pages.ModerationSettingsIsland)"
+           render-mode="ServerPrerendered"
+           param-GuildId="@Model.GuildId.ToString()" />
+```
+
+> **Why classic Blazor Server, not `MapRazorComponents<App>()`?** The new model wants a root
+> `App.razor` and owns routing — that's the full-rewrite path. The classic model lets a Razor
+> Page keep its route, layout, breadcrumb, and auth, and host *just one interactive region*.
+> Minimal blast radius, no routing conflicts, no `App.razor`.
+
+> **Discord snowflake gotcha** (per `CLAUDE.md`): pass guild/user IDs to islands as **strings**
+> (`param-GuildId="@Model.GuildId.ToString()"`), never as `ulong`, to avoid JS precision loss
+> during the prerender → interactive handoff.
+
+### 3.2 Coexistence with the existing SignalR hub
+
+The Blazor circuit is itself a SignalR connection (`/_blazor`). The existing `DashboardHub`
+(`/hubs/dashboard`) and all 55 JS modules keep working untouched on non-Blazor pages.
+
+For real-time **inside** an island, the component must **not** open a WebSocket back to our own
+hub. Instead, introduce an in-process pub/sub and have the existing notifier services
+**dual-publish** (additive — JS path unchanged):
+
+```csharp
+// New singleton; raised by existing notifiers in addition to IHubContext<DashboardHub>
+public interface IDashboardEventBus
+{
+    event Action<HealthMetricsUpdateDto>     HealthMetrics;
+    event Action<UserNotificationDto>        NotificationReceived;
+    event Action<NotificationSummaryDto>     NotificationCountChanged;
+    event Action<BotStatusDto>               BotStatusChanged;
+    event Action<PerformanceIncidentDto>     AlertTriggered;
+    // ...mirrors DashboardHub broadcasts
+}
+```
+
+Islands subscribe in `OnInitialized`, marshal to the UI thread with
+`InvokeAsync(StateHasChanged)`, and unsubscribe in `Dispose`. This keeps a single source of
+truth for real-time events and avoids a second hub round-trip.
+
+Notifier services to touch (dual-publish, ~7, all additive):
+`DashboardNotifier`, `PerformanceNotifier`, `NotificationBroadcaster`,
+`PerformanceMetricsBroadcastService`, plus audio/bulk-purge notifiers as those islands land.
+
+### 3.3 Auth, DbContext, lifetime
+
+- **Auth** — `AddCascadingAuthenticationState()` + the host page's existing `[Authorize]`
+  policy already gate the island. For guild-scoped islands, call
+  `IAuthorizationService.AuthorizeAsync(user, guildId, "GuildAccess")` inside the component
+  (the `GuildAccessHandler` reads `RouteValues` today — when an island needs it outside a
+  routed Razor Page request, pass `guildId` via `context.Resource`; a tiny handler tweak, only
+  needed once we host islands on non-guild routes).
+- **DbContext** — Blazor circuits are long-lived, so data-bound islands must use
+  `IDbContextFactory<BotDbContext>` (create-use-dispose per operation) rather than a scoped
+  context. Register `AddDbContextFactory` with a scoped fallback so all existing repositories
+  keep working unchanged. This is the **one** infra change shared across data islands.
+- **Circuit hygiene** — set `DisconnectedCircuitMaxRetained` / retention sensibly; show a
+  reconnect UI (the default Blazor reconnect modal, themed). Each island disposes its event-bus
+  subscriptions.
+
+### 3.4 Reuse, don't rebuild
+
+- **Toasts / theme** — wrap the existing `toast.js` and `theme.js` with thin
+  `IJSRuntime` interop services (`ToastInterop`, `ThemeInterop`) so islands raise the *same*
+  toasts and respect the *same* theme. No reimplementation.
+- **Tailwind** — islands use the identical utility classes; `tailwind.config.js` already scans
+  `.razor`. Zero CSS changes.
+- **Charts** — keep Chart.js; a small `ChartInterop` (`create/update/destroy` by canvas id)
+  called from `OnAfterRenderAsync` covers the few islands that chart.
+
+---
+
+## 4. Phase 0 — Foundation (the enabling slice)
+
+Deliver these once; everything else builds on them.
+
+| Item | File(s) | Notes |
+|---|---|---|
+| Blazor Server registration | `Extensions/WebServiceExtensions.cs`, `Program.cs` | `AddServerSideBlazor`, `MapBlazorHub`, blazor script in `_Layout` |
+| `_Imports.razor` | `Blazor/_Imports.razor` | global usings (DI, auth, components) |
+| Interop bridges | `Blazor/Interop/{ToastInterop,ThemeInterop,ChartInterop}.cs` | wrap existing JS |
+| In-process event bus | `Blazor/Services/IDashboardEventBus.cs` (+ impl, singleton) | dual-publish target |
+| DbContext factory | `Infrastructure/Extensions/ServiceCollectionExtensions.cs` | `AddDbContextFactory` + scoped fallback |
+| Component kit (minimal) | `Blazor/Shared/*` | only what the first islands need (below) |
+| Proof island | drop a trivial `[Authorize]` island into one existing page | verify auth, theme, Tailwind, prerender |
+
+**Component kit — build only these first** (the 80/20 of the selected pages):
+
+- `TabbedFormShell.razor` — tab strip + per-tab content + **centralized dirty-flag** +
+  unsaved-changes guard + 3-state save button. Replaces the WeakMap button-state machine and
+  `isDirty` bookkeeping duplicated across `settings.js`, `moderation-settings.js`.
+- `ConfirmModal.razor` / `TypedConfirmModal.razor` — replaces `quick-actions.js` confirm flow.
+- `FilterableTable.razor` + `Pagination.razor` — **debounced** filter inputs, server-side
+  paging via `IDbContextFactory`. Backbone for Commands logs + Member directory.
+- `Button.razor`, `FormToggle.razor`, `FormInput.razor`, `FormSelect.razor` — atomic ports of
+  the existing partials (Tailwind classes copied verbatim).
+
+> Place all Blazor code under a new top-level `src/DiscordBot.Bot/Blazor/` folder to avoid
+> confusion with the existing `Components/` C# folder (`ComponentIdBuilder.cs`) and the
+> `Pages/Shared/Components/` partials.
+
+---
+
+## 5. Selected targets
+
+### 5.1 Components (reusable, cross-page)
+
+| Component | Replaces | Real-time? | Rationale |
+|---|---|---|---|
+| **NotificationBell** | `notification-bell.js` (714 lines) | Yes (event bus) | Pure push + optimistic state; classic Blazor win. Lives in `_Layout` as one island. |
+| **BotStatusCard / Banner** | `bot-status-refresh.js` (282 lines, **30s polling**) | Yes (event bus) | Replaces polling with push — strictly fewer requests. |
+| **TabbedFormShell** | dirty/button logic in `settings.js`, `moderation-settings.js` | No | Eliminates the most duplicated, bug-prone JS pattern. |
+| **ConfirmModal** | `quick-actions.js` modal/AJAX path | No | Reused by every destructive action. |
+| **FilterableTable + Pagination** | `command-filters/pagination.js`, `member-directory.js` filter logic | No | Server-side, debounced; reused by logs + members. |
+
+### 5.2 Pages (island conversions)
+
+Ranked by ROI. Each becomes a Razor Page that hosts **one** Blazor island for its interactive body.
+
+**Tier 1 — do first (form-centric, no charting/audio blockers):**
+
+1. **Moderation Settings** (`/Guilds/{id}/ModerationSettings`) — *the proof slice*.
+   Multi-tab (Overview/Spam/Content/Raid/Tags), simple/advanced toggle, per-tab save, tag CRUD,
+   dirty-flag. Low state complexity (540 JS lines), guild-scoped, contained. Best first target:
+   exercises `TabbedFormShell` + `ConfirmModal` + guild auth end-to-end with low risk.
+2. **Admin Settings** (`/Admin/Settings`) — 7 tabs, 9 save handlers, button-state machine,
+   bot status polling, typed-confirm shutdown. Replaces `settings.js` (1101 lines). Admin-only
+   (low concurrency) so server round-trips are fine. Chunk the 54KB template into tab components.
+3. **Commands** (`/Commands`) — three tabs (List/Logs/Analytics). Convert **List + Logs** to
+   islands using `FilterableTable`/`Pagination`/`ConfirmModal` and the log-details modal.
+   Keep the **Analytics** charts on Chart.js via `ChartInterop` (don't block on charting).
+   Retires most of the 9 `command-*.js` modules.
+
+**Tier 2 — next:**
+
+4. **Member Directory** (`/Guilds/{id}/Members`) — `FilterableTable` + `Virtualize` for the
+   list, bulk-select toolbar as component state, async member-detail modal. Replaces
+   `member-directory.js` (496 lines).
+5. **Soundboard portal grid** (`/Portal/Soundboard/{id}`) — replace the hand-rolled
+   `VirtualSoundGrid` + `IntersectionObserver` with Blazor `<Virtualize>`; move
+   search/sort/filter/favorites/upload state into the component. **Keep audio playback in JS**
+   (a tiny `playSound(id)` interop) — low-latency client behavior stays client-side.
+
+**Tier 3 — real-time widgets (after event bus proven by the bell):**
+
+6. **Performance dashboard widgets** — convert the *live metric tiles* (health, system,
+   command, alerts) to islands subscribing to `IDashboardEventBus`, retiring
+   `performance/*-realtime.js`. **Defer the charts** (and `dashboard.js`, 41KB) — they stay
+   Chart.js for now. This captures the real-time win without the charting rewrite.
+
+### 5.3 Explicitly NOT in this increment
+
+- **TTS portal** — audio preview + speed/pitch slider scrubbing need client latency. Leave in JS.
+- **VOX portal** — trivial tab+play UI; no payoff.
+- **Global autocomplete / search** — lightweight, cross-cutting; keystroke latency argues for JS.
+- **Full Performance charting rewrite** — Chart.js via interop is good enough; revisit only if
+  we commit to the full-rewrite north star.
+- Any **.NET 9 upgrade**, page deletion, or controller removal.
+
+---
+
+## 6. SignalR & debouncing strategy
+
+The user's explicit ask: *use SignalR/server interactivity intelligently, but debounce.*
+Blazor Server already runs every UI event over the circuit's SignalR connection, so the risk is
+**chattiness**, not transport. Concrete rules for these islands:
+
+**Inbound (server → UI) real-time:**
+- Subscribe islands to `IDashboardEventBus`, not a second hub connection.
+- **Coalesce high-frequency streams**: health metrics arrive every 5s, system every 10s — fine
+  as-is, but cap UI re-render to **≤ 1 Hz** per widget. If a burst arrives, drop intermediate
+  frames (keep latest) before `StateHasChanged`.
+- Keep the existing **sliding windows** (20-point sparkline, 100-point command charts) so memory
+  is bounded; feed them server-side now.
+- Use `@key` + targeted child components + `ShouldRender` so a metric tick re-diffs one tile,
+  not the page.
+
+**Outbound (UI → server) interaction:**
+- **Debounce text/filter inputs ~250–300ms** (matches today's `command-filters` 300ms /
+  soundboard 150ms search). Bind on `oninput`, gate with a `System.Threading.Timer` or a small
+  `Debouncer` helper; cancel the in-flight query with a `CancellationTokenSource` before issuing
+  the next (mirrors the existing `AbortController` pattern).
+- **Avoid `@bind:event="oninput"` straight to a server query** — that's one round-trip per
+  keystroke. Bind to a field, debounce, then query.
+- For **autosave** (settings drafts), debounce ~1–2s (TTS draft autosave is 2s today) and skip
+  the save if nothing is dirty.
+- For **virtualized lists** use `<Virtualize ItemsProvider>` so only visible rows round-trip.
+- Keep **optimistic updates** for notification mark-read/dismiss (as the JS does today): update
+  local state immediately, reconcile/rollback on the server callback.
+
+**Circuit cost guardrails:**
+- One persistent circuit per open tab; islands are cheap but not free. Don't put islands on
+  hot anonymous/public pages (e.g. the public leaderboard) — those stay static.
+- Set reconnection UI + retained-circuit limits; dispose subscriptions on `IDisposable`.
+
+---
+
+## 7. Sequencing
+
+```
+Phase 0  Foundation: Blazor Server wiring, interop bridges, event bus,
+         IDbContextFactory, minimal component kit, proof island.            (enabling)
+
+Slice 1  Moderation Settings island  → proves TabbedFormShell + ConfirmModal
+         + guild auth on a low-risk, self-contained page.                   (Tier 1)
+
+Slice 2  NotificationBell + BotStatusCard islands → proves event-bus
+         real-time + dual-publish; deletes polling + bell JS.               (real-time proof)
+
+Slice 3  Admin Settings island (reuses shell/modal/bot-status).            (Tier 1)
+
+Slice 4  Commands List+Logs islands (FilterableTable/Pagination/modal);
+         Analytics stays Chart.js via interop.                              (Tier 1)
+
+Slice 5  Member Directory island (FilterableTable + Virtualize).           (Tier 2)
+
+Slice 6  Soundboard grid island (Virtualize; audio stays JS).              (Tier 2)
+
+Slice 7  Performance live-tile islands (event bus); charts stay JS.        (Tier 3)
+```
+
+Each slice is independently shippable and revertible. Stop after any slice and the app is
+consistent. After Slice 7, reassess whether to pursue the full-rewrite north star or hold.
+
+---
+
+## 8. Risks & mitigations (scoped to this increment)
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| EF concurrency across long-lived circuits | High | `IDbContextFactory` in Phase 0; scoped fallback keeps existing code working |
+| Guild auth handler reads `RouteValues` (null in circuit) | Med | Pass `guildId` via `context.Resource`; one-time handler tweak when island leaves a guild route |
+| Snowflake precision loss in prerender params | Med | Pass IDs as strings (`CLAUDE.md` rule); never `ulong` to JS |
+| Chatty circuits from un-debounced inputs | Med | §6 debounce/throttle rules are mandatory for every island |
+| Dual SignalR (circuit + DashboardHub) confusion | Low | Additive; JS path untouched; islands use event bus not the hub |
+| Prerender double-execution of `OnInitialized` | Low | Keep init idempotent; heavy work in `OnAfterRenderAsync` or guard with `firstRender` |
+| Cookie expiry mid-circuit | Low | Add `RevalidatingServerAuthenticationStateProvider` (30-min revalidate) when first auth-sensitive island ships |
+| Theme/toast divergence between JS & Blazor | Low | Islands call the *same* `toast.js`/`theme.js` via interop |
+
+---
+
+## 9. Testing & rollout
+
+- **bUnit** component tests for `TabbedFormShell`, `FilterableTable`, `ConfirmModal`,
+  `NotificationBell` (render, dirty-flag, debounce timing, event-bus updates).
+- **Parity gate**: keep the old JS page reachable (feature flag or query param) until the island
+  reaches visual + behavioral parity, then flip the default.
+- **Manual regression** per slice: auth on the host page, theme switch, toast on save, reconnect
+  behavior, and that non-Blazor pages + `DashboardHub` JS still work.
+- **Load sanity** on the real-time islands: confirm coalescing caps re-render rate; watch
+  per-circuit memory under a handful of concurrent admin sessions.
+
+---
+
+## 10. Documentation to update as slices land
+
+- `CLAUDE.md` — drop the stale HTMX/Alpine mention; add the Blazor-island pattern + snowflake
+  param rule.
+- `.claude/agents/web-ui-portal.md` — note Blazor islands now exist under `Blazor/`.
+- `docs/articles/component-api.md` — document the new Blazor component kit alongside the partials.
+- This file + `blazor-migration-plan.md` — cross-link; mark which slices are done.

--- a/src/DiscordBot.Bot/Blazor/Common/Debouncer.cs
+++ b/src/DiscordBot.Bot/Blazor/Common/Debouncer.cs
@@ -1,0 +1,56 @@
+namespace DiscordBot.Bot.Blazor.Common;
+
+/// <summary>
+/// Coalesces rapid calls (e.g. per-keystroke filter input) into a single
+/// trailing-edge invocation after a quiet period. Each new call cancels the
+/// previous pending action, so only the final one within the window runs.
+/// </summary>
+/// <remarks>
+/// This is the server-side equivalent of the <c>AbortController</c> +
+/// <c>setTimeout</c> debounce pattern used throughout the existing JS modules
+/// (e.g. <c>command-filters.js</c> at 300ms). Hold one instance per debounced
+/// input and dispose it with the component.
+/// </remarks>
+public sealed class Debouncer : IDisposable
+{
+    private readonly TimeSpan _delay;
+    private CancellationTokenSource? _cts;
+
+    public Debouncer(TimeSpan delay) => _delay = delay;
+
+    public Debouncer(int milliseconds) : this(TimeSpan.FromMilliseconds(milliseconds)) { }
+
+    /// <summary>
+    /// Schedules <paramref name="action"/> to run after the debounce delay,
+    /// cancelling any previously scheduled (still-pending) action. The provided
+    /// <see cref="CancellationToken"/> is cancelled if a newer call supersedes
+    /// this one, so long-running work can bail out early.
+    /// </summary>
+    public async Task DebounceAsync(Func<CancellationToken, Task> action)
+    {
+        _cts?.Cancel();
+        _cts?.Dispose();
+        _cts = new CancellationTokenSource();
+        var token = _cts.Token;
+
+        try
+        {
+            await Task.Delay(_delay, token).ConfigureAwait(false);
+            if (!token.IsCancellationRequested)
+            {
+                await action(token).ConfigureAwait(false);
+            }
+        }
+        catch (TaskCanceledException)
+        {
+            // Superseded by a newer call — expected, ignore.
+        }
+    }
+
+    public void Dispose()
+    {
+        _cts?.Cancel();
+        _cts?.Dispose();
+        _cts = null;
+    }
+}

--- a/src/DiscordBot.Bot/Blazor/Interop/ThemeInterop.cs
+++ b/src/DiscordBot.Bot/Blazor/Interop/ThemeInterop.cs
@@ -1,0 +1,23 @@
+using Microsoft.JSInterop;
+
+namespace DiscordBot.Bot.Blazor.Interop;
+
+/// <summary>
+/// Thin wrapper over the existing <c>theme.js</c> manager so Blazor components
+/// apply themes through the same code path (and persistence) as the rest of the
+/// portal. Calls the window-attached shim in <c>blazor-interop.js</c>.
+/// </summary>
+/// <remarks>Registered as a scoped service. Invoke only after first render.</remarks>
+public sealed class ThemeInterop
+{
+    private readonly IJSRuntime _js;
+
+    public ThemeInterop(IJSRuntime js) => _js = js;
+
+    /// <summary>
+    /// Applies the given theme key, optionally persisting the preference to the
+    /// server (mirrors <c>ThemeManager.applyTheme(key, persist)</c>).
+    /// </summary>
+    public ValueTask ApplyThemeAsync(string themeKey, bool persistToServer = false)
+        => _js.InvokeVoidAsync("blazorInterop.applyTheme", themeKey, persistToServer);
+}

--- a/src/DiscordBot.Bot/Blazor/Interop/ToastInterop.cs
+++ b/src/DiscordBot.Bot/Blazor/Interop/ToastInterop.cs
@@ -1,0 +1,44 @@
+using Microsoft.JSInterop;
+
+namespace DiscordBot.Bot.Blazor.Interop;
+
+/// <summary>
+/// Thin wrapper over the existing <c>toast.js</c> notification system so Blazor
+/// components raise the same toasts as the rest of the portal. Calls the
+/// window-attached shim in <c>blazor-interop.js</c> (which forwards to
+/// <c>ToastManager.show</c>).
+/// </summary>
+/// <remarks>
+/// Registered as a scoped service. Interop must only be invoked after the first
+/// render (the JS runtime is not available during prerendering), so callers
+/// should invoke these from event handlers or <c>OnAfterRenderAsync</c>.
+/// </remarks>
+public sealed class ToastInterop
+{
+    private readonly IJSRuntime _js;
+
+    public ToastInterop(IJSRuntime js) => _js = js;
+
+    /// <summary>Shows a success toast (auto-dismiss).</summary>
+    public ValueTask SuccessAsync(string message, string? title = null)
+        => ShowAsync("success", message, title);
+
+    /// <summary>Shows an error toast (persists until dismissed).</summary>
+    public ValueTask ErrorAsync(string message, string? title = null)
+        => ShowAsync("error", message, title);
+
+    /// <summary>Shows a warning toast.</summary>
+    public ValueTask WarningAsync(string message, string? title = null)
+        => ShowAsync("warning", message, title);
+
+    /// <summary>Shows an informational toast.</summary>
+    public ValueTask InfoAsync(string message, string? title = null)
+        => ShowAsync("info", message, title);
+
+    /// <summary>
+    /// Shows a toast of the given <paramref name="type"/>
+    /// (<c>success</c>, <c>error</c>, <c>warning</c>, or <c>info</c>).
+    /// </summary>
+    public ValueTask ShowAsync(string type, string message, string? title = null)
+        => _js.InvokeVoidAsync("blazorInterop.toast", type, message, title);
+}

--- a/src/DiscordBot.Bot/Blazor/Pages/FoundationProbe.razor
+++ b/src/DiscordBot.Bot/Blazor/Pages/FoundationProbe.razor
@@ -1,0 +1,71 @@
+@namespace DiscordBot.Bot.Blazor.Pages
+@using DiscordBot.Bot.ViewModels.Components
+@inject ToastInterop Toast
+@implements IDisposable
+
+@*
+    Phase 0 proof-of-concept island. Hosted on the /Components showcase page via the
+    component tag helper. Verifies, end-to-end, that:
+      - a Blazor Server circuit boots and round-trips events (the counter),
+      - the JS interop bridge reaches the existing toast system,
+      - the ported UiButton / UiToggle render with the design system styling,
+      - the Debouncer coalesces rapid input.
+    Not wired into any production page. Safe to delete once the foundation is trusted.
+*@
+
+<div class="bg-bg-secondary border border-border-primary rounded-lg p-6 space-y-6">
+    <div>
+        <h3 class="text-lg font-semibold text-text-primary">Blazor foundation probe</h3>
+        <p class="text-sm text-text-secondary mt-1">
+            Interactive Server island — proves circuit, interop, and component parity.
+        </p>
+    </div>
+
+    <div class="flex items-center gap-4">
+        <UiButton Text="Increment" Variant="ButtonVariant.Primary" OnClick="Increment" />
+        <span class="text-text-primary text-sm">Server-held count: <strong>@_count</strong></span>
+    </div>
+
+    <div class="flex items-center gap-4">
+        <UiButton Text="Show toast" Variant="ButtonVariant.Secondary" OnClick="ShowToastAsync" />
+        <span class="text-text-secondary text-sm">Calls the existing ToastManager via interop.</span>
+    </div>
+
+    <UiToggle @bind-Value="_enabled" Label="Sample toggle" Description="Two-way bound switch using the ported design-system styling." />
+
+    <div class="space-y-1">
+        <label for="probe-search" class="block text-sm font-semibold text-text-primary">Debounced input (300ms)</label>
+        <input id="probe-search"
+               type="text"
+               class="w-full max-w-sm px-3 py-2 bg-bg-tertiary border border-border-primary rounded-md text-sm text-text-primary"
+               placeholder="Type to debounce…"
+               @oninput="OnSearchInput" />
+        <p class="text-xs text-text-secondary">Last committed value: <span class="font-mono">@_debouncedValue</span> (fired @_debounceCount×)</p>
+    </div>
+</div>
+
+@code {
+    private int _count;
+    private bool _enabled = true;
+    private string _debouncedValue = string.Empty;
+    private int _debounceCount;
+    private readonly Debouncer _searchDebouncer = new(300);
+
+    private void Increment() => _count++;
+
+    private async Task ShowToastAsync()
+        => await Toast.SuccessAsync($"Hello from Blazor — count is {_count}.", "Foundation probe");
+
+    private async Task OnSearchInput(ChangeEventArgs e)
+    {
+        var value = e.Value?.ToString() ?? string.Empty;
+        await _searchDebouncer.DebounceAsync(async _ =>
+        {
+            _debouncedValue = value;
+            _debounceCount++;
+            await InvokeAsync(StateHasChanged);
+        });
+    }
+
+    public void Dispose() => _searchDebouncer.Dispose();
+}

--- a/src/DiscordBot.Bot/Blazor/Shared/UiButton.razor
+++ b/src/DiscordBot.Bot/Blazor/Shared/UiButton.razor
@@ -1,0 +1,111 @@
+@namespace DiscordBot.Bot.Blazor.Shared
+@using DiscordBot.Bot.ViewModels.Components
+
+@*
+    Blazor twin of Pages/Shared/Components/_Button.cshtml.
+    Same Tailwind classes / variants so it is visually identical to the partial,
+    but with a server-side @onclick EventCallback instead of a JS handler string.
+*@
+
+<button type="@Type"
+        class="@CssClass"
+        disabled="@(Disabled || Loading)"
+        aria-busy="@(Loading ? "true" : null)"
+        aria-label="@EffectiveAriaLabel"
+        @onclick="HandleClickAsync"
+        @attributes="SplatAttributes">
+    @if (Loading)
+    {
+        <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+        </svg>
+        <span class="sr-only">Loading</span>
+    }
+    else if (!string.IsNullOrEmpty(IconLeft))
+    {
+        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="@IconLeft" />
+        </svg>
+    }
+
+    @if (!IconOnly)
+    {
+        <span>@(Loading && !string.IsNullOrEmpty(LoadingText) ? LoadingText : Text)</span>
+    }
+
+    @ChildContent
+</button>
+
+@code {
+    [Parameter] public string Text { get; set; } = string.Empty;
+    [Parameter] public ButtonVariant Variant { get; set; } = ButtonVariant.Primary;
+    [Parameter] public ButtonSize Size { get; set; } = ButtonSize.Medium;
+    [Parameter] public string Type { get; set; } = "button";
+    [Parameter] public string? IconLeft { get; set; }
+    [Parameter] public bool Disabled { get; set; }
+    [Parameter] public bool Loading { get; set; }
+    [Parameter] public string? LoadingText { get; set; }
+    [Parameter] public bool IconOnly { get; set; }
+    [Parameter] public string? AriaLabel { get; set; }
+    [Parameter] public EventCallback OnClick { get; set; }
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+
+    /// <summary>Any extra HTML attributes (including <c>class</c>) are merged onto the button.</summary>
+    [Parameter(CaptureUnmatchedValues = true)]
+    public IReadOnlyDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private string? EffectiveAriaLabel => AriaLabel ?? (IconOnly ? Text : null);
+
+    private string? ExtraClass =>
+        AdditionalAttributes is not null && AdditionalAttributes.TryGetValue("class", out var c)
+            ? c?.ToString()
+            : null;
+
+    // Splat everything except class (class is folded into CssClass to avoid a duplicate attribute).
+    private IReadOnlyDictionary<string, object>? SplatAttributes =>
+        AdditionalAttributes is null
+            ? null
+            : AdditionalAttributes.Where(a => a.Key != "class").ToDictionary(a => a.Key, a => a.Value);
+
+    private string CssClass
+    {
+        get
+        {
+            var sizeClasses = Size switch
+            {
+                ButtonSize.Small => "px-3 py-1.5 text-xs",
+                ButtonSize.Large => "px-6 py-3 text-base",
+                _ => "px-5 py-2.5 text-sm"
+            };
+
+            var variantClasses = Variant switch
+            {
+                ButtonVariant.Secondary => "text-text-primary bg-transparent border border-border-primary hover:bg-bg-hover",
+                ButtonVariant.Accent => "text-white bg-accent-blue hover:bg-accent-blue-hover active:bg-accent-blue-active",
+                ButtonVariant.Danger => "text-white bg-error hover:bg-error/80",
+                ButtonVariant.Ghost => "text-text-secondary hover:text-text-primary hover:bg-bg-hover",
+                _ => "text-white bg-accent-orange hover:bg-accent-orange-hover active:bg-accent-orange-active"
+            };
+
+            var baseClasses = IconOnly
+                ? "p-2.5 text-text-secondary hover:text-text-primary hover:bg-bg-hover rounded-md transition-colors"
+                : $"inline-flex items-center justify-center gap-2 {sizeClasses} font-semibold {variantClasses} rounded-md transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-blue disabled:opacity-50 disabled:cursor-not-allowed";
+
+            return string.IsNullOrEmpty(ExtraClass) ? baseClasses : $"{baseClasses} {ExtraClass}";
+        }
+    }
+
+    private async Task HandleClickAsync()
+    {
+        if (Disabled || Loading)
+        {
+            return;
+        }
+
+        if (OnClick.HasDelegate)
+        {
+            await OnClick.InvokeAsync();
+        }
+    }
+}

--- a/src/DiscordBot.Bot/Blazor/Shared/UiToggle.razor
+++ b/src/DiscordBot.Bot/Blazor/Shared/UiToggle.razor
@@ -1,0 +1,83 @@
+@namespace DiscordBot.Bot.Blazor.Shared
+
+@*
+    Blazor twin of Pages/Shared/Components/_FormToggle.cshtml.
+    Two-way bindable switch (@bind-Value). The toggle CSS is inlined below to match
+    the partial's approach, so it works on island-only pages without depending on
+    the scoped-CSS bundle being linked in the layout.
+*@
+
+<div class="flex items-start gap-4">
+    <label class="form-toggle @(Disabled ? "opacity-60 cursor-not-allowed" : "cursor-pointer")">
+        <input type="checkbox"
+               id="@Id"
+               class="form-toggle-input"
+               checked="@Value"
+               disabled="@Disabled"
+               @onchange="OnChangedAsync" />
+        <span class="form-toggle-track">
+            <span class="form-toggle-thumb"></span>
+        </span>
+    </label>
+
+    @if (!string.IsNullOrEmpty(Label) || !string.IsNullOrEmpty(Description))
+    {
+        <div class="flex-1">
+            @if (!string.IsNullOrEmpty(Label))
+            {
+                <label for="@Id" class="block text-sm font-semibold text-text-primary @(Disabled ? "cursor-not-allowed" : "cursor-pointer")">
+                    @Label
+                </label>
+            }
+            @if (!string.IsNullOrEmpty(Description))
+            {
+                <p class="text-xs text-text-secondary mt-1">@Description</p>
+            }
+        </div>
+    }
+</div>
+
+<style>
+    .form-toggle { display: flex; align-items: center; gap: 0.75rem; }
+    .form-toggle-input { position: absolute; opacity: 0; width: 0; height: 0; }
+    .form-toggle-track {
+        position: relative; display: inline-block; width: 2.75rem; height: 1.5rem;
+        background-color: #3f4447; border-radius: 9999px; flex-shrink: 0;
+        transition: background-color 0.2s ease-in-out;
+    }
+    .form-toggle-thumb {
+        position: absolute; top: 0.125rem; left: 0.125rem; width: 1.25rem; height: 1.25rem;
+        background-color: #d7d3d0; border-radius: 50%;
+        transition: transform 0.2s ease-in-out, background-color 0.2s ease-in-out;
+    }
+    .form-toggle:hover .form-toggle-track { background-color: #4a4f52; }
+    .form-toggle:hover .form-toggle-input:checked + .form-toggle-track { background-color: #e5591f; }
+    .form-toggle-input:focus-visible + .form-toggle-track { outline: 2px solid #098ecf; outline-offset: 2px; }
+    .form-toggle-input:checked + .form-toggle-track { background-color: #cb4e1b; }
+    .form-toggle-input:checked + .form-toggle-track .form-toggle-thumb { transform: translateX(1.25rem); background-color: white; }
+    .form-toggle-input:disabled + .form-toggle-track { opacity: 0.6; cursor: not-allowed; }
+</style>
+
+@code {
+    [Parameter] public bool Value { get; set; }
+    [Parameter] public EventCallback<bool> ValueChanged { get; set; }
+    [Parameter] public string? Label { get; set; }
+    [Parameter] public string? Description { get; set; }
+    [Parameter] public bool Disabled { get; set; }
+    [Parameter] public string Id { get; set; } = $"toggle-{Guid.NewGuid():N}";
+
+    private async Task OnChangedAsync(ChangeEventArgs e)
+    {
+        if (Disabled)
+        {
+            return;
+        }
+
+        var newValue = e.Value is bool b ? b : bool.TryParse(e.Value?.ToString(), out var parsed) && parsed;
+        Value = newValue;
+        if (ValueChanged.HasDelegate)
+        {
+            await ValueChanged.InvokeAsync(newValue);
+        }
+    }
+}

--- a/src/DiscordBot.Bot/Blazor/_Imports.razor
+++ b/src/DiscordBot.Bot/Blazor/_Imports.razor
@@ -1,0 +1,13 @@
+@using System.Net.Http
+@using System.Threading
+@using System.Threading.Tasks
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.JSInterop
+@using DiscordBot.Bot.Blazor.Common
+@using DiscordBot.Bot.Blazor.Interop
+@using DiscordBot.Bot.Blazor.Shared

--- a/src/DiscordBot.Bot/Extensions/WebServiceExtensions.cs
+++ b/src/DiscordBot.Bot/Extensions/WebServiceExtensions.cs
@@ -1,3 +1,4 @@
+using DiscordBot.Bot.Blazor.Interop;
 using DiscordBot.Bot.Handlers;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -28,6 +29,18 @@ public static class WebServiceExtensions
         services.AddControllers();
         services.AddRazorPages();
         services.AddEndpointsApiExplorer();
+
+        // Blazor Server foundation (islands-first modernization — see
+        // docs/architecture/blazor-modernization-selective-plan.md). Interactive
+        // components are embedded into existing Razor Pages via the component tag
+        // helper; routing and auth stay with Razor Pages.
+        services.AddServerSideBlazor();
+        services.AddCascadingAuthenticationState();
+
+        // Interop bridges to the existing toast.js / theme.js modules so islands
+        // reuse the portal's notification and theme systems.
+        services.AddScoped<ToastInterop>();
+        services.AddScoped<ThemeInterop>();
 
         return services;
     }

--- a/src/DiscordBot.Bot/Pages/Components.cshtml
+++ b/src/DiscordBot.Bot/Pages/Components.cshtml
@@ -12,6 +12,10 @@
 @section Scripts {
     <script src="~/js/nav-tabs.js" asp-append-version="true"></script>
     <script src="~/js/settings.js" asp-append-version="true"></script>
+    <!-- Blazor interop shim (must load after toast.js/theme.js, which the layout renders first) -->
+    <script src="~/js/blazor-interop.js" asp-append-version="true"></script>
+    <!-- Blazor Server circuit (only loaded on pages that host an island) -->
+    <script src="~/_framework/blazor.server.js"></script>
 }
 
 <div class="space-y-8">
@@ -20,6 +24,17 @@
         <h1 class="text-3xl font-bold text-text-primary mb-2">Component Showcase</h1>
         <p class="text-text-secondary">Visual reference for all UI components with their various states and variants.</p>
     </div>
+
+    <!-- 0. BLAZOR FOUNDATION PROBE (Phase 0 proof-of-concept island) -->
+    <section class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden">
+        <div class="px-6 py-4 border-b border-border-primary">
+            <h3 class="text-lg font-semibold text-text-primary">Blazor Foundation (Interactive Server island)</h3>
+            <p class="text-sm text-text-secondary mt-1">Proof-of-concept for the islands-first modernization. Remove once trusted.</p>
+        </div>
+        <div class="p-6">
+            <component type="typeof(DiscordBot.Bot.Blazor.Pages.FoundationProbe)" render-mode="ServerPrerendered" />
+        </div>
+    </section>
 
     <!-- 1. BUTTONS -->
     <section class="bg-bg-secondary border border-border-primary rounded-lg overflow-hidden">

--- a/src/DiscordBot.Bot/Program.cs
+++ b/src/DiscordBot.Bot/Program.cs
@@ -295,6 +295,10 @@ try
     // Map SignalR hub for real-time dashboard
     app.MapHub<DashboardHub>("/hubs/dashboard");
 
+    // Map the Blazor Server circuit hub (/_blazor) used by interactive islands.
+    // Coexists with the dashboard hub above; non-Blazor pages are unaffected.
+    app.MapBlazorHub();
+
     // Map Prometheus metrics endpoint
     app.UseOpenTelemetryPrometheusScrapingEndpoint();
 

--- a/src/DiscordBot.Bot/wwwroot/js/blazor-interop.js
+++ b/src/DiscordBot.Bot/wwwroot/js/blazor-interop.js
@@ -1,0 +1,41 @@
+// Blazor interop shim.
+//
+// The existing toast.js / theme.js modules expose `ToastManager` and `ThemeManager`
+// as top-level `const`s (classic scripts), so they live in the global lexical scope
+// but are NOT properties of `window`. Blazor's IJSRuntime resolves dotted paths
+// against `window`/`globalThis`, so it cannot reach them directly.
+//
+// This shim is a classic script loaded AFTER toast.js/theme.js. It can reference
+// those lexically-scoped bindings and re-exposes a small, stable, window-attached
+// surface for Blazor interop services to call.
+(function () {
+    "use strict";
+
+    window.blazorInterop = {
+        // Bridges DiscordBot.Bot.Blazor.Interop.ToastInterop -> ToastManager.show(type, message, options)
+        toast: function (type, message, title) {
+            try {
+                if (typeof ToastManager !== "undefined" && ToastManager) {
+                    ToastManager.show(type, message, title ? { title: title } : {});
+                } else {
+                    console.warn("blazorInterop.toast: ToastManager not loaded");
+                }
+            } catch (e) {
+                console.error("blazorInterop.toast failed", e);
+            }
+        },
+
+        // Bridges DiscordBot.Bot.Blazor.Interop.ThemeInterop -> ThemeManager.applyTheme(key, persist)
+        applyTheme: function (themeKey, persistToServer) {
+            try {
+                if (typeof ThemeManager !== "undefined" && ThemeManager) {
+                    ThemeManager.applyTheme(themeKey, persistToServer === true);
+                } else {
+                    console.warn("blazorInterop.applyTheme: ThemeManager not loaded");
+                }
+            } catch (e) {
+                console.error("blazorInterop.applyTheme failed", e);
+            }
+        }
+    };
+})();


### PR DESCRIPTION
## Summary

Adds Blazor Server **interactive islands** to the existing .NET 8 Razor Pages app to modernize the highest-ROI UI, **without** a full rewrite, framework upgrade, or routing/auth change. This is the pragmatic near-term increment; the maximalist end-state remains documented in `blazor-migration-plan.md`.

The plan document lands first; implementation follows slice-by-slice, each in its own commit.

## Approach

- **Classic Blazor Server islands on .NET 8** — each existing Razor Page hosts one interactive region via the Component Tag Helper. No `App.razor`, no routing takeover; islands inherit page auth. Independently revertible.
- **Real-time via an in-process `IDashboardEventBus`** that existing notifier services dual-publish to (additive — the existing `DashboardHub` + JS path stay untouched). Islands subscribe server-side instead of opening a second hub connection.
- **Debounce/throttle discipline** for SignalR-backed interactivity: ≤1 Hz inbound coalescing, 250–300ms input debounce with cancellation, `<Virtualize>` + `ShouldRender`/`@key`.
- **Reuse, don't rebuild** — islands call the existing `toast.js`/`theme.js` via interop and use identical Tailwind classes (config already globs `.razor`).

## Phases / slices (each = one commit)

- **Phase 0** — Foundation: Blazor Server wiring, interop bridges, event bus, `IDbContextFactory`, minimal component kit.
- **Slice 1** — Moderation Settings island (proves form pattern + guild auth).
- **Slice 2** — NotificationBell + BotStatusCard (proves event-bus real-time; replaces polling + 714-line bell JS).
- **Slice 3** — Admin Settings (retires `settings.js`).
- **Slice 4** — Commands List+Logs (Analytics stays Chart.js).
- **Slice 5** — Member Directory (`<Virtualize>`).
- **Slice 6** — Soundboard grid (`<Virtualize>`; audio stays JS).
- **Slice 7** — Performance live tiles (charts stay Chart.js).

Explicitly left in JS: TTS audio/sliders, VOX, global autocomplete, performance charts.

See [`docs/architecture/blazor-modernization-selective-plan.md`](https://github.com/cpike5/discordbot/blob/claude/bot-ui-blazor-plan-slot47/docs/architecture/blazor-modernization-selective-plan.md) for the full plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)